### PR TITLE
closes #1498; as.IDate doesn't lose timezone data given POSIXct input

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -233,6 +233,8 @@
   67. `get()` / `mget()` play nicely with `.SD` / `.SDcols`, [#1744](https://github.com/Rdatatable/data.table/issues/1753). Thanks @franknarf1.
 
   68. Joins on integer64 columns assigns `NA` correctly for no matching rows, [#1385](https://github.com/Rdatatable/data.table/issues/1385) and partly [#1459](https://github.com/Rdatatable/data.table/issues/1459). Thanks @dlithio and @abielr.
+  
+  69. Added `as.IDate.POSIXct` to prevent loss of timezone information, [#1498](https://github.com/Rdatatable/data.table/issues/1498). Thanks @dougedmunds for reporting and @MichaelChirico for the investigating & fixing.
 
 #### NOTES
 

--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -12,6 +12,10 @@ as.IDate.Date <- function(x, ...) {
     structure(as.integer(x), class=c("IDate","Date"))
 }    
 
+as.IDate.POSIXct <- function(x, ...) {
+  as.IDate(as.Date(x, tz = attr(x, "tzone"), ...))
+}
+
 as.IDate.IDate <- function(x, ...) x
 
 as.Date.IDate <- function(x, ...) { 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -9070,6 +9070,9 @@ if ("package:bit64" %in% search()) {
     test(1688.2, merge(x1, x2, all=TRUE, by="x")$y, as.integer64(c(0, NA)))
 }
 
+test(1689, capture.output(IDateTime(as.POSIXct("2016/01/13 17:00", tz = "America/Los_Angeles"))),
+     c("        idate    itime", "1: 2016-01-13 17:00:00"))
+
 ##########################
 
 # TODO: Tests involving GForce functions needs to be run with optimisation level 1 and 2, so that both functions are tested all the time.


### PR DESCRIPTION
Problem was basically the input was being sent to `as.Date` without respecting the presence of a `tz` attribute.

Not sure if maybe this fix is too narrow, but it covers the problem at hand and we haven't had anybody else file any similar issues. So I figure this very focused solution should suffice.