### PR TITLE
Closes #1706, library(data.table) fails if "Packaged" field is not pr…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -203,6 +203,8 @@
   
   59. 55. Added `+.IDate` method so that IDate + integer doesn't revert to `Date`, [#1528](https://github.com/Rdatatable/data.table/issues/1528); thanks @MichaelChirico for FR&PR.
 
+  60. Fixed test in `onAttach()` for when `Packaged` field is missing from `DESCRIPTION`, [#1706](https://github.com/Rdatatable/data.table/issues/1706); thanks @restonslacker for BR&PR.
+
 #### NOTES
 
   1. Updated error message on invalid joins to reflect the new `on=` syntax, [#1368](https://github.com/Rdatatable/data.table/issues/1368). Thanks @MichaelChirico.

--- a/R/onAttach.R
+++ b/R/onAttach.R
@@ -2,13 +2,17 @@
   # Runs when attached to search() path such as by library() or require()
   if (interactive()) {
     v = packageVersion("data.table")
-    d = try(read.dcf(system.file("DESCRIPTION", package="data.table"))[,"Packaged"])
-    if(inherits(d, "try-error")){
-      d = try(strsplit(read.dcf(system.file("DESCRIPTION", package="data.table"))[,"Built"], split="; ")$Built[3])
-      if(inherits(d, "try-error")){
-        return()
+    d = read.dcf(system.file("DESCRIPTION", package="data.table"), fields = c("Packaged", "Built"))
+    if(is.na(d[1])){
+      if(is.na(d[2])){
+        return() #neither field exists
+      } else{
+        d = unlist(strsplit(d[2], split="; "))[3]
       }
+    } else {
+      d = d[1]
     }
+      
     dev = as.integer(v[1,3])%%2 == 1  # version number odd
     packageStartupMessage("data.table ", v, if(dev) paste0(" IN DEVELOPMENT built ", d))
     if (dev && (Sys.Date() - as.Date(d))>28) packageStartupMessage("**********\nThis development version of data.table was built more than 4 weeks ago. Please update.\n**********")

--- a/R/onAttach.R
+++ b/R/onAttach.R
@@ -1,13 +1,18 @@
 .onAttach <- function(libname, pkgname) {
-    # Runs when attached to search() path such as by library() or require()
-    if (interactive()) {
-        v = packageVersion("data.table")
-        d = read.dcf(system.file("DESCRIPTION", package="data.table"))[,"Packaged"]
-        dev = as.integer(v[1,3])%%2 == 1  # version number odd
-        packageStartupMessage("data.table ", v, if(dev) paste0(" IN DEVELOPMENT built ", d))
-        if (dev && (Sys.Date() - as.Date(d))>28) packageStartupMessage("**********\nThis development version of data.table was built more than 4 weeks ago. Please update.\n**********")
-        packageStartupMessage('For help type ?data.table or https://github.com/Rdatatable/data.table/wiki')
-        packageStartupMessage('The fastest way to learn (by data.table authors): https://www.datacamp.com/courses/data-analysis-the-data-table-way')
+  # Runs when attached to search() path such as by library() or require()
+  if (interactive()) {
+    v = packageVersion("data.table")
+    d = try(read.dcf(system.file("DESCRIPTION", package="data.table"))[,"Packaged"])
+    if(inherits(d, "try-error")){
+      d = try(strsplit(read.dcf(system.file("DESCRIPTION", package="data.table"))[,"Built"], split="; ")$Built[3])
+      if(inherits(d, "try-error")){
+        return()
+      }
     }
+    dev = as.integer(v[1,3])%%2 == 1  # version number odd
+    packageStartupMessage("data.table ", v, if(dev) paste0(" IN DEVELOPMENT built ", d))
+    if (dev && (Sys.Date() - as.Date(d))>28) packageStartupMessage("**********\nThis development version of data.table was built more than 4 weeks ago. Please update.\n**********")
+    packageStartupMessage('For help type ?data.table or https://github.com/Rdatatable/data.table/wiki')
+    packageStartupMessage('The fastest way to learn (by data.table authors): https://www.datacamp.com/courses/data-analysis-the-data-table-way')
+  }
 }
-


### PR DESCRIPTION
…esent in DESCRIPTION


Recently, R seems to no longer add the "Packaged" field to DESCRIPTION when building from source. This prevents an end-user from loading the dev version because of the "staleness" check in `onAttach()`. However, "Built" is in there.  This PR attempts to capture that and use it as a substitute.  If that fails, it skips the rest of the check.
