### PR TITLE
Closes #1577; setkeyv accepts comma-separated key argument

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -347,10 +347,6 @@ data.table <-function(..., keep.rownames=FALSE, check.names=FALSE, key=NULL, str
     setattr(value,"class",c("data.table","data.frame"))
     if (!is.null(key)) {
       if (!is.character(key)) stop("key argument of data.table() must be character")
-      if (length(key)==1L) {
-          key = strsplit(key,split=",")[[1L]]
-          # eg key="A,B"; a syntax only useful in key argument to data.table(), really.
-      }
       setkeyv(value,key)
     } else {
        # retain key of cbind(DT1, DT2, DT3) where DT2 is keyed but not DT1. cbind calls data.table().

--- a/R/setkey.R
+++ b/R/setkey.R
@@ -32,6 +32,7 @@ setkeyv <- function(x, cols, verbose=getOption("datatable.verbose"), physical=TR
     } else {
         # remove backticks from cols 
         cols <- gsub("`", "", cols)
+        if (length(cols) == 1L) cols <- strsplit(cols, ",")[[1L]]
         miss = !(cols %in% colnames(x))
         if (any(miss)) stop("some columns are not in the data.table: " %+% cols[miss])
     }

--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@
   21. Added a FAQ entry for the new update to `:=` which sometimes doesn't print the result on the first time, [#939](https://github.com/Rdatatable/data.table/issues/939).
 
   22. Added `Note` section and examples to `?":="` for [#905](https://github.com/Rdatatable/data.table/issues/905).
+  
+  23. `setkeyv` now understands comma-separated arguments, i.e., `setkeyv(DT, "key1,key2")` works, as previously was acceptable only in `data.table()`. By proxy, this syntax is now accepted anywhere with a `key` argument (e.g., `setDT`). Thanks @MichaelChirico.
 
 ### Changes in v1.9.6  (on CRAN 19 Sep 2015)
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -7893,6 +7893,13 @@ test(1630.4, copy(dt1)[id>5, z := 2], data.table(id = 1:2, x = 3:4, z = NA_real_
 test(1630.5, copy(dt1)[dt2, z := y, on="id"], data.table(id = 1:2, x = 3:4, z = NA_integer_))
 test(1630.6, copy(dt1)[dt2, z := y, on="id", by=.EACHI], data.table(id = 1:2, x = 3:4, z = NA_integer_))
 
+# #1577 -- comma-separated keys in key arguments
+DT <- data.table(a = 1:3, b = 4:6)
+test(1631.1, key(data.table(a = 1:3, b = 4:6, key = "a,b")), c("a", "b"))
+test(1631.2, key(setkeyv(DT, "a,b")), c("a", "b"))
+test(1631.3, key(setDT(as.data.frame(DT), key = "a,b")), c("a", "b"))
+
+
 ##########################
 
 # TODO: Tests involving GForce functions needs to be run with optimisation level 1 and 2, so that both functions are tested all the time.

--- a/man/setkey.Rd
+++ b/man/setkey.Rd
@@ -31,7 +31,7 @@ key(x) <- value   #  DEPRECATED, please use setkey or setkeyv instead.
 \arguments{
   \item{x}{ A \code{data.table}. }
   \item{\dots}{ The columns to sort by. Do not quote the column names. If \code{\dots} is missing (i.e. \code{setkey(DT)}), all the columns are used. \code{NULL} removes the key. }
-  \item{cols}{ A character vector (only) of column names. }
+  \item{cols}{ A character vector of column names, \emph{or} a comma-separated length-one string such as \code{"x,y,z"}. }
   \item{value}{ In (deprecated) \code{key<-}, a character vector (only) of column names.}
   \item{verbose}{ Output status and information. }
   \item{physical}{ TRUE changes the order of the data in RAM. FALSE adds a secondary key a.k.a. index. }


### PR DESCRIPTION
I left the (basically redundant) error message in `data.table()` since the arguments are named differently:

    if (!is.character(key)) stop("key argument of data.table() must be character")

Once this is merged I'll edit #1578.