### PR TITLE
named logical vector in i now selects expected row. Closes #2152

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -44,6 +44,8 @@
 
 12. The `as.IDate.POSIXct` method passed `tzone` along but was not exported. So `tzone` is now taken into account by `as.IDate` too as well as `IDateTime`, [#977](https://github.com/Rdatatable/data.table/issues/977) and [#1498](https://github.com/Rdatatable/data.table/issues/1498). Tests added.
 
+13. Named logical vector now select rows as expected from single row data.table. Thanks to @skranz for reporting. Closes [#2152](https://github.com/Rdatatable/data.table/issues/2152).
+
 #### NOTES
 
 1. `?data.table` makes explicit the option of using a `logical` vector in `j` to select columns, [#1978](https://github.com/Rdatatable/data.table/issues/1978). Thanks @Henrik-P for the note and @MichaelChirico for filing.

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -812,7 +812,7 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
             # i is not a data.table
             if (!is.logical(i) && !is.numeric(i)) stop("i has not evaluated to logical, integer or double")
             if (is.logical(i)) {
-                if (isTRUE(i)) irows=i=NULL
+                if (isTRUE(unname(i))) irows=i=NULL # unname() required for #2152 - length 1 named logical vector
                 # NULL is efficient signal to avoid creating 1:nrow(x) but still return all rows, fixes #1249
                 
                 else if (length(i)<=1L) irows=i=integer(0)

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -812,7 +812,8 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
             # i is not a data.table
             if (!is.logical(i) && !is.numeric(i)) stop("i has not evaluated to logical, integer or double")
             if (is.logical(i)) {
-                if (isTRUE(unname(i))) irows=i=NULL # unname() required for #2152 - length 1 named logical vector
+                if (length(i)==1L  # to avoid unname copy when length(i)==nrow (normal case we don't want to slow down)
+		    && isTRUE(unname(i))) irows=i=NULL  # unname() for #2152 - length 1 named logical vector.
                 # NULL is efficient signal to avoid creating 1:nrow(x) but still return all rows, fixes #1249
                 
                 else if (length(i)<=1L) irows=i=integer(0)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -9928,6 +9928,13 @@ test(1765, print(IDateTime(x)), output=".*idate.*itime.*1: 2017-03-17 00:00:00")
 # use capture.output() in this case rather than output= to ensure NULL is not output
 test(1766, capture.output(print(data.table(NULL))), "Null data.table (0 rows and 0 cols)")
 
+# Bug on subset of 1-row data.table when expr returns a named logical vector #2152
+op = options(datatable.auto.index=FALSE)
+dt = data.table(x=1, y="a")
+val = c(foo=1L)
+test(1767, dt[x == val], data.table(x=1, y="a"))
+options(op)
+
 ##########################
 
 test(1800, fread("A\n6e55693457e549ecfce0\n"), data.table(A=c("6e55693457e549ecfce0")))


### PR DESCRIPTION
Unfortunately named `TRUE` will not return true when passed to `isTRUE(c(foo=TRUE))` therefore `unname()` has been added in check condition. Also closes duplicate report #2210.
CI failures seems to be related to fwrite, not this PR.