### PR TITLE
Interim reset of default for quote on fwrite

### DIFF
--- a/R/fwrite.R
+++ b/R/fwrite.R
@@ -1,4 +1,4 @@
-fwrite <- function(x, file.path, append=FALSE, quote="auto",
+fwrite <- function(x, file.path, append=FALSE, quote=TRUE,
                    sep=",", eol=if (.Platform$OS.type=="windows") "\r\n" else "\n",
                    na="", col.names=TRUE, qmethod="double", verbose=FALSE, turbo=TRUE) {
 

--- a/man/fwrite.Rd
+++ b/man/fwrite.Rd
@@ -5,7 +5,7 @@
 As \code{write.csv} and but \emph{much} faster (e.g. 1 minute versus 2 seconds) and just as flexible. Machines with 16GB of RAM or more always have more than one core so \code{fwrite} uses them; on all operating systems including Linux, Mac and Windows.
 }
 \usage{
-fwrite(x, file.path, append = FALSE, quote = "auto", sep = ",",
+fwrite(x, file.path, append = FALSE, quote = TRUE, sep = ",",
        eol = if (.Platform$OS.type=="windows") "\r\n" else "\n",
        na = "", col.names = TRUE, qmethod = "double",
        verbose=FALSE, turbo=TRUE)


### PR DESCRIPTION
See discussion on #1664 and [here on SO](http://stackoverflow.com/questions/39282655/r-fwrite-separates-a-dataframe-entry-that-has-commas).

Agree that mid- to long-term solution is to make `fwrite` smarter and optimize the `quote = "auto"` setup, but in the meantime, having `quote = "auto"` is only hurting, it seems.
