### PR TITLE
Add a simple Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+
+R ?= R
+
+.PHONY: all
+all:
+	$(MAKE) clean
+	$(MAKE) build
+	$(MAKE) install
+	$(MAKE) test
+
+.PHONY: clean
+clean:
+	rm -f data.table_1.10.5.tar.gz
+
+.PHONY: build
+build:
+	$(R) CMD build . --no-build-vignettes
+
+.PHONY: install
+install:
+	$(R) CMD install data.table_1.10.5.tar.gz
+
+.PHONY: test
+test:
+	$(R) -e 'require(data.table); test.data.table()'


### PR DESCRIPTION
With this file present, one can simply  type `make` on a command line to compile the latest data.table, then install it, and then launch the test suite.