### PR TITLE
Closes #1177: print.data.table now has quote option mirroring that of print.data.frame

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -93,7 +93,7 @@ setPackageName("data.table",.global)
 print.data.table <- function(x,
     topn=getOption("datatable.print.topn"),   # (5) print the top topn and bottom topn rows with '---' inbetween
     nrows=getOption("datatable.print.nrows"), # (100) under this the whole (small) table is printed, unless topn is provided
-    row.names = TRUE, ...)
+    row.names = TRUE, quote = FALSE, ...)
 {
     if (.global$print!="" && address(x)==.global$print) {   # The !="" is to save address() calls and R's global cache of address strings
         #  := in [.data.table sets .global$print=address(x) to suppress the next print i.e., like <- does. See FAQ 2.22 and README item in v1.9.5
@@ -141,13 +141,13 @@ print.data.table <- function(x,
     if (printdots) {
         toprint = rbind(head(toprint,topn),"---"="",tail(toprint,topn))
         rownames(toprint) = format(rownames(toprint),justify="right")
-        print(toprint,right=TRUE,quote=FALSE)
+        print(toprint,right=TRUE,quote=quote)
         return(invisible())
     }
     if (nrow(toprint)>20L)
         # repeat colnames at the bottom if over 20 rows so you don't have to scroll up to see them
         toprint=rbind(toprint,matrix(colnames(toprint),nrow=1)) # fixes bug #4934
-    print(toprint,right=TRUE,quote=FALSE)
+    print(toprint,right=TRUE,quote=quote)
     invisible()
 }
 

--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@
 
   64. Using `.GRP` unnamed in `j` now returns a variable named `GRP` instead of `.GRP` as the period was causing issues. Same for `.BY`. Closes [#1243](https://github.com/Rdatatable/data.table/issues/1243); thanks to @MichaelChirico for the PR.
 
+  65. `print.data.table` now accepts a `quote` argument defaulting to `FALSE` (_a la_ `print.data.frame` in `base`). This option surrounds all printed elements with quotes and, e.g., makes whitespace more evident. Closes [#1177](https://github.com/Rdatatable/data.table/issues/1177); thanks to @MichaelChirico for the PR.
+
 #### NOTES
 
   1. Clearer explanation of what `duplicated()` does (borrowed from base). Thanks to @matthieugomez for pointing out. Closes [#872](https://github.com/Rdatatable/data.table/issues/872).

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -6868,6 +6868,16 @@ test(1552.3, fread(str, na.strings=c("#N/A", "-999", "+1")), read_table(str, na.
 test(1552.4, fread(str, na.strings=c("#N/A", "-999", "+1", "1")), read_table(str, na.strings=c("#N/A", "-999", "+1", "1")))
 test(1552.5, fread(str, na.strings=c("#N/A", "-999", "FALSE")), read_table(str, na.strings=c("#N/A", "-999", "FALSE")))
 
+# FR #1177: 'quote' option of 'print.data.table'
+DT1 <- data.table(s1=paste0(" ",LETTERS[1:5]),s2=LETTERS[1:5])
+ans1 <- c("     s1  s2","1: \" A\" \"A\"",
+          "2: \" B\" \"B\"","3: \" C\" \"C\"",
+          "4: \" D\" \"D\"","5: \" E\" \"E\"")
+ans2 <- c("   s1 s2","1:  A  A","2:  B  B",
+          "3:  C  C","4:  D  D","5:  E  E")
+test(1553.1, capture.output(print(DT1, quote = TRUE)), ans1)
+test(1553.2, capture.output(print(DT1)), ans2)
+
 ##########################
 
 


### PR DESCRIPTION
It seems this fix was as easy as this. Let me know if you'd like to add tests.