### PR TITLE
Remove blank line from description (breaks install with packrat)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,4 +13,3 @@ BugReports: https://github.com/Rdatatable/data.table/issues
 MailingList: datatable-help@lists.r-forge.r-project.org
 VignetteBuilder: knitr
 ByteCompile: TRUE
-


### PR DESCRIPTION
This prevents `data.table` from working with `packrat`

Previously done in Rdatatable/data.table#1118