### PR TITLE
Closes #1658, adds detail to ?IDateTime inre: wday, etc.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -238,6 +238,8 @@
   25. `data.table`'s dependency has been moved forward from R 2.14.1 to R 2.15.0 (Mar 2012; i.e. 4 years old). We keep this dependency as old as possible for as long as possible as requested by users in managed environments. This bump allows `data.table` to use `paste0()` internally and in tests for the first time. Before release to CRAN [our procedures](https://github.com/Rdatatable/data.table/blob/master/CRAN_Release.cmd) include running the test suite using this stated dependency.
 
   26. New option `options(datatable.use.index = TRUE)` (default) gives better control over usage of indices, when combined with `options(datatable.auto.index = FALSE)` it allows to use only indices created manually with `setindex` or `setindexv`. Closes [#1422](https://github.com/Rdatatable/data.table/issues/1422).  
+  
+  27. `?IDateTime` now makes clear that `wday`, `yday` and `month` are all 1- (not 0- as in `POSIXlt`) based, [#1658](https://github.com/Rdatatable/data.table/issues/1658); thanks @MichaelChirico.
 
 ### Changes in v1.9.6  (on CRAN 19 Sep 2015)
 

--- a/man/IDateTime.Rd
+++ b/man/IDateTime.Rd
@@ -153,6 +153,8 @@ round to weeks, months, quarters, and years.
    for hour, day of year, day of week, day of month, week, month,
    quarter, and year.
    
+   These values are all taken directly from the \code{POSIXlt} representation of \code{x}, with the notable difference that while \code{yday}, \code{wday}, and \code{mon} are all 0-based, here they are 1-based.
+   
 }
 \references{
 


### PR DESCRIPTION
I didn't want to say Sunday = 1 because I'm not sure that this is true across all locales. I know in Japan/China they generally consider the week to start from Monday. Despite this, Sunday = 1 appears to be true in `locale = "ja_JP-UTF-8"` as well, but I'm not enough of an expert here to generalize.