### PR TITLE
faster setkeyv if keys already exist.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,8 @@
     * gains `print.keys` argument, `FALSE` by default, which displays the keys and/or indices (secondary keys) of a `data.table`. Thanks @MichaelChirico for the PR, Yike Lu for the suggestion and Arun for honing that idea to its present form.
     
     * gains `col.names` argument, `"auto"` by default, which toggles which registers of column names to include in printed output. `"top"` forces `data.frame`-like behavior where column names are only ever included at the top of the output, as opposed to the default behavior which appends the column names below the output as well for longer (>20 rows) tables. `"none"` shuts down column name printing altogether. Thanks @MichaelChirico for the PR, Oleg Bondar for the suggestion, and Arun for guiding commentary.
+    
+10. setkeyv accelerated if key already exists [#2331](https://github.com/Rdatatable/data.table/issues/2331). Thanks to @MarkusBonsch for the PR.
 
 
 #### BUG FIXES

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -1025,12 +1025,6 @@ DT = as.data.table(rbind(DF,DF))
 test(345, DT[,sum(y),by=x], {.x=as.IDate(c("2010-01-01","2010-01-02"));mode(.x)="double";data.table(x=.x,V1=c(18L,24L))})
 test(346, setkey(DT,x)[J(as.IDate("2010-01-02"))], {.x=as.IDate(rep("2010-01-02",6L));mode(.x)="double";data.table(x=.x,y=rep(c(2L,4L,6L),2),key="x")})
 
-# Test that invalid keys are reset, without user needing to remove key using key(DT)=NULL first
-DT = data.table(a=letters[1:3],b=letters[6:4],key="a")
-attr(DT,"sorted")="b"  # user can go under the hood
-test(347, setkey(DT,b), data.table(a=letters[3:1],b=letters[4:6],key="b"),
-          warning="Already keyed by this key but had invalid row order, key rebuilt")
-
 # Test .N==0 with nomatch=NA|0, # tests for #963 added as well
 DT = data.table(a=1:2,b=1:6,key="a")
 test(349, DT[J(2:3),.N,nomatch=NA,by=.EACHI]$N, c(3L,0L))
@@ -1731,6 +1725,10 @@ setkey(DT, x, y)
 test(600, is.sorted(DT$x))
 test(601, !is.sorted(DT$y))
 test(602, base::order(DT$x,DT$y), 1:20)
+
+## #2331 test that repeated setting of key works
+test(602.1, setkey(copy(DT), x, y), DT)
+test(602.2, setkey(copy(DT), x), {setkey(DT, NULL); setkey(DT, x)})
 
 # Test that as.list.data.table no longer copies via unclass, so speeding up sapply(DT,class) and lapply(.SD,...) etc, #2000
 N = if (.devtesting) 1e6 else 1e4


### PR DESCRIPTION
Adresses issue #2331.

A small benchmark highlights the benefit of the new implementation (code at the end of the comment):

DT is a data.table with 1e7 rows. x1 and x2 are columns with 10 groups each (1:10), x3 is numeric random numbers.
Time is median time in milliseconds of 100 iterations

|   |   | master | pull request |
|--- | --- | --- | --- | 
| 1 | no existing key ; setkey(DT, x1, x2) | 441 | 445 |
| 2 | existing key on x1 ; setkey(DT, x1, x2) | 284 | 286 |
| 3 | existing key on x1 and x2 ; setkey(DT, x1, x2) | 111 | 49 |
| 4 | existing key on x1, x2, and x3 ; setkey(DT, x1, x2) | 110 | 49 |

Cases 3 and 4 see a significant speed improvement since forderv is not called.

The only drawback is that the internal check that the data.table is really sorted by the key is not performed anymore. This has two implications that are absolutely acceptable from my perspective:
1. The internal logic of data.table is not tested in each call of setkeyv. I believe testing the sanity of the internal logic is a task for `test.data.table()`, and should not hamper the speed of a function that is called frequently.
2. If users 'go under the hood' and manipulate the `sorted` attribute manually, it is not guaranteed that the key is still correct. I believe that users that go under the hood should be expected to know what they do. No need to maintain a costly check for this very specific case.

Of course, I had to remove the test that checked this warning.

Here is the code for my benchmark:

```
library(data.table)
library(microbenchmark)

## timing for setkey
set.seed(100)
nrow <- 1e7
dat_nokey <- data.table(x1 = sample(1:10,nrow, replace = TRUE), x2 = sample(1:10, replace = TRUE), x3 = rnorm(nrow))

dat_onekey <- copy(dat_nokey)
setkey(dat_onekey, x1, verbose = TRUE)

dat_twokey <- copy(dat_nokey)
setkey(dat_twokey, x1, x2, verbose = TRUE)

dat_threekey <- copy(dat_nokey)
setkey(dat_threekey, x1, x2, x3, verbose = TRUE)

timing_setkey <- microbenchmark(nokey =    setkey(copy(dat_nokey), x1, x2),
                                onekey =   setkey(copy(dat_onekey), x1, x2),
                                twokey =   setkey(copy(dat_twokey), x1, x2),
                                threekey = setkey(copy(dat_threekey), x1, x2),
                                times = 100)

## test that all results are identical (except for threekey which is expected to be different)
nokey    = setkey(copy(dat_nokey), x1, x2)
onekey   = setkey(copy(dat_onekey), x1, x2, verbose = TRUE)
twokey   = setkey(copy(dat_twokey), x1, x2)
threekey = setkey(copy(dat_threekey), x1, x2)

if(!identical(nokey, onekey)) stop("Error")
if(!identical(nokey, twokey)) stop("Error")
```