### PR TITLE
test.data.table silent-returns TRUE-FALSE, closes #1117

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@
 
   4. Worked around auto index error in `v1.9.6` to account for indices created with `v1.9.4`, [#1396](https://github.com/Rdatatable/data.table/issues/1396). Thanks @GRandom.
 
+  5. `test.data.table` gets new argument `silent`, if set to TRUE then it will not raise exception but returns TRUE/FALSE based on the test results.
+
 ### Changes in v1.9.6  (on CRAN 19 Sep 2015)
 
 #### NEW FEATURES

--- a/man/test.data.table.Rd
+++ b/man/test.data.table.Rd
@@ -5,17 +5,18 @@
   Runs a set of tests to check data.table is working correctly.
 }
 \usage{
-test.data.table(verbose=FALSE, pkg="pkg")
+test.data.table(verbose=FALSE, pkg="pkg", silent=FALSE)
 }
 \arguments{
 \item{verbose}{ If TRUE sets datatable.verbose to TRUE for the duration of the tests. }
 \item{pkg}{Root directory name under which all package content (ex: DESCRIPTION, src/, R/, inst/ etc..) resides.}
+\item{silent}{Logical, default FASLE, when TRUE it will not raise error on in case of test fails.}
 }
 \details{
    Runs a series of tests. These can be used to see features and examples of usage, too. Running test.data.table will tell you the full location of the test file(s) to open.
 }
 \value{
-    TRUE if all tests were successful. FALSE otherwise.
+When \code{silent} equals to TRUE it will return TRUE if all tests were successful. FALSE otherwise. If \code{silent} equals to FALSE it will return TRUE if all tests were successful. Error otherwise.
 }
 \seealso{ \code{\link{data.table}} }
 \examples{


### PR DESCRIPTION
At the current moment the `test.data.table` manual does not reflects the actual returned value. See:
https://github.com/Rdatatable/data.table/blob/master/man/test.data.table.Rd#L18
```
\value{
    TRUE if all tests were successful. FALSE otherwise.
}
```
https://github.com/Rdatatable/data.table/blob/master/R/test.data.table.R#L38
```
    invisible()
}
```
This PR allows to perform test without raising error if any of the tests fails, and simply returns TRUE/FALSE. So it is much more friendly for programmatic use. It also fixes the manual to match the actual returned value. To catch TRUE/FALSE it should be used with `silent=TRUE`.
Default behavior has changed only for successful tests run, it now returns `invisible(TRUE)` where previously it returns just `invisible()`.  
It was tested by changing one of the test in tests.Rraw to invoke a fail during `test.data.table`.