### PR TITLE
print.data.table gains print.keys argument, #1523

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -93,6 +93,7 @@ print.data.table <- function(x, topn=getOption("datatable.print.topn"),
                              nrows=getOption("datatable.print.nrows"), 
                              class=getOption("datatable.print.class"), 
                              row.names=getOption("datatable.print.rownames"), 
+                             print.keys=getOption("datatable.print.keys"),
                              quote=FALSE, ...) {    # topn  - print the top topn and bottom topn rows with '---' inbetween (5)
     # nrows - under this the whole (small) table is printed, unless topn is provided (100)
     # class - should column class be printed underneath column name? (FALSE)
@@ -119,6 +120,13 @@ print.data.table <- function(x, topn=getOption("datatable.print.topn"),
     if (!is.numeric(topn)) topn = 5L
     topnmiss = missing(topn)
     topn = max(as.integer(topn),1L)
+    if (print.keys){
+      if (!is.null(ky <- key(x))) 
+        cat("Key: <", paste(ky, collapse=", "), ">\n", sep="")
+      if (!is.null(ixs <- indices(x))) 
+        cat("Ind", if (length(ixs) > 1) "ices" else "ex", ": <",
+            paste(ixs, collapse=">, <"), ">\n", sep="")
+    }
     if (nrow(x) == 0L) {
         if (length(x)==0L)
            cat("Null data.table (0 rows and 0 cols)\n")  # See FAQ 2.5 and NEWS item in v1.8.9

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -34,6 +34,7 @@
              "datatable.print.topn"="5L",            # datatable.<argument name>
              "datatable.print.class"="FALSE",        # for print.data.table
              "datatable.print.rownames"="TRUE",      # for print.data.table
+             "datatable.print.keys"="FALSE",         # for print.data.table
              "datatable.allow.cartesian"="FALSE",    # datatable.<argument name>
              "datatable.dfdispatchwarn"="TRUE",                   # not a function argument
              "datatable.warnredundantby"="TRUE",                  # not a function argument

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@
   27. `by` understands `colA:colB` syntax now, like `.SDcols` does, [#1395](https://github.com/Rdatatable/data.table/issues/1395). Thanks @franknarf1.
 
   28. Joins (and binary search based subsets) using `on=` argument now reuses existing (secondary) indices, [#1439](https://github.com/Rdatatable/data.table/issues/1439). Thanks @jangorecki.
+  
+  29. `print.data.table` gains `print.keys` argument, `FALSE` by default, which optionally displays the keys and/or indices (secondary keys) of a `data.table`, more of [#1523](https://github.com/Rdatatable/data.table/issues/1523). Thanks @MichaelChirico for the PR, Yike Lu for the suggestion of an option to highlight keys, and Arun for honing that idea to its present form.
 
 #### BUG FIXES
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -7904,6 +7904,22 @@ v2 = capture.output(ans2 <- dt[.(3:2), on="x", verbose=TRUE])
 test(1634.1, any(grepl("not found", v1)), TRUE)
 test(1634.2, any(grepl("Reusing index", v2)), TRUE)
 
+# verify print.keys works
+DT1 <- data.table(a = 1:3, key = "a")
+test(1635.1, capture.output(print(DT1, print.keys = TRUE)),
+     c("Key: <a>", "   a", "1: 1", "2: 2", "3: 3"))
+DT2 <- data.table(a = 1:3, b = 4:6)
+setindexv(DT2, c("b","a"))
+test(1635.2, capture.output(print(DT2, print.keys = TRUE)),
+     c("Index: <b__a>", "   a b", "1: 1 4", "2: 2 5", "3: 3 6"))
+setindexv(DT2, "b")
+test(1635.3, capture.output(print(DT2, print.keys = TRUE)),
+     c("Indices: <b__a>, <b>", "   a b", "1: 1 4", "2: 2 5", "3: 3 6"))
+setkey(DT2, a)
+setindexv(DT2, c("b","a"))
+test(1635.4, capture.output(print(DT2, print.keys = TRUE)),
+     c("Key: <a>", "Index: <b__a>", "   a b", "1: 1 4", "2: 2 5", "3: 3 6"))
+
 ##########################
 
 # TODO: Tests involving GForce functions needs to be run with optimisation level 1 and 2, so that both functions are tested all the time.

--- a/man/print.data.table.Rd
+++ b/man/print.data.table.Rd
@@ -12,6 +12,7 @@
     nrows=getOption("datatable.print.nrows"),        # default: 100
     class=getOption("datatable.print.class"),  # default: FALSE
     row.names=getOption("datatable.print.rownames"), # default: TRUE
+    print.keys=getOption("datatable.print.keys")     # default: FALSE
     quote=FALSE,...)
 }
 \arguments{
@@ -20,6 +21,7 @@
   \item{nrows}{ The number of rows which will be printed before truncation is enforced. }
   \item{class}{ If \code{TRUE}, the resulting output will include above each column its storage class (or a self-evident abbreviation thereof). }
   \item{row.names}{ If \code{TRUE}, row indices will be printed alongside \code{x}. }
+  \item{print.keys}{ If \code{TRUE}, any \code{\link{key}} and/or \code{\link[=indices]{index}} currently assigned to \code{x} will be printed prior to the preview of the data. }
   \item{quote}{ If \code{TRUE}, all output will appear in quotes, as in \code{print.default}. }
   \item{\dots}{ Other arguments ultimately passed to \code{format}. }
 }
@@ -46,4 +48,10 @@
   #`row.names` can be eliminated to save space
   DT <- data.table(a = 1:3)
   print(DT, row.names = FALSE)
+  
+  #`print.keys` can alert which columns are currently keys
+  DT <- data.table(a=1:3, b=4:6, c=7:9, key="b,a")
+  setindexv(DT, c("a", "b"))
+  setindexv(DT, "a")
+  print(DT, print.keys=TRUE)
 }


### PR DESCRIPTION
Went with `print.keys` -- naming it `keys` or `key` seemed too misleading (though those names would be more in line with `class` or `row.names` arguments' logic).

Will have to be adjusted once #1589 is handled (if more than one index, use `paste(sapply(indices(x), paste, collapse=", "), collapse=">, <")`).