### PR TITLE
Fix NOTE bc extra files

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,5 @@
 ^\.RData$
 ^\.Rhistory$
 ^data\.table_.*\.tar\.gz$
+^cc\.R$
+^Makefile$

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,7 +36,6 @@ build:
   script:
     - Rscript -e 'install.packages("knitr", repos=file.path("file:",normalizePath("bus/mirror-packages/cran")))'
     - rm -r bus
-    - echo "Commit:" $CI_BUILD_REF >> ./DESCRIPTION
     - R CMD build .
     - mkdir -p bus/$CI_BUILD_NAME/cran/src/contrib
     - mv $(ls -1t data.table_*.tar.gz | head -n 1) bus/$CI_BUILD_NAME/cran/src/contrib/.


### PR DESCRIPTION
fixes --as-cran NOTE
```
* checking top-level files ... NOTE
Non-standard files/directories found at top level:
  ‘cc.R’ ‘Makefile’
```
and (this only affects gitlab builds)
```
* checking CRAN incoming feasibility ... NOTE
Unknown, possibly mis-spelled, fields in DESCRIPTION:
  ‘Commit’
```