### PR TITLE
fixing some memory leaks in fread.c and improving docs in fread.h

### DIFF
--- a/R/fread.R
+++ b/R/fread.R
@@ -19,7 +19,7 @@ fread <- function(input="",file,sep="auto",sep2="auto",dec=".",quote="\"",nrows=
     stopifnot(length(skip)==1)
     stopifnot(is.numeric(nThread) && length(nThread)==1)
     nThread=as.integer(nThread)
-    stopifnot(nThread>=1)    
+    stopifnot(nThread>=1)
     if (!missing(file)) {
         if (!identical(input, "")) stop("You can provide 'input' or 'file', not both.")
         if (!file.exists(file)) stop(sprintf("Provided file '%s' does not exists.", file))
@@ -38,7 +38,7 @@ fread <- function(input="",file,sep="auto",sep2="auto",dec=".",quote="\"",nrows=
         if (!is_secureurl(input)) {
             #1668 - force "auto" when is_file to
             #  ensure we don't use an invalid option, e.g. wget
-            method <- if (is_file(input)) "auto" else 
+            method <- if (is_file(input)) "auto" else
                 getOption("download.file.method", default = "auto")
             download.file(input, tt, method = method,
                           mode = "wb", quiet = !showProgress)
@@ -81,8 +81,9 @@ fread <- function(input="",file,sep="auto",sep2="auto",dec=".",quote="\"",nrows=
         }
     }
     if (is.numeric(skip)) skip = as.integer(skip)
+    warnings2errors = getOption("warn") >= 2
     ans = .Call(CfreadR,input,sep,dec,quote,header,nrows,skip,na.strings,strip.white,blank.lines.skip,
-                        fill,showProgress,nThread,verbose,select,drop,colClasses,integer64,encoding)
+                        fill,showProgress,nThread,verbose,warnings2errors,select,drop,colClasses,integer64,encoding)
     nr = length(ans[[1]])
     if ((!"bit64" %chin% loadedNamespaces()) && any(sapply(ans,inherits,"integer64"))) require_bit64()
     setattr(ans,"row.names",.set_row_names(nr))
@@ -121,7 +122,7 @@ fread <- function(input="",file,sep="auto",sep2="auto",dec=".",quote="\"",nrows=
     if (!missing(col.names))
         setnames(ans, col.names) # setnames checks and errors automatically
     if (!is.null(key) && data.table) {
-        if (!is.character(key)) 
+        if (!is.character(key))
             stop("key argument of data.table() must be character")
         if (length(key) == 1L) {
             key = strsplit(key, split = ",")[[1L]]

--- a/src/fread.h
+++ b/src/fread.h
@@ -17,6 +17,7 @@ typedef enum {
 
 extern size_t typeSize[NUMTYPE];
 extern const char typeName[NUMTYPE][10];
+extern const long double pow10lookup[701];
 
 // Strings are pushed by fread_main using an offset from an anchor address plus string length
 // freadR.c then manages strings appropriately
@@ -25,31 +26,96 @@ typedef struct {
   uint32_t off;
 } lenOff;
 
+
 #define NA_BOOL8         INT8_MIN
 #define NA_INT32         INT32_MIN
 #define NA_INT64         INT64_MIN
 #define NA_FLOAT64_I64   0x7FF00000000007A2
 #define NA_LENOFF        INT32_MIN  // lenOff.len only; lenOff.off undefined for NA
 
-typedef struct {
+
+
+// *****************************************************************************
+
+typedef struct freadMainArgs
+{
+  // Name of the file to open (a \0-terminated C string). If the file name
+  // contains non-ASCII characters, it should be UTF-8 encoded (however fread
+  // will not validate the encoding).
   const char *filename;
+
+  // Data buffer: a \0-terminated C string. When this parameter is given,
+  // fread() will read from the provided string. This parameter is exclusive
+  // with `filename`.
   const char *input;
+
+  // Character to use for a field separator. Multi-character separators are not
+  // supported. If `sep` is '\0', then fread will autodetect it. A quotation
+  // mark '"' is not allowed as field separator.
   char sep;
+
+  // Decimal separator for numbers (usually '.'). This may coincide with `sep`,
+  // in which case floating-point numbers will have to be quoted. Multi-char
+  // (or non-ASCII) decimal separators are not supported. A quotation mark '"'
+  // is not allowed as decimal separator.
+  // See: https://en.wikipedia.org/wiki/Decimal_mark
   char dec;
+
+  // Character to use as a quotation mark (usually '"'). Pass '\0' to disable
+  // field quoting. This parameter cannot be auto-detected. Multi-character,
+  // non-ASCII, or different open/closing quotation marks are not supported.
   char quote;
-  int8_t header;          // true|false|NA_BOOL8
-  uint64_t nrowLimit;     // UINT64_MAX represents no limit
-  uint64_t skipNrow;
+
+  // Is there a header at the beginning of the file?
+  // 0 = no, 1 = yes, -128 = autodetect
+  int8_t header;
+
+  // Maximum number of rows to read, or INT64_MAX to read the entire dataset.
+  // Note that even if `nrowLimit = 0`, fread() will scan a sample of rows in
+  // the file to detect column names and types (and other parsing settings).
+  int64_t nrowLimit;
+
+  // Number of input lines to skip when reading the file.
+  int64_t skipNrow;
+
+  // Skip to the line containing this string. This parameter cannot be used
+  // with `skipLines`.
   const char *skipString;
+
+  // List of strings that should be converted into NA values.
   const char **NAstrings;
-  uint32_t nNAstrings;
+
+  // Number of entries in the `NAstrings` array.
+  int32_t nNAstrings;
+
+  // Strip the whitespace from fields (usually True).
   _Bool stripWhite;
+
+  // If True, empty lines in the file will be skipped. Otherwise empty lines
+  // will produce rows of NAs.
   _Bool skipEmptyLines;
+
+  // If True, then rows are allowed to have variable number of columns, and
+  // all ragged rows will be filled with NAs on the right.
   _Bool fill;
+
+  // If True, then emit progress messages during the parsing.
   _Bool showProgress;
-  uint32_t nth;        // number of threads >= 1
+
+  // Maximum number of threads (should be >= 1).
+  int32_t nth;
+
+  // Emit extra debug-level information.
   _Bool verbose;
+
+  // If true, then warnings should be treated as errors. (This field is
+  // checked from the DTWARN macro).
+  _Bool warningsAreErrors;
+
 } freadMainArgs;
+
+
+// *****************************************************************************
 
 int freadMain(freadMainArgs args);
 
@@ -62,13 +128,20 @@ void progress(double percent/*[0,1]*/, double ETA/*secs*/);
 void pushBuffer(int8_t *type, int ncol, void **buff, const char *anchor,
                 int nStringCols, int nNonStringCols, int nRows, uint64_t ansi);
 void STOP(const char *format, ...);
-void freadCleanup();
+void freadCleanup(void);
+void freadLastWarning(const char *format, ...);
 
 #define STRICT_R_HEADERS   // https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Error-handling
 #include <R.h>
-#define DTERROR error
-#define DTWARN  warning
 #define DTPRINT Rprintf
+
+
+#define DTWARN(...) { \
+  if (warningsAreErrors) \
+    freadLastWarning(__VA_ARGS__); \
+  else \
+    warning(__VA_ARGS__); \
+}
 
 
 #endif


### PR DESCRIPTION
* freadCleanup(): do more thorough cleanup
  All global parameters are reset to their default values, ensuring that they do not accidentally carry-over from previous runs of fread.
* print error message from munmap/UnmapViewOfFile; 
  (this was a TODO comment). The messages are very simplistic, because frankly it's nearly impossible to trigger those error conditions...
* added check that freadCleanup should always be run when fread exits; 
  This check allows to detect potential memory leaks, which apparently there were quite a few (see below)...
* prevent memory leak where `oldType` was sometimes not deallocated; 
  `oldType` is now a static global vars, and is freed in freadCleanup together with all other global static variables.
* prevent memory leak when running fread with `options(warn=2)`, in which case freadCleanup() was not triggered;
  This was a tricky one... R has a mode where warnings are treated as errors, in this case calling `warning(...)` causes an exception to be thrown, and execution of fread terminates as if it was `STOP`. However even in this case we need to do proper cleanup -- hence I now pass a new `warningsAreErrors` arg, which tells `DTWARN` macro that it needs to cleanup the environment.
* added arguments descriptions in `fread.h`
* some arguments that were `uint64_t` converted to `int64_t` to avoid accidental overflows when used together with signed integers.
* `mmp` is changed from `const char *` to `void*`, which is the native type for `mmap` / `munmap`, and avoids warnings about const casts.