### PR TITLE
Add trailing `[]` to each merge() call in examples

### DIFF
--- a/man/merge.Rd
+++ b/man/merge.Rd
@@ -99,17 +99,17 @@ allow.cartesian=getOption("datatable.allow.cartesian"),  # default FALSE
 \examples{
 (dt1 <- data.table(A = letters[1:10], X = 1:10, key = "A"))
 (dt2 <- data.table(A = letters[5:14], Y = 1:10, key = "A"))
-merge(dt1, dt2)
-merge(dt1, dt2, all = TRUE)
+merge(dt1, dt2)[]
+merge(dt1, dt2, all = TRUE)[]
 
 (dt1 <- data.table(A = letters[rep(1:3, 2)], X = 1:6, key = "A"))
 (dt2 <- data.table(A = letters[rep(2:4, 2)], Y = 6:1, key = "A"))
-merge(dt1, dt2, allow.cartesian=TRUE)
+merge(dt1, dt2, allow.cartesian=TRUE)[]
 
 (dt1 <- data.table(A = c(rep(1L, 5), 2L), B = letters[rep(1:3, 2)], X = 1:6, key = "A,B"))
 (dt2 <- data.table(A = c(rep(1L, 5), 2L), B = letters[rep(2:4, 2)], Y = 6:1, key = "A,B"))
-merge(dt1, dt2)
-merge(dt1, dt2, by="B", allow.cartesian=TRUE)
+merge(dt1, dt2)[]
+merge(dt1, dt2, by="B", allow.cartesian=TRUE)[]
 
 # test it more:
 d1 <- data.table(a=rep(1:2,each=3), b=1:6, key="a,b")
@@ -117,34 +117,34 @@ d2 <- data.table(a=0:1, bb=10:11, key="a")
 d3 <- data.table(a=0:1, key="a")
 d4 <- data.table(a=0:1, b=0:1, key="a,b")
 
-merge(d1, d2)
-merge(d2, d1)
-merge(d1, d2, all=TRUE)
-merge(d2, d1, all=TRUE)
+merge(d1, d2)[]
+merge(d2, d1)[]
+merge(d1, d2, all=TRUE)[]
+merge(d2, d1, all=TRUE)[]
 
-merge(d3, d1)
-merge(d1, d3)
-merge(d1, d3, all=TRUE)
-merge(d3, d1, all=TRUE)
+merge(d3, d1)[]
+merge(d1, d3)[]
+merge(d1, d3, all=TRUE)[]
+merge(d3, d1, all=TRUE)[]
 
-merge(d1, d4)
-merge(d1, d4, by="a", suffixes=c(".d1", ".d4"))
-merge(d4, d1)
-merge(d1, d4, all=TRUE)
-merge(d4, d1, all=TRUE)
+merge(d1, d4)[]
+merge(d1, d4, by="a", suffixes=c(".d1", ".d4"))[]
+merge(d4, d1)[]
+merge(d1, d4, all=TRUE)[]
+merge(d4, d1, all=TRUE)[]
 
 # new feature, no need to set keys anymore
 set.seed(1L)
 d1 <- data.table(a=sample(rep(1:3,each=2)), z=1:6)
 d2 <- data.table(a=2:0, z=10:12)
-merge(d1, d2, by="a")
-merge(d1, d2, by="a", all=TRUE)
+merge(d1, d2, by="a")[]
+merge(d1, d2, by="a", all=TRUE)[]
 
 # new feature, using by.x and by.y arguments
 setnames(d2, "a", "b")
-merge(d1, d2, by.x="a", by.y="b")
-merge(d1, d2, by.x="a", by.y="b", all=TRUE)
-merge(d2, d1, by.x="b", by.y="a")
+merge(d1, d2, by.x="a", by.y="b")[]
+merge(d1, d2, by.x="a", by.y="b", all=TRUE)[]
+merge(d2, d1, by.x="b", by.y="a")[]
 }
 
 \keyword{ data }


### PR DESCRIPTION
That way the output will be printed (rather than silently returned, which might confuse some users).