### PR TITLE
extended setNumericRound man for POSIXct

### DIFF
--- a/man/setNumericRounding.Rd
+++ b/man/setNumericRounding.Rd
@@ -3,7 +3,7 @@
 \alias{getNumericRounding}
 \title{ Change or turn off numeric rounding }
 \description{
-  Change rounding to 0, 1 or 2 bytes when joining or grouping numeric (i.e. double) columns.
+  Change rounding to 0, 1 or 2 bytes when joining, grouping or ordering numeric (i.e. double, POSIXct) columns.
 }
 \usage{
 setNumericRounding(x)
@@ -24,6 +24,8 @@ getNumericRounding()
   choice of default is not for speed however, but to avoid surprising results such as in the example below.
 
   For large numbers (integers > 2^31), we recommend using \code{bit64::integer64} rather than setting rounding to \code{0}.
+  
+  If you're using \code{POSIXct} type column with \emph{millisecond} (or lower) resolution, you might want to consider setting \code{setNumericRounding(1)} . This'll become the default for \code{POSIXct} types in the future, instead of the default \code{2}.
 }
 \value{
     \code{setNumericRounding} returns no value; the new value is applied. \code{getNumericRounding} returns the current value: 0, 1 or 2.


### PR DESCRIPTION
I think it is worth to highlight POSIXct ordering in data.table
```r
library(data.table)
l <- list()
for(i in 1:5){
    l[[i]] <- data.table(i = i, ts = Sys.time())
    Sys.sleep(0.001)
}
set.seed(1)
dt <- rbindlist(l)[sample(1:5)]
setNumericRounding(2)
dt[order(ts)]
#    i                  ts
# 1: 2 2015-05-20 20:01:29
# 2: 1 2015-05-20 20:01:29
# 3: 5 2015-05-20 20:01:29
# 4: 4 2015-05-20 20:01:29
# 5: 3 2015-05-20 20:01:29
setNumericRounding(1)
dt[order(ts)]
#    i                  ts
# 1: 1 2015-05-20 20:01:29
# 2: 2 2015-05-20 20:01:29
# 3: 3 2015-05-20 20:01:29
# 4: 4 2015-05-20 20:01:29
# 5: 5 2015-05-20 20:01:29
```
P.S. I know POSIXct is double.