### PR TITLE
R code cleanups (nchar, sapply)

### DIFF
--- a/R/as.data.table.R
+++ b/R/as.data.table.R
@@ -30,28 +30,10 @@ as.data.table.Date <- as.data.table.ITime <- function(x, keep.rownames=FALSE, ..
     as.data.table.list(x, FALSE)
 }
 
-R300_provideDimnames <- function (x, sep = "", base = list(LETTERS)) {
-    # backported from R3.0.0 so data.table can depend on R 2.14.0 
-    dx <- dim(x)
-    dnx <- dimnames(x)
-    if (new <- is.null(dnx)) 
-        dnx <- vector("list", length(dx))
-    k <- length(M <- vapply(base, length, 1L))
-    for (i in which(vapply(dnx, is.null, NA))) {
-        ii <- 1L + (i - 1L)%%k
-        dnx[[i]] <- make.unique(base[[ii]][1L + 0:(dx[i] - 1L)%%M[ii]], 
-            sep = sep)
-        new <- TRUE
-    }
-    if (new) 
-        dimnames(x) <- dnx
-    x
-}
-
 # as.data.table.table - FR #4848
 as.data.table.table <- function(x, keep.rownames=FALSE, ...) {
     # Fix for bug #5408 - order of columns are different when doing as.data.table(with(DT, table(x, y)))
-    val = rev(dimnames(R300_provideDimnames(x)))
+    val = rev(dimnames(provideDimnames(x)))
     if (is.null(names(val)) || all(nchar(names(val)) == 0L)) 
         setattr(val, 'names', paste("V", rev(seq_along(val)), sep=""))
     ans <- data.table(do.call(CJ, c(val, sorted=FALSE)), N = as.vector(x))

--- a/R/as.data.table.R
+++ b/R/as.data.table.R
@@ -34,7 +34,7 @@ as.data.table.Date <- as.data.table.ITime <- function(x, keep.rownames=FALSE, ..
 as.data.table.table <- function(x, keep.rownames=FALSE, ...) {
     # Fix for bug #5408 - order of columns are different when doing as.data.table(with(DT, table(x, y)))
     val = rev(dimnames(provideDimnames(x)))
-    if (is.null(names(val)) || all(nchar(names(val)) == 0L)) 
+    if (is.null(names(val)) || all(!nzchar(names(val))))
         setattr(val, 'names', paste("V", rev(seq_along(val)), sep=""))
     ans <- data.table(do.call(CJ, c(val, sorted=FALSE)), N = as.vector(x))
     setcolorder(ans, c(rev(head(names(ans), -1)), "N"))
@@ -56,7 +56,8 @@ as.data.table.matrix <- function(x, keep.rownames=FALSE, ...) {
     ic <- seq_len(ncols)
     dn <- dimnames(x)
     collabs <- dn[[2L]]
-    if (any(empty <- nchar(collabs) == 0L))
+    empty <- !nzchar(collabs)
+    if (any(empty))
         collabs[empty] <- paste("V", ic, sep = "")[empty]
     value <- vector("list", ncols)
     if (mode(x) == "character") {

--- a/R/cedta.R
+++ b/R/cedta.R
@@ -32,7 +32,7 @@ cedta <- function(n=2L) {
         "data.table" %chin% tryCatch(get(".Depends",paste("package",nsname,sep=":"),inherits=FALSE),error=function(e)NULL) ||
         (nsname == "utils" && exists("debugger.look",parent.frame(n+1L))) || 
         (nsname == "base"  && all(c("FUN", "X") %in% ls(parent.frame(n)))  ) || # lapply
-        (nsname %chin% cedta.pkgEvalsUserCode && any(sapply(sys.calls(), "[[", 1L)=="eval")) ||
+        (nsname %chin% cedta.pkgEvalsUserCode && any(vcapply(sys.calls(), "[[", 1L)=="eval")) ||
         nsname %chin% cedta.override ||
         identical(TRUE, tryCatch(get(".datatable.aware",asNamespace(nsname),inherits=FALSE),error=function(e)NULL))
     if (!ans && getOption("datatable.verbose"))

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -20,7 +20,7 @@ mimicsAutoPrint = c("knit_print.default")
 # add maybe repr_text.default.  See https://github.com/Rdatatable/data.table/issues/933#issuecomment-220237965
 
 shouldPrint = function(x) {
-  ret = (.global$print=="" ||   # to save address() calls and adding lots of address strings to R's global cache
+  ret = (!nzchar(.global$print) ||   # to save address() calls and adding lots of address strings to R's global cache
          address(x)!=.global$print)
   .global$print = ""
   ret

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -73,7 +73,7 @@ print.data.table <- function(x, topn=getOption("datatable.print.topn"),
     }
     toprint=format.data.table(toprint, ...)
     # fix for #975.
-    if (any(sapply(x, function(col) "integer64" %in% class(col))) && !"package:bit64" %in% search()) {
+    if (any(vlapply(x, function(col) "integer64" %in% class(col))) && !"package:bit64" %in% search()) {
         warning("Some columns have been read as type 'integer64' but package bit64 isn't loaded. Those columns will display as strange looking floating point data. There is no need to reload the data. Just require(bit64) to obtain the integer64 print method and print the data again.")
     }
     # FR #5020 - add row.names = logical argument to print.data.table
@@ -130,7 +130,7 @@ format.data.table <- function (x, ..., justify="none") {
     }
     do.call("cbind",lapply(x,function(col,...){
         if (!is.null(dim(col))) stop("Invalid column: it has dimensions. Can't format it. If it's the result of data.table(table()), use as.data.table(table()) instead.")
-        if (is.list(col)) col = sapply(col, format.item)
+        if (is.list(col)) col = vcapply(col, format.item)
         else col = format(char.trunc(col), justify=justify, ...) # added an else here to fix #5435
         col
     },...))
@@ -995,7 +995,7 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
                 
                 orderedirows = .Call(CisOrderedSubset, irows, nrow(x))  # TRUE when irows is NULL (i.e. no i clause)
                 # orderedirows = is.sorted(f__)
-                bysameorder = orderedirows && haskey(x) && all(sapply(bysubl,is.name)) && length(allbyvars) && identical(allbyvars,head(key(x),length(allbyvars)))
+                bysameorder = orderedirows && haskey(x) && all(vlapply(bysubl,is.name)) && length(allbyvars) && identical(allbyvars,head(key(x),length(allbyvars)))
                 if (is.null(irows))
                     if (is.call(bysub) && length(bysub) == 3L && bysub[[1L]] == ":" && is.name(bysub[[2L]]) && is.name(bysub[[3L]])) {
                         byval = eval(bysub, setattr(as.list(seq_along(x)), 'names', names(x)), parent.frame())
@@ -1051,7 +1051,7 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
                 for (jj in seq_len(length(byval))) {
                     if (!typeof(byval[[jj]]) %chin% c("integer","logical","character","double")) stop("column or expression ",jj," of 'by' or 'keyby' is type ",typeof(byval[[jj]]),". Do not quote column names. Usage: DT[,sum(colC),by=list(colA,month(colB))]")
                 }
-                tt = sapply(byval,length)
+                tt = viapply(byval,length)
                 if (any(tt!=xnrow)) stop("The items in the 'by' or 'keyby' list are length (",paste(tt,collapse=","),"). Each must be same length as rows in x or number of rows returned by i (",xnrow,").")
                 if (is.null(bynames)) bynames = rep.int("",length(byval))
                 if (any(bynames=="")) {
@@ -1436,11 +1436,11 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
         # More speedup - only check + copy if irows is NULL
         if (is.null(irows)) {
             if (!is.list(jval)) { # performance improvement when i-arg is S4, but not list, #1438, Thanks @DCEmilberg.
-                jcpy = address(jval) %in% sapply(SDenv$.SD, address) # %chin% errors when RHS is list()
+                jcpy = address(jval) %in% vcapply(SDenv$.SD, address) # %chin% errors when RHS is list()
                 if (jcpy) jval = copy(jval)
             } else if (address(jval) == address(SDenv$.SD)) {
                 jval = copy(jval)
-            } else if ( length(jcpy <- which(sapply(jval, address) %in% sapply(SDenv, address))) ) {
+            } else if ( length(jcpy <- which(vcapply(jval, address) %in% vcapply(SDenv, address))) ) {
                 for (jidx in jcpy) jval[[jidx]] = copy(jval[[jidx]])
             } else if (is.call(jsub) && jsub[[1L]] == "get" && is.list(jval)) {
                 jval = copy(jval) # fix for #1212
@@ -2177,7 +2177,7 @@ within.data.table <- function (data, expr, ...)
     e <- evalq(environment(), data, parent)
     eval(substitute(expr), e)  # might (and it's known that some user code does) contain rm()
     l <- as.list(e)
-    l <- l[!sapply(l, is.null)]
+    l <- l[!vlapply(l, is.null)]
     nD <- length(del <- setdiff(names(data), (nl <- names(l))))
     ans = copy(data)
     if (length(nl)) ans[,nl] <- l
@@ -2326,7 +2326,7 @@ split.data.table <- function(x, f, drop = FALSE, by, sorted = FALSE, keep.by = T
     if (".ll.tech.split" %in% names(x)) stop("column '.ll.tech.split' is reserved for split.data.table processing")
     if (".nm.tech.split" %in% by) stop("column '.nm.tech.split' is reserved for split.data.table processing")
     if (!all(by %in% names(x))) stop("argument 'by' must refer to data.table column names")
-    if (!all(by.atomic <- sapply(by, function(.by) is.atomic(x[[.by]])))) stop(sprintf("argument 'by' must refer only to atomic type columns, classes of '%s' columns are not atomic type", paste(by[!by.atomic], collapse=", ")))
+    if (!all(by.atomic <- vlapply(by, function(.by) is.atomic(x[[.by]])))) stop(sprintf("argument 'by' must refer only to atomic type columns, classes of '%s' columns are not atomic type", paste(by[!by.atomic], collapse=", ")))
     # list of data.tables (flatten) or list of lists of ... data.tables
     make.levels = function(x, cols, sorted) {
         by.order = if (!sorted) x[, funique(.SD), .SDcols=cols] # remember order of data, only when not sorted=FALSE
@@ -2345,7 +2345,7 @@ split.data.table <- function(x, f, drop = FALSE, by, sorted = FALSE, keep.by = T
     # this builds data.table call - is much more cleaner than handling each case one by one
     dtq = as.list(call("[", as.name("x")))
     join = FALSE
-    flatten_any = flatten && any(sapply(by, function(col) is.factor(x[[col]])))
+    flatten_any = flatten && any(vlapply(by, function(col) is.factor(x[[col]])))
     nested_current = !flatten && is.factor(x[[.by]])
     if (!drop && (flatten_any || nested_current)) {
         dtq[["i"]] = substitute(make.levels(x, cols=.cols, sorted=.sorted), list(.cols=if (flatten) by else .by, .sorted=sorted))

--- a/R/fcast.R
+++ b/R/fcast.R
@@ -114,7 +114,7 @@ dcast.data.table <- function(data, formula, fun.aggregate = NULL, sep = "_", ...
     }
     setattr(lvars, 'names', c("lhs", "rhs"))
     # Have to take care of duplicate names, and provide names for expression columns properly.
-    varnames = make.unique(sapply(unlist(lvars), all.vars, max.names=1L), sep=sep)
+    varnames = make.unique(vcapply(unlist(lvars), all.vars, max.names=1L), sep=sep)
     dupidx = which(valnames %in% varnames)
     if (length(dupidx)) {
         dups = valnames[dupidx]
@@ -125,7 +125,7 @@ dcast.data.table <- function(data, formula, fun.aggregate = NULL, sep = "_", ...
     rhsnames = tail(varnames, -length(lvars$lhs))
     setattr(dat, 'names', c(varnames, valnames))
     setDT(dat)
-    if (any(sapply(as.list(dat)[varnames], is.list))) {
+    if (any(vlapply(as.list(dat)[varnames], is.list))) {
         stop("Columns specified in formula can not be of type list")
     }
     m <- as.list(match.call()[-1L])
@@ -198,7 +198,7 @@ dcast.data.table <- function(data, formula, fun.aggregate = NULL, sep = "_", ...
             .Call(Csetlistelt, mapunique, 2L, seq_len(nrow(rhs_)))
             lhs = lhs_; rhs = rhs_
         }
-        maplen = sapply(mapunique, length)
+        maplen = viapply(mapunique, length)
         idx = do.call("CJ", mapunique)[map, I := .I][["I"]] # TO DO: move this to C and avoid materialising the Cross Join.
         ans = .Call(Cfcast, lhs, val, maplen[[1L]], maplen[[2L]], idx, fill, fill.default, is.null(fun.call))
         allcols = do.call("paste", c(rhs, sep=sep))

--- a/R/fread.R
+++ b/R/fread.R
@@ -103,7 +103,7 @@ fread <- function(input="",sep="auto",sep2="auto",nrows=-1L,header="auto",na.str
     if (is.atomic(colClasses) && !is.null(names(colClasses))) colClasses = tapply(names(colClasses),colClasses,c,simplify=FALSE)
     ans = .Call(Creadfile,input,sep,as.integer(nrows),header,na.strings,verbose,as.integer(autostart),skip,select,drop,colClasses,integer64,dec,encoding,quote,strip.white,blank.lines.skip,fill,as.integer(showProgress))
     nr = length(ans[[1]])
-    if ( integer64=="integer64" && !exists("print.integer64") && any(sapply(ans,inherits,"integer64")) )
+    if ( integer64=="integer64" && !exists("print.integer64") && any(vlapply(ans,inherits,"integer64")) )
         warning("Some columns have been read as type 'integer64' but package bit64 isn't loaded. Those columns will display as strange looking floating point data. There is no need to reload the data. Just require(bit64) to obtain the integer64 print method and print the data again.")
     setattr(ans,"row.names",.set_row_names(nr))
 

--- a/R/setkey.R
+++ b/R/setkey.R
@@ -36,7 +36,7 @@ setkeyv <- function(x, cols, verbose=getOption("datatable.verbose"), physical=TR
         return(invisible(x))
     }
     if (identical(cols,"")) stop("cols is the empty string. Use NULL to remove the key.")
-    if (any(nchar(cols)==0)) stop("cols contains some blanks.")
+    if (!all(nzchar(cols))) stop("cols contains some blanks.")
     if (!length(cols)) {
         cols = colnames(x)   # All columns in the data.table, usually a few when used in this form
     } else {
@@ -276,7 +276,7 @@ setorderv <- function(x, cols, order=1L, na.last=FALSE)
         warning("cols is a character vector of zero length. Use NULL instead, or wrap with suppressWarnings() to avoid this warning.")
         return(x)
     }
-    if (any(nchar(cols)==0)) stop("cols contains some blanks.")     # TODO: probably I'm checking more than necessary here.. there are checks in 'forderv' as well
+    if (!all(nzchar(cols))) stop("cols contains some blanks.")     # TODO: probably I'm checking more than necessary here.. there are checks in 'forderv' as well
     if (!length(cols)) {
         cols = colnames(x)   # All columns in the data.table, usually a few when used in this form
     } else {

--- a/R/setops.R
+++ b/R/setops.R
@@ -136,8 +136,8 @@ all.equal.data.table <- function(target, current, trim.levels=TRUE, check.attrib
     if (ignore.col.order && diff.colorder) current = setcolorder(shallow(current), names(target))
     
     # Always check modes equal, like base::all.equal
-    targetModes = sapply(target, mode)
-    currentModes = sapply(current,  mode)
+    targetModes = vcapply(target, mode)
+    currentModes = vcapply(current,  mode)
     if (any( d<-(targetModes!=currentModes) )) {
         w = head(which(d),3)
         return(paste0("Datasets have different column modes. First 3: ",paste(
@@ -148,8 +148,8 @@ all.equal.data.table <- function(target, current, trim.levels=TRUE, check.attrib
     if (check.attributes) {
         squashClass = function(x) if (is.object(x)) paste(class(x),collapse=";") else mode(x)
         # else mode() is so that integer==numeric, like base all.equal does.
-        targetTypes = sapply(target, squashClass)
-        currentTypes = sapply(current, squashClass)
+        targetTypes = vcapply(target, squashClass)
+        currentTypes = vcapply(current, squashClass)
         if (length(targetTypes) != length(currentTypes))
             stop("Internal error: ncol(current)==ncol(target) was checked above")
         if (any( d<-(targetTypes != currentTypes))) {
@@ -204,7 +204,7 @@ all.equal.data.table <- function(target, current, trim.levels=TRUE, check.attrib
         tolerance.msg = if (identical(tolerance, 0)) ", be aware you are using `tolerance=0` which may result into visually equal data" else ""
         if (target_dup || current_dup) {
             # handling 'tolerance' for duplicate rows - those `msg` will be returned only when equality with tolerance will fail
-            if (any(sapply(target,typeof)=="double") && !identical(tolerance, 0)) {
+            if (any(vcapply(target,typeof)=="double") && !identical(tolerance, 0)) {
                 if (target_dup && !current_dup) msg = c(msg, "Dataset 'target' has duplicate rows while 'current' doesn't")
                 else if (!target_dup && current_dup) msg = c(msg, "Dataset 'current' has duplicate rows while 'target' doesn't")
                 else { # both
@@ -226,7 +226,7 @@ all.equal.data.table <- function(target, current, trim.levels=TRUE, check.attrib
             c(".seqn", setdiff(names(target), ".seqn"))
         } else names(target)
         # handling 'tolerance' for factor cols - those `msg` will be returned only when equality with tolerance will fail
-        if (any(sapply(target,is.factor)) && !identical(tolerance, 0)) {
+        if (any(vlapply(target,is.factor)) && !identical(tolerance, 0)) {
             if (!identical(tolerance, sqrt(.Machine$double.eps))) # non-default will raise error
                 stop("Factor columns and ignore.row.order cannot be used with non 0 tolerance argument")
             msg = c(msg, "Using factor columns together together with ignore.row.order, this force 'tolerance' argument to 0")

--- a/R/tables.R
+++ b/R/tables.R
@@ -5,7 +5,7 @@ tables <- function(mb=TRUE,order.col="NAME",width=80,env=parent.frame(),silent=F
 {
     # Prints name, size and colnames of all data.tables in the calling environment by default
     tt = objects(envir=env, all.names=TRUE)
-    ss = which(as.logical(sapply(tt, function(x) is.data.table(get(x,envir=env)))))
+    ss = which(vlapply(tt, function(x) is.data.table(get(x,envir=env))))
     if (!length(ss)) {
         if (!silent) cat("No objects of class data.table exist in .GlobalEnv\n")
         return(invisible(data.table(NULL)))

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -45,7 +45,7 @@ test.data.table <- function(verbose=FALSE, pkg="pkg", silent=FALSE) {
 # .devtesting = TRUE
 
 compactprint <- function(DT, topn=2) {
-    cn = paste(" [Key=",paste(key(DT),collapse=",")," Types=",paste(substring(gsub("integer64","i64",sapply(DT,class)),1,3),collapse=","),"]",sep="")
+    cn = paste(" [Key=",paste(key(DT),collapse=",")," Types=",paste(substring(gsub("integer64","i64",vcapply(DT,class)),1,3),collapse=","),"]",sep="")
     print(copy(DT)[,(cn):=""], topn=topn)
     invisible()
 }
@@ -144,15 +144,15 @@ test <- function(num,x,y,error=NULL,warning=NULL,output=NULL) {
             xc=copy(x)
             yc=copy(y)  # so we don't affect the original data which may be used in the next test
             # drop unused levels in factors
-            if (length(x)) for (i in which(sapply(x,is.factor))) {.xi=x[[i]];xc[,(i):=factor(.xi)]}
-            if (length(y)) for (i in which(sapply(y,is.factor))) {.yi=y[[i]];yc[,(i):=factor(.yi)]}
+            if (length(x)) for (i in which(vlapply(x,is.factor))) {.xi=x[[i]];xc[,(i):=factor(.xi)]}
+            if (length(y)) for (i in which(vlapply(y,is.factor))) {.yi=y[[i]];yc[,(i):=factor(.yi)]}
             setattr(xc,"row.names",NULL)  # for test 165+, i.e. x may have row names set from inheritance but y won't, consider these equal
             setattr(yc,"row.names",NULL)
             setattr(xc,"index",NULL)   # too onerous to create test RHS with the correct index as well, just check result
             setattr(yc,"index",NULL)
             if (identical(xc,yc) && identical(key(x),key(y))) return()  # check key on original x and y because := above might have cleared it on xc or yc
             if (isTRUE(all.equal(xc,yc)) && identical(key(x),key(y)) &&
-                identical(sapply(xc,typeof), sapply(yc,typeof))) return()
+                identical(vcapply(xc,typeof), vcapply(yc,typeof))) return()
         }
         if (is.factor(x) && is.factor(y)) {
             x = factor(x)

--- a/R/utils.R
+++ b/R/utils.R
@@ -47,3 +47,18 @@ UseMethod("%+%")
 
 "%+%.default" <- function(x,y) paste(paste(x,collapse=","),paste(y,collapse=","),sep="")
 # we often construct warning msgs with a msg followed by several items of a vector, so %+% is for convenience
+
+# vapply for return value character(1) 
+vcapply <- function (x, fun, ..., use.names = TRUE) {
+  vapply(X = x, FUN = fun, ..., FUN.VALUE = NA_character_, USE.NAMES = use.names)
+}
+
+# vapply for return value logical(1)
+vlapply <- function (x, fun, ..., use.names = TRUE) {
+  vapply(X = x, FUN = fun, ..., FUN.VALUE = NA, USE.NAMES = use.names)
+}
+
+# vapply for return value integer(1)
+viapply <- function (x, fun, ..., use.names = TRUE) {
+  vapply(X = x, FUN = fun, ..., FUN.VALUE = NA_integer_, USE.NAMES = use.names)
+}

--- a/R/xts.R
+++ b/R/xts.R
@@ -10,7 +10,7 @@ as.data.table.xts <- function(x, keep.rownames = TRUE, ...) {
 as.xts.data.table <- function(x, ...) {
     stopifnot(requireNamespace("xts"), !missing(x), is.data.table(x))
     if (!any((index_class <- class(x[[1L]])) %in% c("POSIXct","Date"))) stop("data.table must have a POSIXct, Date or IDate column on first position, use `setcolorder` function.")
-    colsNumeric = sapply(x, is.numeric)[-1L] # exclude first col, xts index
+    colsNumeric = vlapply(x, is.numeric)[-1L] # exclude first col, xts index
     if (any(!colsNumeric)) warning(paste("Following columns are not numeric and will be omitted:", paste(names(colsNumeric)[!colsNumeric], collapse=", ")))
     r = setDF(x[, .SD, .SDcols=names(colsNumeric)[colsNumeric]])
     xts::as.xts(r, order.by=if ("IDate" %in% index_class) as.Date(x[[1L]]) else x[[1L]])


### PR DESCRIPTION
While reading some source files of data.table, I've spotted you are using `sapply()` instead of `vapply()`. The latter is type safe and usually faster. Furthermore, you are using `nchar(x) == 0L` instead of the faster `nzchar()`. 
I quickly grepped over the package and replaced the respective functions. My changes probably won't have a big impact on performance, but you basically get it for free.

I've also removed an outdated backport of `provideDimnames()`.
