### PR TITLE
move chron to suggests, closes #1558

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,8 +4,8 @@ Title: Extension of Data.frame
 Author: M Dowle, A Srinivasan, T Short, S Lianoglou with contributions from R Saporta, E Antonyan
 Maintainer: Matt Dowle <mattjdowle@gmail.com>
 Depends: R (>= 2.14.1)
-Imports: methods, chron
-Suggests: ggplot2 (>= 0.9.0), plyr, reshape, reshape2, testthat (>= 0.4), hexbin, fastmatch, nlme, xts, bit64, gdata, GenomicRanges, caret, knitr, curl, zoo, plm
+Imports: methods
+Suggests: chron, ggplot2 (>= 0.9.0), plyr, reshape, reshape2, testthat (>= 0.4), hexbin, fastmatch, nlme, xts, bit64, gdata, GenomicRanges, caret, knitr, curl, zoo, plm
 Description: Fast aggregation of large data (e.g. 100GB in RAM), fast ordered joins, fast add/modify/delete of columns by group using no copies at all, list columns and a fast file reader (fread). Offers a natural and flexible syntax, for faster development.
 License: GPL-3 | file LICENSE
 URL: https://github.com/Rdatatable/data.table/wiki

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -91,7 +91,7 @@ S3method(na.omit, data.table)
 export(as.IDate,as.ITime,IDateTime)
 export(hour,yday,wday,mday,week,month,quarter,year)
 
-importFrom(chron, chron, as.chron)
+#importFrom(chron, chron, as.chron) # chron went to Suggests since #1558
 export(as.chron.IDate,as.chron.ITime)
 
 S3method("[", ITime)

--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -163,19 +163,23 @@ as.POSIXlt.ITime <- function(x, ...) {
 # chron support
 
 as.chron.IDate <- function(x, time = NULL, ...) {
-    if (!is.null(time)) {
-        chron(dates. = as.chron(as.Date(x)), times. = as.chron(time))
-    } else {
-        chron(dates. = as.chron(as.Date(x)))
-    }    
+    if(!requireNamespace("chron", quietly = TRUE)) stop("Install suggested `chron` package to use `as.chron.IDate` function.") else {
+        if (!is.null(time)) {
+            chron::chron(dates. = chron::as.chron(as.Date(x)), times. = chron::as.chron(time))
+        } else {
+            chron::chron(dates. = chron::as.chron(as.Date(x)))
+        }    
+    }
 }
 
 as.chron.ITime <- function(x, date = NULL, ...) {
-    if (!is.null(date)) {
-        chron(dates. = as.chron(as.Date(date)), times. = as.chron(x))
-    } else {
-        chron(times. = as.character(x))
-    }    
+    if(!requireNamespace("chron", quietly = TRUE)) stop("Install suggested `chron` package to use `as.chron.ITime` function.") else {
+        if (!is.null(date)) {
+            chron::chron(dates. = chron::as.chron(as.Date(date)), times. = chron::as.chron(x))
+        } else {
+            chron::chron(times. = as.character(x))
+        }  
+    }
 }
 
 as.ITime.times <- function(x, ...) {

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@
 
   17. Travis-CI will now automatically deploy package to drat repository hosted on [data.table@gh-pages](https://github.com/Rdatatable/data.table/tree/gh-pages) branch allowing to install latest devel from source via `install.packages("data.table", repos = c("https://Rdatatable.github.io/data.table", "https://cran.rstudio.com"))`. CRAN repo is still required to reach `chron` dependency. Closes [#1505](https://github.com/Rdatatable/data.table/issues/1505).
 
+  18. Dependency on `chron` package has been changed to *suggested*. Closes [#1558](https://github.com/Rdatatable/data.table/issues/1558).
+
 ### Changes in v1.9.6  (on CRAN 19 Sep 2015)
 
 #### NEW FEATURES

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -6,8 +6,8 @@ if (!exists("test.data.table",.GlobalEnv,inherits=FALSE)) {
     require(data.table)   # in dev the package should not be loaded
     options(warn=0)  # use require() so it warns but doesn't halt if not available
     inst_pkgs = rownames(installed.packages())
-    sugg_pkgs = c("plyr","ggplot2","hexbin","nlme","xts","bit64","gdata","GenomicRanges","caret","knitr","plm")
-    lapply(sugg_pkgs, function(pkg) if(pkg %in% inst_pkgs) require(pkg, character.only=TRUE))
+    sugg_pkgs = c("chron", "ggplot2", "plyr", "reshape", "reshape2", "testthat", "hexbin", "fastmatch", "nlme", "xts", "bit64", "gdata", "GenomicRanges", "caret", "knitr", "curl", "zoo", "plm")
+    lapply(setNames(nm = sugg_pkgs), function(pkg) if(pkg %in% inst_pkgs) require(pkg, character.only=TRUE))
     # reshape2 ahead of reshape ...
     try(detach(package:reshape2),silent=TRUE)
     try(detach(package:reshape),silent=TRUE)
@@ -7406,6 +7406,17 @@ test(1601.1, merge(data.table(a=1),data.table(a=1), by="a"), data.table(a=1, key
 test(1601.2, tryCatch(merge(data.table(a=1),data.table(NULL), by="a"), warning = function(w) w$message), "You are trying to join data.tables where 'y' argument is 0 columns data.table.")
 test(1601.3, tryCatch(merge(data.table(NULL),data.table(a=1), by="a"), warning = function(w) w$message), "You are trying to join data.tables where 'x' argument is 0 columns data.table.")
 test(1601.4, tryCatch(merge(data.table(NULL),data.table(NULL), by="a"), warning = function(w) w$message), "You are trying to join data.tables where 'x' and 'y' arguments are 0 columns data.table.")
+
+# migrate `chron` dependency to Suggests #1558
+dd = as.IDate("2016-02-28")
+tt = as.ITime("03:04:43")
+if(!requireNamespace("chron", quietly = TRUE)){
+    test(1602.1, as.chron.IDate(dd), error = "Install suggested `chron` package to use `as.chron.IDate` function.")
+    test(1602.2, as.chron.ITime(tt), error = "Install suggested `chron` package to use `as.chron.ITime` function.")
+} else {
+    test(1602.3, as.chron.IDate(dd), chron::as.chron(as.Date(dd)))
+    test(1602.4, class(as.chron.ITime(tt)), "times")
+}
 
 
 ##########################


### PR DESCRIPTION
Apparently there was no `chron` related tests so far.