### PR TITLE
Letters T/F are no longer recognized as booleans by fread

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -5110,7 +5110,8 @@ bla <- data.table(x=c(1,1,2,2), y=c(1,1,1,1))
 test(1342, unique(bla)[, bla := 2L], data.table(x=c(1,2),y=1,bla=2L))
 
 # blank and NA fields in logical columns
-test(1343, fread("A,B\n1,TRUE\n2,\n3,False"), data.table(A=1:3, B=c(TRUE,NA,FALSE)))
+test(1343.1, fread("A,B\n1,TRUE\n2,\n3,False"), data.table(A=1:3, B=c(TRUE,NA,FALSE)))
+test(1343.2, fread("A,B\n1,True\n2,\n3,false"), data.table(A=1:3, B=c(TRUE,NA,FALSE)))
 test(1344, fread("A,B\n1,true\n2,NA\n3,"), data.table(A=1:3, B=c(TRUE,NA,NA)))
 
 # .N now available in i

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -2666,8 +2666,8 @@ test(945, DT[,b:=a+1], data.table(a=numeric(),b=numeric()))
 # fread blank column names get default names
 test(946, fread('A,B,,D\n1,3,foo,5\n2,4,bar,6\n'), data.table(A=1:2,B=3:4,c("foo","bar"),D=5:6))
 test(947, fread('0,2,,4\n1,3,foo,5\n2,4,bar,6\n'), data.table(0:2,2:4,c("","foo","bar"),4:6))
-test(948, fread('A,B,C\nD,E,F\n',header=TRUE), data.table(A="D",B="E",C=FALSE))
-test(949, fread('A,B,\nD,E,F\n',header=TRUE), data.table(A="D",B="E",V3=FALSE))
+test(948, fread('A,B,C\nD,E,F\n',header=TRUE), data.table(A="D",B="E",C="F"))
+test(949, fread('A,B,\nD,E,F\n',header=TRUE), data.table(A="D",B="E",V3="F"))
 
 # +/- with no numbers afterwards should read as character
 test(950, fread('A,B,C\n1,+,4\n2,-,5\n3,-,6\n'), data.table(A=1:3,B=c("+","-","-"),C=4:6))
@@ -3135,7 +3135,7 @@ b = rbind(a, data.table(z=2,x=1))
 test(1080, b$z, c(1,2,3,2))
 
 # mid row logical detection
-test(1081, fread("A,B,C\n1,T,2\n"), data.table(A=1L,B=TRUE,C=2L))
+test(1081, fread("A,B,C\n1,T,2\n"), data.table(A=1L,B="T",C=2L))
 
 # cartesian join answer's key should contain only the columns considered in binary search. Fixes #2677
 set.seed(45)
@@ -5110,8 +5110,8 @@ bla <- data.table(x=c(1,1,2,2), y=c(1,1,1,1))
 test(1342, unique(bla)[, bla := 2L], data.table(x=c(1,2),y=1,bla=2L))
 
 # blank and NA fields in logical columns
-test(1343, fread("A,B\n1,TRUE\n2,\n3,F"), data.table(A=1:3, B=c(TRUE,NA,FALSE)))
-test(1344, fread("A,B\n1,T\n2,NA\n3,"), data.table(A=1:3, B=c(TRUE,NA,NA)))
+test(1343, fread("A,B\n1,TRUE\n2,\n3,False"), data.table(A=1:3, B=c(TRUE,NA,FALSE)))
+test(1344, fread("A,B\n1,true\n2,NA\n3,"), data.table(A=1:3, B=c(TRUE,NA,NA)))
 
 # .N now available in i
 DT = data.table(a=1:3,b=1:6)

--- a/src/fread.c
+++ b/src/fread.c
@@ -578,7 +578,7 @@ static _Bool StrtoB(const char **this, int8_t *target)
         *target = 1;
         if ((ch+3<eof && ch[1]=='R' && ch[2]=='U' && ch[3]=='E') ||
             (ch+3<eof && ch[1]=='r' && ch[2]=='u' && ch[3]=='e')) ch += 4;
-    } else if (*ch=='F') {
+    } else if (*ch=='F' || *ch=='f') {
         *target = 0;
         if ((ch+4<eof && ch[1] == 'A' && ch[2] == 'L' && ch[3] == 'S' && ch[4] == 'E') ||
             (ch+4<eof && ch[1] == 'a' && ch[2] == 'l' && ch[3] == 's' && ch[4] == 'e')) ch += 5;

--- a/src/fread.c
+++ b/src/fread.c
@@ -559,12 +559,12 @@ static _Bool StrtoD(const char **this, void *target)
     return na;
 }
 
-static _Bool StrtoB(const char **this, void *target)
+static _Bool StrtoB(const char **this, int8_t *target)
 {
     // These usually come from R when it writes out.
     const char *ch = *this;
     skip_white(&ch);
-    *(int8_t *)target = NA_BOOL8;
+    *target = NA_BOOL8;
     if (on_sep(&ch)) { *this=ch; return true; }  // empty field ',,'
     const char *start=ch;
     _Bool quoted = false;
@@ -572,20 +572,20 @@ static _Bool StrtoB(const char **this, void *target)
     if (quoted && *ch==quote) { ch++; if (on_sep(&ch)) {*this=ch; return true;} else return false; }  // empty quoted field ',"",'
     _Bool logical01 = false;  // expose to user and should default be true?
     if ( ((*ch=='0' || *ch=='1') && logical01) || (*ch=='N' && ch+1<eof && *(ch+1)=='A' && ch++)) {
-        *(int8_t *)target = (*ch=='1' ? true : (*ch=='0' ? false : NA_BOOL8));
+        *target = (*ch=='1' ? 1 : (*ch=='0' ? 0 : NA_BOOL8));
         ch++;
-    } else if (*ch=='T') {
-        *(int8_t *)target = true;
-        if (++ch+2<eof && ((*ch=='R' && *(ch+1)=='U' && *(ch+2)=='E') ||
-                           (*ch=='r' && *(ch+1)=='u' && *(ch+2)=='e'))) ch+=3;
+    } else if (*ch=='T' || *ch=='t') {
+        *target = 1;
+        if ((ch+3<eof && ch[1]=='R' && ch[2]=='U' && ch[3]=='E') ||
+            (ch+3<eof && ch[1]=='r' && ch[2]=='u' && ch[3]=='e')) ch += 4;
     } else if (*ch=='F') {
-        *(int8_t *)target = false;
-        if (++ch+3<eof && ((*ch=='A' && *(ch+1)=='L' && *(ch+2)=='S' && *(ch+3)=='E') ||
-                           (*ch=='a' && *(ch+1)=='l' && *(ch+2)=='s' && *(ch+3)=='e'))) ch+=4;
+        *target = 0;
+        if ((ch+4<eof && ch[1] == 'A' && ch[2] == 'L' && ch[3] == 'S' && ch[4] == 'E') ||
+            (ch+4<eof && ch[1] == 'a' && ch[2] == 'l' && ch[3] == 's' && ch[4] == 'e')) ch += 5;
     }
     if (quoted) { if (ch>=eof || *ch!=quote) return false; else ch++; }
     if (on_sep(&ch)) { *this=ch; return true; }
-    *(int8_t *)target = NA_BOOL8;
+    *target = NA_BOOL8;
     next_sep(&ch);
     *this=ch;
     return is_NAstring(start);


### PR DESCRIPTION
StrToB function no longer recognizes `T`/`F` as booleans, but instead treats them as strings. At the same time it now recognizes `true`/`false` as valid boolean literals.