### PR TITLE
Fix for #1515 (simple man page typo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@
   9. Run `install_name_tool` when building on OS X to ensure that the install name for datatable.so matches its filename. Fixes [#1144](https://github.com/Rdatatable/data.table/issues/1144). Thanks to @chenghlee for the PR.
   
   10. Updated documentation of `i` in `[.data.table` to emphasize the emergence of the new `on` option as an alternative to keyed joins, [#1488](https://github.com/Rdatatable/data.table/issues/1488). Thanks @MichaelChirico.
+  
+  11. Fixed typo for usage of `%like%` in `?like` whereby `%` was commented out, [#1515](https://github.com/Rdatatable/data.table/issues/1515). Thanks @MichaelChirico.
 
 ### Changes in v1.9.6  (on CRAN 19 Sep 2015)
 

--- a/man/like.Rd
+++ b/man/like.Rd
@@ -3,14 +3,14 @@
 \alias{\%like\%}
 \title{ Convenience function for calling regexpr. }
 \description{
-  Intended for use in [.data.table i.
+  Intended for use in \code{i} in \code{[.data.table}.
 }
 \usage{
 like(vector,pattern)
-vector %like% pattern
+vector \%like\% pattern
 }
 \arguments{
-   \item{vector}{ Either a character vector or a factor. A factor is faster. }
+   \item{vector}{ Either a \code{character} vector or a \code{factor}. A \code{factor} is faster. }
    \item{pattern}{ Passed on to \code{\link{grepl}}. }
 }
 % \details{
@@ -25,4 +25,3 @@ DT = data.table(Name=c("Mary","George","Martha"), Salary=c(2,3,4))
 DT[Name \%like\% "^Mar"]
 }
 \keyword{ data }
-


### PR DESCRIPTION
Nice and easy. `%chin%` doesn't have this issue, so combined with my other PR this should fix this mistake in all the man pages.