### PR TITLE
Closes #1482, adds options for controlling how print displays column names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,7 +32,11 @@
 
 8. `as.data.table()` gains new method for `array`s to return a useful data.table, [#1418](https://github.com/Rdatatable/data.table/issues/1418).
 
-9. `print.data.table` gains `print.keys` argument, `FALSE` by default, which displays the keys and/or indices (secondary keys) of a `data.table`, more of [#1523](https://github.com/Rdatatable/data.table/issues/1523). Thanks @MichaelChirico for the PR, Yike Lu for the suggestion and Arun for honing that idea to its present form.
+9. `print.data.table()` (all via master issue  [#1523](https://github.com/Rdatatable/data.table/issues/1523)):
+
+    * gains `print.keys` argument, `FALSE` by default, which displays the keys and/or indices (secondary keys) of a `data.table`. Thanks @MichaelChirico for the PR, Yike Lu for the suggestion and Arun for honing that idea to its present form.
+    
+    * gains `col.names` argument, `"auto"` by default, which toggles which registers of column names to include in printed output. `"top"` forces `data.frame`-like behavior where column names are only ever included at the top of the output, as opposed to the default behavior which appends the column names below the output as well for longer (>20 rows) tables. `"none"` shuts down column name printing altogether. Thanks @MichaelChirico for the PR, Oleg Bondar for the suggestion, and Arun for guiding commentary.
 
 
 #### BUG FIXES

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -34,6 +34,7 @@
              "datatable.print.topn"="5L",            # datatable.<argument name>
              "datatable.print.class"="FALSE",        # for print.data.table
              "datatable.print.rownames"="TRUE",      # for print.data.table
+             "datatable.print.colnames"="'auto'",      # for print.data.table
              "datatable.print.keys"="FALSE",         # for print.data.table
              "datatable.allow.cartesian"="FALSE",    # datatable.<argument name>
              "datatable.dfdispatchwarn"="TRUE",                   # not a function argument

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -10461,6 +10461,23 @@ test(1820.1, fread("name,id\nfoo,1\nbar%\n"), error="Expecting 2 fields but foun
 test(1820.2, fread("name,id\nfoo,1\nbar%d"), error="Expecting 2 fields but found 1: <<bar%d>>")
 test(1820.3, fread("name,id\nfoo,1\nbar%s"), error="Expecting 2 fields but found 1: <<bar%s>>")
 
+# new argument for print.data.table: col.names
+#   issue #1482 / PR #1483
+DT = data.table(a = 1:21, b = 22:42)
+test(1821.1, sum(grepl("a.*b", capture.output(print(DT, col.names = "auto")))), 2L)
+test(1821.2, sum(grepl("a.*b", capture.output(print(DT, col.names = "top")))), 1L)
+x = capture.output(print(DT, col.names = "none"))
+test(1821.3, sum(grepl("a.*b", x)), 0L)
+test(1821.4, length(x), nrow(DT))
+test(1821.5, print(DT, col.names = "asdf"), error = "Valid options")
+test(1821.6, capture.output(print(DT[1:5], col.names = "none", class = TRUE)),
+     c("1: 1 22", "2: 2 23", "3: 3 24", "4: 4 25", "5: 5 26"), 
+     warning = "Column classes.*suppressed")
+suppressWarnings(
+  x <- capture.output(print(DT, col.names = "none", class = TRUE))
+)
+test(1821.7, sum(grepl("<", x)), 0L)
+
 
 ##########################
 

--- a/man/print.data.table.Rd
+++ b/man/print.data.table.Rd
@@ -12,6 +12,7 @@
     nrows=getOption("datatable.print.nrows"),        # default: 100
     class=getOption("datatable.print.class"),  # default: FALSE
     row.names=getOption("datatable.print.rownames"), # default: TRUE
+    col.names=getOption("datatable.print.colnames"), # default: "auto"
     print.keys=getOption("datatable.print.keys"),    # default: FALSE
     quote=FALSE,...)
 }
@@ -21,6 +22,7 @@
   \item{nrows}{ The number of rows which will be printed before truncation is enforced. }
   \item{class}{ If \code{TRUE}, the resulting output will include above each column its storage class (or a self-evident abbreviation thereof). }
   \item{row.names}{ If \code{TRUE}, row indices will be printed alongside \code{x}. }
+  \item{col.names}{ One of three flavors for controlling the display of column names in output. \code{"auto"} includes column names above the data, as well as below the table if \code{nrow(x) > 20}. \code{"top"} excludes this lower register when applicable, and \code{"none"} suppresses column names altogether (as well as column classes if \code{class = TRUE}. }
   \item{print.keys}{ If \code{TRUE}, any \code{\link{key}} and/or \code{\link[=indices]{index}} currently assigned to \code{x} will be printed prior to the preview of the data. }
   \item{quote}{ If \code{TRUE}, all output will appear in quotes, as in \code{print.default}. }
   \item{\dots}{ Other arguments ultimately passed to \code{format}. }


### PR DESCRIPTION
More progress towards #1523. I'm not convinced we need the three options anymore... in particular wondering whether `col.names = "none"` would actually be used. See also #1483. 