### PR TITLE
Minor spelling and formatting fixes to a few help pages

### DIFF
--- a/man/IDateTime.Rd
+++ b/man/IDateTime.Rd
@@ -31,13 +31,13 @@
 \alias{split.IDate}
 \alias{second}
 \alias{minute}
-\alias{hour}   
-\alias{yday}   
-\alias{wday}   
-\alias{mday}   
-\alias{week}   
+\alias{hour}
+\alias{yday}
+\alias{wday}
+\alias{mday}
+\alias{week}
 \alias{isoweek}
-\alias{month}  
+\alias{month}
 \alias{quarter}
 \alias{year}
 \alias{IDate-class}
@@ -69,15 +69,15 @@ IDateTime(x, ...)
 
 second(x)
 minute(x)
-hour(x)   
-yday(x)   
-wday(x)   
-mday(x)   
-week(x)   
+hour(x)
+yday(x)
+wday(x)
+mday(x)
+week(x)
 isoweek(x)
-month(x)  
+month(x)
 quarter(x)
-year(x)   
+year(x)
 
 }
 
@@ -95,7 +95,7 @@ year(x)
 \code{IDate} is a date class derived from \code{Date}. It has the same
 internal representation as the \code{Date} class, except the storage
 mode is integer. \code{IDate} is a relatively simple wrapper, and it
-should work in almost all situations as a replacement for \code{Date}. 
+should work in almost all situations as a replacement for \code{Date}.
 
 Functions that use \code{Date} objects generally work for
 \code{IDate} objects. This package provides specific methods for
@@ -124,7 +124,7 @@ following: \code{as.POSIXct(time, date)} or \code{as.POSIXct(date,
 time)}.
 
 \code{IDateTime} takes a date-time input and returns a data table with
-columns \code{date} and \code{time}. 
+columns \code{date} and \code{time}.
 
 Using integer storage allows dates and/or times to be used as data table
 keys. With positive integers with a range less than 100,000, grouping
@@ -154,14 +154,14 @@ round to weeks, months, quarters, and years.
    For \code{IDateTime}, a data table with columns \code{idate} and
    \code{itime} in \code{IDate} and \code{ITime} format.
 
-   \code{second}, \code{minute}, \code{hour}, code{yday}, \code{wday}, 
-   \code{mday}, \code{week}, \code{month}, \code{quarter}, 
+   \code{second}, \code{minute}, \code{hour}, \code{yday}, \code{wday},
+   \code{mday}, \code{week}, \code{month}, \code{quarter},
    and \code{year} return integer values
-   for second, minute, hour, day of year, day of week, 
+   for second, minute, hour, day of year, day of week,
    day of month, week, month, quarter, and year, respectively.
-   
+
    These values are all taken directly from the \code{POSIXlt} representation of \code{x}, with the notable difference that while \code{yday}, \code{wday}, and \code{mon} are all 0-based, here they are 1-based.
-   
+
 }
 \references{
 
@@ -169,7 +169,7 @@ round to weeks, months, quarters, and years.
   R News, vol. 4, no. 1, June 2004.
 
   H. Wickham, http://gist.github.com/10238.
-  
+
   ISO 8601, http://www.iso.org/iso/home/standards/iso8601.htm
 }
 
@@ -187,7 +187,7 @@ round to weeks, months, quarters, and years.
 
 # S4 coercion also works
 identical(as.IDate("2001-01-01"), as("2001-01-01", "IDate"))
- 
+
 # create ITime:
 (t <- as.ITime("10:45"))
 
@@ -200,18 +200,18 @@ identical(as.ITime("10:45"), as("10:45", "ITime"))
 
 as.POSIXct("2001-01-01") + as.ITime("10:45")
 
