### PR TITLE
Ensure .so install name & filename match on OSX (fixes #1144)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@
 
   13. GForce is optimised for `.SD[val]` and `col[val]` where `val` is a positive length-1 value. Partly addresses [#523](https://github.com/Rdatatable/data.table/issues/523).
 
+  14. Run `install_name_tool` when building on OS X to ensure that the install name for datatable.so matches its filename. Fixes [#1144](https://github.com/Rdatatable/data.table/issues/1144). Thanks to @chenghlee for the PR.
+
 #### BUG FIXES
 
   1. Now compiles and runs on IBM AIX gcc. Thanks to Vinh Nguyen for investigation and testing, [#1351](https://github.com/Rdatatable/data.table/issues/1351).

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,5 +1,6 @@
 
 all: $(SHLIB)
 	mv $(SHLIB) datatable$(SHLIB_EXT)
+	if [ `uname -s` = 'Darwin' ]; then install_name_tool -id datatable$(SHLIB_EXT) datatable$(SHLIB_EXT); fi
 
 


### PR DESCRIPTION
OS X convention requires that the basename part of a shared library's
install name (i.e., install name minus directory components) match the
actual filename of said shared library. Otherwise, the dynamic linker
(and related tools) could get confused when trying to find, process,
and/or load the dynamic library.

On OS X, the "mv" command at the end of the build process changes the
shared library filename to "datatable.so" while leaving the install name
as "data.table.so", so we need to run install_name_tool(1) to fix the
install name to match the filename. Currently not a big issue for most
users (since not much else links to this shared library), but not doing
this causes issues with build systems (e.g., conda) that end up
modifying the .so's RPATH for some reason.