### PR TITLE
Correct speed units

### DIFF
--- a/vignettes/datatable-reference-semantics.Rmd
+++ b/vignettes/datatable-reference-semantics.Rmd
@@ -135,7 +135,7 @@ For the rest of the vignette, we will work with `flights` *data.table*.
 #### -- How can we add columns *speed* and *total delay* of each flight to `flights` *data.table*?
 
 ```{r}
-flights[, `:=`(speed = distance / (air_time/60), # speed in km/h
+flights[, `:=`(speed = distance / (air_time/60), # speed in mph (mi/h)
                delay = arr_delay + dep_delay)]   # delay in minutes
 head(flights)
 


### PR DESCRIPTION
Distances between airports are given in statute miles in the data according to description by   [Bureau of Transporation Statistics](http://www.transtats.bts.gov/DL_SelectFields.asp?Table_ID=236) and verified with [Great Circle Mapper](http://www.gcmap.com/dist?P=JFK-LAX).