-datetime <- seq(as.POSIXct("2001-01-01"), as.POSIXct("2001-01-03"), by = "5 hour")    
+datetime <- seq(as.POSIXct("2001-01-01"), as.POSIXct("2001-01-03"), by = "5 hour")
 (af <- data.table(IDateTime(datetime), a = rep(1:2, 5), key = "a,idate,itime"))
 
 af[, mean(a), by = "itime"]
 af[, mean(a), by = list(hour = hour(itime))]
-af[, mean(a), by = list(wday = factor(weekdays(idate)))] 
-af[, mean(a), by = list(wday = wday(idate))] 
+af[, mean(a), by = list(wday = factor(weekdays(idate)))]
+af[, mean(a), by = list(wday = wday(idate))]
 
-as.POSIXct(af$idate) 
-as.POSIXct(af$idate, time = af$itime) 
-as.POSIXct(af$idate, af$itime) 
-as.POSIXct(af$idate, time = af$itime, tz = "GMT") 
+as.POSIXct(af$idate)
+as.POSIXct(af$idate, time = af$itime)
+as.POSIXct(af$idate, af$itime)
+as.POSIXct(af$idate, time = af$itime, tz = "GMT")
 
 as.POSIXct(af$itime, af$idate)
 as.POSIXct(af$itime) # uses today's date
@@ -226,7 +226,7 @@ if (require(chron)) {
     as.chron(as.ITime("10:45"), as.IDate("2000-01-01"))
     as.ITime(chron(times = "11:01:01"))
     IDateTime(chron("12/31/98","10:45:00"))
-}  
+}
 
 }
 \keyword{utilities}

--- a/man/J.Rd
+++ b/man/J.Rd
@@ -14,7 +14,8 @@ CJ(..., sorted = TRUE, unique = FALSE)  # DT[CJ(...)]
 }
 
 \arguments{
-  \item{\dots}{ Each argument is a vector. Generally each vector is the same length but if they are not then usual silent repitition is applied. }
+  \item{\dots}{ Each argument is a vector. Generally each vector is the
+  same length but if they are not then the usual silent repetition is applied. }
   \item{sorted}{ logical. Should the input order be retained?}
   \item{unique}{ logical. When \code{TRUE}, only unique values of each vectors are used (automatically). }
 }
@@ -45,7 +46,7 @@ DT[list("b")]   # same
 # CJ usage examples
 CJ(c(5,NA,1), c(1,3,2)) # sorted and keyed data.table
 do.call(CJ, list(c(5,NA,1), c(1,3,2))) # same as above
-CJ(c(5,NA,1), c(1,3,2), sorted=FALSE) # same order as input, unkeyed 
+CJ(c(5,NA,1), c(1,3,2), sorted=FALSE) # same order as input, unkeyed
 # use for 'unique=' argument
 x = c(1,1,2)
 y = c(4,6,4)

