### PR TITLE
Split buffer passed to `pushBuffer` into 3 parts with different alignments

### DIFF
--- a/src/fread.h
+++ b/src/fread.h
@@ -129,7 +129,9 @@ size_t allocateDT(int8_t *type, int8_t *size, int ncol, int ndrop, int64_t alloc
 void setFinalNrow(int64_t nrow);
 void reallocColType(int col, colType newType);
 void progress(double percent/*[0,1]*/, double ETA/*secs*/);
-void pushBuffer(const void *buff, const char *anchor, int nRows, int64_t DTi, int rowSize, int nStringCols, int nNonStringCols);
+void pushBuffer(const void *buff8, const void *buff4, const void *buff1, const char *anchor,
+                int nRows, int64_t DTi, int rowSize8, int rowSize4, int rowSize1,
+                int nStringCols, int nNonStringCols);
 void STOP(const char *format, ...);
 void freadCleanup(void);
 void freadLastWarning(const char *format, ...);

--- a/src/fread.h
+++ b/src/fread.h
@@ -125,12 +125,12 @@ int freadMain(freadMainArgs __args);
 
 // Called from freadMain; implemented in freadR.c
 _Bool userOverride(int8_t *type, lenOff *colNames, const char *anchor, int ncol);
-size_t allocateDT(int8_t *type, int8_t *size, int ncol, int ndrop, int64_t allocNrow);
-void setFinalNrow(int64_t nrow);
+size_t allocateDT(int8_t *type, int8_t *size, int ncol, int ndrop, size_t allocNrow);
+void setFinalNrow(size_t nrow);
 void reallocColType(int col, colType newType);
 void progress(double percent/*[0,1]*/, double ETA/*secs*/);
 void pushBuffer(const void *buff8, const void *buff4, const void *buff1, const char *anchor,
-                int nRows, int64_t DTi, int rowSize8, int rowSize4, int rowSize1,
+                int nRows, size_t DTi, int rowSize8, int rowSize4, int rowSize1,
                 int nStringCols, int nNonStringCols);
 void STOP(const char *format, ...);
 void freadCleanup(void);

--- a/src/freadR.c
+++ b/src/freadR.c
@@ -311,7 +311,7 @@ _Bool userOverride(int8_t *type, lenOff *colNames, const char *anchor, int ncol)
 }
 
 
-size_t allocateDT(int8_t *typeArg, int8_t *sizeArg, int ncolArg, int ndrop, int64_t allocNrow) {
+size_t allocateDT(int8_t *typeArg, int8_t *sizeArg, int ncolArg, int ndrop, size_t allocNrow) {
   // save inputs for use by pushBuffer
   ncol = ncolArg;
   size = sizeArg;
@@ -349,7 +349,7 @@ void reallocColType(int col,  // which column of the result, not of type[]. (the
 }
 
 
-void setFinalNrow(int64_t nrow) {
+void setFinalNrow(size_t nrow) {
   // TODO realloc
   if (length(DT)) {
     if (nrow == length(VECTOR_ELT(DT, 0)))
@@ -363,7 +363,7 @@ void setFinalNrow(int64_t nrow) {
 
 
 void pushBuffer(const void *buff8, const void *buff4, const void *buff1,
-                const char *anchor, int nRows, int64_t DTi,
+                const char *anchor, int nRows, size_t DTi,
                 int rowSize8, int rowSize4, int rowSize1,
                 int nStringCols, int nNonStringCols)
 {


### PR DESCRIPTION
Now instead of a single buffer `myBuff` we maintain 3 separate ones: `myBuff8`, `myBuff4`, and `myBuff1`, storing data that must be aligned at 8-, 4- and 1-byte boundaries respectively.

Additionally, fixed warnings reported by Clang with `-Weverything` (this mostly involved converting some variables from int64_t into size_t, and adding occasional explicit casts).