### PR TITLE
Initialize data->fn_rows in rbindlist (fixes #2019)

### DIFF
--- a/src/rbindlist.c
+++ b/src/rbindlist.c
@@ -502,7 +502,6 @@ static void preprocess(SEXP l, Rboolean usenames, Rboolean fill, struct preproce
     // And warning that it'll be matched by names is not necessary, I think, as that's the default for 'rbind'. We 
     // should instead document it.
     for (i=0; i<LENGTH(l); i++) { // isNull is checked already in rbindlist
-        data->fn_rows[i] = 0;  // careful to initialize before continues as R_alloc above doesn't initialize
         li = VECTOR_ELT(l, i);
         if (isNull(li)) continue;
         if (TYPEOF(li) != VECSXP) error("Item %d of list input is not a data.frame, data.table or list",i+1);
@@ -513,6 +512,7 @@ static void preprocess(SEXP l, Rboolean usenames, Rboolean fill, struct preproce
     if (!isNull(col_name)) { data->colname = PROTECT(col_name); data->protecti++; }
     if (usenames) { lnames = PROTECT(allocVector(VECSXP, LENGTH(l))); data->protecti++;}
     for (i=0; i<LENGTH(l); i++) {
+        data->fn_rows[i] = 0;  // careful to initialize before continues as R_alloc above doesn't initialize
         li = VECTOR_ELT(l, i);
         if (isNull(li)) continue;
         if (TYPEOF(li) != VECSXP) error("Item %d of list input is not a data.frame, data.table or list",i+1);


### PR DESCRIPTION
`data.fn_rows` is initialized here:
https://github.com/Rdatatable/data.table/blob/master/src/rbindlist.c#L505

However, this loop has a conditional break, resulting in `data.fn_rows[i]` being undefined if not set in 
https://github.com/Rdatatable/data.table/blob/master/src/rbindlist.c#L524
which again is only executed conditionally (continue in L517+L519).

This may lead to a segfault while writing values to the id column in https://github.com/Rdatatable/data.table/blob/master/src/rbindlist.c#L770 
and https://github.com/Rdatatable/data.table/blob/master/src/rbindlist.c#L778.