### PR TITLE
Closes #1320

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2428,15 +2428,25 @@ address <- function(x) .Call(Caddress, eval(substitute(x), parent.frame()))
 
 ":=" <- function(...) stop('Check that is.data.table(DT) == TRUE. Otherwise, := and `:=`(...) are defined for use in j, once only and in particular ways. See help(":=").')
 
-setDF <- function(x) {
+setDF <- function(x, rownames=NULL) {
     if (!is.list(x)) stop("setDF only accepts data.table, data.frame or list of equal length as input")
     if (is.data.table(x)) {
         # copied from as.data.frame.data.table
-        setattr(x, "row.names", .set_row_names(nrow(x)))
+        if (!is.null(rownames)) {
+            if (length(rownames) != nrow(x))
+              stop("rownames incorrect length")
+            else rn <- rownames
+        }   else rn <- .set_row_names(nrow(x))
+        setattr(x, "row.names", rn)
         setattr(x, "class", "data.frame")
         setattr(x, "sorted", NULL)
         setattr(x, ".internal.selfref", NULL)
     } else if (is.data.frame(x)) {
+        if (!is.null(rownames)){
+            if (length(rownames) != nrow(x)) 
+                stop("rownames incorrect length")
+            else setattr(x, "row.names", rownames)
+        }
         x
     } else {
         n = vapply(x, length, 0L)
@@ -2453,7 +2463,12 @@ setDF <- function(x) {
                 setattr(x, "names", xn)
             }
         }
-        setattr(x,"row.names",.set_row_names(max(n)))
+        if (!is.null(rownames)) {
+            if (length(rownames) != mn)
+                stop("rownames incorrect length")
+            else rn <- rownames
+        }   else rn <- .set_row_names(mn)
+        setattr(x,"row.names", rn)
         setattr(x,"class","data.frame")
     }
     invisible(x)

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@
 
   28. `fread()` gains `quote` argument with default value `"\""`. Setting `quote=""` disables (could be useful in reading columns with uneven quotes). Closes [#568](https://github.com/Rdatatable/data.table/issues/568). Also addresses/closes [#1256](https://github.com/Rdatatable/data.table/issues/1256), [#1077](https://github.com/Rdatatable/data.table/issues/1077), [#1079](https://github.com/Rdatatable/data.table/issues/1079) and [#1095](https://github.com/Rdatatable/data.table/issues/1095). Thanks to @Synergist, @daroczig, @geotheory and @rsaporta for the reports.
 
+  29. `setDF()` gains `rownames` argument for ready conversion to a `data.frame` with user-specified rows. Closes [#1320](https://github.com/Rdatatable/data.table/issues/1320). Thanks to @MichaelChirico for the FR and PR.
+
 #### BUG FIXES
 
   1. `if (TRUE) DT[,LHS:=RHS]` no longer prints, [#869](https://github.com/Rdatatable/data.table/issues/869) and [#1122](https://github.com/Rdatatable/data.table/issues/1122). Tests added. To get this to work we've had to live with one downside: if a `:=` is used inside a function with no `DT[]` before the end of the function, then the next time `DT` or `print(DT)` is typed at the prompt, nothing will be printed. A repeated `DT` or `print(DT)` will print. To avoid this: include a `DT[]` after the last `:=` in your function. If that is not possible (e.g., it's not a function you can change) then `DT[]` at the prompt is guaranteed to print. As before, adding an extra `[]` on the end of a `:=` query is a recommended idiom to update and then print; e.g. `> DT[,foo:=3L][]`. Thanks to Jureiss and Jan Gorecki for reporting.

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -4759,6 +4759,22 @@ df <- list(1:5, 6:10)
 test(1305.4, setDF(as.data.table(df)), setDF(df))
 test(1305.5, setDF(1:5), error="setDF only accepts")
 test(1305.6, setDF(list(1, 2:3)), error="All elements in argument")
+dt  <- data.table(a=1:5, b=6:10)
+df  <- data.frame(a=1:5, b=6:10)
+lst <- list(a=1:5, b=6:10)
+df2 <- data.frame(a=1:5, b=6:10)
+rownames(df2) <- LETTERS[1:5]
+# setDF accepts rownames argument, #1320
+test(1305.7, setDF(dt, rownames=LETTERS[1:5]), df2)
+test(1305.8, setDF(df, rownames=LETTERS[1:5]), df2)
+test(1305.9, setDF(lst,rownames=LETTERS[1:5]), df2)
+# setDF returns an error for each type if rownames incorrect length
+dt  <- data.table(a=1:5, b=6:10)
+df  <- data.frame(a=1:5, b=6:10)
+lst <- list(a=1:5, b=6:10)
+test(1305.10, setDF(dt, rownames="a"), error="rownames incorrect length")
+test(1305.11, setDF(df, rownames="a"), error="rownames incorrect length")
+test(1304.12, setDF(lst,rownames="a"), error="rownames incorrect lenght")
 
 # .SD retains as much of head(key) as appropriate.
 #  by= always keeps data appearance order, so it's which columns are grouped and selected that drive how much of key is retained


### PR DESCRIPTION
adds `rownames` argument to `setDF`, per [#1320](https://github.com/Rdatatable/data.table/issues/1320); adds an error for the case that `rownames` is given of incorrect length. 