### PR TITLE
new prettyprint.char argument to print.data.table for easier pretty print, closes #1374

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@
 
   13. GForce is optimised for `.SD[val]` and `col[val]` where `val` is a positive length-1 value. Partly addresses [#523](https://github.com/Rdatatable/data.table/issues/523).
 
+  14. data.table `print` method gets new argument `prettyprint.char` default to `getOption("datatable.prettyprint.char")` which allows easier pretty print without the need to set options. Closes [#1374](https://github.com/Rdatatable/data.table/issues/1374). Thanks @jangorecki.
+
 #### BUG FIXES
 
   1. Now compiles and runs on IBM AIX gcc. Thanks to Vinh Nguyen for investigation and testing, [#1351](https://github.com/Rdatatable/data.table/issues/1351).

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -7217,6 +7217,12 @@ options(datatable.optimize=optim)
 # handle NULL value correctly #1429
 test(1582, uniqueN(NULL), 0L)
 
+# print data.table prettyprint.char argument #1374 
+test(1584.1, capture.output(print(data.table(a = "1234567890"))), c("            a","1: 1234567890"))
+test(1584.2, capture.output(print(data.table(a = "1234567890"), prettyprint.char = 5)), c("          a","1: 12345..."))
+test(1584.3, capture.output(print(data.table(a = rep("1234567890",101)), prettyprint.char = 5)), c("            a", "  1: 12345...", "  2: 12345...", "  3: 12345...", "  4: 12345...", "  5: 12345...", " ---         ", " 97: 12345...", " 98: 12345...", " 99: 12345...", "100: 12345...", "101: 12345..."))
+
+
 ##########################
 
 # TODO: Tests involving GForce functions needs to be run with optimisation level 1 and 2, so that both functions are tested all the time.


### PR DESCRIPTION
`print.data.table` and `format.data.table` gets `prettyprint.char` argument.