### PR TITLE
Improve efficiency of wday

### DIFF
--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -244,7 +244,7 @@ second  <- function(x) as.integer(as.POSIXlt(x)$sec)
 minute  <- function(x) as.POSIXlt(x)$min
 hour    <- function(x) as.POSIXlt(x)$hour
 yday    <- function(x) as.POSIXlt(x)$yday + 1L
-wday    <- function(x) as.POSIXlt(x)$wday + 1L
+wday    <- function(x) (unclass(as.IDate(x)) + 4L) %% 7L + 1L
 mday    <- function(x) as.POSIXlt(x)$mday
 week    <- function(x) yday(x) %/% 7L + 1L
 isoweek <- function(x) {


### PR DESCRIPTION
The other functions are a bit trickier to do directly, but for `wday` in particular, it doesn't make sense to convert to `POSIXlt` since we just need to look at the residual modulo 7. On an example with my data I saw 4x speed-up from this simple fix.

I also wrote a version for `year` I'm calling `quick_year` (see [here](https://github.com/MichaelChirico/funchir/blob/master/R/utils.R#L96-L102)), but that will technically lose accuracy for a small number of dates before 1900 and after 2100 due to leap centuries, so even though I doubt many people are using this functionality with such dates, probably not ideal as production code.
