### PR TITLE
Closes #1653; fixes 0-rounding issue in vignette

### DIFF
--- a/vignettes/datatable-keys-fast-subset.Rmd
+++ b/vignettes/datatable-keys-fast-subset.Rmd
@@ -464,7 +464,7 @@ dim(ans2)
 identical(ans1$val, ans2$val)
 ```
 
-* The speedup is **~`r round(t1[3]/t2[3])`x**!
+* The speedup is **~`r round(t1[3]/max(t2[3], .001))`x**!
 
 ### b) Why does keying a *data.table* result in blazing fast susbets?
 


### PR DESCRIPTION
Leaving it as `max(0, .001)` because it would be cheating to do otherwise without `microbenchmark`; from `proc.time`:

> The resolution of the times will be system-specific and on Unix-alikes **times are rounded down to milliseconds**. On modern systems they will be that accurate, but on older systems they might be accurate to 1/100 or 1/60 sec. They are typically available to 10ms on Windows.

(and even here we're _technically_ cheating on Windows systems, albeit probably only on very slow ones)