### PR TITLE
rbindlist default argument modification

### DIFF
--- a/man/rbindlist.Rd
+++ b/man/rbindlist.Rd
@@ -7,7 +7,7 @@
   Same as \code{do.call("rbind", l)} on \code{data.frame}s, but much faster. See \code{DETAILS} for more.
 }
 \usage{
-rbindlist(l, use.names=fill, fill=FALSE, idcol=NULL)
+rbindlist(l, use.names=TRUE, fill=FALSE, idcol=NULL)
 # rbind(..., use.names=TRUE, fill=FALSE, idcol=NULL)
 }
 \arguments{


### PR DESCRIPTION
In man/rbindlist.Rd, changed use.names default argument in rbindlist function prototype from fill to TRUE.