### PR TITLE
fread: use download.file(..., quiet=!show.Progress)

### DIFF
--- a/R/fread.R
+++ b/R/fread.R
@@ -5,7 +5,7 @@ fread = function(input="",sep="auto",sep2="auto",nrows=-1L,header="auto",na.stri
     } else if (substring(input,1,7) %chin% c("http://","https:/","file://")) {
         tt = tempfile()
         on.exit(unlink(tt), add=TRUE)
-        download.file(input, tt, mode="wb")  # In text mode R doubles up \r to make \r\r\n line endings. Binary mode avoids that. See ?connections:"CRLF"
+        download.file(input, tt, mode="wb", quiet=!showProgress)  # In text mode R doubles up \r to make \r\r\n line endings. Binary mode avoids that. See ?connections:"CRLF"
         input = tt
     } else if (input == "" || length(grep('\\n|\\r', input)) > 0) {
         # if text input


### PR DESCRIPTION
- fread prints stuff even with showProgress=FALSE when loading URL
- call download.file with quiet = !showProgress so that the progess
  information can be suppressed.
