### PR TITLE
closes #874; adds second() and minute() time extraction functions

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -100,7 +100,7 @@ S3method(na.omit, data.table)
 
 # IDateTime support:
 export(as.IDate,as.ITime,IDateTime)
-export(hour,yday,wday,mday,week,month,quarter,year)
+export(second,minute,hour,yday,wday,mday,week,month,quarter,year)
 
 export(as.chron.IDate, as.chron.ITime)
 export(as.Date.IDate) # workaround for zoo bug, see #1500

--- a/NEWS.md
+++ b/NEWS.md
@@ -91,6 +91,8 @@
   42. `melt.data.table` finds variables provided to `patterns()` when called from within user defined functions, [#1749](https://github.com/Rdatatable/data.table/issues/1749). Thanks to @kendonB for the report.
 
   43. `first()` is now exported to return the first element of vectors, data.frames and data.tables.
+  
+  44. Added `second` and `minute` extraction functions which, like extant `hour`/`yday`/`week`/etc, always return an integer, [#874](https://github.com/Rdatatable/data.table/issues/874). Thanks to @bthieurmel for the FR and @MichaelChirico for the PR.
 
 #### BUG FIXES
 

--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -221,6 +221,8 @@ as.ITime.times <- function(x, ...) {
 #   lubridate routines do not return integer values.
 ###################################################################
 
+second  <- function(x) as.integer(as.POSIXlt(x)$sec)
+minute  <- function(x) as.POSIXlt(x)$min
 hour    <- function(x) as.POSIXlt(x)$hour
 yday    <- function(x) as.POSIXlt(x)$yday + 1L
 wday    <- function(x) as.POSIXlt(x)$wday + 1L

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -9103,6 +9103,18 @@ test(1691, rbind(dt, dt), rbind(dt, as.matrix(dt)))
 test(1692, capture.output(as.data.table(structure(57600L, class = "ITime"))),
      c("         V1", "1: 16:00:00"))
 
+# testing all time part extraction routines (subsumes #874)
+t <- "2016-08-03 01:02:03.45"
+test(1693.1, second(t), 3L)
+test(1693.2, minute(t), 2L)
+test(1693.3, hour(t), 1L)
+test(1693.4, yday(t), 216L)
+test(1693.5, wday(t), 4L)
+test(1693.6, week(t), 31L)
+test(1693.7, month(t), 8L)
+test(1693.8, quarter(t), 3L)
+test(1693.9, year(t), 2016L)
+
 ##########################
 
 # TODO: Tests involving GForce functions needs to be run with optimisation level 1 and 2, so that both functions are tested all the time.

--- a/man/IDateTime.Rd
+++ b/man/IDateTime.Rd
@@ -29,6 +29,8 @@
 \alias{round.IDate}
 \alias{seq.IDate}
 \alias{split.IDate}
+\alias{second}
+\alias{minute}
 \alias{hour}   
 \alias{yday}   
 \alias{wday}   
@@ -64,6 +66,8 @@ as.ITime(x, ...)
 IDateTime(x, ...)
 \method{IDateTime}{default}(x, ...)
 
+second(x)
+minute(x)
 hour(x)   
 yday(x)   
 wday(x)   
@@ -148,10 +152,11 @@ round to weeks, months, quarters, and years.
    For \code{IDateTime}, a data table with columns \code{idate} and
    \code{itime} in \code{IDate} and \code{ITime} format.
 
-   \code{hour}, code{yday}, \code{wday}, \code{mday}, \code{week},
-   \code{month}, \code{quarter}, and \code{year} return integer values
-   for hour, day of year, day of week, day of month, week, month,
-   quarter, and year.
+   \code{second}, \code{minute}, \code{hour}, code{yday}, \code{wday}, 
+   \code{mday}, \code{week}, \code{month}, \code{quarter}, 
+   and \code{year} return integer values
+   for second, minute, hour, day of year, day of week, 
+   day of month, week, month, quarter, and year, respectively.
    
    These values are all taken directly from the \code{POSIXlt} representation of \code{x}, with the notable difference that while \code{yday}, \code{wday}, and \code{mon} are all 0-based, here they are 1-based.
    


### PR DESCRIPTION
issue of using `as.POSIXlt` swept under the rug again, for now...