### PR TITLE
implements #1482: adds option to print.data.table to exclude lower register of column names when printing more than 20 rows

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -92,7 +92,7 @@ setPackageName("data.table",.global)
 print.data.table <- function(x,
     topn=getOption("datatable.print.topn"),   # (5) print the top topn and bottom topn rows with '---' inbetween
     nrows=getOption("datatable.print.nrows"), # (100) under this the whole (small) table is printed, unless topn is provided
-    row.names = TRUE, quote = FALSE, ...)
+    row.names = TRUE, quote = FALSE, col.names = TRUE, ...)
 {
     if (.global$print!="" && address(x)==.global$print) {   # The !="" is to save address() calls and R's global cache of address strings
         #  := in [.data.table sets .global$print=address(x) to suppress the next print i.e., like <- does. See FAQ 2.22 and README item in v1.9.5
@@ -147,10 +147,10 @@ print.data.table <- function(x,
         print(toprint,right=TRUE,quote=quote)
         return(invisible())
     }
-    if (nrow(toprint)>20L)
+    if (nrow(toprint) > 20L)
         # repeat colnames at the bottom if over 20 rows so you don't have to scroll up to see them
-        toprint=rbind(toprint,matrix(colnames(toprint),nrow=1)) # fixes bug #4934
-    print(toprint,right=TRUE,quote=quote)
+        toprint = rbind(toprint, if (col.names) matrix(colnames(toprint), nrow = 1)) # fixes bug #97 & implements #1482
+    print(toprint, right = TRUE, quote = quote)
     invisible()
 }
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@
 
   15. `fread` gains `key` argument, [#590](https://github.com/Rdatatable/data.table/issues/590).
 
+  16. `print.data.table` gains `col.names` argument, [#1482](https://github.com/Rdatatable/data.table/issues/1482). Disabling prevents printing of column names at the bottom of tables whose printed length exceeds 20 rows. Thanks Oleg Bondar on StackOverflow for the suggestion and @MichaelChirico for the PR.
+
 #### BUG FIXES
 
   1. Now compiles and runs on IBM AIX gcc. Thanks to Vinh Nguyen for investigation and testing, [#1351](https://github.com/Rdatatable/data.table/issues/1351).

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -3122,7 +3122,7 @@ test(1087, class(DT$last.x1), "ITime")
 
 # Tests 1088-1093 were non-ASCII. Now in DtNonAsciiTests
 
-# print of unnamed DT with >20 <= 100 rows, #4934
+# print of unnamed DT with >20 <= 100 rows, #97
 DT <- data.table(x=1:25, y=letters[1:25])
 DT.unnamed <- unname(copy(DT))
 test(1094, print(DT.unnamed), output="NA NA 1:  1  a 2:  2  b 3:  3  c")
@@ -7276,6 +7276,10 @@ test(1587, fread(text, key="y"), setDT(fread(text), key="y"))
 dt = data.table(i=1:10, f=as.factor(1:10))
 test(1588.1, dt[f %in% 3:4], dt[3:4])
 test(1588.2, dt[f == 3], dt[3])
+
+# FR # 1482
+op <- capture.output(print(data.table(x = 1:25, y = letters[1:25]), nrow = 25, col.names = FALSE))
+test(1589, op[length(op)], "25: 25 y")
 
 ##########################
 


### PR DESCRIPTION
also updated the R-Forge issue number to the corresponding GitHub issue number. Not sure if that's kosher...