### PR TITLE
Closes #1654; dcast is more selective on erroring for duplicated columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -180,6 +180,8 @@
   50. Joins using `on=` retains (and discards) keys properly, [#1268](https://github.com/Rdatatable/data.table/issues/1268). Thanks @DouglasClark for [this SO post](http://stackoverflow.com/q/29918595/559784) that helped discover the issue.
 
   51. Secondary keys are properly removed when those columns get updated, [#1479](https://github.com/Rdatatable/data.table/issues/1479). Thanks @fabiangehring for the report, and also @ChristK for the MRE.
+  
+  52. `dcast` no longer errors on tables with duplicate columns that are unused in the call, [#1654](https://github.com/Rdatatable/data.table/issues/1654). Thanks @MichaelChirico for FR&PR.
 
 #### NOTES
 

--- a/R/fcast.R
+++ b/R/fcast.R
@@ -24,6 +24,8 @@ check_formula <- function(formula, varnames, valnames) {
     vars = all.vars(formula)
     vars = vars[!vars %chin% c(".", "...")]
     allvars = c(vars, valnames)
+    if (any(allvars %in% varnames[duplicated(varnames)])) 
+      stop('data.table to cast must have unique column names')
     ans = deparse_formula(as.list(formula)[-1L], varnames, allvars)
 }
 
@@ -92,7 +94,6 @@ aggregate_funs <- function(funs, vals, sep="_", ...) {
 
 dcast.data.table <- function(data, formula, fun.aggregate = NULL, sep = "_", ..., margins = NULL, subset = NULL, fill = NULL, drop = TRUE, value.var = guess(data), verbose = getOption("datatable.verbose")) {
     if (!is.data.table(data)) stop("'data' must be a data.table.")
-    if (anyDuplicated(names(data))) stop('data.table to cast must have unique column names')
     drop = as.logical(rep(drop, length.out=2L))
     if (any(is.na(drop))) stop("'drop' must be logical TRUE/FALSE")
     lvals = value_vars(value.var, names(data))

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -8797,6 +8797,15 @@ test(1666.16, grep("Looking for existing (secondary) index", capture.output(d1[d
 # reset defaults
 options("datatable.use.index"=TRUE, "datatable.auto.index"=TRUE)
 
+
+#testing fix to #1654 (dcast should only error when _using_ duplicated names)
+DT <- data.table(a = 1:4, a = 1:4, id = rep(1:4, 2), V1 = 8:1)
+test(1667.1, capture.output(dcast(DT, id ~ rowid(id), value.var = "V1")), 
+     c("   id 1 2", "1:  1 8 4", "2:  2 7 3",
+       "3:  3 6 2", "4:  4 5 1"))
+DT <- data.table(a = 1:4, id = 1:4, id = rep(1:4, 2), V1 = 8:1)
+test(1667.2, dcast(DT, id ~ rowid(id), value.var = "V1"), error = "data.table to cast")
+
 ##########################
 
 # TODO: Tests involving GForce functions needs to be run with optimisation level 1 and 2, so that both functions are tested all the time.


### PR DESCRIPTION
This was the most straightforward way I could find for this. I guess it could use `%chin%` but that's pretty minor