### PR TITLE
Parameter `nth` for fread can now be 0 or negative. 

### DIFF
--- a/src/fread.c
+++ b/src/fread.c
@@ -630,7 +630,7 @@ int freadMain(freadMainArgs _args) {
       if (nth > maxth) nth = maxth;
       if (nth <= 0) nth += maxth;
       if (nth <= 0) nth = 1;
-      if (verbose) DTPRINT("  Num threads = %d (system allows up to %d threads)\n", nth, maxth);
+      if (verbose) DTPRINT("  Using %d threads (omp_get_max_threads()=%d, nth=%d)\n", nth, maxth, args.nth);
     }
 
     uint64_t ui64 = NA_FLOAT64_I64;

--- a/src/fread.c
+++ b/src/fread.c
@@ -625,10 +625,12 @@ int freadMain(freadMainArgs _args) {
     }
 
     int nth = args.nth;
-    if (nth <= 0) STOP("nThreads must be >= 1, received %d", nth);
-    if (nth > omp_get_max_threads()) {
-      nth = omp_get_max_threads();
-      DTPRINT("Limited nth=%d to omp_get_max_threads()=%d\n", args.nth, nth);
+    {
+      int maxth = omp_get_max_threads();
+      if (nth > maxth) nth = maxth;
+      if (nth <= 0) nth += maxth;
+      if (nth <= 0) nth = 1;
+      if (verbose) DTPRINT("  Num threads = %d (system allows up to %d threads)\n", nth, maxth);
     }
 
     uint64_t ui64 = NA_FLOAT64_I64;

--- a/src/fread.h
+++ b/src/fread.h
@@ -102,7 +102,10 @@ typedef struct freadMainArgs
   // If True, then emit progress messages during the parsing.
   _Bool showProgress;
 
-  // Maximum number of threads (should be >= 1).
+  // Maximum number of threads. If 0, then fread will use the maximum possible
+  // number of threads, as determined by omp_get_max_threads(). If negative,
+  // then fread will use that many threads less than allowed maximum (but
+  // always at least 1).
   int32_t nth;
 
   // Emit extra debug-level information.


### PR DESCRIPTION
* when `nth = 0` it means use maximum possible number of threads, 
* when `nth < 0` it means use that many threads less than the maximum (for example `nth = -1` means use `max-1` threads).

This is a convenience feature for clients who want to use all available threads (or almost all) but do not have access to the `omp_get_max_threads()` call.

Previously fread was throwing an exception when `nth <= 0`, so this change will not invalidate any existing valid programs.