### PR TITLE
attempt at fixing #1683

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -198,6 +198,8 @@
   56. as.data.table's `data.table` method returns a copy as it should, [#1681](https://github.com/Rdatatable/data.table/issues/1681).
 
   57. Grouped update operations, e.g., `DT[, y := val, by=x]` where `val` is an unsupported type errors *without adding an unnamed column*, [#1676](https://github.com/Rdatatable/data.table/issues/1676). Thanks @wligtenberg.
+  
+  58. Handled use of `.I` in some `GForce` operations, [#1683](https://github.com/Rdatatable/data.table/issues/1683). Thanks gibbz00 from SO and @franknarf1 for reporting and @MichaelChirico for the PR.
 
 #### NOTES
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -8839,6 +8839,27 @@ test(1670.2, class(as.data.table(x)), class(x)[2:3])
 dt = data.table(x=1, y=2)
 test(1671, dt[, z := sd, by=x], error="invalid type/length (closure/1)")
 
+# 1683
+DT <- data.table(V1 = rep(1:2, 3), V2 = 1:6)
+test(1672.1, capture.output(DT[ , .(.I[1L], V2[1L]), by = V1]),
+     c("   V1 V1 V2", "1:  1  1  1", "2:  2  2  2"))
+#make sure GForce operating
+test(1672.2, DT[ , .(.I[1L], V2[1L]), by = V1, verbose = TRUE],
+     output = "GForce optimized j")
+#make sure works on .I by itself
+test(1672.3, capture.output(DT[ , .I[1L], by = V1]),
+     c("   V1 V1", "1:  1  1", "2:  2  2"))
+#make sure GForce here as well
+test(1672.4, DT[ , .I[1L], by = V1, verbose = TRUE],
+     output = "GForce optimized j")
+#make sure works with order
+test(1672.5, capture.output(DT[order(V1), .I[1L], by = V1]),
+     c("   V1 V1", "1:  1  1", "2:  2  2"))
+# should also work with subsetting
+test(1672.6, capture.output(DT[1:5, .(.I[1L], V2[1L]), by = V1]),
+     c("   V1 V1 V2", "1:  1  1  1", "2:  2  2  2"))
+     
+
 ##########################
 
 # TODO: Tests involving GForce functions needs to be run with optimisation level 1 and 2, so that both functions are tested all the time.


### PR DESCRIPTION
Probably not exactly the way we want to do this, but it gets the job done.

The core of the issue is that `DT[ , .(.I[1L], V2[1L]), by = V1]` currently gets `GForce = TRUE` because the `.ok` helper function doesn't check that the subsetted variable (i.e., `.I`) is actually part of `ansvars`. But then when passing to`` `g[` ``only the things in `ansvars` are passed to the evaluating environment. `.I` is not part of `ansvars`, so we get this error.

Is there a particular reason `.I` is excluded from `ansvars`?

Should `GForce` be activated on `DT[ , .I[1L], by = V1]` as well?