### PR TITLE
test.data.table try to load only available pkgs, closes #1193

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@
 
   14. `fread` with `stringsAsFactors = TRUE` no longer produces factors with NA as a factor level, [#1408](https://github.com/Rdatatable/data.table/pull/1408). Thanks to @DexGroves.
 
+  15. `test.data.table` no longer raise warning if suggested packages are not available. Thanks to @jangorecki for PR [#1403](https://github.com/Rdatatable/data.table/pull/1403), closes [#1193](https://github.com/Rdatatable/data.table/issues/1193).
+
 #### NOTES
 
   1. Updated error message on invalid joins to reflect the new `on=` syntax, [#1368](https://github.com/Rdatatable/data.table/issues/1368). Thanks @MichaelChirico.

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -5,22 +5,14 @@
 if (!exists("test.data.table",.GlobalEnv,inherits=FALSE)) {
     require(data.table)   # in dev the package should not be loaded
     options(warn=0)  # use require() so it warns but doesn't halt if not available
-    require(plyr)
-    require(ggplot2)
-    require(hexbin)
-    require(nlme)
-    require(xts)
-    require(bit64)
-    require(gdata)
-    require(GenomicRanges)
-    require(caret)
-    require(knitr)
-    require(plm)
+    inst_pkgs = rownames(installed.packages())
+    sugg_pkgs = c("plyr","ggplot2","hexbin","nlme","xts","bit64","gdata","GenomicRanges","caret","knitr","plm")
+    lapply(sugg_pkgs, function(pkg) if(pkg %in% inst_pkgs) require(pkg, character.only=TRUE))
     # reshape2 ahead of reshape ...
     try(detach(package:reshape2),silent=TRUE)
     try(detach(package:reshape),silent=TRUE)
-    library(reshape2, pos="package:base", logical.return=TRUE)
-    library(reshape, pos="package:base", logical.return=TRUE)
+    if("reshape2" %in% inst_pkgs) library(reshape2, pos="package:base", logical.return=TRUE)
+    if("reshape" %in% inst_pkgs) library(reshape, pos="package:base", logical.return=TRUE)
     .devtesting=FALSE
 } else {
     # Matt has suppressMessages(require(bit64)) in .Rprofile


### PR DESCRIPTION
Don't know why the `test.data.table()` call is failing for me in [test 1104.1](https://github.com/Rdatatable/data.table/blob/093da46eb1342fef51897625d189611314b487fa/inst/tests/tests.Rraw#L3171) while in interactive execution it is passing fine. Will see what results travis will produce.

edit: Looks OK.