### PR TITLE
Edited col.names argument text to default TRUE

### DIFF
--- a/man/fwrite.Rd
+++ b/man/fwrite.Rd
@@ -28,7 +28,7 @@ fwrite(x, file = "", append = FALSE, quote = "auto",
   \item{na}{The string to use for missing values in the data. Default is a blank string \code{""}.}
   \item{dec}{The decimal separator, by default \code{"."}. See link in references. Cannot be the same as \code{sep}.}
   \item{row.names}{Should row names be written? For compatibility with \code{data.frame} and \code{write.csv} since \code{data.table} never has row names. Hence default \code{FALSE} unlike \code{write.csv}.} 
-  \item{col.names}{Should the column names (header row) be written? If missing, \code{append=TRUE} and the file already exists, the default is set to \code{FALSE} for convenience to prevent column names appearing again mid file.}
+  \item{col.names}{Should the column names (header row) be written? The default is TRUE. However, if missing, \code{append=TRUE} and the file already exists, the default is set to \code{FALSE} for convenience to prevent column names appearing again mid file.}
   \item{qmethod}{A character string specifying how to deal with embedded double quote characters when quoting strings.
       \itemize{
 	\item{"escape" - the quote character (as well as the backslash character) is escaped in C style by a backslash, or}


### PR DESCRIPTION
The documentation in ?data.table::fwrite states: "Should the column names (header row) be written?  If missing, append=TRUE and the file already exists, the default is set to FALSE for convenience to prevent column names appearing again mid file".

Meanwhile, examining the Usage section, one sees col.names = TRUE. I recommend changing the documentation to explicitly state that the default is TRUE unless the above condition is met. I have implemented this change to the documentation. Since this is trivial, no issue was created.