### PR TITLE
Don't allow NA as a factor level with fread stringsAsFactors = TRUE

### DIFF
--- a/R/fread.R
+++ b/R/fread.R
@@ -35,7 +35,7 @@ fread <- function(input="",sep="auto",sep2="auto",nrows=-1L,header="auto",na.str
                 }
                 if (toupper(tt)!=toupper(i)) {
                     warning(cmd, " returned '",tt,"' != '",i,"' (not NULL not '' and allowing for case differences). This may not be a problem but please report.")
-                } 
+                }
                 if (Sys.localeconv()["decimal_point"] == dec) break
                 if (verbose) cat("Successfully changed locale but it provides dec='",Sys.localeconv()["decimal_point"],"' not the desired dec", sep="")
             }
@@ -98,7 +98,7 @@ fread <- function(input="",sep="auto",sep2="auto",nrows=-1L,header="auto",na.str
         setattr(ans, 'names', make.unique(names(ans)))
     }
     as_factor <- function(x) {
-        lev = forderv(x, retGrp = TRUE)
+        lev = forderv(x, retGrp = TRUE, na.last = NA)
         # get levels, also take care of all sorted condition
         if (length(lev)) lev = x[lev[attributes(lev)$starts]]
         else lev = x[attributes(lev)$starts]
@@ -110,7 +110,7 @@ fread <- function(input="",sep="auto",sep2="auto",nrows=-1L,header="auto",na.str
         cols = which(vapply(ans, is.character, TRUE))
         if (length(cols)) {
             if (verbose) cat("Converting column(s) [", paste(names(ans)[cols], collapse = ", "), "] from 'char' to 'factor'\n", sep = "")
-            for (j in cols) 
+            for (j in cols)
                 set(ans, j = j, value = as_factor(.subset2(ans, j)))
         }
     }

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@
 
   13. `fread` reads text input with empty newline but with just spaces properly, for e.g., fread('a,b\n1,2\n   '), [#1384](https://github.com/Rdatatable/data.table/issues/1384). Thanks to @ladida771.
 
+  14. `fread` with `stringsAsFactors = TRUE` no longer produces factors with NA as a factor level, [#1408](https://github.com/Rdatatable/data.table/pull/1408). Thanks to @DexGroves.
+
 #### NOTES
 
   1. Updated error message on invalid joins to reflect the new `on=` syntax, [#1368](https://github.com/Rdatatable/data.table/issues/1368). Thanks @MichaelChirico.

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -7075,6 +7075,14 @@ setattr(attr(X, 'index'), 'x', 5:1) # auto indexed attribute as created from v1.
 ans = capture.output(X[, z := 1:5, verbose=TRUE])
 test(1576, ans[4], "Dropping index 'x' as it doesn't have '__' at the beginning of index name. It is very likely created using v1.9.4 of data.table.")
 
+# fix for #1408
+X = fread("a|b|c|d
+          this|is|row|1
+          this|is|row|2
+          this|NA|NA|3
+          this|is|row|4", stringsAsFactors = TRUE)
+test(201.1, is.na(X[3, b]), TRUE)
+
 ##########################
 
 


### PR DESCRIPTION
The old `fread` with `stringsAsFactors = TRUE` was producing undesirable and difficult to manipulate factors. NA gets assigned as a possible level of the factor, and `is.na` doesn't produce TRUE.

 ```R
devtools::install_github("Rdatatable/data.table")

library("data.table")

data <- "a   |b |c  |d
         this|is|row|1
         this|is|row|2
         this|NA|NA|3
         this|is|row|4
         this|is|row|5
         this|is|row|6
         this|is|row|7
         this|is|row|8
         this|is|row|9
         this|is|row|10"
 
tmp_filename <- tempfile()
write(data, tmp_filename)
 
test_dt <- fread(tmp_filename, sep = "|", stringsAsFactors = TRUE)
test_df <- read.delim(tmp_filename, sep = "|", stringsAsFactors = TRUE)

# fread produces an NA that produces FALSE with is.na
is.na(test_dt$b[3])
# [1] FALSE
is.na(test_df$b[3])
# [1] TRUE

# Even weirder, `levels(x) <- levels(x)` 'fixes' the is.na behaviour.
is.na(test_dt$b[3])
# [1] FALSE
levels(test_dt$b) <- levels(test_dt$b)
is.na(test_dt$b[3])
# [1] TRUE
```

This is annoying especially for situations where you want to recast an NA so you can use it with `model.matrix` or similar.
```R
dt[is.na(factor_with_NAs), factor_with_NAs := "Missing"]
# arrrrgh
```

Simple fix forbids NA as a factor level, in line with the the default behavior of `as.factor`.