### PR TITLE
Only attempt to print if x is a suitable data.table

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -78,6 +78,8 @@ print.data.table = function(x,
     nrows=getOption("datatable.print.nrows"), # (100) under this the whole (small) table is printed, unless topn is provided
     row.names = TRUE, ...)
 {
+    if (class(unclass(x)) != 'list')
+        stop('Not a suitable data.table')
     if (!.global$print) {
         #  := in [.data.table sets print=FALSE, when appropriate, to suppress := autoprinting at the console
         .global$print = TRUE


### PR DESCRIPTION
Fixes #832 by only attempting to print suitable data.tables, e.g. those that satisfy class(unclass(x)) == 'list'.