### PR TITLE
Add test coverage reporting with covr and codecov.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,10 @@ script: ./travis-tool.sh run_tests
 after_failure:
   - ./travis-tool.sh dump_logs
 
+after_success:
+  - ./travis-tool.sh github_install covr
+  - Rscript -e 'library(covr);codecov()'
+
 notifications:
   email:
     on_success: change


### PR DESCRIPTION
This will turn on automatic test coverage reporting and tracking using
[covr](https://github.com/jimhester/covr) and codecov.io.  You will need
to first enable the data.table repository at https://codecov.io to
enable the reports (it is free for open source repositories).  You can
see an example report at https://codecov.io/github/jimhester/covr.

If you want to track coverage interactively you can run the following
from within the data.table directory hierarchy.

```r
cov <- package_coverage()

cov

shine(cov)
```

By default covr only sources all of the files in `tests/`, if you have
additional tests you would like to run you can just pass the expressions
to run to the coverage functions.