### PR TITLE
all.equal.data.table ignore row/col order, closes #1106

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -6287,6 +6287,21 @@ test(1508.4, setDT(df, keep="foo"), ans)
 
 # 1509 test added for melt above.
 
+# all.equal.data.table, #1106 - ignore.row.order, ignore.col.order
+DT1 <- data.table(a = 1:4, b = letters[1:4])
+DT2 <- data.table(b = letters[1:4], a = 1:4)
+test(1510.1, all.equal(DT1, DT2, ignore.col.order=TRUE), TRUE)
+DT1 <- data.table(a = 1:4, b = letters[1:4])
+DT2 <- data.table(a = 4:1, b = letters[4:1])
+test(1510.2, all.equal(DT1, DT2, ignore.row.order=TRUE), TRUE)
+DT1 <- data.table(a = 1:4, b = letters[1:4])
+DT2 <- data.table(b = letters[4:1], a = 4:1)
+test(1510.3, all.equal(DT1, DT2, ignore.row.order=TRUE, ignore.col.order=TRUE), TRUE)
+DT1 <- data.table(a = 1:4, b = letters[1:4])
+DT2 <- data.table(a = c(1:4,4L), b = letters[c(1:4,4L)])
+test(1510.4, all.equal(DT1, DT2, ignore.row.order=TRUE), FALSE)
+
+
 ##########################
 
 

--- a/man/all.equal.data.table.Rd
+++ b/man/all.equal.data.table.Rd
@@ -8,7 +8,7 @@
 }
 
 \usage{
-  \method{all.equal}{data.table}(target, current, trim.levels = TRUE, ...)
+  \method{all.equal}{data.table}(target, current, trim.levels = TRUE, ignore.row.order = FALSE, ignore.col.order = FALSE, ...)
 }
 
 \arguments{
@@ -19,6 +19,14 @@
   \item{trim.levels}{
     A logical indicating whether or not to remove all unused levels in columns
     that are factors before running equality check.
+  }
+  
+  \item{ignore.row.order}{
+    A logical indicating whether or not to ignore rows order in \code{data.table}.
+  }
+  
+  \item{ignore.col.order}{
+    A logical indicating whether or not to ignore columns order in \code{data.table}.
   }
 
   \item{\dots}{


### PR DESCRIPTION
**this is not yet ready** see last comments

Should be fully working.
What can be improved further?
- meaningful `cat` messages like `all.equal.list` instead of `FALSE` only
- `ignore.row.order=TRUE` could utilize `setdiff_` function