### PR TITLE
Fwrite should always quote empty strings

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -9501,7 +9501,7 @@ if ("package:bit64" %in% search()) {
     "+2147483648",
     "+2147483649"
   )))
-  ans = c("V1","-9223372036854775807","9223372036854775807","-9223372036854775806","9223372036854775806",
+  ans = c('"V1"',"-9223372036854775807","9223372036854775807","-9223372036854775806","9223372036854775806",
           "0","-1","1","__NA__","__NA__",
           "-2147483646","-2147483647","-2147483648","-2147483649",
           "2147483646","2147483647","2147483648","2147483649")
@@ -9511,6 +9511,7 @@ if ("package:bit64" %in% search()) {
   test(1731.3, fwrite(DT, f, na="__NA__"), NULL)
   test(1731.4, readLines(f), ans)
   unlink(f)
+  ans[1] = "V1"  # the field is unquoted under `quote=FALSE`
   test(1731.5, write.csv(DT,na="__NA__",row.names=FALSE,quote=FALSE), output=paste(ans,collapse=""))
   # write.csv works on integer64 because it calls bit64's as.character method
 } else {
@@ -9538,7 +9539,7 @@ ans = c('x,"ColName,WithComma","Three', 'Line', 'ColName"',
         'foo,2,noNeedToQuote',
         '"b\\"ar",3,"a',  'long', "\\\"sentence\\\"\"",
         ',4,0000',
-        ',5," ','  "',
+        '"",5," ','  "',
         "NA,6,\"   \\\"", "  \"")
 test(1732.4, readLines(f), ans)
 fwrite(DT,f,quote='auto',qmethod='double')
@@ -9549,6 +9550,10 @@ test(1732.5, readLines(f), ans)
 DT = data.table(A=c("foo","ba,r","baz"), B=c("AA","BB","CC"), C=c("DD","E\nE","FF"))
 test(1732.6, fwrite(DT, quote='auto'), output='A,B,Cfoo,AA,DD"ba,r",BB,"EE"baz,CC,FF')
 unlink(f)
+
+DT = data.table(A=c(NA, "NA", "", "monty"), B=c(5, 7, 0, NA))
+test(1732.7, fwrite(DT, quote='auto'), output='A,B,5NA,7"",0monty,')
+test(1732.8, fwrite(DT, quote='auto', na="NA"), output='"A","B"NA,5"NA",7"",0"monty",NA')
 
 # dec=","
 test(1733.1, fwrite(data.table(pi),dec=","), error="dec != sep is not TRUE")

--- a/src/fwrite.c
+++ b/src/fwrite.c
@@ -265,6 +265,12 @@ static void writeString(SEXP column, int i, char **thisCh)
     Rboolean q = quote;
     if (q==NA_LOGICAL) { // quote="auto"
       const char *tt = CHAR(x);
+      if (*tt == '\0') {
+        // Empty strings are always quoted: this distinguishes them from NAs
+        *ch = '"'; ch[1] = '"';
+        *thisCh += 2;
+        return;
+      }
       while (*tt!='\0' && *tt!=sep && *tt!=sep2 && *tt!='\n' && *tt!='"') *ch++ = *tt++;
       // Windows includes \n in its \r\n so looking for \n only is sufficient
       // sep2 is set to '\0' when no list columns are present
@@ -602,6 +608,8 @@ SEXP writefile(SEXP DFin,               // any list of same length vectors; e.g.
   na = CHAR(STRING_ELT(na_Arg, 0));
   dec = *CHAR(STRING_ELT(dec_Arg,0));
   quote = LOGICAL(quote_Arg)[0];
+  // When NA is a non-empty string, then we must quote all string fields
+  if (*na != '\0' && quote == NA_LOGICAL) quote = TRUE;
   qmethod_escape = LOGICAL(qmethod_escapeArg)[0];
   const char *filename = CHAR(STRING_ELT(filename_Arg, 0));
   logicalAsInt = LOGICAL(logicalAsInt_Arg)[0];


### PR DESCRIPTION
 (under quote='auto' at least), so that NA strings and empty strings can be distinguished in the output. Closes #2215