### PR TITLE
Bug833 asdt list

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1532,7 +1532,14 @@ as.matrix.data.table = function(x,...)
 
 as.data.table.matrix = function(x, keep.rownames=FALSE)
 {
-    if (keep.rownames) return(data.table(rn=rownames(x), x, keep.rownames=FALSE))
+    if (keep.rownames) {
+        ## matricies and arrays may not have rownames attribute
+        if (is.null(rownames(x))) {
+            warning("keep.rownames has been set to TRUE but rownames(x) is NULL. rn column will be NA_character_")
+            return(data.table(rn=rep(NA_character_, nrow(x)), x, keep.rownames=FALSE))
+        } else 
+            return(data.table(rn=rownames(x), x, keep.rownames=FALSE))
+    }
     d <- dim(x)
     nrows <- d[1L]
     ir <- seq_len(nrows)

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1661,8 +1661,9 @@ as.data.table.list = function(x, keep.rownames=FALSE, bind.using=c("cbind", "rbi
         if (any(range(L) != mean(L)))
           stop(sprintf("arguments imply differing number of %s: %s\n\nMore Info: 'x', the list provided to as.data.table(), has at least one element that is two-dimensional. For consistency with as.data.frame, there is no recycling when the number of %1$s / length of each element of x are not all the same.\nYou may want to consider:    do.call(cbind, x)", ifelse(bind.using == "cbind", "rows", "cols"), paste(L, collapse=", ")))
 
-        # return(as.data.table(do.call(bind.func, x)))
-        return(do.call(bind.func, lapply(x, as.data.table)))
+        # We cannot simply c/rbind since this will force coercian. 
+        # The first element in the list must be a data.table 
+        return(do.call(bind.func, c(list(as.data.table(x[[1L]])), x[-1L])))
     } else {
     ## Proceed as "normal" (prior to Implementing #833)
         n = vapply(x, length, 0L)

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1616,6 +1616,13 @@ as.data.table.list = function(x, keep.rownames=FALSE, bind.using=c("cbind", "rbi
 
     ## Implementing #833
     dims <- vapply(x, function(xi) length(dim(xi)), 0)
+
+    ## Check for nested lists. 
+    ## Throw warning to notify of lack of compatibility with as.data.frame
+    vapply(x, is.list, NA) & (!dims)
+        warning("as.data.table(x) and as.data.frame(X) differ in how they handle nested lists.\nNamely, as.data.table will allow for a list to be a single element in a column.\nIf you would like to force compatibility please use:\n   as.data.table(as.data.frame(x))")
+
+
     ## If any element has dim, then convert to data.table using rbind/cbind 
     ## For consistency with as.data.frame, as.data.table should 
     ##   fail if inconsisent dimensions. 

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1566,6 +1566,26 @@ as.data.table.matrix = function(x, keep.rownames=FALSE)
     alloc.col(value)
 }
 
+as.data.table.array = function(x, keep.rownames=FALSE)
+{
+
+    if (keep.rownames) {
+        ## matricies and arrays may not have rownames attribute
+        if (is.null(rownames(x))) {
+            warning("keep.rownames has been set to TRUE but rownames(x) is NULL. rn column will be NA_character_")
+            return(data.table(rn=rep(NA_character_, nrow(x)), x, keep.rownames=FALSE))
+        } else 
+            return(data.table(rn=rownames(x), x, keep.rownames=FALSE))
+    }
+
+    ## deep copy, since we will modify original
+    x <- copy(x)
+    ## Convert to matrix
+    d <- dim(x)
+    setattr(x, "dim", c(d[1L], prod(d[-1L])))
+    return(as.data.table.matrix(x, keep.rownames=keep.rownames))
+}
+
 as.data.table.data.frame = function(x, keep.rownames=FALSE)
 {
     if (keep.rownames) return(data.table(rn=rownames(x), x, keep.rownames=FALSE))

--- a/inst/tests/test-as.data.frame-as.data.table-same.R
+++ b/inst/tests/test-as.data.frame-as.data.table-same.R
@@ -1,0 +1,101 @@
+context("as.data.table and as.data.frame should yield comparable results")
+
+as.dt_as.df_are.same <- function(x, quietly=FALSE, check.names=FALSE, showWarnings=TRUE) {
+## compares as.data.table(x) to as.data.frame(x) 
+##  by wrapping the former in as.data.frame and testing with identical
+## returns TRUE if all values are equal, FALSE otherswise
+
+
+  x.dt <- try(as.data.table(x), silent=TRUE)
+  x.df <- try(as.data.frame(x, stringsAsFactors=FALSE), silent=TRUE)
+
+  ## Check for errors
+  iserr.dt <- inherits(x.dt, "try-error")
+  iserr.df <- inherits(x.df, "try-error")
+  if (iserr.dt && iserr.df) {
+    message("both of as.data.frame(x) and as.data.table(x) threw an error")
+    return(invisible(TRUE))
+  }
+  if (iserr.dt && !iserr.df) {
+    warning("DT failed but DF did not")
+    return(invisible(FALSE))
+  }
+  if (!iserr.dt && iserr.df) {
+    warning("DF failed but DT did not")
+    return(invisible(FALSE))
+  }
+
+  ## will compare x.dt_as.df to x.df
+  x.dt_as.df <- as.data.frame(x.dt)
+
+  if (!check.names) {
+    setattr(x.dt, "names", rep(NA_character_, ncol(x.dt)))
+    setattr(x.df, "names", rep(NA_character_, ncol(x.df)))
+    rownames(x.df) <- NULL
+    setattr(x.dt_as.df, "names", rep(NA_character_, ncol(x.df)))
+    rownames(x.dt_as.df) <- NULL
+  }
+
+  ret <- identical(x.dt_as.df, x.df)
+
+  ## if indetical fails, check the acutal values. 
+  ## Perhaps it is just an attribtue that is different
+  if (!ret && identical(dim(x.dt_as.df), dim(x.df))) {
+    if (all(x.dt_as.df == x.df)) {
+      ## try clearing attributes
+      setattr(x.df[[1]], "dim", NULL)
+      ## if still not idetnical, throw warning, but return TRUE
+      if (showWarnings && !identical(x.df, x.dt_as.df))
+        warning("All values and dimensions are the same between DF and DT.\nHowever, some differences remain, perhaps in attirbute or attirbute of a column")
+      return(invisible(TRUE))
+    }
+  }
+
+  ## If FALSE, use expect_equal for the detailed output
+  if (!ret)
+    return(testthat::expect_equal(x.dt_as.df, x.df, info="comparing as.data.frame(x) to as.data.frame(as.data.table(x))"))
+
+  return(invisible(ret))
+}
+
+
+###############################################################################
+## as.* conversions
+test_that("convert matrices to data.table/data.frame", {
+  mat_num  <- matrix(1:12, ncol=3)
+  mat_char <- matrix(LETTERS[1:12], ncol=3)
+
+  A <- array(1:30, dim=c(3, 2, 5))
+  B <- array(-(1:600), dim=c(3, 2, 5, 2))
+  A_onedim <- array(1:3, dim=c(3))
+  A_twodim <- array(1:6, dim=c(3, 2))
+  A_twodim_1x6 <- array(1:6, dim=c(1, 6))
+  A.char <- copy(A)
+  A.char[] <- c(LETTERS, letters)[A]
+  B.char <- copy(B)
+  B.char[] <- sapply(seq(B), function(x) paste(sample(LETTERS, 3), collapse=""))
+  list_of_arrays <- list(A, B, 101:103)
+  list_of_arrays_mats <- list(A, B, t(mat_char), 101:103)
+  list_of_arrays_mats2 <- list(B.char, A, B, t(mat_char), 101:103)
+  list_of_one_dim_arrays <- list(A_onedim, A_onedim)
+  list_of_arrays_mats_fail <- list(A, B, mat_char, 101:103)  # failure expected for this one
+
+  expect_error(as.data.table(list_of_arrays_mats_fail), regex="imply differing number", info="list of matrix and vectors. as.data.table should fail")
+
+  expect_true(  as.dt_as.df_are.same(mat_char) )
+  expect_true(  as.dt_as.df_are.same(mat_num) )
+  expect_true(  as.dt_as.df_are.same(A) )
+  expect_true(  as.dt_as.df_are.same(B) )
+  expect_true(  as.dt_as.df_are.same( mat_char ) )
+  expect_true(  as.dt_as.df_are.same( A_onedim ) )
+  expect_true(  as.dt_as.df_are.same( A_twodim ) )
+  expect_true(  as.dt_as.df_are.same( A_twodim_1x6 ) )
+  expect_true(  as.dt_as.df_are.same( A.char ) )
+  expect_true(  as.dt_as.df_are.same( B.char ) )
+  expect_true(  as.dt_as.df_are.same( list_of_arrays ) )
+  expect_true(  as.dt_as.df_are.same( list_of_arrays_mats ) )
+  expect_true(  as.dt_as.df_are.same( list_of_arrays_mats2 ) )
+  expect_true(  as.dt_as.df_are.same(list_of_one_dim_arrays, showWarnings=FALSE) )
+
+})
+


### PR DESCRIPTION
Addresses `issue #833`
"as.data.table behavior inconsistent with as.data.frame for matrix list members #833"

## Modified / Added:

* as.data.table.list
* as.data.table.matrix
* as.data.table.array (added)


details: 
---------
**as.data.table.list** -- checks if any element has dim, then rest of function splits into two parts (yes/no dim).  If an element has dimension, several other tests are performed and eventually returns `do.call(cbind, lapply(x, as.data.table))`   Additionally, gave user option to use `rbind` instead of `cbind` via the argument `bind.using`.  This is useful for list of matrices. For mixed lists, a warning is thrown to inform user that `rbind` may coerce data types. 


**as.data.table.matrix** -- fixed issue where if `keep.rownames=TRUE` but `x` does not have rownames, an error would result.  Solution implemented is to use `rn=NA_character_`.   Alternative is to override user and set `keep.rownames=FALSE`


**as.data.tabel.array** -- added this function.  Goal was to mimic results of `as.data.frame.array` as closely as possible.  One issue remains. Namely, for single-dimension array, as.data.frame preserves dim info. We cannot do that with as.data.table since a column having a dim attribtue will annoy `print(x)`.  

 