### PR TITLE
bugfix to `last` for case when `xts` not installed, closes #1560

### DIFF
--- a/R/last.R
+++ b/R/last.R
@@ -9,7 +9,12 @@ last <- function(x, ...) {
         	if (!length(x)) return(x) else return(x[[length(x)]])  # for vectors, [[ works like [
         } else if (is.data.frame(x)) return(x[NROW(x),])
     }
-    # fix with suggestion from Joshua, #1347
-    if (!"package:xts" %in% search()) tail(x,...)
-    xts::last(x,...)   # UseMethod("last") doesn't find xts's methods, not sure what I did wrong.
+    if(!requireNamespace("xts", quietly = TRUE)) {
+        tail(x, n = 1L, ...)
+    } else {
+        # fix with suggestion from Joshua, #1347
+        if (!"package:xts" %in% search()) {
+            tail(x, n = 1L, ...)
+        } else xts::last(x, ...) # UseMethod("last") doesn't find xts's methods, not sure what I did wrong.
+    }
 }

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@
 
   28. Providing the first argument to `.Call`, for e.g., `.Call("Crbindlist", ...)` seems to result in *"not resolved in current namespace"* error. A potential fix is to simply remove the quotes like so many other calls in data.table. Potentially fixes [#1467](https://github.com/Rdatatable/data.table/issues/1467). Thanks to @rBatt, @rsaporta and @damienchallet.
 
+  29. `last` function will now properly redirect method if `xts` is not installed or not attached on search path. Closes [#1560](https://github.com/Rdatatable/data.table/issues/1560).
+
 #### NOTES
 
   1. Updated error message on invalid joins to reflect the new `on=` syntax, [#1368](https://github.com/Rdatatable/data.table/issues/1368). Thanks @MichaelChirico.

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -6961,9 +6961,9 @@ test(1558, as.ITime(NA), setattr(NA_integer_, 'class', 'ITime'))
 if (!"package:xts" %in% search()) {
     # #1347, xts issue from Joshua
     x = as.Date(1:5, origin="2015-01-01")
-    test(1559.1, last(x), tail(x, 1L))
+    test(1559.11, last(x), tail(x, 1L))
 } else {
-    test(1559.2, last(.xts(1:3,1:3)), .xts(1:3, 1:3)[3, ])
+    test(1559.12, last(.xts(1:3,1:3)), .xts(1:3, 1:3)[3, ])
 }
 
 # fix for #1352


### PR DESCRIPTION
The #1560 was caused be bug in `last` on the end of function body:
```r
if (!"package:xts" %in% search()) tail(x,...)
xts::last(x,...) 
```
Due to missing `else` it was trying to evaluate `xts::last` regardless the `if` in line above.

I've also change `num` in tests as the were not unique in the whole tests.Rraw.