### PR TITLE
Fix Typos & rm. trailing whitespace in vignettes

### DIFF
--- a/vignettes/datatable-faq.Rmd
+++ b/vignettes/datatable-faq.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Frequently Asked Questions about data.table"
 date: "`r Sys.Date()`"
-output: 
+output:
   rmarkdown::html_document:
     toc: true
     number_sections: true
@@ -38,7 +38,7 @@ Say column 5 is called `"region"`, just do `DT[ , region]` instead. Notice there
 
 You can place _any_ *R* expression in `j` _e.g._, `DT[ , colA*colB/2]`. Further, `j` may be a set of *R* expressions (including calls to any *R* package) wrapped with `list()`, `.()` or an anonymous code block wrapped with braces `{}`. A simple example is `DT[ , fitdistr(d1, "normal")]`.
 
-Having said this, there are some circumstances where referring to a column by number is ok, such as
+Having said this, there are some circumstances where referring to a column by number is OK, such as
 a sequence of columns. In these situations just do `DT[ , 5:10, with=FALSE]` or `DT[ , c(1,4,10), with=FALSE]`.
 
 See `?data.table` for an explanation of the `with` argument. When `FALSE`, it lets you use `data.table` the same way as `data.frame`, when you need to.
@@ -105,7 +105,7 @@ myfunction = function(dt, expr) {
 myfunction(DT, sum(Sepal.Width))
 ```
 
-`quote()` and `eval()` are like macros in other languages. Instead of `j = myfunction()` (which won't work without laboriously passing in all the arguments) it's `j = eval(mymacro)`. This can be more efficient than a function call, and convenient. When `data.table` sees `j = eval(mymacro)` it knows to find `mymacro` in calling scope so as not to be tripped up if a column name happens to be called `mymacro`, too. 
+`quote()` and `eval()` are like macros in other languages. Instead of `j = myfunction()` (which won't work without laboriously passing in all the arguments) it's `j = eval(mymacro)`. This can be more efficient than a function call, and convenient. When `data.table` sees `j = eval(mymacro)` it knows to find `mymacro` in calling scope so as not to be tripped up if a column name happens to be called `mymacro`, too.
 
 For example, let's make sure that exactly the same `j` is run for a set of different grouping criteria :
 
@@ -122,13 +122,13 @@ DT[, eval(whatToRun), by=.(Petal.Width = round(Petal.Width, 0))]
 
 `j` doesn't have to be just column names. You can write any *R* _expression_ of column names directly as `j`, _e.g._, `DT[ , mean(x*y/z)]`.  The same applies to `i`, _e.g._, `DT[x>1000, sum(y*z)]`.
 
-This runs the `j` expression on the set of rows where the `i` expression is true. You don't even need to return data, _e.g._, `DT[x>1000, plot(y, z)]`. Finally, you can do `j` by group simply by adding `by=`, _e.g._, `DT[x>1000, sum(y*z), by=w]`. This runs `j` for each group in column `w` but just over the rows where `x>1000`. By placing the 3 parts of the query (where, select and group by) inside the square brackets, `data.table` sees this query as a whole before any part of it is evaluated. Thus it can optimize the query for performance. 
+This runs the `j` expression on the set of rows where the `i` expression is true. You don't even need to return data, _e.g._, `DT[x>1000, plot(y, z)]`. Finally, you can do `j` by group simply by adding `by=`, _e.g._, `DT[x>1000, sum(y*z), by=w]`. This runs `j` for each group in column `w` but just over the rows where `x>1000`. By placing the 3 parts of the query (where, select and group by) inside the square brackets, `data.table` sees this query as a whole before any part of it is evaluated. Thus it can optimize the query for performance.
 
 ## OK, I'm starting to see what `data.table` is about, but why didn't you just enhance `data.frame` in *R*? Why does it have to be a new package?
 
 As [highlighted above](#j-num), `j` in `[.data.table` is fundamentally different from `j` in `[.data.frame`. Even something as simple as `DF[ , 1]` would break existing code in many packages and user code.  This is by design. We want it to work this way for more complicated syntax to work. There are other differences, too (see [below](#SmallerDiffs) ).
 
-Furthermore, `data.table` _inherits_ from `data.frame`. It _is_ a `data.frame`, too. A `data.table` can be passed to any package that only accepts `data.frame` and that package can use `[.data.frame` syntax on the `data.table`. 
+Furthermore, `data.table` _inherits_ from `data.frame`. It _is_ a `data.frame`, too. A `data.table` can be passed to any package that only accepts `data.frame` and that package can use `[.data.frame` syntax on the `data.table`.
 
 We _have_ proposed enhancements to *R* wherever possible, too. One of these was accepted as a new feature in *R* 2.12.0 :
 
@@ -169,7 +169,7 @@ This behaviour changed in v1.9.4 (Sep 2014). It now does the `X[Y]` join and the
 For example, (further complicating it by using _join inherited scope_, too):
 
 ```{r}
-X = data.table(grp = c("a", "a", "b", 
+X = data.table(grp = c("a", "a", "b",
                        "b", "b", "c", "c"), foo = 1:7)
 setkey(X, grp)
 Y = data.table(c("b", "c"), bar = c(4, 2))
@@ -185,7 +185,7 @@ The request to change came from users. The feeling was that if a query is doing 
 
 Of the 66 packages on CRAN or Bioconductor that depend on or import `data.table` at the time of releasing v1.9.4, only one was affected by the change. That could be because many packages don't have comprehensive tests, or just that grouping by each row in `i` wasn't being used much by downstream packages. We always test the new version with all dependent packages before release and coordinate any changes with those maintainers. So this release was quite straightforward in that regard.
 
-Another compelling reason to make the change was that previously, there was no efficient way to achieve what `X[Y, sum(foo*bar)]` does now. You had to write `X[Y][ , sum(foo*bar)]`. That was suboptimal because `X[Y]` joined all the columns and passed them all to the second compound query without knowing that only `foo` and `bar` are needed. To solve that efficiency problem, extra programming effort was required: `X[Y, list(foo, bar)][ , sum(foo*bar)]`.  The change to `by = .EACHI` has simplified this by allowing both queries to be expressed inside a single `DT[...]` query for efficieny.
+Another compelling reason to make the change was that previously, there was no efficient way to achieve what `X[Y, sum(foo*bar)]` does now. You had to write `X[Y][ , sum(foo*bar)]`. That was suboptimal because `X[Y]` joined all the columns and passed them all to the second compound query without knowing that only `foo` and `bar` are needed. To solve that efficiency problem, extra programming effort was required: `X[Y, list(foo, bar)][ , sum(foo*bar)]`.  The change to `by = .EACHI` has simplified this by allowing both queries to be expressed inside a single `DT[...]` query for efficiency.
 
 # General Syntax
 
@@ -294,7 +294,7 @@ Try something like this:
 DT[ , {
   cat("Objects:", paste(objects(), collapse=","), "\n")
   cat("Trace: x=", as.character(x), " y=", y, "\n")
-  sum(y)}, 
+  sum(y)},
   by=x]
 ```
 
@@ -400,7 +400,7 @@ Yes :
  - `nomatch=0`  $\Leftrightarrow$  inner join
  - `mult="first"|"last"`  $\Leftrightarrow$  N/A because SQL is inherently unordered
  - `roll=TRUE`  $\Leftrightarrow$  N/A because SQL is inherently unordered
- 
+
 The general form is :
 
 ```{r, eval = FALSE}
@@ -476,7 +476,7 @@ base::cbind.data.frame
 That modification is made dynamically, _i.e._, the `base` definition of `cbind.data.frame` is fetched, the `for` loop added to the beginning and then assigned back to `base`. This solution is intended to be robust to different definitions of `base::cbind.data.frame` in different versions of *R*, including unknown future changes. Again, it is a last resort until a better solution is known or made available. The competing requirements are:
 
  - `cbind(DT, DF)` needs to work. Defining `cbind.data.table` doesn't work because `base::cbind` does its own S3 dispatch and requires that the _first_ `cbind` method for each object it is passed is _identical_. This is not true in `cbind(DT, DF)` because the first method for `DT` is `cbind.data.table` but the first method for `DF` is `cbind.data.frame`. `base::cbind` then falls through to its internal `bind` code which appears to treat `DT` as a regular `list` and returns very odd looking and unusable `matrix` output. See [below](#cbinderror). We cannot just advise users not to call `cbind(DT, DF)` because packages such as `ggplot2` make such a call ([test 167.2](https://github.com/Rdatatable/data.table/blob/master/inst/tests/tests.Rraw#L444-L447)).
- 
+
  - This naturally leads to trying to mask `cbind.data.frame` instead. Since a `data.table` is a `data.frame`, `cbind` would find the same method for both `DT` and `DF`. However, this doesn't work either because `base::cbind` appears to find methods in `base` first; _i.e._, `base::cbind.data.frame` isn't maskable. This is reproducible as follows :
 
 ```{r}
@@ -494,7 +494,7 @@ If you know of a better solution that still solves all the issues above, then pl
 
 This comes up quite a lot, but it's really earth-shatteringly simple. A function such as `merge` is _generic_ if it consists of a call to `UseMethod`. When you see people talking about whether or not functions are _generic_ functions they are merely typing the function without `()` afterwards, looking at the program code inside it and if they see a call to `UseMethod` then it is _generic_.  What does `UseMethod` do? It literally slaps the function name together with the class of the first argument, separated by period (`.`) and then calls that function, passing along the same arguments. It's that simple. For example, `merge(X, Y)` contains a `UseMethod` call which means it then _dispatches_ (i.e. calls) `paste("merge", class(X), sep=".")`. Functions with dots in their name may or may not be methods. The dot is irrelevant really, other than dot being the separator that `UseMethod` uses. Knowing this background should now highlight why, for example, it is obvious to R folk that `as.data.table.data.frame`  is the `data.frame` method for the `as.data.table` generic function. Further, it may help to elucidate that, yes, you are correct, it is not obvious from its name alone that `ls.fit` is not the fit method of the `ls` generic function. You only know that by typing `ls` (not `ls()`) and observing it isn't a single call to `UseMethod`.
 
-You might now ask: where is this documented in R? Answer: it's quite clear, but, you need to first know to look in `?UseMethod` and _that_ help file contains : 
+You might now ask: where is this documented in R? Answer: it's quite clear, but, you need to first know to look in `?UseMethod` and _that_ help file contains :
 
 <div id="proposed-enhancements" class="section level4 bs-callout bs-callout-info">
 When a function calling `UseMethod('fun')` is applied to an object with class attribute `c('first', 'second')`, the system searches for a function called `fun.first` and, if it finds it, applies it to the object. If no such function is found a function called `fun.second` is tried. If no class name produces a suitable function, the function `fun.default` is used, if it exists, or an error results.
@@ -568,7 +568,7 @@ DT[ , { mySD = copy(.SD)
 
 ## "cannot change value of locked binding for `.N`"
 
-Please upgrade to v1.8.1 or later. From this version, if `.N` is returned by `j` it is renamed to `N` to avoid any abiguity in any subsequent grouping between the `.N` special variable and a column called `".N"`.
+Please upgrade to v1.8.1 or later. From this version, if `.N` is returned by `j` it is renamed to `N` to avoid any ambiguity in any subsequent grouping between the `.N` special variable and a column called `".N"`.
 
 The old behaviour can be reproduced by forcing `.N` to be called `.N`, like this :
 ```{r}
@@ -580,7 +580,7 @@ cat(try(
 , silent=TRUE))
 ```
 
-If you are already running v1.8.1 or later then the error message is now more helpful than the "cannot change value of locked binding" error, as you can see above, since this vignette was produced using v1.8.1 or later. 
+If you are already running v1.8.1 or later then the error message is now more helpful than the "cannot change value of locked binding" error, as you can see above, since this vignette was produced using v1.8.1 or later.
 
 The more natural syntax now works :
 ```{r}
@@ -595,7 +595,7 @@ if (packageVersion("data.table") >= "1.9.3") {
 # Warning messages
 ## "The following object(s) are masked from `package:base`: `cbind`, `rbind`"
 
-This warning was present in v1.6.5 and v.1.6.6 only, when loading the package. The motivation was to allow `cbind(DT, DF)` to work, but as it transpired, this broke (full) compatibility with package `IRanges`. Please upgrade to v1.6.7 or later. 
+This warning was present in v1.6.5 and v.1.6.6 only, when loading the package. The motivation was to allow `cbind(DT, DF)` to work, but as it transpired, this broke (full) compatibility with package `IRanges`. Please upgrade to v1.6.7 or later.
 
 ## "Coerced numeric RHS to integer to match the column's type"
 

--- a/vignettes/datatable-intro.Rmd
+++ b/vignettes/datatable-intro.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Introduction to data.table"
 date: "`r Sys.Date()`"
-output: 
+output:
   rmarkdown::html_document:
     theme: spacelab
     highlight: pygments
@@ -30,11 +30,11 @@ This vignette introduces the *data.table* syntax, its general form, how to *subs
 
 Data manipulation operations such as *subset*, *group*, *update*, *join* etc., are all inherently related. Keeping these *related operations together* allows for:
 
-* *concise* and *consistent* syntax irrespective of the set of operations you would like to perform to achieve your end goal. 
+* *concise* and *consistent* syntax irrespective of the set of operations you would like to perform to achieve your end goal.
 
-* performing analysis *fluidly* without the cognitive burden of having to map each operation to a particular function from a set of functions available before to perform the analysis. 
+* performing analysis *fluidly* without the cognitive burden of having to map each operation to a particular function from a set of functions available before to perform the analysis.
 
-* *automatically* optimising operations internally, and very effectively, by knowing precisely the data required for each operation and therefore very fast and memory efficient. 
+* *automatically* optimising operations internally, and very effectively, by knowing precisely the data required for each operation and therefore very fast and memory efficient.
 
 Briefly, if you are interested in reducing *programming* and *compute* time tremendously, then this package is for you. The philosophy that *data.table* adheres to makes this possible. Our goal is to illustrate it through this series of vignettes.
 
@@ -63,7 +63,7 @@ In this vignette, we will
 
 1. start with basics - what is a *data.table*, its general form, how to *subset* rows, *select and compute* on columns
 
-2. and then we will look at performing data aggregations by group, 
+2. and then we will look at performing data aggregations by group,
 
 ## 1. Basics {#basics-1}
 
@@ -86,7 +86,7 @@ You can also convert existing objects to a *data.table* using `as.data.table()`.
 * Row numbers are printed with a `:` in order to visually separate the row number from the first column.
 
 * When the number of rows to print exceeds the global option `datatable.print.nrows` (default = `r getOption("datatable.print.nrows")`), it automatically prints only the top 5 and bottom 5 rows (as can be seen in the [Data](#data) section).
-    
+
     ```{.r}
     getOption("datatable.print.nrows")
     ```
@@ -110,7 +110,7 @@ Users who have a SQL background might perhaps immediately relate to this syntax.
 
 Take `DT`, subset rows using `i`, then calculate `j`, grouped by `by`.
 
-# 
+#
 
 Let's begin by looking at `i` and `j` first - subsetting rows and operating on columns.
 
@@ -203,7 +203,7 @@ head(ans)
 
 #
 
-*data.tables* (and *data.frames*) are internally *lists*  as well, but with all its columns of equal length and with a *class* attribute. Allowing `j` to return a *list* enables converting and returning a *data.table* very efficiently. 
+*data.tables* (and *data.frames*) are internally *lists*  as well, but with all its columns of equal length and with a *class* attribute. Allowing `j` to return a *list* enables converting and returning a *data.table* very efficiently.
 
 #### Tip: {.bs-callout .bs-callout-warning #tip-1}
 
@@ -223,7 +223,7 @@ head(ans)
 
 * Wrap both columns within `.()`, or `list()`. That's it.
 
-# 
+#
 
 #### -- Select both `arr_delay` and `dep_delay` columns *and* rename them to `delay_arr` and `delay_dep`.
 
@@ -247,14 +247,14 @@ ans
 
 #### What's happening here? {.bs-callout .bs-callout-info}
 
-* *data.table*'s `j` can handle more than just *selecting columns* - it can handle *expressions*, i.e., *compute on columns*. This shouldn't be surprising, as columns can be referred to as if they are variables. Then we should be able to *compute* by calling functions on those variables. And that's what precisely happens here. 
+* *data.table*'s `j` can handle more than just *selecting columns* - it can handle *expressions*, i.e., *compute on columns*. This shouldn't be surprising, as columns can be referred to as if they are variables. Then we should be able to *compute* by calling functions on those variables. And that's what precisely happens here.
 
 ### f) Subset in `i` *and* do in `j`
 
 #### -- Calculate the average arrival and departure delay for all flights with "JFK" as the origin airport in the month of June.
 
 ```{r}
-ans <- flights[origin == "JFK" & month == 6L, 
+ans <- flights[origin == "JFK" & month == 6L,
                .(m_arr=mean(arr_delay), m_dep=mean(dep_delay))]
 ans
 ```
@@ -265,7 +265,7 @@ ans
 
 * Now, we look at `j` and find that it uses only *two columns*. And what we have to do is to compute their `mean()`. Therefore we subset just those columns corresponding to the matching rows, and compute their `mean()`.
 
-Because the three main components of the query (`i`, `j` and `by`) are *together* inside `[...]`, *data.table* can see all three and optimise the query altogether *before evaluation*, not each separately. We are able to therefore avoid the entire subset, for both speed and memory efficiency. 
+Because the three main components of the query (`i`, `j` and `by`) are *together* inside `[...]`, *data.table* can see all three and optimise the query altogether *before evaluation*, not each separately. We are able to therefore avoid the entire subset, for both speed and memory efficiency.
 
 #### -- How many trips have been made in 2014 from "JFK" airport in the month of June?
 
@@ -274,7 +274,7 @@ ans <- flights[origin == "JFK" & month == 6L, length(dest)]
 ans
 ```
 
-The function `length()` requires an input argument. We just needed to compute the number of rows in the subset. We could have used any other column as input argument to `length()` really. 
+The function `length()` requires an input argument. We just needed to compute the number of rows in the subset. We could have used any other column as input argument to `length()` really.
 
 This type of operation occurs quite frequently, especially while grouping as we will see in the next section, that *data.table* provides a *special symbol* `.N` for it.
 
@@ -294,7 +294,7 @@ ans
 
 * Once again, we subset in `i` to get the *row indices* where `origin` airport equals *"JFK"*, and `month` equals *6*.
 
-* We see that `j` uses only `.N` and no other columns. Therefore the entire subset is not materialised. We simply return the number of rows in the subset (which is just the length of row indices). 
+* We see that `j` uses only `.N` and no other columns. Therefore the entire subset is not materialised. We simply return the number of rows in the subset (which is just the length of row indices).
 
 * Note that we did not wrap `.N` with `list()` or `.()`. Therefore a vector is returned.
 
@@ -302,7 +302,7 @@ We could have accomplished the same operation by doing `nrow(flights[origin == "
 
 ### g) Great! But how can I refer to columns by names in `j` (like in a *data.frame*)?
 
-You can refer to column names the *data.frame* way using `with = FALSE`. 
+You can refer to column names the *data.frame* way using `with = FALSE`.
 
 #### -- Select both `arr_delay` and `dep_delay` columns the *data.frame* way.
 
@@ -325,7 +325,7 @@ DF[with(DF, x > 1), ]
 
 #### {.bs-callout .bs-callout-info #with_false}
 
-* Using `with()` in (2) allows using `DF`'s column `x` as if it were a variable. 
+* Using `with()` in (2) allows using `DF`'s column `x` as if it were a variable.
 
     Hence the argument name `with` in *data.table*. Setting `with=FALSE` disables the ability to refer to columns as if they are variables, thereby restoring the "*data.frame* mode".
 
@@ -356,7 +356,7 @@ DF[with(DF, x > 1), ]
 
     This is particularly handy while working interactively.
 
-# 
+#
 
 `with = TRUE` is default in *data.table* because we can do much more by allowing `j` to handle expressions - especially when combined with `by` as we'll see in a moment.
 
@@ -395,7 +395,7 @@ ans
 
     We'll use this convenient form wherever applicable hereafter.
 
-# 
+#
 
 #### -- How can we calculate the number of trips for each origin airport for carrier code *"AA"*? {#origin-.N}
 
@@ -429,8 +429,8 @@ head(ans)
 #### -- How can we get the average arrival and departure delay for each `orig,dest` pair for each month for carrier code *"AA"*? {#origin-dest-month}
 
 ```{r}
-ans <- flights[carrier == "AA", 
-        .(mean(arr_delay), mean(dep_delay)), 
+ans <- flights[carrier == "AA",
+        .(mean(arr_delay), mean(dep_delay)),
         by=.(origin, dest, month)]
 ans
 ```
@@ -447,13 +447,13 @@ Now what if we would like to order the result by those grouping columns `origin`
 
 ### b) keyby
 
-*data.table* retaining the original order of groups is intentional and by design. There are cases when preserving the original order is essential. But at times we would like to automatically sort by the variables we grouped by. 
+*data.table* retaining the original order of groups is intentional and by design. There are cases when preserving the original order is essential. But at times we would like to automatically sort by the variables we grouped by.
 
 #### -- So how can we directly order by all the grouping variables?
 
 ```{r}
-ans <- flights[carrier == "AA", 
-        .(mean(arr_delay), mean(dep_delay)), 
+ans <- flights[carrier == "AA",
+        .(mean(arr_delay), mean(dep_delay)),
         keyby=.(origin, dest, month)]
 ans
 ```
@@ -462,7 +462,7 @@ ans
 
 * All we did was to change `by` to `keyby`. This automatically orders the result by the grouping variables in increasing order. Note that `keyby()` is applied after performing the  operation, i.e., on the computed result.
 
-**Keys:** Actually `keyby` does a little more than *just ordering*. It also *sets a key* after ordering by setting an *attribute* called `sorted`. But we'll learn more about `keys` in the next vignette. 
+**Keys:** Actually `keyby` does a little more than *just ordering*. It also *sets a key* after ordering by setting an *attribute* called `sorted`. But we'll learn more about `keys` in the next vignette.
 
 For now, all you've to know is you can use `keyby` to automatically order by the columns specified in `by`.
 
@@ -476,7 +476,7 @@ ans <- flights[carrier == "AA", .N, by = .(origin, dest)]
 
 #### -- How can we order `ans` using the columns `origin` in ascending order, and `dest` in descending order?
 
-We can store the intermediate result in a variable, and then use `order(origin, -dest)` on that variable. It seems fairly straightforward. 
+We can store the intermediate result in a variable, and then use `order(origin, -dest)` on that variable. It seems fairly straightforward.
 
 ```{r}
 ans <- ans[order(origin, -dest)]
@@ -491,7 +491,7 @@ head(ans)
 
 #
 
-But this requires having to assign the intermediate result and then overwriting that result. We can do one better and avoid this intermediate assignment on to a variable altogther by `chaining` expressions.
+But this requires having to assign the intermediate result and then overwriting that result. We can do one better and avoid this intermediate assignment on to a variable altogether by `chaining` expressions.
 
 ```{r}
 ans <- flights[carrier == "AA", .N, by=.(origin, dest)][order(origin, -dest)]
@@ -505,9 +505,9 @@ head(ans, 10)
 * Or you can also chain them vertically:
 
     ```{r eval=FALSE}
-    DT[ ... 
-     ][ ... 
-     ][ ... 
+    DT[ ...
+     ][ ...
+     ][ ...
      ]
     ```
 
@@ -528,7 +528,7 @@ ans
 
 * Note that we did not provide any names to `by-expression`. And names have been automatically assigned in the result.
 
-* You can provide other columns along with expressions, for example: `DT[, .N, by=.(a, b>0)]`. 
+* You can provide other columns along with expressions, for example: `DT[, .N, by=.(a, b>0)]`.
 
 ### e) Multiple columns in `j` - `.SD`
 
@@ -536,15 +536,15 @@ ans
 
 It is of course not practical to have to type `mean(myCol)` for every column one by one. What if you had a 100 columns to compute `mean()` of?
 
-How can we do this efficiently? To get there, refresh on [this tip](#tip-1) - *"As long as j-expression returns a list, each element of the list will be converted to a column in the resulting data.table"*. Suppose we can refer to the *data subset for each group* as a variable *while grouping*, then we can loop through all the columns of that variable using the already familiar base function `lapply()`. We don't have to learn any new function. 
+How can we do this efficiently? To get there, refresh on [this tip](#tip-1) - *"As long as j-expression returns a list, each element of the list will be converted to a column in the resulting data.table"*. Suppose we can refer to the *data subset for each group* as a variable *while grouping*, then we can loop through all the columns of that variable using the already familiar base function `lapply()`. We don't have to learn any new function.
 
 #### Special symbol `.SD`: {.bs-callout .bs-callout-info #special-SD}
 
-*data.table* provides a *special* symbol, called `.SD`. It stands for **S**ubset of **D**ata. It by itself is a *data.table* that holds the data for *the current group* defined using `by`. 
+*data.table* provides a *special* symbol, called `.SD`. It stands for **S**ubset of **D**ata. It by itself is a *data.table* that holds the data for *the current group* defined using `by`.
 
 Recall that a *data.table* is internally a list as well with all its columns of equal length.
 
-# 
+#
 
 Let's use the [*data.table* `DT` from before](#what-is-datatable-1a) to get a glimpse of what `.SD` looks like.
 
@@ -556,7 +556,7 @@ DT[, print(.SD), by=ID]
 
 #### {.bs-callout .bs-callout-info}
 
-* `.SD` contains all the columns *except the grouping columns* by default. 
+* `.SD` contains all the columns *except the grouping columns* by default.
 
 * It is also generated by preserving the original order - data corresponding to `ID = "b"`, then `ID = "a"`, and then `ID = "c"`.
 
@@ -570,25 +570,25 @@ DT[, lapply(.SD, mean), by=ID]
 
 #### {.bs-callout .bs-callout-info}
 
-* `.SD` holds the rows corresponding to columns *a*, *b* and *c* for that group. We compute the `mean()` on each of these columns using the already familiar base function `lapply()`. 
+* `.SD` holds the rows corresponding to columns *a*, *b* and *c* for that group. We compute the `mean()` on each of these columns using the already familiar base function `lapply()`.
 
 * Each group returns a list of three elements containing the mean value which will become the columns of the resulting `data.table`.
 
 * Since `lapply()` returns a *list*, there is no need to wrap it with an additional `.()` (if necessary, refer to [this tip](#tip-1)).
 
-# 
+#
 
-We are almost there. There is one little thing left to address. In our `flights` *data.table*, we only wanted to calculate the `mean()` of two columns `arr_delay` and `dep_delay`. But `.SD` would contain all the columns other than the grouping variables by default. 
+We are almost there. There is one little thing left to address. In our `flights` *data.table*, we only wanted to calculate the `mean()` of two columns `arr_delay` and `dep_delay`. But `.SD` would contain all the columns other than the grouping variables by default.
 
 #### -- How can we specify just the columns we would like to compute the `mean()` on?
 
 #### .SDcols {.bs-callout .bs-callout-info}
 
-Using the argument `.SDcols`. It accepts either column names or column indices. For example, `.SDcols = c("arr_delay", "dep_delay")` ensures that `.SD` contains only these two columns for each group. 
+Using the argument `.SDcols`. It accepts either column names or column indices. For example, `.SDcols = c("arr_delay", "dep_delay")` ensures that `.SD` contains only these two columns for each group.
 
 Similar to the [with = FALSE section](#with_false), you can also provide the columns to remove instead of columns to keep using `-` or `!` sign as well as select consecutive columns as `colA:colB` and deselect consecutive columns as `!(colA:colB) or `-(colA:colB)`.
 
-# 
+#
 Now let us try to use `.SD` along with `.SDcols` to get the `mean()` of `arr_delay` and `dep_delay` columns grouped by `origin`, `dest` and `month`.
 
 ```{r}
@@ -617,7 +617,7 @@ head(ans)
 
 So that we have a consistent syntax and keep using already existing (and familiar) base functions instead of learning new functions. To illustrate, let us use the *data.table* `DT` we created at the very beginning under [What is a data.table?](#what-is-datatable-1a) section.
 
-#### -- How can we concatenate columns `a` and `b` for each group in `ID`? 
+#### -- How can we concatenate columns `a` and `b` for each group in `ID`?
 
 ```{r}
 DT[, .(val = c(a,b)), by=ID]
@@ -639,8 +639,8 @@ DT[, .(val = list(c(a,b))), by=ID]
 
 * Note those commas are for display only. A list column can contain any object in each cell, and in this example, each cell is itself a vector and some cells contain longer vectors than others.
 
-# 
-Once you start internalising usage in `j`, you will realise how powerful the syntax can be. A very useful way to understand it is by playing around, with the help of `print()`. 
+#
+Once you start internalising usage in `j`, you will realise how powerful the syntax can be. A very useful way to understand it is by playing around, with the help of `print()`.
 
 For example:
 
@@ -687,12 +687,12 @@ We can do much more in `i` by keying a *data.table*, which allows blazing fast s
 #
 
 #### Using `by`: {.bs-callout .bs-callout-info}
- 
+
 * Using `by`, we can group by columns by specifying a *list of columns* or a *character vector of column names* or even *expressions*. The flexibility of `j`, combined with `by` and `i` makes for a very powerful syntax.
 
-* `by` can handle multiple columns and also *expressions*. 
+* `by` can handle multiple columns and also *expressions*.
 
-* We can `keyby` grouping columns to automatically sort the grouped result. 
+* We can `keyby` grouping columns to automatically sort the grouped result.
 
 * We can use `.SD` and `.SDcols` in `j` to operate on multiple columns using already familiar base functions. Here are some examples:
 
@@ -708,7 +708,7 @@ We can do much more in `i` by keying a *data.table*, which allows blazing fast s
 
 As long as `j` returns a *list*, each element of the list will become a column in the resulting *data.table*.
 
-# 
+#
 
 We will see how to *add/update/delete* columns *by reference* and how to combine them with `i` and `by` in the next vignette.
 

--- a/vignettes/datatable-keys-fast-subset.Rmd
+++ b/vignettes/datatable-keys-fast-subset.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Keys and fast binary search based subset"
 date: "`r Sys.Date()`"
-output: 
+output:
   rmarkdown::html_document:
     theme: spacelab
     highlight: pygments
@@ -23,7 +23,7 @@ knitr::opts_chunk$set(
 options(datatable.auto.index=FALSE)
 ```
 
-This vignette is aimed at those who are already familiar with *data.table* syntax, its general form, how to subset rows in `i`, select and compute on columns, add/modify/delete columns *by reference* in `j` and  group by using `by`. If you're not familar with these concepts, please read the *"Introduction to data.table"* and *"data.table reference semantics"* vignettes first.
+This vignette is aimed at those who are already familiar with *data.table* syntax, its general form, how to subset rows in `i`, select and compute on columns, add/modify/delete columns *by reference* in `j` and  group by using `by`. If you're not familiar with these concepts, please read the *"Introduction to data.table"* and *"data.table reference semantics"* vignettes first.
 
 ***
 
@@ -57,15 +57,15 @@ In this vignette, we will
 
 ### a) What is a *key*?
 
-In the *"Introduction to data.table"* vignette, we saw how to subset rows in `i` using logical expressions, row numbers and using `order()`. In this section, we will look at another way of subsetting incredibly fast - using *keys*. 
+In the *"Introduction to data.table"* vignette, we saw how to subset rows in `i` using logical expressions, row numbers and using `order()`. In this section, we will look at another way of subsetting incredibly fast - using *keys*.
 
 But first, let's start by looking at *data.frames*. All *data.frames* have a row names attribute. Consider the *data.frame* `DF` below.
 
 ```{r}
 set.seed(1L)
-DF = data.frame(ID1 = sample(letters[1:2], 10, TRUE), 
+DF = data.frame(ID1 = sample(letters[1:2], 10, TRUE),
                 ID2 = sample(1:3, 10, TRUE),
-                val = sample(10), 
+                val = sample(10),
                 stringsAsFactors = FALSE,
                 row.names = sample(LETTERS[1:10]))
 DF
@@ -79,11 +79,11 @@ We can *subset* a particular row using its row name as shown below:
 DF["C", ]
 ```
 
-i.e., row names are more or less *an index* to rows of a *data.frame*. However, 
+i.e., row names are more or less *an index* to rows of a *data.frame*. However,
 
 1. Each row is limited to *exactly one* row name.
 
-    But, a person (for example) has at least two names - a *first* and a *second* name. It is useful to organise a telephone directory by *surname* then *first name*. 
+    But, a person (for example) has at least two names - a *first* and a *second* name. It is useful to organise a telephone directory by *surname* then *first name*.
 
 2. And row names should be *unique*.
 
@@ -102,11 +102,11 @@ DT
 rownames(DT)
 ```
 
-* Note that row names have been reset. 
+* Note that row names have been reset.
 
 * *data.tables* never uses row names. Since *data.tables* **inherit** from *data.frames*, it still has the row names attribute. But it never uses them. We'll see in a moment as to why.
 
-    If you would like to preserve the row names, use `keep.rownames = TRUE` in `as.data.table()` - this will create a new column called `rn` and assign row names to this column. 
+    If you would like to preserve the row names, use `keep.rownames = TRUE` in `as.data.table()` - this will create a new column called `rn` and assign row names to this column.
 
 Instead, in *data.tables* we set and use `keys`. Think of a `key` as **supercharged rownames**.
 
@@ -114,11 +114,11 @@ Instead, in *data.tables* we set and use `keys`. Think of a `key` as **superchar
 
 1. We can set keys on *multiple columns* and the column can be of *different types* -- *integer*, *numeric*, *character*, *factor*, *integer64* etc. *list* and *complex* types are not supported yet.
 
-2. Uniqueness is not enforced, i.e., duplicate key values are allowed. Since rows are sorted by key, any duplicates in the key columns will appear consecutively.  
+2. Uniqueness is not enforced, i.e., duplicate key values are allowed. Since rows are sorted by key, any duplicates in the key columns will appear consecutively.
 
-3. Setting a `key` *does two things*: 
+3. Setting a `key` *does two things*:
 
-    a. reorders the rows of the *data.table* by the column(s) provided *by reference*, always in *increasing* order. 
+    a. reorders the rows of the *data.table* by the column(s) provided *by reference*, always in *increasing* order.
 
     b. marks those columns as *key* columns by setting an attribute called `sorted` to the *data.table*.
 
@@ -158,7 +158,7 @@ In *data.table*, the `:=` operator and all the `set*` (e.g., `setkey`, `setorder
 
 #
 
-Once you *key* a *data.table* by certain columns, you can subset by querying those key columns using the `.()` notation in `i`. Recall that `.()` is an *alias to* `list()`. 
+Once you *key* a *data.table* by certain columns, you can subset by querying those key columns using the `.()` notation in `i`. Recall that `.()` is an *alias to* `list()`.
 
 #### -- Use the key column `origin` to subset all rows where the origin airport matches *"JFK"*
 
@@ -205,7 +205,7 @@ key(flights)
 
 ### c) Keys and multiple columns
 
-To refresh, *keys* are like *supercharged* rownames. We can set key on multiple columns and they can be of multiple types. 
+To refresh, *keys* are like *supercharged* row names. We can set key on multiple columns and they can be of multiple types.
 
 #### -- How can I set keys on both `origin` *and* `dest` columns?
 
@@ -231,11 +231,11 @@ flights[.("JFK", "MIA")]
 
 #### How does the subset work here? {.bs-callout .bs-callout-info #multiple-key-point}
 
-* It is important to undertand how this works internally. *"JFK"* is first matched against the first key column `origin`. And *within those matching rows*, *"MIA"* is matched against the second key column `dest` to obtain *row indices* where both `origin` and `dest` match the given values. 
+* It is important to undertand how this works internally. *"JFK"* is first matched against the first key column `origin`. And *within those matching rows*, *"MIA"* is matched against the second key column `dest` to obtain *row indices* where both `origin` and `dest` match the given values.
 
 * Since no `j` is provided, we simply return *all columns* corresponding to those row indices.
 
-# 
+#
 
 #### -- Subset all rows where just the first key column `origin` matches *"JFK"*
 
@@ -257,7 +257,7 @@ flights[.(unique(origin), "MIA")]
 
 #### What's happening here? {.bs-callout .bs-callout-info}
 
-* Read [this](#multiple-key-point) again. The value provided for the second key column *"MIA"* has to find the matching vlaues in `dest` key column *on the matching rows provided by the first key column `origin`*. We can not skip the values of key columns *before*. Therfore we provide *all* unique values from key column `origin`.
+* Read [this](#multiple-key-point) again. The value provided for the second key column *"MIA"* has to find the matching values in `dest` key column *on the matching rows provided by the first key column `origin`*. We can not skip the values of key columns *before*. Therefore we provide *all* unique values from key column `origin`.
 
 * *"MIA"* is automatically recycled to fit the length of `unique(origin)` which is *3*.
 
@@ -276,12 +276,12 @@ flights[.("LGA", "TPA"), .(arr_delay)]
 
 #### {.bs-callout .bs-callout-info}
 
-* The *row indices* corresponding to `origin == "LGA" and `dest == "TPA"` are obtained using *key based subset*.
+* The *row indices* corresponding to `origin == "LGA"` and `dest == "TPA"` are obtained using *key based subset*.
 
 * Once we have the row indices, we look at `j` which requires only the `arr_delay` column. So we simply select the column `arr_delay` for those *row indices* in the exact same way as we have seen in *Introduction to data.table* vignette.
 
 * We could have returned the result by using `with = FALSE` as well.
- 
+
     ```{r eval = FALSE}
     flights[.("LGA", "TPA"), "arr_delay", with=FALSE]
     ```
@@ -360,7 +360,7 @@ key(ans)
 
 #### {.bs-callout .bs-callout-info}
 
-* We subset on the `key` column *origin* to obtain the *row indices* corresponding to *"JFK"*. 
+* We subset on the `key` column *origin* to obtain the *row indices* corresponding to *"JFK"*.
 
 * Once we obtain the row indices, we only need two columns - `month` to group by and `dep_delay` to obtain `max()` for each group. *data.table's* query optimisation therefore subsets just those two columns corresponding to the *row indices* obtained in `i`, for speed and memory efficiency.
 
@@ -388,7 +388,7 @@ flights[.(c("LGA", "JFK", "EWR"), "XNA"), mult="last"]
 
 #### {.bs-callout .bs-callout-info}
 
-* The query *"JFK", "XNA"* doesn't match any rows in `flights` and therefore returns `NA`. 
+* The query *"JFK", "XNA"* doesn't match any rows in `flights` and therefore returns `NA`.
 
 * Once again, the query for second key column `dest`,  *"XNA"*, is recycled to fit the length of the query for first key column `origin`, which is of length 3.
 
@@ -423,17 +423,17 @@ we could have done:
 flights[origin == "JFK" & dest == "MIA"]
 ```
 
-One advantage very likely is shorter syntax. But even more than that, *binary search based subsets* are **incredibly fast**. 
+One advantage very likely is shorter syntax. But even more than that, *binary search based subsets* are **incredibly fast**.
 
 ### a) Performance of binary search approach
 
-To illustrate, let's create a sample *data.table* with 20 million rows and three columns and key it by columns `x` and `y`. 
+To illustrate, let's create a sample *data.table* with 20 million rows and three columns and key it by columns `x` and `y`.
 
 ```{r}
 set.seed(2L)
 N = 2e7L
-DT = data.table(x = sample(letters, N, TRUE), 
-                y = sample(1000L, N, TRUE), 
+DT = data.table(x = sample(letters, N, TRUE),
+                y = sample(1000L, N, TRUE),
                 val=runif(N), key = c("x", "y"))
 print(object.size(DT), units="Mb")
 
@@ -480,9 +480,9 @@ To understand that, let's first look at what *vector scan approach* (method 1) d
 
 This is what we call a *vector scan approach*. And this is quite inefficient, especially on larger tables and when one needs repeated subsetting, because it has to scan through all the rows each time.
 
-# 
+#
 
-Now let us look at binary search approach (method 2). Recall from [Properties of key](#key-properties) - *setting keys reorders the data.table by key columns*. Since the data is sorted, we don't have to *scan through the entire length of the column*! We can instead use *binary search* to search a value in `O(log n)` as opposed to `O(n)` in case of *vector scan approach*, where `n` is the number of rows in the *data.table*. 
+Now let us look at binary search approach (method 2). Recall from [Properties of key](#key-properties) - *setting keys reorders the data.table by key columns*. Since the data is sorted, we don't have to *scan through the entire length of the column*! We can instead use *binary search* to search a value in `O(log n)` as opposed to `O(n)` in case of *vector scan approach*, where `n` is the number of rows in the *data.table*.
 
 #### Binary search approach: {.bs-callout .bs-callout-info}
 
@@ -506,7 +506,7 @@ A vector scan approach on the other hand would have to scan through all the valu
 
 #
 
-It can be seen that with every search we reduce the number of searches by half. This is why *binary search* based subsets are **incredibly fast**. Since rows of each column of *data.tables* have contiguous locations in memory, the operations are performed in a very cache efficient manner (also contributes to *speed*). 
+It can be seen that with every search we reduce the number of searches by half. This is why *binary search* based subsets are **incredibly fast**. Since rows of each column of *data.tables* have contiguous locations in memory, the operations are performed in a very cache efficient manner (also contributes to *speed*).
 
 In addition, since we obtain the matching row indices directly without having to create those huge logical vectors (equal to the number of rows in a *data.table*), it is quite **memory efficient** as well.
 
@@ -516,7 +516,7 @@ In this vignette, we have learnt another method to subset rows in `i` by keying 
 
 #### {.bs-callout .bs-callout-info}
 
-* set key and subset using the key on a *data.table*. 
+* set key and subset using the key on a *data.table*.
 
 * subset using keys which fetches *row indices* in `i`, but much faster.
 
@@ -526,7 +526,7 @@ Key based subsets are **incredibly fast** and are particularly useful when the t
 
 #
 
-We don't have to set and use keys for aggregation operations in general, unless the data is extremely large and/or the task requires repeated subsetting where key based subsets will be noticeably performant. 
+We don't have to set and use keys for aggregation operations in general, unless the data is extremely large and/or the task requires repeated subsetting where key based subsets will be noticeably performant.
 
 However, keying *data.tables* are essential to *join* two *data.tables* which is the subject of discussion in the next vignette *"Joins and rolling joins"*. We will extend the concept of key based subsets to joining two *data.tables* based on `key` columns.
 

--- a/vignettes/datatable-reference-semantics.Rmd
+++ b/vignettes/datatable-reference-semantics.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Reference semantics"
 date: "`r Sys.Date()`"
-output: 
+output:
   rmarkdown::html_document:
     theme: spacelab
     highlight: pygments
@@ -22,7 +22,7 @@ knitr::opts_chunk$set(
   collapse=TRUE)
 # options(datatable.auto.index=FALSE)
 ```
-This vignette discusses *data.table*'s reference semantics which allows to *add/update/delete* columns of a *data.table by reference*, and also combine them with `i` and `by`. It is aimed at those who are already familiar with *data.table* syntax, its general form, how to subset rows in `i`, select and compute on columns, and perform aggregations by group. If you're not familar with these concepts, please read the *"Introduction to data.table"* vignette first.
+This vignette discusses *data.table*'s reference semantics which allows to *add/update/delete* columns of a *data.table by reference*, and also combine them with `i` and `by`. It is aimed at those who are already familiar with *data.table* syntax, its general form, how to subset rows in `i`, select and compute on columns, and perform aggregations by group. If you're not familiar with these concepts, please read the *"Introduction to data.table"* vignette first.
 
 ***
 
@@ -86,14 +86,14 @@ With *data.table's* `:=` operator, absolutely no copies are made in *both* (1) a
 
 ### b) The `:=` operator
 
-It can be used in `j` in two ways: 
+It can be used in `j` in two ways:
 
 (a) The `LHS := RHS` form
 
     ```{r eval=FALSE}
     DT[, c("colA", "colB", ...) := list(valA, valB, ...)]
 
-    # when you have only one column to assign to you 
+    # when you have only one column to assign to you
     # can drop the quotes and list(), for convenience
     DT[, colA := valA]
 	  ```
@@ -111,15 +111,15 @@ It can be used in `j` in two ways:
 
 Note that the code above explains how `:=` can be used. They are not working examples. We will start using them on `flights` *data.table* from the next section.
 
-# 
+#
 
 #### {.bs-callout .bs-callout-info}
 
-* In (a), `LHS` takes a character vector of column names and `RHS` a *list of values*. `RHS` just needs to be a `list`, irrespective of how its generated (e.g., using `lapply()`, `list()`, `mget()`, `mapply()` etc.). This form is usually easy to program with and is particularly useful when you don't know the columns to assign values to in advance. 
+* In (a), `LHS` takes a character vector of column names and `RHS` a *list of values*. `RHS` just needs to be a `list`, irrespective of how its generated (e.g., using `lapply()`, `list()`, `mget()`, `mapply()` etc.). This form is usually easy to program with and is particularly useful when you don't know the columns to assign values to in advance.
 
 * On the other hand, (b) is handy if you would like to jot some comments down for later.
 
-* The result is returned *invisibly*. 
+* The result is returned *invisibly*.
 
 * Since `:=` is available in `j`, we can combine it with `i` and `by` operations just like the aggregation operations we saw in the previous vignette.
 
@@ -136,7 +136,7 @@ For the rest of the vignette, we will work with `flights` *data.table*.
 #### -- How can we add columns *speed* and *total delay* of each flight to `flights` *data.table*?
 
 ```{r}
-flights[, `:=`(speed = distance / (air_time/60), # speed in km/hr
+flights[, `:=`(speed = distance / (air_time/60), # speed in km/h
                delay = arr_delay + dep_delay)]   # delay in minutes
 head(flights)
 
@@ -148,7 +148,7 @@ head(flights)
 
 * We did not have to assign the result back to `flights`.
 
-* The `flights` *data.table* now contains the two newly added columns. This is what we mean by *added by reference*. 
+* The `flights` *data.table* now contains the two newly added columns. This is what we mean by *added by reference*.
 
 * We used the functional form so that we could add comments on the side to explain what the computation does. You can also see the `LHS := RHS` form (commented).
 
@@ -192,7 +192,7 @@ flights[, sort(unique(hour))]
 
 #### Exercise: {.bs-callout .bs-callout-warning #update-by-reference-question}
 
-What is the difference between `flights[hour == 24L, hour := 0L]` and `flights[hour == 24L][, hour := 0L]`? Hint: The latter needs an assignment (`<-`) if you would want to use the result later. 
+What is the difference between `flights[hour == 24L, hour := 0L]` and `flights[hour == 24L][, hour := 0L]`? Hint: The latter needs an assignment (`<-`) if you would want to use the result later.
 
 If you can't figure it out, have a look at the `Note` section of `?":="`.
 
@@ -305,10 +305,10 @@ The `copy()` function *deep* copies the input object and therefore any subsequen
 
 There are two particular places where `copy()` function is essential:
 
-1. Contrary to the situation we have seen in the previous point, we may not want the input data.table to a function to be modified *by reference*. As an example, let's consider the task in the previous section, except we don't want to modify `flghts` by reference. 
+1. Contrary to the situation we have seen in the previous point, we may not want the input data.table to a function to be modified *by reference*. As an example, let's consider the task in the previous section, except we don't want to modify `flights` by reference.
 
     Let's first delete the `speed` column we generated in the previous section.
-    
+
     ```{r}
     flights[, speed := NULL]
     ```
@@ -366,9 +366,9 @@ However we could improve this functionality further by *shallow* copying instead
 
 * We can use `:=` for its side effect or use `copy()` to not modify the original object while updating by reference.
 
-# 
+#
 
-So far we have seen a whole lot in `j`, and how to combine it with `by` and little of `i`. Let's turn our attention back to `i` in the next vignette *"Keys and fast binary search based subset"* to peform *blazing fast subsets* by *keying data.tables*. 
+So far we have seen a whole lot in `j`, and how to combine it with `by` and little of `i`. Let's turn our attention back to `i` in the next vignette *"Keys and fast binary search based subset"* to perform *blazing fast subsets* by *keying data.tables*.
 
 ***
 

--- a/vignettes/datatable-reshape.Rmd
+++ b/vignettes/datatable-reshape.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Efficient reshaping using data.tables"
 date: "`r Sys.Date()`"
-output: 
+output:
   rmarkdown::html_document:
     theme: spacelab
     highlight: pygments
@@ -32,20 +32,20 @@ options(width=100)
 
 ## Data
 
-We will load the data sets directly within sections. 
+We will load the data sets directly within sections.
 
 ## Introduction
 
-The `melt` and `dcast` functions for *data.tables* are extensions of the corresponding functions from the [reshape2](http://cran.r-project.org/package=reshape2) package.  
+The `melt` and `dcast` functions for *data.tables* are extensions of the corresponding functions from the [reshape2](http://cran.r-project.org/package=reshape2) package.
 
 In this vignette, we will
 
 1. first briefly look at the default *melting* and *casting* of *data.tables* to convert them from *wide* to *long* format and vice versa,
 
-2. then look at scenarios where the current functionalities becomes cumbersome and inefficient, 
+2. then look at scenarios where the current functionalities becomes cumbersome and inefficient,
 
 3. and finally look at the new improvements to both `melt` and `dcast` methods for *data.tables* to handle multiple columns simultaneously.
-    
+
 The extended functionalities are in line with *data.table's* philosophy of performing operations efficiently and in a straightforward manner.
 
 #### Note: {.bs-callout .bs-callout-info}
@@ -61,7 +61,7 @@ Suppose we have a `data.table` (artificial data) as shown below:
 
 ```{r}
 DT = fread("melt_default.csv")
-DT 
+DT
 ## dob stands for date of birth.
 
 str(DT)
@@ -76,7 +76,7 @@ str(DT)
 We could accomplish this using `melt()` by specifying `id.vars` and `measure.vars` arguments as follows:
 
 ```{r}
-DT.m1 = melt(DT, id.vars = c("family_id", "age_mother"), 
+DT.m1 = melt(DT, id.vars = c("family_id", "age_mother"),
                 measure.vars = c("dob_child1", "dob_child2", "dob_child3"))
 DT.m1
 str(DT.m1)
@@ -97,17 +97,17 @@ str(DT.m1)
 #
 
 #### - Name the `variable` and `value` columns to `child` and `dob` respectively
- 
+
 
 ```{r}
-DT.m1 = melt(DT, measure.vars = c("dob_child1", "dob_child2", "dob_child3"), 
+DT.m1 = melt(DT, measure.vars = c("dob_child1", "dob_child2", "dob_child3"),
                variable.name = "child", value.name = "dob")
 DT.m1
 ```
 
 #### {.bs-callout .bs-callout-info}
 
-* By default, when one of `id.vars` or `measure.vars` is missing, the rest of the columns are *automatically assigned* to the missing argument. 
+* By default, when one of `id.vars` or `measure.vars` is missing, the rest of the columns are *automatically assigned* to the missing argument.
 
 * When neither `id.vars` nor `measure.vars` are specified, as mentioned under `?melt`, all *non*-`numeric`, `integer`, `logical` columns will be assigned to `id.vars`.
 
@@ -117,7 +117,7 @@ DT.m1
 
 In the previous section, we saw how to get from wide form to long form. Let's see the reverse operation in this section.
 
-#### - How can we get back to the original data table `DT` from `DT.m`? 
+#### - How can we get back to the original data table `DT` from `DT.m`?
 
 That is, we'd like to collect all *child* observations corresponding to each `family_id, age_mother` together under the same row. We can accomplish it using `dcast` as follows:
 
@@ -127,16 +127,16 @@ dcast(DT.m1, family_id + age_mother ~ child, value.var = "dob")
 
 #### {.bs-callout .bs-callout-info}
 
-* `dcast` uses *formula* interface. The variables on the *LHS* of formula represents the *id* vars and *RHS* the *measure*  vars. 
+* `dcast` uses *formula* interface. The variables on the *LHS* of formula represents the *id* vars and *RHS* the *measure*  vars.
 
 * `value.var` denotes the column to be filled in with while casting to wide format.
 
 * `dcast` also tries to preserve attributes in result wherever possible.
- 
-# 
+
+#
 
 #### - Starting from `DT.m`, how can we get the number of children in each family?
- 
+
 You can also pass a function to aggregate by in `dcast` with the argument `fun.aggregate`. This is particularly essential when the formula provided does not identify single observation for each cell.
 
 ```{r}
@@ -154,10 +154,10 @@ However, there are situations we might run into where the desired operation is n
 ```{r}
 DT = fread("melt_enhanced.csv")
 DT
-## 1 = female, 2 = male 
-``` 
+## 1 = female, 2 = male
+```
 
-And you'd like to combine (melt) all the `dob` columns together, and `gender` columns together. Using the current functionalty, we can do something like this:
+And you'd like to combine (melt) all the `dob` columns together, and `gender` columns together. Using the current functionality, we can do something like this:
 
 ```{r}
 DT.m1 = melt(DT, id = c("family_id", "age_mother"))
@@ -185,7 +185,7 @@ str(DT.c1) ## gender column is character type now!
 In fact, `base::reshape` is capable of performing this operation in a very straightforward manner. It is an extremely useful and often underrated function. You should definitely give it a try!
 
 ## 3. Enhanced (new) functionality
-		
+
 ### a) Enhanced `melt`
 
 Since we'd like for *data.tables* to perform this operation straightforward and efficient using the same interface, we went ahead and implemented an *additional functionality*, where we can `melt` to multiple columns *simultaneously*.
@@ -201,7 +201,7 @@ DT.m2 = melt(DT, measure = list(colA, colB), value.name = c("dob", "gender"))
 DT.m2
 
 str(DT.m2) ## col type is preserved
-``` 
+```
 
 #### - Using `patterns()`
 
@@ -223,8 +223,8 @@ That's it!
 ### b) Enhanced `dcast`
 
 Okay great! We can now melt into multiple columns simultaneously. Now given the data set `DT.m2` as shown above, how can we get back to the same format as the original data we started with?
- 
-If we use the current functionality of `dcast`, then we'd have to cast twice and bind the results together. But that's once again verbose, not straightforward and is also inefficient. 
+
+If we use the current functionality of `dcast`, then we'd have to cast twice and bind the results together. But that's once again verbose, not straightforward and is also inefficient.
 
 #### - Casting multiple `value.var`s simultaneously
 
@@ -242,13 +242,13 @@ DT.c2
 
 * Everything is taken care of internally, and efficiently. In addition to being fast, it is also very memory efficient.
 
-# 
+#
 
 #### Multiple functions to `fun.aggregate`: {.bs-callout .bs-callout-info}
 
 You can also provide *multiple functions* to `fun.aggregate` to `dcast` for *data.tables*. Check the examples in `?dcast` which illustrates this functionality.
 
-# 
+#
 
 ***
 


### PR DESCRIPTION
- (Very) few transposition errors in the vignettes.
- Trailing whitespace was removed.

The vignettes were a tremendous help. Thank you very much for the great work.