### PR TITLE
Update .Rbuildignore /.gitignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,7 @@
 ^\.Rproj\.user$
 ^appveyor\.yml$
 ^.gitlab-ci\.yml$
+^\.idea$
+^\.RData$
+^\.Rhistory$
+^data\.table_.*\.tar\.gz$

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,13 @@
 # Source: https://github.com/github/gitignore/blob/master/R.gitignore
 # History files
+.RData
 .Rhistory
 .Rapp.history
 
-# Example code in package build process
+# Package build process
 *-Ex.R
+data.table_*.tar.gz
+data.table.Rcheck
 
 # RStudio files
 .Rproj.user


### PR DESCRIPTION
Add extra entries in `.Rbuildignore` / `.gitignore` so that the package can be built correctly from the data.table directory.

Although we usually build from folder `data.table/..`, some user might accidentally build the package from folder `data.table`. This PR makes that less error-prone