### PR TITLE
Closes #1320; setDF gains rownames argument

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2433,11 +2433,13 @@ setDF <- function(x, rownames=NULL) {
     if (any(duplicated(rownames))) stop("rownames contains duplicates")
     if (is.data.table(x)) {
         # copied from as.data.frame.data.table
-        if (!is.null(rownames)) {
+        if (is.null(rownames)) {
+            rn <- .set_row_names(nrow(x))
+        }   else {
             if (length(rownames) != nrow(x))
                 stop("rownames incorrect length; expected ", nrow(x), " names, got ", length(rownames))
-            else rn <- rownames
-        }   else rn <- .set_row_names(nrow(x))
+            rn <- rownames
+        }
         setattr(x, "row.names", rn)
         setattr(x, "class", "data.frame")
         setattr(x, "sorted", NULL)
@@ -2446,7 +2448,7 @@ setDF <- function(x, rownames=NULL) {
         if (!is.null(rownames)){
             if (length(rownames) != nrow(x)) 
                 stop("rownames incorrect length; expected ", nrow(x), " names, got ", length(rownames))
-            else setattr(x, "row.names", rownames)
+            setattr(x, "row.names", rownames)
         }
         x
     } else {
@@ -2464,11 +2466,13 @@ setDF <- function(x, rownames=NULL) {
                 setattr(x, "names", xn)
             }
         }
-        if (!is.null(rownames)) {
+        if (is.null(rownames)) {
+            rn <- .set_row_names(mn)
+        } else {
             if (length(rownames) != mn)
                 stop("rownames incorrect length; expected ", mn, " names, got ", length(rownames))
-            else rn <- rownames
-        }   else rn <- .set_row_names(mn)
+            rn <- rownames
+        }
         setattr(x,"row.names", rn)
         setattr(x,"class","data.frame")
     }

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@
 
   28. `fread()` gains `quote` argument with default value `"\""`. Setting `quote=""` disables (could be useful in reading columns with uneven quotes). Closes [#568](https://github.com/Rdatatable/data.table/issues/568). Also addresses/closes [#1256](https://github.com/Rdatatable/data.table/issues/1256), [#1077](https://github.com/Rdatatable/data.table/issues/1077), [#1079](https://github.com/Rdatatable/data.table/issues/1079) and [#1095](https://github.com/Rdatatable/data.table/issues/1095). Thanks to @Synergist, @daroczig, @geotheory and @rsaporta for the reports.
 
+  29. `setDF()` gains `rownames` argument for ready conversion to a `data.frame` with user-specified rows. Closes [#1320](https://github.com/Rdatatable/data.table/issues/1320). Thanks to @MichaelChirico for the FR and PR.
+
 #### BUG FIXES
 
   1. `if (TRUE) DT[,LHS:=RHS]` no longer prints, [#869](https://github.com/Rdatatable/data.table/issues/869) and [#1122](https://github.com/Rdatatable/data.table/issues/1122). Tests added. To get this to work we've had to live with one downside: if a `:=` is used inside a function with no `DT[]` before the end of the function, then the next time `DT` or `print(DT)` is typed at the prompt, nothing will be printed. A repeated `DT` or `print(DT)` will print. To avoid this: include a `DT[]` after the last `:=` in your function. If that is not possible (e.g., it's not a function you can change) then `DT[]` at the prompt is guaranteed to print. As before, adding an extra `[]` on the end of a `:=` query is a recommended idiom to update and then print; e.g. `> DT[,foo:=3L][]`. Thanks to Jureiss and Jan Gorecki for reporting.

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -4759,12 +4759,12 @@ df <- list(1:5, 6:10)
 test(1305.4, setDF(as.data.table(df)), setDF(df))
 test(1305.5, setDF(1:5), error="setDF only accepts")
 test(1305.6, setDF(list(1, 2:3)), error="All elements in argument")
+# Tests .7 - .13 for FR #1320: setDF accepts rownames argument
 dt  <- data.table(a=1:5, b=6:10)
 df  <- data.frame(a=1:5, b=6:10)
 lst <- list(a=1:5, b=6:10)
 df2 <- data.frame(a=1:5, b=6:10)
 rownames(df2) <- LETTERS[1:5]
-# setDF accepts rownames argument, #1320
 test(1305.7, setDF(dt, rownames=LETTERS[1:5]), df2)
 test(1305.8, setDF(df, rownames=LETTERS[1:5]), df2)
 test(1305.9, setDF(lst,rownames=LETTERS[1:5]), df2)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -4759,6 +4759,24 @@ df <- list(1:5, 6:10)
 test(1305.4, setDF(as.data.table(df)), setDF(df))
 test(1305.5, setDF(1:5), error="setDF only accepts")
 test(1305.6, setDF(list(1, 2:3)), error="All elements in argument")
+dt  <- data.table(a=1:5, b=6:10)
+df  <- data.frame(a=1:5, b=6:10)
+lst <- list(a=1:5, b=6:10)
+df2 <- data.frame(a=1:5, b=6:10)
+rownames(df2) <- LETTERS[1:5]
+# setDF accepts rownames argument, #1320
+test(1305.7, setDF(dt, rownames=LETTERS[1:5]), df2)
+test(1305.8, setDF(df, rownames=LETTERS[1:5]), df2)
+test(1305.9, setDF(lst,rownames=LETTERS[1:5]), df2)
+# setDF returns an error for each type if rownames incorrect length
+dt  <- data.table(a=1:5, b=6:10)
+df  <- data.frame(a=1:5, b=6:10)
+lst <- list(a=1:5, b=6:10)
+test(1305.10, setDF(dt, rownames="a"), error='rownames incorrect length')
+test(1305.11, setDF(df, rownames="a"), error='rownames incorrect length')
+test(1305.12, setDF(lst,rownames="a"), error='rownames incorrect length')
+# setDF returns an error when rownames contains duplicates
+test(1305.13, setDF(dt, rownames=rep("a",5)), error='rownames contains duplicates')
 
 # .SD retains as much of head(key) as appropriate.
 #  by= always keeps data appearance order, so it's which columns are grouped and selected that drive how much of key is retained


### PR DESCRIPTION
adds `rownames` argument to `setDF`, per #1320; adds errors for the case that `rownames` is given of incorrect length and for `rownames` containing duplicates.