--- a/man/foverlaps.Rd
+++ b/man/foverlaps.Rd
@@ -2,123 +2,123 @@
 \alias{foverlaps}
 \title{Fast overlap joins}
 \description{
-A \emph{fast} binary-search based \emph{overlap join} of two \code{data.table}s. 
-This is very much inspired by \code{findOverlaps} function from the bioconductor 
+A \emph{fast} binary-search based \emph{overlap join} of two \code{data.table}s.
+This is very much inspired by \code{findOverlaps} function from the Bioconductor
 package \code{IRanges} (see link below under \code{See Also}).
-    
-Usually, \code{x} is a very large data.table with small interval ranges, and 
-\code{y} is much smaller \emph{keyed} \code{data.table} with relatively larger 
-interval spans. For an usage in \code{genomics}, see the examples section.
 
-NOTE: This is still under development, meaning it's stable, but some features 
-are yet to be implemented. Also, some arguments and/or the function name itself 
+Usually, \code{x} is a very large data.table with small interval ranges, and
+\code{y} is much smaller \emph{keyed} \code{data.table} with relatively larger
+interval spans. For a usage in \code{genomics}, see the examples section.
+
+NOTE: This is still under development, meaning it's stable, but some features
+are yet to be implemented. Also, some arguments and/or the function name itself
 could be changed.
 }
 
 \usage{
-foverlaps(x, y, by.x = if (!is.null(key(x))) key(x) else key(y), 
-    by.y = key(y), maxgap = 0L, minoverlap = 1L, 
-    type = c("any", "within", "start", "end", "equal"), 
-    mult = c("all", "first", "last"), 
-    nomatch = getOption("datatable.nomatch"), 
+foverlaps(x, y, by.x = if (!is.null(key(x))) key(x) else key(y),
+    by.y = key(y), maxgap = 0L, minoverlap = 1L,
+    type = c("any", "within", "start", "end", "equal"),
+    mult = c("all", "first", "last"),
+    nomatch = getOption("datatable.nomatch"),
     which = FALSE, verbose = getOption("datatable.verbose"))
 }
 \arguments{
-\item{x, y}{ \code{data.table}s. \code{y} needs to be keyed, but not necessarily 
+\item{x, y}{ \code{data.table}s. \code{y} needs to be keyed, but not necessarily
 \code{x}. See examples. }
-\item{by.x, by.y}{A vector of column names (or numbers) to compute the overlap 
-joins. The last two columns in both \code{by.x} and \code{by.y} should each 
-correspond to the \code{start} and \code{end} interval columns in \code{x} and 
-\code{y} respectively. And the \code{start} column should always be <= \code{end} 
-column. If \code{x} is keyed,  \code{by.x} is equal to \code{key(x)}, else 
+\item{by.x, by.y}{A vector of column names (or numbers) to compute the overlap
+joins. The last two columns in both \code{by.x} and \code{by.y} should each
+correspond to the \code{start} and \code{end} interval columns in \code{x} and
+\code{y} respectively. And the \code{start} column should always be <= \code{end}
+column. If \code{x} is keyed,  \code{by.x} is equal to \code{key(x)}, else
 \code{key(y)}. \code{by.y} defaults to \code{key(y)}. }
-\item{maxgap}{It should be a non-negative integer value, >= 0. Default is 0 (no 
-gap). For intervals \code{[a,b]} and \code{[c,d]}, where \code{a<=b} and 
-\code{c<=d}, when \code{c > b} or \code{d < a}, the two intervals don't overlap. 
-If the gap between these two intervals is \code{<= maxgap}, these two intervals 
+\item{maxgap}{It should be a non-negative integer value, >= 0. Default is 0 (no
+gap). For intervals \code{[a,b]} and \code{[c,d]}, where \code{a<=b} and
+\code{c<=d}, when \code{c > b} or \code{d < a}, the two intervals don't overlap.
+If the gap between these two intervals is \code{<= maxgap}, these two intervals
 are considered as overlapping. Note: This is not yet implemented.}
-\item{minoverlap}{ It should be a positive integer value, > 0. Default is 1. For 
-intervals \code{[a,b]} and \code{[c,d]}, where \code{a<=b} and \code{c<=d}, when 
-\code{c<=b} and \code{d>=a}, the two intervals overlap. If the length of overlap 
-between these two intervals is \code{>= minoverlap}, then these two intervals are 
+\item{minoverlap}{ It should be a positive integer value, > 0. Default is 1. For
+intervals \code{[a,b]} and \code{[c,d]}, where \code{a<=b} and \code{c<=d}, when
+\code{c<=b} and \code{d>=a}, the two intervals overlap. If the length of overlap
+between these two intervals is \code{>= minoverlap}, then these two intervals are
 considered to be overlapping. Note: This is not yet implemented.}
-\item{type}{ Default value is \code{any}. Allowed values are \code{any}, 
-\code{within}, \code{start}, \code{end} and \code{equal}. Note: \code{equal} is 
-not yet implemented. But this is just a normal join of the type \code{y[x, ...]}, 
-unless you require also using \code{maxgap} and \code{minoverlap} arguments. 
+\item{type}{ Default value is \code{any}. Allowed values are \code{any},
+\code{within}, \code{start}, \code{end} and \code{equal}. Note: \code{equal} is
+not yet implemented. But this is just a normal join of the type \code{y[x, ...]},
+unless you require also using \code{maxgap} and \code{minoverlap} arguments.
 
-The types shown here are identical in functionality to the function 
-\code{findOverlaps} in the bioconductor package \code{IRanges}. Let \code{[a,b]} 
-and \code{[c,d]} be intervals in \code{x} and \code{y} with \code{a<=b} and 
-\code{c<=d}. For \code{type="start"}, the intervals overlap iff \code{a == c}. 
-For \code{type="end"}, the intervals overlap iff \code{b == d}. For 
-\code{type="within"}, the intervals overlap iff \code{a>=c and b<=d}. For 
-\code{type="equal"}, the intervals overlap iff \code{a==c and b==d}. For 
-\code{type="any"}, as long as \code{c<=b and d>=a}, they overlap. In addition 
-to these requirments, they also have to satisfy the \code{minoverlap} argument 
+The types shown here are identical in functionality to the function
+\code{findOverlaps} in the bioconductor package \code{IRanges}. Let \code{[a,b]}
+and \code{[c,d]} be intervals in \code{x} and \code{y} with \code{a<=b} and
+\code{c<=d}. For \code{type="start"}, the intervals overlap iff \code{a == c}.
+For \code{type="end"}, the intervals overlap iff \code{b == d}. For
+\code{type="within"}, the intervals overlap iff \code{a>=c and b<=d}. For
+\code{type="equal"}, the intervals overlap iff \code{a==c and b==d}. For
+\code{type="any"}, as long as \code{c<=b and d>=a}, they overlap. In addition
+to these requirments, they also have to satisfy the \code{minoverlap} argument
 as explained above.
-  
-NB: \code{maxgap} argument, when > 0, is to be interpreted according to the type 
+
+NB: \code{maxgap} argument, when > 0, is to be interpreted according to the type
 of the overlap. This will be updated once \code{maxgap} is implemented.}
 
-\item{mult}{ When multiple rows in \code{y} match to the row in \code{x}, 
-\code{mult=.} controls which values are returned - \code{"all"} (default), 
+\item{mult}{ When multiple rows in \code{y} match to the row in \code{x},
+\code{mult=.} controls which values are returned - \code{"all"} (default),
 \code{"first"} or \code{"last"}.}
-\item{nomatch}{ Same as \code{nomatch} in \code{\link{match}}. When a row (with 
-interval say, \code{[a,b]}) in \code{x} has no match in \code{y}, \code{nomatch=NA} 
-(default) means \code{NA} is returned for \code{y}'s non-\code{by.y} columns for 
-that row of \code{x}. \code{nomatch=0} means no rows will be returned for that 
-row of \code{x}. The default value (used when \code{nomatch} is not supplied) 
+\item{nomatch}{ Same as \code{nomatch} in \code{\link{match}}. When a row (with
+interval say, \code{[a,b]}) in \code{x} has no match in \code{y}, \code{nomatch=NA}
+(default) means \code{NA} is returned for \code{y}'s non-\code{by.y} columns for
+that row of \code{x}. \code{nomatch=0} means no rows will be returned for that
+row of \code{x}. The default value (used when \code{nomatch} is not supplied)
 can be changed from \code{NA} to \code{0} using \code{options(datatable.nomatch=0)}.}
-\item{which}{ When \code{TRUE}, if \code{mult="all"} returns a two column 
-\code{data.table} with the first column corresponding to \code{x}'s row number 
-and the second corresponding to \code{y}'s. when \code{nomatch=NA}, no matches 
-return \code{NA} for \code{y}, and if \code{nomatch=0}, those rows where no 
-match is found will be skipped; if \code{mult="first" or "last"}, a vector of 
-length equal to the number of rows in \code{x} is returned, with no-match entries 
-filled with \code{NA} or \code{0} corresponding to the \code{nomatch} argument. 
+\item{which}{ When \code{TRUE}, if \code{mult="all"} returns a two column
+\code{data.table} with the first column corresponding to \code{x}'s row number
+and the second corresponding to \code{y}'s. when \code{nomatch=NA}, no matches
+return \code{NA} for \code{y}, and if \code{nomatch=0}, those rows where no
+match is found will be skipped; if \code{mult="first" or "last"}, a vector of
+length equal to the number of rows in \code{x} is returned, with no-match entries
+filled with \code{NA} or \code{0} corresponding to the \code{nomatch} argument.
 Default is \code{FALSE}, which returns a join with the rows in \code{y}.}
-\item{verbose}{ \code{TRUE} turns on status and information messages to the 
-console. Turn this on by default using \code{options(datatable.verbose=TRUE)}. 
+\item{verbose}{ \code{TRUE} turns on status and information messages to the
+console. Turn this on by default using \code{options(datatable.verbose=TRUE)}.
 The quantity and types of verbosity may be expanded in future.}
 }
 \details{
-Very briefly, \code{foverlaps()} collapses the two-column interval in \code{y} 
-to one-column of \emph{unique} values to generate a \code{lookup} table, and 
-then performs the join depending on the type of \code{overlap}, using the 
-already available \code{binary search} feature of \code{data.table}. The time 
-(and space) required to generate the \code{lookup} is therefore proportional 
-to the number of unique values present in the interval columns of \code{y} 
-when combined together. 
+Very briefly, \code{foverlaps()} collapses the two-column interval in \code{y}
+to one-column of \emph{unique} values to generate a \code{lookup} table, and
+then performs the join depending on the type of \code{overlap}, using the
+already available \code{binary search} feature of \code{data.table}. The time
+(and space) required to generate the \code{lookup} is therefore proportional
+to the number of unique values present in the interval columns of \code{y}
+when combined together.
 
-Overlap joins takes advantage of the fact that \code{y} is sorted to speed-up 
-finding overlaps. Therefore \code{y} has to be keyed (see \code{?setkey}) 
-prior to running \code{foverlaps()}. A key on \code{x} is not necessary, 
-although it \emph{might} speed things further. The columns in \code{by.x} 
-argument should correspond to the columns specified in \code{by.y}. The last 
-two columns should be the \emph{interval} columns in both \code{by.x} and 
-\code{by.y}. The first interval column in \code{by.x} should always be <= the 
-second interval column in \code{by.x}, and likewise for \code{by.y}. The 
-\code{\link{storage.mode}} of the interval columns must be either \code{double} 
+Overlap joins takes advantage of the fact that \code{y} is sorted to speed-up
+finding overlaps. Therefore \code{y} has to be keyed (see \code{?setkey})
+prior to running \code{foverlaps()}. A key on \code{x} is not necessary,
+although it \emph{might} speed things further. The columns in \code{by.x}
+argument should correspond to the columns specified in \code{by.y}. The last
+two columns should be the \emph{interval} columns in both \code{by.x} and
+\code{by.y}. The first interval column in \code{by.x} should always be <= the
+second interval column in \code{by.x}, and likewise for \code{by.y}. The
+\code{\link{storage.mode}} of the interval columns must be either \code{double}
 or \code{integer}. It therefore works with \code{bit64::integer64} type as well.
 
-The \code{lookup} generation step could be quite time consuming if the number 
-of unique values in \code{y} are too large (ex: in the order of tens of millions). 
-There might be improvements possible by constructing lookup using RLE, which is 
-a pending feature request. However most scenarios will not have too many unique 
+The \code{lookup} generation step could be quite time consuming if the number
+of unique values in \code{y} are too large (ex: in the order of tens of millions).
+There might be improvements possible by constructing lookup using RLE, which is
+a pending feature request. However most scenarios will not have too many unique
 values for \code{y}.
 }
 \value{
-A new \code{data.table} by joining over the interval columns (along with other 
-additional identifier columns) specified in \code{by.x} and \code{by.y}. 
+A new \code{data.table} by joining over the interval columns (along with other
+additional identifier columns) specified in \code{by.x} and \code{by.y}.
 
-NB: When \code{which=TRUE}: \code{a)} \code{mult="first" or "last"} returns a 
-\code{vector} of matching row numbers in \code{y}, and \code{b)} when 
-\code{mult="all"} returns a data.table with two columns with the first 
-containing row numbers of \code{x} and the second column with corresponding 
+NB: When \code{which=TRUE}: \code{a)} \code{mult="first" or "last"} returns a
+\code{vector} of matching row numbers in \code{y}, and \code{b)} when
+\code{mult="all"} returns a data.table with two columns with the first
+containing row numbers of \code{x} and the second column with corresponding
 row numbers of \code{y}.
 
-\code{nomatch=NA or 0} also influences whether non-matching rows are returned 
+\code{nomatch=NA or 0} also influences whether non-matching rows are returned
 or not, as explained above.
 }
 
@@ -134,9 +134,9 @@ foverlaps(x, y, type="any", mult="first") ## returns only first match
 foverlaps(x, y, type="within") ## matches iff 'x' is within 'y'
 
 ## with extra identifiers (ex: in genomics)
-x = data.table(chr=c("Chr1", "Chr1", "Chr2", "Chr2", "Chr2"), 
+x = data.table(chr=c("Chr1", "Chr1", "Chr2", "Chr2", "Chr2"),
                start=c(5,10, 1, 25, 50), end=c(11,20,4,52,60))
-y = data.table(chr=c("Chr1", "Chr1", "Chr2"), start=c(1, 15,1), 
+y = data.table(chr=c("Chr1", "Chr1", "Chr2"), start=c(1, 15,1),
                end=c(4, 18, 55), geneid=letters[1:3])
 setkey(y, chr, start, end)
 foverlaps(x, y, type="any", which=TRUE)
@@ -147,17 +147,17 @@ foverlaps(x, y, type="within")
 foverlaps(x, y, type="start")
 
 ## x and y have different column names - specify by.x
-x = data.table(seq=c("Chr1", "Chr1", "Chr2", "Chr2", "Chr2"), 
+x = data.table(seq=c("Chr1", "Chr1", "Chr2", "Chr2", "Chr2"),
                start=c(5,10, 1, 25, 50), end=c(11,20,4,52,60))
-y = data.table(chr=c("Chr1", "Chr1", "Chr2"), start=c(1, 15,1), 
+y = data.table(chr=c("Chr1", "Chr1", "Chr2"), start=c(1, 15,1),
                end=c(4, 18, 55), geneid=letters[1:3])
 setkey(y, chr, start, end)
-foverlaps(x, y, by.x=c("seq", "start", "end"), 
+foverlaps(x, y, by.x=c("seq", "start", "end"),
             type="any", which=TRUE)
 }
 \seealso{
-\code{\link{data.table}}, 
-\url{http://www.bioconductor.org/packages/release/bioc/html/IRanges.html}, 
+\code{\link{data.table}},
+\url{http://www.bioconductor.org/packages/release/bioc/html/IRanges.html},
 \code{\link{setNumericRounding}}
 }
 \keyword{ data }


### PR DESCRIPTION
Made the following four fixes:

repitition -> repetition
bioconductor -> Bioconductor
an usage -> a usage
code{yday} -> \code{yday}

Unfortunately, my Emacs seems also to have stripped trailing whitespace from a bunch of lines, so the pull request ends up looking a lot bigger than it is (and may be annoying if you want that trailing whitespace).