### PR TITLE
setcolorder works like setnames

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2124,8 +2124,8 @@ setcolorder = function(x,old, new)
     o <- rep(NA,length(x))
     o[new] <- i
     o[is.na(o)] <- setdiff(1:length(x),i)
-    print(o)
     .Call(Csetcolorder, x, o)
+    invisible(x)
 }
 
 set = function(x,i=NULL,j,value)  # low overhead, loopable


### PR DESCRIPTION
This solves #798 and #592 in a way consistent with how setnames works.
When only one argument is given (beyond the data.table) , setcolorder behavior does the exact same thing as before.  However, I renamed this argument from "neworder" to "old" to be consistent with setnames. 

A second argument (a numeric vector) can now be specified.

``` R
dt <- data.table(id = c(1,2), date = c(1999, 2000))
setcolorder(dt, "date", 1)
setcolorder(dt, 2, 1)
setcolorder(dt, "id", 2)
setcolorder(dt, 1, 2)
```
