### PR TITLE
updating class argument to print.data.table, #1523

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -6,7 +6,7 @@ exportClasses(data.table, IDate, ITime)
 ##
 
 export(data.table, tables, setkey, setkeyv, key, "key<-", haskey, CJ, SJ, copy)
-export(set2key, set2keyv, key2)
+export(set2key, set2keyv, key2, setindex, setindexv)
 export(as.data.table,is.data.table,test.data.table,last,like,"%like%",between,"%between%")
 export(timetaken)
 export(truelength, alloc.col, ":=")

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -154,18 +154,18 @@ print.data.table <- function(x, topn=getOption("datatable.print.topn"),
       abbs = unname(class_abb[classes])
       if ( length(idx <- which(is.na(abbs))) )
         abbs[idx] = paste("<", classes[idx], ">", sep="")
-      toprint = rbind(abbs, toprint)
-      rownames(toprint)[1L] = ""
+      toprint = rbind(colnames(toprint), toprint)
+      colnames(toprint) <- abbs
     }
     if (printdots) {
-        toprint = rbind(head(toprint,topn),"---"="",tail(toprint,topn))
+        toprint = rbind(head(toprint,topn + class),"---"="",tail(toprint,topn))
         rownames(toprint) = format(rownames(toprint),justify="right")
         print(toprint,right=TRUE,quote=quote)
         return(invisible())
     }
-    if (nrow(toprint)>20L)
+    if (nrow(toprint)>20L + class)
         # repeat colnames at the bottom if over 20 rows so you don't have to scroll up to see them
-        toprint=rbind(toprint,matrix(colnames(toprint),nrow=1)) # fixes bug #4934
+        toprint=rbind(toprint, if (isTRUE(class)) toprint[1, ] else colnames(toprint)) # fixes bug #4934
     print(toprint,right=TRUE,quote=quote)
     invisible()
 }
