### PR TITLE
Fix garbage output for NA_integer in fwrite

### DIFF
--- a/src/fwrite.c
+++ b/src/fwrite.c
@@ -49,7 +49,7 @@ static inline void writeInteger(int x, char **thisCh)
   char *ch = *thisCh;
   if (x == NA_INTEGER) {
     if (na_len) { memcpy(ch, na_str, na_len); ch += na_len; }
-  } if (x == 0) {
+  } else if (x == 0) {
     *ch++ = '0';
   } else {
     if (x<0) { *ch++ = '-'; x=-x; }


### PR DESCRIPTION
When a data.table contains a integer missing value,
`fwrite` writes it with a garbage contents.

This patch adds a missing *else* in `writeInteger` function in
`src/fwrite.c` : if x==NA_INTEGER and na_len==0, the
default, then do nothing.

Fix issue #1837