### PR TITLE
print.data.table in non-scientific numbers, closes #1167

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -136,7 +136,7 @@ print.data.table <- function(x,
     }
     toprint=format.data.table(toprint, ...)
     # FR #5020 - add row.names = logical argument to print.data.table
-    if (isTRUE(row.names)) rownames(toprint)=paste(format(rn,right=TRUE),":",sep="") else rownames(toprint)=rep.int("", nrow(x))
+    if (isTRUE(row.names)) rownames(toprint)=paste(format(rn,right=TRUE,scientific=FALSE),":",sep="") else rownames(toprint)=rep.int("", nrow(x))
     if (is.null(names(x))) colnames(toprint)=rep("NA", ncol(toprint)) # fixes bug #4934
     if (printdots) {
         toprint = rbind(head(toprint,topn),"---"="",tail(toprint,topn))

--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@
 
   61. `merge.data.table()` didn't set column order (and therefore names) properly in some cases. Fixed now. Closes [#1290](https://github.com/Rdatatable/data.table/issues/1290). Thanks to @ChristK for the minimal example.
 
+  63. Printing data.table will not print row numbers in scientific notation. Closes [#1167](https://github.com/Rdatatable/data.table/issues/1167). Thanks to @jangorecki.
+
 #### NOTES
 
   1. Clearer explanation of what `duplicated()` does (borrowed from base). Thanks to @matthieugomez for pointing out. Closes [#872](https://github.com/Rdatatable/data.table/issues/872).

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -6775,6 +6775,13 @@ text="A,B\ną,ž\nū,į\nų,ė\nš,ę\n"
 test(1548.1, unique(unlist(lapply(fread(text, sep=",", header=TRUE), Encoding))), "unknown")
 test(1548.2, unique(unlist(lapply(fread(text, sep=",", header=TRUE, encoding="UTF-8"), Encoding))), "UTF-8")
 test(1548.3, fread(text, sep=",", encoding="UTF-8", data.table=FALSE), read.table(text=text, sep=",", header=TRUE, encoding="UTF-8", stringsAsFactors=FALSE))
+
+# #1167 print.data.table row id in non-scientific notation 
+DT <- data.table(a = rep(1:5,3*1e6), b = rep(letters[1:3],5*1e6))
+test(1549, capture.output(print(DT)), c("          a b", "       1: 1 a", "       2: 2 b", "       3: 3 c", "       4: 4 a", "       5: 5 b", "      ---    ", "14999996: 1 b", "14999997: 2 c", "14999998: 3 a", "14999999: 4 b", "15000000: 5 c"))
+rm(DT)
+
+
 ##########################
 
 


### PR DESCRIPTION
The PR assumes you agree to have non-scientific notation for row id, which I believe is desired.
I've also made a gap in `test(` numbers, I skip the `1547` number which I used in PR #1275