@@ -541,7 +541,7 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
                     xo = get2key(x,isub2)  # Can't be any index with that col as the first one because those indexes will reorder within each group
                     if (is.null(xo)) {   # integer() would be valid and signifies o=1:.N
                         if (verbose) {cat("Creating new index '",isub2,"'\n",sep="");flush.console()}
-                        set2keyv(x,isub2)
+                        setindexv(x,isub2)
                         xo = get2key(x,isub2)
                     } else {
                         if (verbose) {cat("Using existing index '",isub2,"'\n",sep="");flush.console()}

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -32,7 +32,7 @@
              "datatable.optimize"="Inf",             # datatable.<argument name>
              "datatable.print.nrows"="100L",         # datatable.<argument name>
              "datatable.print.topn"="5L",            # datatable.<argument name>
-             "datatable.print.class"="FALSE",        # for print.data.table
+             "datatable.print.class"="TRUE",         # for print.data.table
              "datatable.print.rownames"="TRUE",      # for print.data.table
              "datatable.allow.cartesian"="FALSE",    # datatable.<argument name>
              "datatable.dfdispatchwarn"="TRUE",                   # not a function argument

--- a/R/setkey.R
+++ b/R/setkey.R
@@ -7,8 +7,18 @@ setkey <- function(x, ..., verbose=getOption("datatable.verbose"), physical=TRUE
     setkeyv(x, cols, verbose=verbose, physical=physical)
 }
 
-set2key <- function(...) setkey(..., physical=FALSE)
-set2keyv <- function(...) setkeyv(..., physical=FALSE)
+# FR #1442
+setindex <- function(...) setkey(..., physical=FALSE)
+setindexv <- function(...) setkeyv(..., physical=FALSE)
+
+set2key <- function(...) {
+    warning("set2key will be deprecated in the next relase. Please use setindex instead.")
+    setkey(..., physical=FALSE)
+}
+set2keyv <- function(...) {
+    warning("set2key will be deprecated in the next relase. Please use setindex instead.")
+    setkeyv(..., physical=FALSE)
+}
 
 setkeyv <- function(x, cols, verbose=getOption("datatable.verbose"), physical=TRUE)
 {

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
 
   20. `data.table()` function gains `stringsAsFactors` argument with default `FALSE`, [#643](https://github.com/Rdatatable/data.table/issues/643). Thanks to @Jan for reviving this issue.
   
-  21. New argument `print.class` for `print.data.table` allows for including column class under column names (as inspired by `tbl_df` in `dplyr`); default (adjustable via `"datatable.print.class"` option) is `FALSE`, the inherited behavior. Part of [#1523](https://github.com/Rdatatable/data.table/issues/1523); thanks to @MichaelChirico for the FR & PR.
+  21. New argument `class` for `print.data.table` allows for including column class above column names (as inspired by `tbl_df` in `dplyr`); default (adjustable via `"datatable.print.class"` option) is `TRUE`. Part of [#1523](https://github.com/Rdatatable/data.table/issues/1523); thanks to @MichaelChirico for the FR & PR.
   
   22. `all.equal.data.table` gets new features for testing equality of data.tables, new arguments are `check.attributes`, `ignore.col.order`, `ignore.row.order`. It will now also check column classes match, unlike `all.equal.list` it will also report *integer/real* types mismatch.
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -1594,7 +1594,8 @@ test(557, DT[, f(.SD), by=x], error="[.]SD is locked.*reserved for possible futu
 # Test printing on nested data.table, bug #1803
 DT = data.table(x=letters[1:3],y=list(1:10,letters[1:4],data.table(a=1:3,b=4:6)))
 test(558, capture.output(print(DT)),
-          c("   x            y","1: a 1,2,3,4,5,6,","2: b      a,b,c,d","3: c <data.table>"))
+          c("   <char>       <list>", "        x            y", "1:      a 1,2,3,4,5,6,", 
+            "2:      b      a,b,c,d", "3:      c <data.table>"))
 test(559, setkey(DT,x)["a",y][[1]], 1:10)   # y is symbol representing list column, specially detected in dogroups
 
 # Test renaming of .N to N
@@ -1802,12 +1803,19 @@ test(639, key(DT[,a:=99L,by=a]), NULL)
 
 # Test printing is right aligned without quotes etc, and rownames are repeated ok for more than 20 rows
 DT=data.table(a=8:10,b=c("xy","x","xyz"),c=c(1.1,22.1,0))
-test(640, capture.output(print(DT)), c("    a   b    c","1:  8  xy  1.1","2:  9   x 22.1","3: 10 xyz  0.0"))
+test(640, capture.output(print(DT)),
+     c("   <int> <char> <num>", "       a      b     c", "1:     8     xy   1.1", 
+       "2:     9      x  22.1", "3:    10    xyz   0.0"))
 DT=data.table(a=letters,b=1:26)
-test(641, tail(capture.output(print(DT[1:20])),2), c("19: s 19","20: t 20"))
-test(642, tail(capture.output(print(DT[1:21])),2), c("21: u 21","    a  b"))
+test(641, tail(capture.output(print(DT[1:20])),2), c("19:      s    19", "20:      t    20"))
+test(642, tail(capture.output(print(DT[1:21])),2), c("21:      u    21", "         a     b"))
 DT=data.table(a=as.character(as.hexmode(1:500)), b=1:500)
-test(643, capture.output(print(DT)), c("       a   b","  1: 001   1","  2: 002   2","  3: 003   3","  4: 004   4","  5: 005   5"," ---        ","496: 1f0 496","497: 1f1 497","498: 1f2 498","499: 1f3 499","500: 1f4 500"))
+test(643, capture.output(print(DT)),
+     c("     <char> <int>", "          a     b", "  1:    001     1", 
+       "  2:    002     2", "  3:    003     3", "  4:    004     4", 
+       "  5:    005     5", " ---             ", "496:    1f0   496", 
+       "497:    1f1   497", "498:    1f2   498", "499:    1f3   499", 
+       "500:    1f4   500"))
 
 # Test inconsistent length of columns error.
 DT = list(a=3:1,b=4:3)
@@ -2149,7 +2157,8 @@ DT = data.table(a=1:3,b=c("a","a","b"))
 setattr(DT$b, "names", c("a","b","c"))  # Force names in there to test #2307
 test(777, names(DT$b), c("a","b","c"))
 test(778, DT[,sum(a),by=b], data.table(b=c("a","b"),V1=c(3L,3L)))  #2307 retained names length 3 on the length 2 vector result causing it not to print.
-test(779, print(DT[,sum(a),by=b]), output="   b V11: a  32: b  3$")
+test(779, capture.output(print(DT[,sum(a),by=b])),
+     c("   <char> <int>", "        b    V1", "1:      a     3", "2:      b     3"))
 
 # Test new .GRP binding
 test(780, data.table(a=1:3,b=1:6)[,i:=.GRP,by=a][,i2:=.GRP], data.table(a=1:3,b=1:6,i=rep(1:3,2),i2=1L))
@@ -2379,7 +2388,9 @@ test(867, names(ans2<-DT[,list(name1=sum(v),name2=sum(w)),by="a,b"]), c("a","b",
 test(868, ans1, ans2)
 # and related to setnames, too
 DT = data.table(a=1:3,b=1:6,key="a")
-test(869, DT[J(2,42,84),print(.SD),by=.EACHI], output="   b1: 22: 5.*Empty data.table (0 rows) of 3 cols: a,V2,V3")
+test(869, capture.output(DT[J(2,42,84),print(.SD),by=.EACHI]),
+     c("   <int>", "       b", "1:     2", "2:     5",
+       "Empty data.table (0 rows) of 3 cols: a,V2,V3"))
 
 # Test setnames with duplicate colnames
 DT = data.table(a=1:3,b=4:6,b=7:9)
@@ -2400,7 +2411,10 @@ f = function() {
   print(DT[a>localvar,sum(b)])
   print(DT[a>localvar,sum(b),by=a])  # bug fix 2368
 }
-test(876, f(), output="   a b1: 3 32: 3 6.*[1] 9.*   a V11: 3  9")
+test(876, capture.output(f()),
+     c("   <int> <int>", "       a     b", "1:     3     3", 
+       "2:     3     6", "[1] 9", "   <int> <int>", 
+       "       a    V1", "1:     3     9"))
 
 # segfault when assigning NA names, #2393
 DT = data.table(a=1:3, b=4:6)
@@ -2780,7 +2794,20 @@ DT = data.table(a=1:3,b=4:6,b=7:9,c=10:12)
 test(1005, rbind(DT,DT), data.table(a=rep(1:3,2),b=rep(4:6,2),b=rep(7:9,2),c=rep(10:12,2)))
 M <- mtcars
 colnames(M)[11] <- NA
-test(1006, print(as.data.table(M), nrows=10), output="gear NA.*1: 21.0")
+test(1006, capture.output(print(as.data.table(M), nrows=10)),
+     c("    <num> <num> <num> <num> <num> <num> <num> <num> <num> <num> <num>", 
+       "      mpg   cyl  disp    hp  drat    wt  qsec    vs    am  gear    NA", 
+       " 1:  21.0     6 160.0   110  3.90 2.620 16.46     0     1     4     4", 
+       " 2:  21.0     6 160.0   110  3.90 2.875 17.02     0     1     4     4", 
+       " 3:  22.8     4 108.0    93  3.85 2.320 18.61     1     1     4     1", 
+       " 4:  21.4     6 258.0   110  3.08 3.215 19.44     1     0     3     1", 
+       " 5:  18.7     8 360.0   175  3.15 3.440 17.02     0     0     3     2",
+       "---                                                                  ", 
+       "28:  30.4     4  95.1   113  3.77 1.513 16.90     1     1     5     2", 
+       "29:  15.8     8 351.0   264  4.22 3.170 14.50     0     1     5     4", 
+       "30:  19.7     6 145.0   175  3.62 2.770 15.50     0     1     5     6", 
+       "31:  15.0     8 301.0   335  3.54 3.570 14.60     0     1     5     8", 
+       "32:  21.4     4 121.0   109  4.11 2.780 18.60     1     1     4     2"))
 
 # rbinding factor with non-factor/character
 DT1 <- data.table(x=1:5, y=factor("a"))
@@ -3010,8 +3037,16 @@ test(1055, x[0, number := 1L], x)
 
 # print.data.table heeds digits=2 etc, #2535
 DT = data.table(x=rep(c("a","b","c"),each=3), y=(30/7)^(2:10))[, logy := log(y)]
-test(1056, print(DT, digits=2), output="   x       y logy1: a      18  2.92: a      79  4.43: a     337  5.8")
-test(1057, print(DT, digits=2, big.mark=","), output="   x         y logy1: a        18  2.9.*6: b    26,556 10.27: c   113,811 11.6")
+test(1056, capture.output(print(DT, digits=2)), 
+     c("   <char>   <num> <num>", "        x       y  logy", "1:      a      18   2.9", 
+       "2:      a      79   4.4", "3:      a     337   5.8", "4:      b    1446   7.3", 
+       "5:      b    6196   8.7", "6:      b   26556  10.2", "7:      c  113811  11.6", 
+       "8:      c  487763  13.1", "9:      c 2090413  14.6"))
+test(1057, capture.output(print(DT, digits=2, big.mark=",")),
+     c("   <char>     <num> <num>", "        x         y  logy", "1:      a        18   2.9", 
+       "2:      a        79   4.4", "3:      a       337   5.8", "4:      b     1,446   7.3", 
+       "5:      b     6,196   8.7", "6:      b    26,556  10.2", "7:      c   113,811  11.6", 
+       "8:      c   487,763  13.1", "9:      c 2,090,413  14.6"))
 
 # bug #2758 fix - segfault with zeros in i and factors in by
 x <- data.table(letters=letters[1:5], factor=factor(letters[1:5]), number=1:5)
@@ -3046,7 +3081,13 @@ test(1073, fread(f,drop=2:3), fread(f,select=c(1,4)))  # tests coercing numeric 
 
 # that problem printing duplicate columns doesn't return, #4788
 DT = data.table(V1 = c(1:1000), V2 = c(10001:11000))
-test(1074, DT[, sum(V2), by = V1], output="1000: 1000 11000")  # x has two columns both called V1 here
+# x has two columns both called V1 here
+test(1074, capture.output(DT[, sum(V2), by = V1]),
+    c("      <int> <int>", "         V1    V1", "   1:     1 10001", 
+      "   2:     2 10002", "   3:     3 10003", "   4:     4 10004", 
+      "   5:     5 10005", "  ---            ", " 996:   996 10996", 
+      " 997:   997 10997", " 998:   998 10998", " 999:   999 10999", 
+      "1000:  1000 11000")) 
 
 # add test from #2446. Already fixed but add anyway. "names in neworder not found in x: 'colnames with spaces' from merge() when all.y=TRUE"
 X = data.table(a=1:3,b=4:6,"c d"=7:9)
@@ -3123,7 +3164,15 @@ test(1087, class(DT$last.x1), "ITime")
 # print of unnamed DT with >20 <= 100 rows, #4934
 DT <- data.table(x=1:25, y=letters[1:25])
 DT.unnamed <- unname(copy(DT))
-test(1094, print(DT.unnamed), output="NA NA 1:  1  a 2:  2  b 3:  3  c")
+test(1094, capture.output(print(DT.unnamed)),
+     c("    <int> <char>", "       NA     NA", " 1:     1      a",
+       " 2:     2      b", " 3:     3      c", " 4:     4      d", " 5:     5      e", 
+       " 6:     6      f", " 7:     7      g", " 8:     8      h", " 9:     9      i", 
+       "10:    10      j", "11:    11      k", "12:    12      l", "13:    13      m", 
+       "14:    14      n", "15:    15      o", "16:    16      p", "17:    17      q", 
+       "18:    18      r", "19:    19      s", "20:    20      t", "21:    21      u", 
+       "22:    22      v", "23:    23      w", "24:    24      x", "25:    25      y", 
+       "       NA     NA"))
 
 # DT[!TRUE] or DT[!TRUE, which=TRUE], #4930. !TRUE still can be a recycling operation with !(all TRUE)
 DT <- data.table(x=1:3, y=4:6)
@@ -3557,13 +3606,22 @@ test(1137.12, DT[, lapply(.SD, sum), by=x, .SDcols=-"y"], DT[, lapply(.SD, sum),
 # test for FR #353 / R-Forge #5020 - print.data.table gets new argument "row.names", default=TRUE. if FALSE, the row-names don't get printed
 # Thanks to Eddi for `capture.output` function!
 DT <- data.table(x=1:5, y=6:10)
-test(1138.1, capture.output(print(DT, row.names=FALSE)), c(" x  y", " 1  6", " 2  7", " 3  8", " 4  9", " 5 10"))
+test(1138.1, capture.output(print(DT, row.names=FALSE)), 
+     c(" <int> <int>", "     x     y", "     1     6", "     2     7", 
+       "     3     8", "     4     9", "     5    10"))
 DT <- data.table(x=1:101, y=6:106) # bug described in #1307
-test(1138.2, capture.output(print(DT, row.names=FALSE)), c("      x   y", "      1   6", "      2   7", "      3   8", "      4   9", "      5  10", "---        ", "     97 102", "     98 103", "     99 104", "    100 105", "    101 106"))
+test(1138.2, capture.output(print(DT, row.names=FALSE)), 
+     c("    <int> <int>", "        x     y", "        1     6",
+       "        2     7", "        3     8", "        4     9", 
+       "        5    10", "---            ", "       97   102", 
+       "       98   103", "       99   104", "      100   105", 
+       "      101   106"))
 
 # test for FR #2591 (format.data.table issue with column of class "formula")
 DT <- data.table(x=c(a~b, c~d+e), y=1:2)
-test(1139, capture.output(print(DT)), c("           x y", "1:     a ~ b 1", "2: c ~ d + e 2"))
+test(1139, capture.output(print(DT)),
+     c("      <list> <int>", "           x     y", 
+       "1:     a ~ b     1", "2: c ~ d + e     2"))
 
 # FR #4813 - provide warnings if there are remainders for both as.data.table.list(.) and data.table(.)
 X = list(a = 1:2, b = 1:3)
@@ -4630,11 +4688,11 @@ c(2497.94263862333,
 "data.frame"), row.names = c(NA, -2L))
 
 if (options()$width<80) options(width=80)
-ans1 = capture.output(print(DT, digits=4, row.names=FALSE))
-ans2 = c(" fisyr  er      eg      esal  fr      fg      fsal    mr      mg      msal", 
-         "  1995 1,3 0.01973 2330,2424 4,4 0.03931 2521,2521  5,30 0.01978 2572,4216", 
-         "  1996 1,3 0.01973 2263,2354 4,4 0.03931 2449,2449  5,30 0.01978 2498,4095")
-test(1293, ans1, ans2)
+test(1293, capture.output(print(DT, digits=4, row.names=FALSE)),
+     c(" <int> <list>   <num>    <list> <list>   <num>    <list> <list>   <num>    <list>", 
+       " fisyr     er      eg      esal     fr      fg      fsal     mr      mg      msal", 
+       "  1995    1,3 0.01973 2330,2424    4,4 0.03931 2521,2521   5,30 0.01978 2572,4216", 
+       "  1996    1,3 0.01973 2263,2354    4,4 0.03931 2449,2449   5,30 0.01978 2498,4095"))
 
 ## Fixes bug #5442
 ## Also improves upon bug fix #2551 to provide better warnings and at better places:
@@ -5354,7 +5412,7 @@ test(1376.7, DT[a==7L,verbose=TRUE], DT[7L], output="Using existing index 'a'")
 setkey(DT,b)
 test(1376.8, key2(DT), NULL)
 test(1376.9, list(DT[a==2L], key2(DT)), list(DT[9L],"a"))  # create key2 for next test
-set2key(DT,NULL)
+setindex(DT,NULL)
 test(1376.10, list(key(DT), key2(DT)), list("b", NULL))
 options(datatable.auto.index = FALSE)
 test(1376.11, list(DT[a==2L], key2(DT)), list(DT[9L],NULL))
@@ -5486,7 +5544,9 @@ test(off-350.2, DT[J(0:4),.N]$N, c(0L,3L,3L,0L,0L), warning=deprecated_warn)
 
 # Test printing on nested data.table, bug #1803
 DT = data.table(x=letters[1:3],y=list(1:10,letters[1:4],data.table(a=1:3,b=4:6)))
-test(off-558, capture.output(print(DT)), c("   x            y","1: a 1,2,3,4,5,6,","2: b      a,b,c,d","3: c <data.table>"))
+test(off-558, capture.output(print(DT)), 
+     c("   <char>       <list>", "        x            y",
+       "1:      a 1,2,3,4,5,6,", "2:      b      a,b,c,d", "3:      c <data.table>"))
 test(off-559, setkey(DT,x)["a",y][[2]][[1]], 1:10, warning=deprecated_warn)   # y is symbol representing list column, specially detected in dogroups
 
 # another test linked from #2162
@@ -5494,7 +5554,9 @@ DT = data.table(x=rep(c("a","b","c"),each=3), y=c(1L,3L,6L), v=1:9, key="x")
 test(off-725, DT[c("a","b","d"),v][,list(v)], DT[J(c("a","b","d")),"v",with=FALSE], warning=deprecated_warn)  # unfiled bug fix for NA matches; see NEWS 1.8.3
 
 DT = data.table(a=1:3,b=1:6,key="a")
-test(off-869, suppressWarnings(DT[J(2,42,84),print(.SD)]), output="   b1: 22: 5.*Empty data.table (0 rows) of 3 cols: a,V2,V3")
+test(off-869, capture.output(suppressWarnings(DT[J(2,42,84),print(.SD)])),
+     c("   <int>", "       b", "1:     2", "2:     5", 
+       "Empty data.table (0 rows) of 3 cols: a,V2,V3"))
 
 rm(deprecated_warn)
 options(datatable.old.bywithoutby=FALSE)
@@ -5682,25 +5744,25 @@ setorder(DT, y)
 test(1412, key2(DT), NULL)
 test(1413, DT[x==5], DT[1])
 DT = data.table(foo=1:3, bar=4:6, baz=9:7)
-set2key(DT,foo,bar,baz)
+setindex(DT,foo,bar,baz)
 test(1414, key2(DT), c("foo__bar__baz"))
 test(1415, DT[2,bar:=10L,verbose=TRUE], output="Dropping index 'foo__bar__baz' due to update on 'bar'")  # test middle
 test(1416, key2(DT), NULL)
-set2key(DT,foo,bar,baz)
+setindex(DT,foo,bar,baz)
 test(1417, DT[2,baz:=10L,verbose=TRUE], output="Dropping index 'foo__bar__baz' due to update on 'baz'")  # test last
-set2key(DT,bar,baz)
+setindex(DT,bar,baz)
 test(1418, DT[2,c("foo","bar"):=10L,verbose=TRUE], output="Dropping index.* due to update on 'bar'")     # test 2nd to 1st
-set2key(DT,bar,baz)
+setindex(DT,bar,baz)
 test(1419, DT[2,c("foo","baz"):=10L,verbose=TRUE], output="Dropping index.* due to update on 'baz'")     # test 2nd to 2nd
 
 # setnames updates secondary key
 DT = data.table(a=1:5,b=10:6)
-set2key(DT,b)
+setindex(DT,b)
 test(1420, key2(DT), "b")
 setnames(DT,"b","foo")
 test(1421, key2(DT), "foo")
 test(1422, DT[foo==9, verbose=TRUE], DT[2], output="Using existing index 'foo'")
-set2key(DT,a,foo)
+setindex(DT,a,foo)
 test(1423, key2(DT), c("foo","a__foo"))   # tests as well that order of attributes is retained although we don't use that property currently.
 test(1424, key2(setnames(DT,"foo","bar")), c("bar","a__bar"))
 test(1425, key2(setnames(DT,"a","baz")), c("bar","baz__bar"))
@@ -6162,13 +6224,13 @@ test(1489, DT[.(TRUE)], DT[1L])
 # Fix for #932
 DT <- data.table(v1 = c(1:3, NA), v2 = c(1,NA,2.5,NaN), v3=c(NA, FALSE, NA, TRUE), v4=c("a", NA, "b", "c"))
 options(datatable.auto.index = TRUE) # just to be sure
-set2key(DT, v1)
+setindex(DT, v1)
 test(1490.1,  DT[v1==3],      subset(DT, v1==3))
 test(1490.2,  DT[!v1==3],     subset(DT, !v1==3))
 test(1490.3,  DT[v1==NA],     subset(DT, v1==NA))
 test(1490.4,  DT[!v1==NA],    subset(DT, !v1==NA))
 
-set2key(DT, v2)
+setindex(DT, v2)
 test(1490.5,  DT[v2==2.5],    subset(DT, v2==2.5))
 test(1490.6,  DT[!v2==2.5],   subset(DT, !v2==2.5))
 test(1490.7,  DT[v2==NA],     subset(DT, v2==NA))
@@ -6176,7 +6238,7 @@ test(1490.8,  DT[!v2==NA],    subset(DT, !v2==NA))
 test(1490.9,  DT[v2==NaN],    subset(DT, v2==NaN))
 test(1490.10, DT[!v2==NaN],   subset(DT, !v2==NaN))
 
-set2key(DT, v3)
+setindex(DT, v3)
 test(1490.11, DT[v3==FALSE],  subset(DT, v3==FALSE))
 test(1490.12, DT[!v3==FALSE], subset(DT, !v3==FALSE))
 test(1490.13, DT[v3==TRUE],   subset(DT, v3==TRUE))
@@ -6186,7 +6248,7 @@ test(1490.16, DT[!v3==NA],    subset(DT, !v3==NA))
 test(1490.17, DT[(v3)],       subset(DT, v3==TRUE))
 test(1490.18, DT[!(v3)],      subset(DT, !v3==TRUE))
 
-set2key(DT, v4)
+setindex(DT, v4)
 test(1490.19, DT[v4=="b"],    subset(DT, v4=="b"))
 test(1490.20, DT[!v4=="b"],   subset(DT, !v4=="b"))
 test(1490.21, DT[v4==NA],     subset(DT, v4==NA))
@@ -6397,7 +6459,7 @@ test(1514.7, isReallyReal(x), FALSE)
 old.option = getOption("datatable.prettyprint.char")
 options(datatable.prettyprint.char = 5L)
 DT = data.table(x=1:2, y=c("abcdefghijk", "lmnopqrstuvwxyz"))
-test(1515.1, grep("abcde...", capture.output(print(DT))), 2L)
+test(1515.1, grep("abcde...", capture.output(print(DT))), 3L)
 options(datatable.prettyprint.char = old.option)
 
 # test 1516: chain setnames() - used while mapping source to target columns
@@ -6781,7 +6843,12 @@ test(1548.2, unique(unlist(lapply(ans2, Encoding))), "UTF-8")
 
 # #1167 print.data.table row id in non-scientific notation 
 DT <- data.table(a = rep(1:5,3*1e6), b = rep(letters[1:3],5*1e6))
-test(1549, capture.output(print(DT)), c("          a b", "       1: 1 a", "       2: 2 b", "       3: 3 c", "       4: 4 a", "       5: 5 b", "      ---    ", "14999996: 1 b", "14999997: 2 c", "14999998: 3 a", "14999999: 4 b", "15000000: 5 c"))
+test(1549, capture.output(print(DT)), 
+     c("          <int> <char>", "              a      b", "       1:     1      a", 
+     "       2:     2      b", "       3:     3      c", "       4:     4      a", 
+     "       5:     5      b", "      ---             ", "14999996:     1      b", 
+     "14999997:     2      c", "14999998:     3      a", "14999999:     4      b", 
+     "15000000:     5      c"))
 rm(DT)
 
 # PR by @dselivanov
@@ -6840,13 +6907,13 @@ test(1552.5, fread(str, na.strings=c("#N/A", "-999", "FALSE")), read_table(str, 
 
 # FR #1177: 'quote' option of 'print.data.table'
 DT1 <- data.table(s1=paste(" ",LETTERS[1:5],sep=""),s2=LETTERS[1:5])
-ans1 <- c("     s1  s2","1: \" A\" \"A\"",
-          "2: \" B\" \"B\"","3: \" C\" \"C\"",
-          "4: \" D\" \"D\"","5: \" E\" \"E\"")
-ans2 <- c("   s1 s2","1:  A  A","2:  B  B",
-          "3:  C  C","4:  D  D","5:  E  E")
-test(1553.1, capture.output(print(DT1, quote = TRUE)), ans1)
-test(1553.2, capture.output(print(DT1)), ans2)
+test(1553.1, capture.output(print(DT1, quote = TRUE)),
+     c("   <char> <char>", "     \"s1\"   \"s2\"", "1:   \" A\"    \"A\"", 
+       "2:   \" B\"    \"B\"", "3:   \" C\"    \"C\"", "4:   \" D\"    \"D\"", 
+       "5:   \" E\"    \"E\""))
+test(1553.2, capture.output(print(DT1)),
+     c("   <char> <char>", "       s1     s2", "1:      A      A", 
+       "2:      B      B", "3:      C      C", "4:      D      D", "5:      E      E"))
 
 # #826 - subset DT on single integer vector stored as matrix the same way as data.frame
 dt <- data.table(a=letters[1:10])
@@ -7458,15 +7525,15 @@ DT1  = data.table(lcol = list(list(1:3), list(1:3), list(1:3)),
                   xcol = as.complex(icol), ocol = factor(icol, ordered = TRUE),
                   fcol = factor(icol))
 test(1610.1, capture.output(print(DT1, class=TRUE)),
-     c("     lcol  icol  ncol   ccol   xcol  ocol   fcol",
-       "   <list> <int> <num> <char> <cplx> <ord> <fctr>", 
+     c("   <list> <int> <num> <char> <cplx> <ord> <fctr>",
+       "     lcol  icol  ncol   ccol   xcol  ocol   fcol",
        "1: <list>     1     1      a   1+0i     1      1", 
        "2: <list>     2     2      b   2+0i     2      2", 
        "3: <list>     3     3      c   3+0i     3      3"))
 # fails on travis and appveyor; no idea why.. Passes on my mac and windows machine.
 # test(1610.2, capture.output(print(DT2, class=TRUE))
-#      c("         Dcol                Pcol   gcol       Icol   ucol", 
-#        "       <Date>              <POSc> <lgcl>     <IDat> <asdf>", 
+#      c("       <Date>              <POSc> <lgcl>     <IDat> <asdf>",
+#        "         Dcol                Pcol   gcol       Icol   ucol", 
 #        "1: 2016-01-01 2016-01-01 01:00:00   TRUE 2016-01-01      1", 
 #        "2: 2016-01-02 2016-01-02 01:00:00   TRUE 2016-01-02      2", 
 #        "3: 2016-01-03 2016-01-03 01:00:00   TRUE 2016-01-03      3"))
@@ -7556,12 +7623,12 @@ test(1613.24, all.equal(DT1, setkeyv(DT2, "a"), check.attributes = TRUE), TRUE)
 # test attributes: index
 DT1 <- data.table(a = 1:4, b = letters[1:4])
 DT2 <- data.table(a = 1:4, b = letters[1:4])
-set2keyv(DT1, "b")
+setindexv(DT1, "b")
 test(1613.25, all.equal(DT1, DT2), "Datasets has different indexes. 'target': b. 'current' has no index.")
 test(1613.26, all.equal(DT1, DT2, check.attributes = FALSE), TRUE)
-test(1613.27, all.equal(DT1, set2keyv(DT2, "a")), "Datasets has different indexes. 'target': b. 'current': a.")
-test(1613.28, all.equal(DT1, set2keyv(DT2, "b")), "Datasets has different indexes. 'target': b. 'current': a, b.")
-test(1613.29, all.equal(DT1, set2keyv(set2keyv(DT2, NULL), "b")), TRUE)
+test(1613.27, all.equal(DT1, setindexv(DT2, "a")), "Datasets has different indexes. 'target': b. 'current': a.")
+test(1613.28, all.equal(DT1, setindexv(DT2, "b")), "Datasets has different indexes. 'target': b. 'current': a, b.")
+test(1613.29, all.equal(DT1, setindexv(setindexv(DT2, NULL), "b")), TRUE)
 # test custom attribute
 DT1 <- data.table(a = 1:4, b = letters[1:4])
 DT2 <- data.table(a = 1:4, b = letters[1:4])
@@ -7686,7 +7753,7 @@ test(1623, fread("~"), error="can not be a directory name")
 old = getOption("datatable.print.rownames")
 options(datatable.print.rownames = FALSE)
 DT <- data.table(a = 1:3)
-test(1624, capture.output(print(DT)), c(" a", " 1", " 2", " 3"))
+test(1624, capture.output(print(DT)), c(" <int>", "     a", "     1", "     2", "     3"))
 options(datatable.print.rownames = old)
 
 # fix for #1575
@@ -7880,11 +7947,11 @@ test(1631, key(A[B, on="x"]), NULL)
 
 # fix for #1479, secondary keys are removed when necessary
 dt = data.table(a = rep(c(F,F,T,F,F,F,F,F,F), 3), b = c("x", "y", "z"))
-set2key(dt, a)
+setindex(dt, a)
 dt[, a := as.logical(sum(a)), by = b]
 test(1632.1, names(attributes(attr(dt, 'index'))), NULL)
 dt = data.table(a = rep(c(F,F,T,F,F,F,F,F,F), 3), b = c("x", "y", "z"))
-set2key(dt, b)
+setindex(dt, b)
 dt[, a := as.logical(sum(a)), by = b]
 test(1632.2, names(attributes(attr(dt, 'index'))), "__b")
 dt = data.table(a = rep(c(F,F,T,F,F,F,F,F,F), 3), b = c("x", "y", "z"))

--- a/man/print.data.table.Rd
+++ b/man/print.data.table.Rd
@@ -10,7 +10,7 @@
   \method{print}{data.table}(x,
     topn=getOption("datatable.print.topn"),          # default: 5
     nrows=getOption("datatable.print.nrows"),        # default: 100
-    class=getOption("datatable.print.class"),  # default: FALSE
+    class=getOption("datatable.print.class"),        # default: TRUE
     row.names=getOption("datatable.print.rownames"), # default: TRUE
     quote=FALSE,...)
 }

--- a/man/setkey.Rd
+++ b/man/setkey.Rd
@@ -6,6 +6,8 @@
 \alias{haskey}
 \alias{set2key}
 \alias{set2keyv}
+\alias{setindex}
+\alias{setindexv}
 \alias{key2}
 \title{ Create key on a data table }
 \description{
@@ -21,8 +23,8 @@
 \usage{
 setkey(x, ..., verbose=getOption("datatable.verbose"), physical = TRUE)
 setkeyv(x, cols, verbose=getOption("datatable.verbose"), physical = TRUE)
-set2key(...)
-set2keyv(...)
+setindex(...)
+setindexv(...)
 key(x)
 key2(x)
 haskey(x)


### PR DESCRIPTION
Should fix everything.

@arunsrinivasan two tangentially related things:

 1. I found a bunch of tests which seem like they're up for the chopping block (all the ones with `test(off-` -- there's a message saying those tests should be deleted after Sep 2015. The old `bywithoutby` tests.

 2. Tests 1378.2 & 1378.3 consistently produce errors for me. At a glance, it seems like the tests are only meant to run on a Windows machine (I'm on Linux), should there be an `if` clause there?