### PR TITLE
regen GH token and prevent forks CI to try push to Rdatatable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ after_success:
   - ./travis-tool.sh install_github jimhester/covr
   - Rscript -e 'library(covr);codecov()'
   - ./travis-tool.sh install_github eddelbuettel/drat
-  - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && bash deploy.sh
+  - test $TRAVIS_REPO_SLUG == "Rdatatable/data.table" && test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && bash deploy.sh
 
 notifications:
   email:
@@ -43,4 +43,4 @@ env:
     - PKG_CFLAGS="-g -O3 -Wall -pedantic"
     - WARNINGS_ARE_ERRORS=1
     # drat using @jangorecki token
-    - secure: aujmS0URy0iTrOgZqoCfn3Z4Km5OqBR38EI+PK5apVNf1yNqEZT6SralGYJin3rJT9HVWH0DSFX2m2FNYoTbkaNzK4l7bBBZ5EsohPuJrN/j7no/rCPfn6m5ZtaIRZRGZNyVzk1jRk4EKJzmYqH04bIyCGgSz9IRveFy7tAMXT4=
+    - secure: "CxDW++rsQApQWos+h1z/F76odysyD6AtXJrDwlCHlgqXeKJNRATR4wZDDR18SK+85jUqjoqOvpyrq+5kKuyg6AnA/zduaX2uYE5mcntEUiyzlG/jJUKbcJqt22nyAvFXP3VS60T2u4H6IIhVmr7dArdxLkv8W+pJvf2Tg6kx8Ws="

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@
 
   16. `merge.data.table` will raise warning if any of data.tables to join has 0 columns. Closes [#597](https://github.com/Rdatatable/data.table/issues/597).
 
-  17. Travis-CI will now automatically deploy package to drat repository hosted on [data.table@gh-pages](https://github.com/Rdatatable/data.table/tree/gh-pages) branch allowing to install latest devel from source via `install.packages("data.table", repos = c("https://Rdatatable.github.io/data.table", "https://cran.rstudio.com"))`. CRAN repo is still required to reach `chron` dependency. Closes [#1505](https://github.com/Rdatatable/data.table/issues/1505).
+  17. Travis-CI will now automatically deploy package to drat repository hosted on [data.table@gh-pages](https://github.com/Rdatatable/data.table/tree/gh-pages) branch allowing to install latest devel from **source** via `install.packages("data.table", repos = "https://Rdatatable.github.io/data.table", type = "source")`. Closes [#1505](https://github.com/Rdatatable/data.table/issues/1505).
 
   18. Dependency on `chron` package has been changed to *suggested*. Closes [#1558](https://github.com/Rdatatable/data.table/issues/1558).
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 set -o errexit -o nounset
+PKG_REPO=$PWD
+PKG_TARBALL=$(ls -1t *.tar.gz | head -n 1)
+cd ..
 
 addToDrat(){
-  PKG_REPO=$PWD
-  PKG_TARBALL=$(ls -1t *.tar.gz | head -n 1)
-
-  cd ..; mkdir drat; cd drat
+  mkdir drat; cd drat
 
   ## Set up Repo parameters
   git init
@@ -21,8 +21,8 @@ addToDrat(){
 
   Rscript -e "drat::insertPackage('$PKG_REPO/$PKG_TARBALL', \
     repodir = '.', \
-    commit='Travis update: build $TRAVIS_BUILD_NUMBER')"
-  git push
+    commit='Travis publish data.table: build $TRAVIS_BUILD_NUMBER')"
+  git push 2>err.txt
   
 }
 


### PR DESCRIPTION
fixes security issue related to exposed GH token, previous token will be deactivated later today.