### PR TITLE
Add elapsed month and quarters, stored as Integers

### DIFF
--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -46,7 +46,7 @@ round.IDate <- function (x, digits=c("weeks", "months", "quarters", "years"), ..
 ###################################################################
 # IMonth --   Stored as elapsed months 
 ###################################################################
-as.monthly <- function(x) {
+as.IMonth <- function(x) {
   UseMethod("as.IMonth")
 }
 as.IMonth.default <- function(x, ...) as.IMonth(as.POSIXlt(x, ...))
@@ -95,7 +95,7 @@ unique.IMonth <- function(x, ...) {as.IMonth(NextMethod())}
 # IQuarter --   Stored as elapsed quarters
 ###################################################################
 
-as.quarterly <- function(x) {
+as.IQuarter <- function(x) {
   UseMethod("as.IQuarter")
 }
 as.IQuarter.default <- function(x, ...) as.IQuarter(as.POSIXlt(x, ...))


### PR DESCRIPTION
Elapsed month and quarters are useful in a lot of cases. An example is to use the `roll` option with respect to  1 month (since one cannot use `roll = month(1)`). 
yearmon and yearqtr exist in zoo but they are stored as elapsed year + 1/12 or 1/4. 
I wrote these integer classes for personal use. Discovering IDate and ITime, it makes sense to add them here.
