### PR TITLE
Closes #1836; adds - method for IDate, with substantial speed-up

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -107,6 +107,7 @@ export(as.Date.IDate) # workaround for zoo bug, see #1500
 
 S3method("[", ITime)
 S3method("+", IDate)
+S3method("-", IDate)
 S3method(as.character, ITime)
 S3method(as.data.frame, ITime)
 S3method(as.Date, IDate)

--- a/NEWS.md
+++ b/NEWS.md
@@ -218,7 +218,7 @@
   
   58. Handled use of `.I` in some `GForce` operations, [#1683](https://github.com/Rdatatable/data.table/issues/1683). Thanks gibbz00 from SO and @franknarf1 for reporting and @MichaelChirico for the PR.
   
-  59. Added `+.IDate` method so that IDate + integer doesn't revert to `Date`, [#1528](https://github.com/Rdatatable/data.table/issues/1528); thanks @MichaelChirico for FR&PR.
+  59. Added `+.IDate` method so that IDate + integer doesn't revert to `Date`, [#1528](https://github.com/Rdatatable/data.table/issues/1528); also add `-.IDate`. Thanks @franknarf1 for [#1836](https://github.com/Rdatatable/data.table/issues/1836) highlighting the need for a subtraction method and @co_biostat on SO for drawing Frank's attention, as well as to MichaelChirico for FR (on `+`) & PR.
   
   60. Radix ordering an integer vector containing INTMAX (2147483647) with decreasing=TRUE and na.last=FALSE failed ASAN check and seg faulted some systems. As reported for base R [#16925](https://bugs.r-project.org/bugzilla/show_bug.cgi?id=16925) whose new code comes from data.table. Simplified code, added test and proposed change to base R.
 

--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -66,6 +66,22 @@ round.IDate <- function (x, digits=c("weeks", "months", "quarters", "years"), ..
               class = c("IDate", "Date"))
 }
 
+#Adapted from `-.Date`
+`-.IDate` <- function(e1, e2) {
+  if (!inherits(e1, "IDate")) `-.Date`(e1, e2)
+  if (nargs() == 1) 
+    stop("unary - is not defined for \"IDate\" objects")
+  if (inherits(e2, "IDate")) 
+    return(structure(unclass(e1) - unclass(e2), units = "days", class = "difftime"))
+  if (inherits(e2, "difftime")) 
+    e2 <- round(switch(attr(e2, "units"), 
+                       secs = x/86400, mins = x/1440, 
+                       hours = x/24, days = x, weeks = 7 * x))
+  if (!is.null(attr(e2, "class"))) 
+    stop("can only subtract numbers from \"IDate\" objects")
+  structure(unclass(e1) - as.integer(e2), class = c("IDate", "Date"))
+}
+
 ###################################################################
 # ITime -- Integer time-of-day class
 #          Stored as seconds in the day

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -8953,9 +8953,14 @@ test(1672.5, capture.output(DT[order(V1), .I[1L], by = V1]),
 test(1672.6, capture.output(DT[1:5, .(.I[1L], V2[1L]), by = V1]),
      c("   V1 V1 V2", "1:  1  1  1", "2:  2  2  2"))
      
-#tests for #1528
+#tests for #1528 and #1836
 TT <- as.IDate("2016-04-25")
-test(1673, class(TT + 4L), c("IDate", "Date"))
+TT2 <- as.IDate("2016-04-26")
+test(1673.1, class(TT + 4L), c("IDate", "Date"))
+test(1673.2, class(TT - 4L), c("IDate", "Date"))
+test(1673.3, -TT, error = "unary - is not defined for \"IDate\"")
+test(1673.4, capture.output(dput(TT2 - TT)), 
+     "structure(1L, units = \"days\", class = \"difftime\")")
 
 # test for radix integer order when MAXINT is present AND decreasing=TRUE AND na.last=FALSE
 # https://bugs.r-project.org/bugzilla/show_bug.cgi?id=16925


### PR DESCRIPTION
We can skirt around the `as.POSIXct.IDate` sluggishness vs. precision tradeoff and still solve the molasses-like subtraction of `IDate`s.

Running @franknarf1 's example on this branch, I find we're now _faster_ than subtracting `Date`s (which should be the case in the first place since we're subtracting integers -- but more so since I tweaked the approach of `-.Date` to be a bit faster).

One potential funkiness is that I'm secretly supplying an `integer` vector to become a `difftime` object, which everywhere else would have a `numeric` vector underneath... not sure how un-kosher that is. Time to create `Idifftime`?

Timings on my current crappy machine:

```
library(data.table)
set.seed(1)
id <- 1:1e4
date_samp <- seq(as.IDate("2010-01-01"),as.IDate("2011-01-01"),"day")
n_samp <- 5e7
DT <- data.table(
  id = sample(id,size = n_samp, replace=TRUE),
  date_1 = sample(date_samp,size = n_samp, replace=TRUE)
)
setkey(DT,id,date_1)

# also with vanilla dates
DT[, dt := as.Date(date_1)]

system.time(DT[, diff := date_1 - shift(date_1), by=id])
#    user  system elapsed 
#   1.775   0.168   1.945 

system.time(DT[, diff2 := dt - shift(dt), by=id])
#    user  system elapsed 
#   3.954   0.213   4.173 
```
