### PR TITLE
fixed merge by.y with duplicate column names. Fixes #637

### DIFF
--- a/R/merge.R
+++ b/R/merge.R
@@ -15,8 +15,8 @@ merge.data.table <- function(x, y, by = NULL, by.x = NULL, by.y = NULL, all = FA
       else {
         by <- by.x
         if (length(by.x) != length(by.y)) stop("by.x and by.y must be of the same length")
-        setnames(y, by.y, by.x)
-        on.exit(setnames(y, by.x, by.y))
+        dupnames.y <- setdiff(intersect(by.x, names(y)), by.y)
+        y <- setnames(shallow(y), c(dupnames.y, by.y), c(sprintf("%s.", dupnames.y), by.x))
       }
     }
     
@@ -92,6 +92,10 @@ merge.data.table <- function(x, y, by = NULL, by.x = NULL, by.y = NULL, all = FA
     if (length(dupnames)) {
         setnames(dt, sprintf("%s.", dupnames), paste(dupnames, suffixes[2], sep=""))
         setnames(dt, sprintf("i.%s.", dupnames), paste(dupnames, suffixes[1], sep=""))
+    }
+    
+    if (length(dupnames.y)) {
+      setnames(dt, sprintf("%s.", dupnames.y), paste(dupnames.y, suffixes[2], sep=""))
     }
     
     dt


### PR DESCRIPTION
I have fixed the problem with duplicate column names using the same approach used for other duplicate names (see [here][1] and [here][2]) in `merge.data.table`. 

Note that there is still a difference to `merge.data.frame`, but in my opinion this behavior is preferable. The data.frame version does not append the suffixes to the duplicate name that occur in `by.x` and gives a warning. The new version of `merge.data.table` does append the suffix to that column and runs without warnings: 

    require(data.table)
    dt1 = data.table(w = 0, x=1:2, y=3:4, z=5:6)
    dt2 = copy(dt1)
    merge(dt1, dt2, by.x="z", by.y="w", all = TRUE)
    ##    z  w x.x y.x x.y y.y z.y
    ## 1: 0 NA  NA  NA   1   3   5
    ## 2: 0 NA  NA  NA   2   4   6
    ## 3: 5  0   1   3  NA  NA  NA
    ## 4: 6  0   2   4  NA  NA  NA
    
    df1 = data.frame(w = 0, x=1:2, y=3:4, z=5:6)
    df2 <- df1
    merge(df1, df2, by.x="z", by.y="w", all = TRUE)
    ##   z  w x.x y.x x.y y.y  z
    ## 1 0 NA  NA  NA   1   3  5
    ## 2 0 NA  NA  NA   2   4  6
    ## 3 5  0   1   3  NA  NA NA
    ## 4 6  0   2   4  NA  NA NA
    ## Warning message:
    ##   In merge.data.frame(df1, df2, by.x = "z", by.y = "w", all = TRUE) :
    ##   column name ‘z’ is duplicated in the result



[1]: https://github.com/Rdatatable/data.table/blob/3d021f9cf0f8c9574a8ec8689f757b75af07c3bf/R/merge.R#L61-L65
[2]: https://github.com/Rdatatable/data.table/blob/3d021f9cf0f8c9574a8ec8689f757b75af07c3bf/R/merge.R#L92-L95