### PR TITLE
Closes #1528, adds S3 method for `+.IDate`

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -103,6 +103,7 @@ export(as.chron.IDate, as.chron.ITime)
 export(as.Date.IDate) # workaround for zoo bug, see #1500
 
 S3method("[", ITime)
+S3method("+", IDate)
 S3method(as.character, ITime)
 S3method(as.data.frame, ITime)
 S3method(as.Date, IDate)

--- a/NEWS.md
+++ b/NEWS.md
@@ -200,6 +200,8 @@
   57. Grouped update operations, e.g., `DT[, y := val, by=x]` where `val` is an unsupported type errors *without adding an unnamed column*, [#1676](https://github.com/Rdatatable/data.table/issues/1676). Thanks @wligtenberg.
   
   58. Handled use of `.I` in some `GForce` operations, [#1683](https://github.com/Rdatatable/data.table/issues/1683). Thanks gibbz00 from SO and @franknarf1 for reporting and @MichaelChirico for the PR.
+  
+  59. 55. Added `+.IDate` method so that IDate + integer doesn't revert to `Date`, [#1528](https://github.com/Rdatatable/data.table/issues/1528); thanks @MichaelChirico for FR&PR.
 
 #### NOTES
 

--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -45,6 +45,23 @@ round.IDate <- function (x, digits=c("weeks", "months", "quarters", "years"), ..
                     years = ISOdate(year(x), 1, 1)))
 }
 
+#Adapted from `+.Date`
+`+.IDate` <- function (e1, e2) {
+    coerceTimeUnit <- function(x) as.vector(round(switch(attr(x, 
+        "units"), secs = x/86400, mins = x/1440, hours = x/24, 
+        days = x, weeks = 7 * x)))
+    if (nargs() == 1L) 
+        return(e1)
+    if (inherits(e1, "Date") && inherits(e2, "Date")) 
+        stop("binary + is not defined for \"IDate\" objects")
+    if (inherits(e1, "difftime")) 
+        e1 <- coerceTimeUnit(e1)
+    if (inherits(e2, "difftime")) 
+        e2 <- coerceTimeUnit(e2)
+    structure(as.integer(unclass(e1) + unclass(e2)), 
+              class = c("IDate", "Date"))
+}
+
 ###################################################################
 # ITime -- Integer time-of-day class
 #          Stored as seconds in the day

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -8859,6 +8859,9 @@ test(1672.5, capture.output(DT[order(V1), .I[1L], by = V1]),
 test(1672.6, capture.output(DT[1:5, .(.I[1L], V2[1L]), by = V1]),
      c("   V1 V1 V2", "1:  1  1  1", "2:  2  2  2"))
      
+#tests for #1528
+TT <- as.IDate("2016-04-25")
+test(1673, class(TT + 4L), c("IDate", "Date"))
 
 ##########################
 


### PR DESCRIPTION
I guess we should cover everything in `methods(class = "Date")` while we're at it?

```
methods(class = "Date")
#  [1] as.character  as.data.frame as.list       as.POSIXct    as.POSIXlt    Axis          c             coerce       
#  [9] cut           -             [<-           [             [[            +             diff          format       
# [17] hist          initialize    is.numeric    julian        Math          mean          months        Ops          
# [25] pretty        print         quarters      rep           round         seq           show          slotsFromS3  
# [33] split         str           summary       Summary       trunc         weekdays      weighted.mean xtfrm
```

`-.Date` brings up perhaps the need for `Idifftime` class as well, with associated methods:

```
methods(class = "difftime")
#  [1] as.data.frame as.double     /             [             *             format        is.numeric    Math         
#  [9] mean          Ops           print         Summary       units<-       units         weighted.mean xtfrm 
```