### PR TITLE
Changed fread logical01 default to TRUE as NEWS item already said.

### DIFF
--- a/R/fread.R
+++ b/R/fread.R
@@ -1,5 +1,5 @@
 
-fread <- function(input="",file,sep="auto",sep2="auto",dec=".",quote="\"",nrows=Inf,header="auto",na.strings="NA",stringsAsFactors=FALSE,verbose=getOption("datatable.verbose"),autostart=NA,skip=0,select=NULL,drop=NULL,colClasses=NULL,integer64=getOption("datatable.integer64"), col.names, check.names=FALSE, encoding="unknown", strip.white=TRUE, fill=FALSE, blank.lines.skip=FALSE, key=NULL, showProgress=interactive(),data.table=getOption("datatable.fread.datatable"),nThread=getDTthreads(),logical01=FALSE)
+fread <- function(input="",file,sep="auto",sep2="auto",dec=".",quote="\"",nrows=Inf,header="auto",na.strings="NA",stringsAsFactors=FALSE,verbose=getOption("datatable.verbose"),autostart=NA,skip=0,select=NULL,drop=NULL,colClasses=NULL,integer64=getOption("datatable.integer64"), col.names, check.names=FALSE, encoding="unknown", strip.white=TRUE, fill=FALSE, blank.lines.skip=FALSE, key=NULL, showProgress=interactive(),data.table=getOption("datatable.fread.datatable"),nThread=getDTthreads(),logical01=TRUE)
 {
     stopifnot( is.character(sep), length(sep)==1, sep=="auto" || nchar(sep)==1 )
     if (sep == "auto") sep=""

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -2568,7 +2568,8 @@ if ("package:bit64" %in% search()) {
 
 # getwd() has been set by test.data.table() to the location of this tests.Rraw file. Test files should be in the same directory.
 f = "ch11b.dat"  # http://www.stats.ox.ac.uk/pub/datasets/csb/ch11b.dat
-test(900, fread(f), as.data.table(read.table(f)))
+test(900.1, fread(f, logical01=FALSE), as.data.table(read.table(f)))
+test(900.2, fread(f), as.data.table(read.table(f))[,V5:=as.logical(V5)])
 
 f = "1206FUT.txt"    # a CRLF line ending file (DOS)
 test(901.1, DT<-fread(f,strip.white=FALSE), setDT(read.table(f,sep="\t",header=TRUE,colClasses=as.vector(sapply(DT,class)))))
@@ -2576,8 +2577,9 @@ test(901.2, DT<-fread(f), setDT(read.table(f,sep="\t",header=TRUE,colClasses=as.
 
 # Test the coerce of column 23 to character on line 179 due to the 'A' for the first time.
 # As from v1.9.8 the columns are guessed better and there is no longer a warning.  Test 899 tests the warning.
+# Columns 'Cancelled' and 'Diverted' seem boolean (so logical01=TRUE good default for those) but Month just happens to be all-Jan
 f = "2008head.csv"
-test(902, fread(f), as.data.table(read.csv(f,stringsAsFactors=FALSE)))
+test(902, fread(f,logical01=FALSE), as.data.table(read.csv(f,stringsAsFactors=FALSE)))
 test(903, fread("A,B\n1,3,foo,5\n2,4,barbaz,6"), data.table(1:2,3:4,c("foo","barbaz"),5:6),
           warning="Starting.*on line 2 <<1,3,foo,5>> with 4 fields.*discarding line 1 <<A,B>>.*fields.*2")  # invalid colnames (too short)
 test(904, fread("A,B,C,D\n1,3,foo,5\n2,4,barbaz,6"), DT<-data.table(A=1:2,B=3:4,C=c("foo","barbaz"),D=5:6))  # ok
@@ -3158,7 +3160,7 @@ b = rbind(a, data.table(z=2,x=1))
 test(1080, b$z, c(1,2,3,2))
 
 # mid row logical detection
-test(1081, fread("A,B,C\n1,T,2\n"), data.table(A=1L,B="T",C=2L))
+test(1081, fread("A,B,C\n1,T,2\n"), data.table(A=TRUE,B="T",C=2L))
 
 # cartesian join answer's key should contain only the columns considered in binary search. Fixes #2677
 set.seed(45)
@@ -4083,8 +4085,8 @@ setNumericRounding(old_rounding)
 
 # that fread reads unescaped (but balanced) quotes in the middle of fields ok, #2694
 test(1215,
-   fread('N_ID VISIT_DATE REQ_URL REQType\n175931 2013-03-08T23:40:30 http://aaa.com/rest/api2.do?api=getSetMobileSession&data={"imei":"60893ZTE-CN13cd","appkey":"android_client","content":"Z0JiRA0qPFtWM3BYVltmcx5MWF9ZS0YLdW1ydXoqPycuJS8idXdlY3R0TGBtU 1'),
-   data.table(N_ID=175931L, VISIT_DATE="2013-03-08T23:40:30", REQ_URL='http://aaa.com/rest/api2.do?api=getSetMobileSession&data={"imei":"60893ZTE-CN13cd","appkey":"android_client","content":"Z0JiRA0qPFtWM3BYVltmcx5MWF9ZS0YLdW1ydXoqPycuJS8idXdlY3R0TGBtU', REQType=1L)
+   fread('N_ID VISIT_DATE REQ_URL REQType\n175931 2013-03-08T23:40:30 http://aaa.com/rest/api2.do?api=getSetMobileSession&data={"imei":"60893ZTE-CN13cd","appkey":"android_client","content":"Z0JiRA0qPFtWM3BYVltmcx5MWF9ZS0YLdW1ydXoqPycuJS8idXdlY3R0TGBtU 2'),
+   data.table(N_ID=175931L, VISIT_DATE="2013-03-08T23:40:30", REQ_URL='http://aaa.com/rest/api2.do?api=getSetMobileSession&data={"imei":"60893ZTE-CN13cd","appkey":"android_client","content":"Z0JiRA0qPFtWM3BYVltmcx5MWF9ZS0YLdW1ydXoqPycuJS8idXdlY3R0TGBtU', REQType=2L)
 )
 test(1216.1, fread('A,B,C\n1.2,Foo"Bar,"a"b\"c"d"\nfo"o,bar,"b,az""\n'),
          data.table(A = c("1.2", "fo\"o"), B = c("Foo\"Bar", "bar"), C = c("a\"b\"c\"d", "b,az\"")))
@@ -5048,10 +5050,10 @@ test(1324, fread('A,B,C\n1,4,"foo"\n2,5,"bar'), data.table(A=1:2,B=4:5,C=c('foo'
 test(1325, fread('A,B,C\n1,4,"foo"\n2,5,"bar"'), data.table(A=1:2,B=4:5,C=c("foo",'bar')))
 test(1326, fread('A,B,C\n1,4,"foo"\n2,5,bar"'), data.table(A=1:2,B=4:5,C=c("foo",'bar"')))
 test(1327, fread('A,B,C\n1,4,"foo"\n2,5,""bar""'), data.table(A=1:2,B=4:5,C=c("foo",'"bar"')))
-cat('A,B\n1,"Joe \\",Bloggs"', file = f<-tempfile())
-test(1328, fread(f), data.table(A=1L, B='Joe \\",Bloggs'))
-cat('A,B\n1,"Joe \\",Bloggs"\n', file = f<-tempfile())
-test(1328.2, fread(f), data.table(A=1L, B='Joe \\",Bloggs'))
+cat('A,B\n2,"Joe \\",Bloggs"', file = f<-tempfile())
+test(1328, fread(f), data.table(A=2L, B='Joe \\",Bloggs'))
+cat('A,B\n2,"Joe \\",Bloggs"\n', file = f<-tempfile())
+test(1328.2, fread(f), data.table(A=2L, B='Joe \\",Bloggs'))
 unlink(f)
 test(1329, fread(), error="empty")
 # add test that that escaped escapes at the end of a quoted field
@@ -5796,16 +5798,16 @@ test(1437, DT[a==factor("b"),verbose=TRUE], DT[c(2,5)], output="Creating new ind
 
 # fread dec=',' e.g. France
 test(1438, fread("A;B\n1;2,34\n", dec="12"), error="nchar(dec) == 1 is not TRUE")
-test(1439, fread("A;B\n1;2,34\n", dec="1"), data.table(A=1L, B="2,34"))
-test(1440, fread("A;B\n1;2,34\n", dec=","), data.table(A=1L, B=2.34))
+test(1439, fread("A;B\n8;2,34\n", dec="1"), data.table(A=8L, B="2,34"))
+test(1440, fread("A;B\n8;2,34\n", dec=","), data.table(A=8L, B=2.34))
 test(1441, fread("A;B\n1;2,34\n", sep=".", dec="."), error="sep == dec ('.') is not allowed")
 test(1442, fread("A;B\n1;2,34\n", dec=",", sep=","), error="sep == dec (',') is not allowed")
 
 # sep=".", issue #502
-input = paste( paste("192.168.1.", 1:10, sep=""), collapse="\n")
-test(1444.1, fread(input, sep=".", dec="*"), ans<-data.table(V1=192L,V2=168L,V3=1L,V4=1:10))
+input = paste( paste("192.168.4.", 1:10, sep=""), collapse="\n")
+test(1444.1, fread(input, sep=".", dec="*"), ans<-data.table(V1=192L,V2=168L,V3=4L,V4=1:10))
 test(1444.2, fread(input, sep=".", dec=","), ans)
-test(1444.3, fread(paste(paste("192. 168. 1. ", 1:10, sep = ""), collapse="\n"), sep=".", dec=","), ans)
+test(1444.3, fread(paste(paste("192. 168. 4. ", 1:10, sep = ""), collapse="\n"), sep=".", dec=","), ans)
 test(1444.4, fread(paste(paste("Hz.BB.GHG.", 1:10, sep = ""), collapse="\n"), sep=".", dec=","),
              data.table(V1="Hz",V2="BB",V3="GHG",V4=1:10))
 
@@ -5860,8 +5862,8 @@ test(1453, fread("fread_line_error.csv"), error="Line 12 from sampling jump 0 st
 # TODO: add comment=="#".   Ensure only after last field is observed.
 
 # no-sep-found => sep="\n", use case for this in #738
-test(1454.1, fread('"Foo"`"Bar"\n1`2\n',sep="`"), data.table(Foo=1L,Bar=2L))
-test(1454.2, fread('"Foo"\n1\n',sep="`"), data.table(Foo=1L))
+test(1454.1, fread('"Foo"`"Bar"\n5`2\n',sep="`"), data.table(Foo=5L,Bar=2L))
+test(1454.2, fread('"Foo"\n5\n',sep="`"), data.table(Foo=5L))
 
 # Fix for #958 - Don't create secondary keys on .SD
 DT <- data.table(a=c(1, 1, 1, 0, 0), b=c("A", "B", "A1", "A", "B"))
@@ -6354,8 +6356,8 @@ test(1499, ans1, ans2)
 
 # Fix for #488
 if ("package:bit64" %in% search()) {
-    test(1500.1, fread("x,y\n0,\n", colClasses = list(integer64 = "y")),
-            data.table(x=0L, y=as.integer64(NA)))
+    test(1500.1, fread("x,y\n3,\n", colClasses = list(integer64 = "y")),
+            data.table(x=3L, y=as.integer64(NA)))
     # more tests after new fix
     test(1500.2, fread("x,y\n0,12345678901234\n0,\n0,\n0,\n0,\n,\n,\n,\n,\n,\n,\n,\n,\n,\n,\n,\n12345678901234,\n0,\n0,\n0,\n0,\n0,\n"),
         data.table(x=as.integer64(c(rep(0L, 5L), rep(NA, 11), 12345678901234, rep(0L,5L))),
@@ -6967,7 +6969,7 @@ str = 'L1\tsome\tunquoted\tstuff\nL2\tsome\t"half" quoted\tstuff\nL3\tthis\t"sho
 test(1551.5, fread(str), data.table(L1 = c("L2", "L3"), some = c("some", "this"), unquoted = c("\"half\" quoted", "should work"), stuff = c("stuff", "ok though")))
 #1095
 rhs = read.table("issue_1095_fread.txt", sep=",", comment.char="", stringsAsFactors=FALSE, quote="", strip.white=TRUE)
-test(1551.6, fread("issue_1095_fread.txt"), setDT(rhs))
+test(1551.6, fread("issue_1095_fread.txt", logical01=FALSE), setDT(rhs))
 
 # FR #1314 rest of na.strings issue
 str = "a,b,c,d\n#N/A,+1,5.5,FALSE\n#N/A,5,6.6,TRUE\n#N/A,+1,#N/A,-999\n#N/A,#N/A,-999,FALSE\n#N/A,1,NA,TRUE"
@@ -7011,23 +7013,23 @@ test(1555.1, ans1, ans2)
 
 # bug #1035, take care of spaces automatically. Note that the columns are also read in proper types. Also with quotes when sep is not space.
 str1=" ITERATION    THETA1       THETA2
-            0  3.95527E+01  2.10651E+01"
+            2  3.95527E+01  2.10651E+01"
 str2=" ITERATION,    THETA1,       THETA2
-            0,  3.95527E+01,  2.10651E+01"
+            2,  3.95527E+01,  2.10651E+01"
 str3=" ITERATION  ,  THETA1   ,    THETA2
-            0  ,  3.95527E+01  ,  2.10651E+01"
+            2  ,  3.95527E+01  ,  2.10651E+01"
 str4=" ITERATION  ,  THETA1   ,    \"THETA2\"
-            0  ,  3.95527E+01  ,  2.10651E+01"
+            2  ,  3.95527E+01  ,  2.10651E+01"
 str5=" ITERATION  ,  THETA1   ,    THETA2
             bla  ,  3.95527E+01  ,  2.10651E+01"
-test(1555.2, fread(str1), data.table(ITERATION=0L, THETA1=39.5527, THETA2=21.0651))
-test(1555.3, fread(str2), data.table(ITERATION=0L, THETA1=39.5527, THETA2=21.0651))
-test(1555.4, fread(str3), data.table(ITERATION=0L, THETA1=39.5527, THETA2=21.0651))
-test(1555.5, fread(str4), data.table(ITERATION=0L, THETA1=39.5527, THETA2=21.0651))
+test(1555.2, fread(str1), data.table(ITERATION=2L, THETA1=39.5527, THETA2=21.0651))
+test(1555.3, fread(str2), data.table(ITERATION=2L, THETA1=39.5527, THETA2=21.0651))
+test(1555.4, fread(str3), data.table(ITERATION=2L, THETA1=39.5527, THETA2=21.0651))
+test(1555.5, fread(str4), data.table(ITERATION=2L, THETA1=39.5527, THETA2=21.0651))
 test(1555.6, fread(str5), data.table(ITERATION="bla", THETA1=39.5527, THETA2=21.0651))
 # without strip.white
 # when sep==' ' as in str1, header col spaces should still be stripped even when strip.white=FALSE
-test(1555.7, fread(str1, strip.white=FALSE), data.table(ITERATION=0L, THETA1=39.5527, THETA2=21.0651))
+test(1555.7, fread(str1, strip.white=FALSE), data.table(ITERATION=2L, THETA1=39.5527, THETA2=21.0651))
 test(1555.8, names(fread(str2, strip.white=FALSE)),  c(" ITERATION","    THETA1","       THETA2"))
 test(1555.9, names(fread(str3, strip.white=FALSE)),  c(" ITERATION  ","  THETA1   ","    THETA2"))
 test(1555.11, names(fread(str4, strip.white=FALSE)), c(" ITERATION  ","  THETA1   ","    \"THETA2\""))
@@ -7035,18 +7037,18 @@ test(1555.11, names(fread(str4, strip.white=FALSE)), c(" ITERATION  ","  THETA1 
 # bug #1035, reply to the post from another user
 str1="  22 4 6 4\n  34 22 34 5\n  6 2 1 4\n"
 str2="22 4 6 4\n34 22 34 5\n6 2 1 4\n"
-test(1555.11, fread(str1), fread(str2))
+test(1555.12, fread(str1), fread(str2))
 
 # bug #785
 rhs <- setDT(read.table("issue_785_fread.txt", header=TRUE, stringsAsFactors=FALSE, sep="\t", strip.white=TRUE))
-test(1555.12, fread("issue_785_fread.txt"), rhs)
+test(1555.13, fread("issue_785_fread.txt", logical01=FALSE), rhs)
 
 # bug #529, http://stackoverflow.com/questions/22229109/r-data-table-fread-command-how-to-read-large-files-with-irregular-separators
 str1=" YYYY MM DD HH mm             19490             40790
  1991 10  1  1  0      1.046465E+00      1.568405E+00"
 str2="YYYY MM DD HH mm             19490             40790
 1991 10  1  1  0      1.046465E+00      1.568405E+00"
-test(1555.13, fread(str1), fread(str2))
+test(1555.14, fread(str1), fread(str2))
 
 # fix for #1330
 test(1556.1, fread("issue_1330_fread.txt", nrow=2), data.table(a=1:2, b=1:2), warning="Found.*discarded.*<<3.*3>>")
@@ -7196,8 +7198,8 @@ test(1572, fread('"abcd efgh." ijkl.\tmnop "qrst uvwx."\t45\n', quote=""),
 
 # Fix for #1384, fread with empty new line, initial checks failed due to extra spaces.
 test(1573, fread('a,b
-       1,2
-       '), data.table(a=1L, b=2L))
+       4,2
+       '), data.table(a=4L, b=2L))
 
 # Fix for #1375
 X = data.table(a=1:3,b=4:6,c=c("foo","bar","baz"))
@@ -7391,7 +7393,7 @@ test(1583.4, dt[, max(y), by=x], ans4)
 options(datatable.optimize=optim)
 
 # Fixed a minor bug in fread when blank.lines.skip=TRUE
-f1 <- function(x, f=TRUE, b=FALSE) fread(x, fill=f, blank.lines.skip=b, data.table=FALSE)
+f1 <- function(x, f=TRUE, b=FALSE) fread(x, fill=f, blank.lines.skip=b, data.table=FALSE, logical01=FALSE)
 f2 <- function(x, f=TRUE, b=FALSE) read.table(x, fill=f, blank.lines.skip=b, sep=",", header=TRUE, stringsAsFactors=FALSE)
 test(1584.1, f1("fread_blank.txt", f=FALSE, b=TRUE), f2("fread_blank.txt", f=FALSE, b=TRUE))
 test(1584.2, f1("fread_blank2.txt", f=FALSE, b=TRUE), f2("fread_blank2.txt", f=FALSE, b=TRUE))
@@ -7841,8 +7843,8 @@ setattr(DT, 'class', c('data.table', 'data.frame')) # simulates over-allocation 
 if (!truelength(DT)) test(1620, truelength(as.data.table(DT)), 1026L)
 
 # fix for #1116, (#1239 and #1201)
-test(1621.1, fread("issue_1116_fread_few_lines.txt"), setDT(read.delim("issue_1116_fread_few_lines.txt", stringsAsFactors=FALSE, sep=",", check.names=FALSE)))
-test(1621.2, fread("issue_1116_fread_few_lines_2.txt"), setDT(read.delim("issue_1116_fread_few_lines_2.txt", stringsAsFactors=FALSE, sep=",", check.names=FALSE)))
+test(1621.1, fread("issue_1116_fread_few_lines.txt", logical01=FALSE), setDT(read.delim("issue_1116_fread_few_lines.txt", stringsAsFactors=FALSE, sep=",", check.names=FALSE)))
+test(1621.2, fread("issue_1116_fread_few_lines_2.txt", logical01=FALSE), setDT(read.delim("issue_1116_fread_few_lines_2.txt", stringsAsFactors=FALSE, sep=",", check.names=FALSE)))
 
 # fix for #1573
 ans1 = fread("issue_1573_fill.txt", fill=TRUE, na.strings="")
@@ -9326,9 +9328,9 @@ test(1702, isoweek(test_cases), test_values)
 
 # fread, ensure no shell commands #1702
 if (.Platform$OS.type=="unix") {
-    cat("a,b\n1,2", file=f<-tempfile())
+    cat("a,b\n4,2", file=f<-tempfile())
     cmd <- sprintf("cat %s", f)
-    test(1703.1, fread(cmd), data.table(a=1L, b=2L))
+    test(1703.1, fread(cmd), data.table(a=4L, b=2L))
     test(1703.2, fread(file=cmd), error=sprintf("Provided file '%s' does not exists", cmd))
     unlink(f)
 }
@@ -9841,8 +9843,8 @@ test(1742.5, substring(x,nchar(x)-10,nchar(x)), c("50,28,95,76","62,87,23,40"))
 options(oldverbose)  # last capture.output(fwrite()) has happened now. TODO: tidy up and remove.
 
 # fread should properly handle NA in colClasses argument #1910
-test(1743.1, sapply(fread("a,b\n1,a", colClasses=c(NA, "factor")), class), c(a="integer", b="factor"))
-test(1743.2, sapply(fread("a,b\n1,a", colClasses=c(NA, NA)), class), c(a="integer", b="character"))
+test(1743.1, sapply(fread("a,b\n3,a", colClasses=c(NA, "factor")), class), c(a="integer", b="factor"))
+test(1743.2, sapply(fread("a,b\n3,a", colClasses=c(NA, NA)), class), c(a="integer", b="character"))
 test(1743.3, fread("a,b\n1,a", colClasses=c(NA, TRUE)), error="colClasses is.*logical.*but it has some TRUE or FALSE.*not allowed")
 # also unknown issue in mixed character/factor output and colClasses vector
 test(1743.4, sapply(fread("a,b\n1,a", colClasses=c("character", "factor")), class), c(a="character", b="factor"))
@@ -10156,7 +10158,7 @@ test(1754, fread("allchar.csv")[c(1,2,17575,17576),col2], c("AAN","BAN","YZZ","Z
 
 # unescaped embedded quotes from here: http://stackoverflow.com/questions/42939866/fread-multiple-separators-in-a-string
 test(1755, fread("unescaped.csv"),
-  data.table(No     =c(0L,1L),
+  data.table(No     =c(FALSE,TRUE),
              Comment=c('he said:"wonderful."', 'The problem is: reading table, and also "a problem, yes." keep going on.'),
              Type   =c('A','A')))
 
@@ -10478,18 +10480,18 @@ test(1800.1, fread("A\n1e55555555\n-1e+234056\n2e-59745"), data.table(A=c("1e555
 # Test files with "round" sizes (different multiples of 2, from 512B to 64KB)
 for (mul in c(16, 128, 512, 1024, 2048)) {
   ff = file(f<-tempfile(), open="wb")
-  cat(paste(rep("1234,5678,9012,3456,7890,abcd,1\x0A", mul), collapse=""), file=ff)
+  cat(paste(rep("1234,5678,9012,3456,7890,abcd,4\x0A", mul), collapse=""), file=ff)
   close(ff)
-  DT = data.table(V1=rep(1234L, mul), V2=5678L, V3=9012L, V4=3456L, V5=7890L, V6="abcd", V7=1L)
+  DT = data.table(V1=rep(1234L, mul), V2=5678L, V3=9012L, V4=3456L, V5=7890L, V6="abcd", V7=4L)
   test(1801 + log2(mul)/100, file.info(f)$size, mul*32)
   test(1802 + log2(mul)/100, fread(f), DT)
 }
 # Test without the newline
 ff = file(f<-tempfile(), open="wb")
-cat(paste("1", paste(rep("1234,5678,9012,3456,7890,zyxw,0", 128), collapse="\x0A"), sep=""), file=ff)
+cat(paste("1", paste(rep("1234,5678,9012,3456,7890,zyxw,4", 128), collapse="\x0A"), sep=""), file=ff)
 close(ff)
 test(1803.1, file.info(f)$size, 4096)
-DT = data.table(V1=rep(1234L, 128), V2=5678L, V3=9012L, V4=3456L, V5=7890L, V6="zyxw", V7=0L)
+DT = data.table(V1=rep(1234L, 128), V2=5678L, V3=9012L, V4=3456L, V5=7890L, V6="zyxw", V7=4L)
 DT[1, 1] = 11234L
 test(1803.2, fread(f), DT)
 
@@ -10504,7 +10506,7 @@ cat("A,B\r1,2\r3,4",file=f<-tempfile())
   test(1808.3, fread(f), data.table(A=c(1L,3L),B=c(2L,4L)))
 unlink(f)
 test(1808.4, fread("A,B\r1,3\r\r\r2,4\r"), data.table(A=1:2, B=3:4))
-test(1808.5, fread("A,B\r1,3\r\r \r2,4\r"), data.table(A=1L, B=3L), warning="afterwards.*discarded.*<<2,4>>")
+test(1808.5, fread("A,B\r4,3\r\r \r2,4\r"), data.table(A=4L, B=3L), warning="afterwards.*discarded.*<<2,4>>")
 test(1808.6, fread("A,B\r1,3\r\r \r2,4\r", blank.lines.skip=TRUE), data.table(A=1:2, B=3:4))
 test(1808.7, fread("A,B\r1,3\r\r \r2,4\r", fill=TRUE), data.table(A=c(1L,NA,2L), B=c(3L,NA,4L)))
 test(1808.8, fread("A,B\r1,3\r\r \r2,\r", blank.lines.skip=TRUE, fill=TRUE), data.table(A=1:2, B=c(3L,NA)))
@@ -10577,7 +10579,7 @@ DT[, z := ncol(.SD) + x, .SDcols = c("x", "y")]
 test(1823.6, DT$z, seq(4, 13))
 
 # Issue 2250
-test(1824, fread("A,B\n1,384325987234905827340958734572934\n"), data.table(A=1L, B="384325987234905827340958734572934"))
+test(1824, fread("A,B\n2,384325987234905827340958734572934\n"), data.table(A=2L, B="384325987234905827340958734572934"))
 
 # Issue 2251
 test(1825.1, fread('A,B\n"1","2"', colClasses = "integer"), data.table(A=1L, B=2L))
@@ -10595,7 +10597,7 @@ unlink(f)
 
 # Issue 2222
 test(1827.1, fread("A,B\n1987,1\n1987,3\n", na.strings=c("1987", "NA")), data.table(A=c(NA,NA),B=c(1L,3L)))
-test(1827.2, fread("A,B\n1987,1\n1,3\n",    na.strings=c("1987", "NA")), data.table(A=c(NA,1L),B=c(1L,3L)))
+test(1827.2, fread("A,B\n1987,1\n4,3\n",    na.strings=c("1987", "NA")), data.table(A=c(NA,4L),B=c(1L,3L)))
 test(1827.3, fread("A,B\n1987,1\n1987,3\n", na.strings="1987"), data.table(A=c(NA,NA),B=c(1L,3L)))
 test(1827.4, fread("A,B\n1987,1\n1,3\n",    na.strings="198"),  data.table(A=c(1987L,1L),B=c(1L,3L)))
 

--- a/man/fread.Rd
+++ b/man/fread.Rd
@@ -3,7 +3,7 @@
 \title{ Fast and friendly file finagler }
 \description{
    Similar to \code{read.table} but faster and more convenient. All controls such as \code{sep}, \code{colClasses} and \code{nrows} are automatically detected. \code{bit64::integer64} types are also detected and read directly without needing to read as character before converting.
-   
+
    Dates are read as character currently. They can be converted afterwards using the excellent \code{fasttime} package or standard base functions.
 
    `fread` is for \emph{regular} delimited files; i.e., where every row has the same number of columns. In future, secondary separator (\code{sep2}) may be specified \emph{within} each column. Such columns will be read as type \code{list} where each cell is itself a vector.
@@ -14,12 +14,12 @@ nrows=Inf, header="auto", na.strings="NA",
 stringsAsFactors=FALSE, verbose=getOption("datatable.verbose"), autostart=NA,
 skip=0, select=NULL, drop=NULL, colClasses=NULL,
 integer64=getOption("datatable.integer64"),         # default: "integer64"
-col.names, 
-check.names=FALSE, encoding="unknown", 
-strip.white=TRUE, fill=FALSE, blank.lines.skip=FALSE, key=NULL, 
+col.names,
+check.names=FALSE, encoding="unknown",
+strip.white=TRUE, fill=FALSE, blank.lines.skip=FALSE, key=NULL,
 showProgress=interactive(),
 data.table=getOption("datatable.fread.datatable"),
-nThread=getDTthreads(), logical01=FALSE
+nThread=getDTthreads(), logical01=TRUE
 )
 }
 \arguments{
@@ -64,20 +64,20 @@ If an empty line is encountered then reading stops there (unless \code{blank.lin
 
 \bold{Line endings:} All known line endings are detected automatically: \code{\\n} (*NIX including Mac), \code{\\r\\n} (Windows CRLF), \code{\\r} (old Mac) and \code{\\n\\r} (just in case). There is no need to convert input files first. \code{fread} running on any architecture will read a file from any architecture. Both \code{\\r} and \code{\\n} may be embedded in character strings (including column names) provided the field is quoted.
 
-\bold{Decimal separator and locale:} \code{fread(...,dec=",")} should just work. \code{fread} uses C function \code{strtod} to read numeric data; e.g., \code{1.23} or \code{1,23}. \code{strtod} retrieves the decimal separator (\code{.} or \code{,} usually) from the locale of the R session rather than as an argument passed to the \code{strtod} function. So for \code{fread(...,dec=",")} to work, \code{fread} changes this (and only this) R session's locale temporarily to a locale which provides the desired decimal separator. 
+\bold{Decimal separator and locale:} \code{fread(...,dec=",")} should just work. \code{fread} uses C function \code{strtod} to read numeric data; e.g., \code{1.23} or \code{1,23}. \code{strtod} retrieves the decimal separator (\code{.} or \code{,} usually) from the locale of the R session rather than as an argument passed to the \code{strtod} function. So for \code{fread(...,dec=",")} to work, \code{fread} changes this (and only this) R session's locale temporarily to a locale which provides the desired decimal separator.
 
 On Windows, "French_France.1252" is tried which should be available as standard (any locale with comma decimal separator would suffice) and on unix "fr_FR.utf8" (you may need to install this locale on unix). \code{fread()} is very careful to set the locale back again afterwards, even if the function fails with an error. The choice of locale is determined by \code{options()$datatable.fread.dec.locale}. This may be a \emph{vector} of locale names and if so they will be tried in turn until the desired \code{dec} is obtained; thus allowing more than two different decimal separators to be selected. This is a new feature in v1.9.6 and is experimental. In case of problems, turn it off with \code{options(datatable.fread.dec.experiment=FALSE)}.
 
-\bold{Quotes:} 
+\bold{Quotes:}
 
-When \code{quote} is a single character, 
+When \code{quote} is a single character,
 
   \itemize{
       \item{Spaces and other whitespace (other than \code{sep} and \code{\\n}) may appear in unquoted character fields, e.g., \code{...,2,Joe Bloggs,3.14,...}.}
 
-      \item{When \code{character} columns are \emph{quoted}, they must start and end with that quoting character immediately followed by \code{sep} or \code{\\n}, e.g., \code{...,2,"Joe Bloggs",3.14,...}. 
+      \item{When \code{character} columns are \emph{quoted}, they must start and end with that quoting character immediately followed by \code{sep} or \code{\\n}, e.g., \code{...,2,"Joe Bloggs",3.14,...}.
 
-      In essence quoting character fields are \emph{required} only if \code{sep} or \code{\\n} appears in the string value. Quoting may be used to signify that numeric data should be read as text. Unescaped quotes may be present in a quoted field, e.g., \code{...,2,"Joe, "Bloggs"",3.14,...}, as well as escaped quotes, e.g., \code{...,2,"Joe \",Bloggs\"",3.14,...}. 
+      In essence quoting character fields are \emph{required} only if \code{sep} or \code{\\n} appears in the string value. Quoting may be used to signify that numeric data should be read as text. Unescaped quotes may be present in a quoted field, e.g., \code{...,2,"Joe, "Bloggs"",3.14,...}, as well as escaped quotes, e.g., \code{...,2,"Joe \",Bloggs\"",3.14,...}.
 
       If an embedded quote is followed by the separator inside a quoted field, the embedded quotes up to that point in that field must be balanced; e.g. \code{...,2,"www.blah?x="one",y="two"",3.14,...}.
 
@@ -147,7 +147,7 @@ require(data.table)
 if(all(sapply(c("sqldf", "ff"), requireNamespace, quietly = TRUE))) {
   require(sqldf)
   require(ff)
-  
+
   system.time(DT <- fread("test.csv"))
   #  3 sec (faster and friendlier)
 
@@ -171,8 +171,8 @@ tables()
 write.table(DTbig,"testbig.csv",sep=",",row.names=FALSE,quote=FALSE)
 # 500MB (10 million rows x 6 columns)
 
-system.time(DF <- read.table("testbig.csv",header=TRUE,sep=",",         
-    quote="",stringsAsFactors=FALSE,comment.char="",nrows=1e7,                     
+system.time(DF <- read.table("testbig.csv",header=TRUE,sep=",",
+    quote="",stringsAsFactors=FALSE,comment.char="",nrows=1e7,
     colClasses=c("integer","integer","numeric",
                  "character","numeric","integer")))
 # 100-200 sec (varies)
@@ -190,7 +190,7 @@ download.file("http://stat-computing.org/dataexpo/2009/2008.csv.bz2",
               destfile="2008.csv.bz2")
 # 109MB (compressed)
 
-system("bunzip2 2008.csv.bz2")                                          
+system("bunzip2 2008.csv.bz2")
 # 658MB (7,009,728 rows x 29 columns)
 
 colClasses = sapply(read.csv("2008.csv",nrows=100),class)
@@ -200,8 +200,8 @@ colClasses = sapply(read.csv("2008.csv",nrows=200),class)
 # 5 character, 24 integer. Correct. Might have missed data only using 100 rows
 # since read.table assumes colClasses is correct.
 
-system.time(DF <- read.table("2008.csv", header=TRUE, sep=",",          
-    quote="",stringsAsFactors=FALSE,comment.char="",nrows=7009730,      
+system.time(DF <- read.table("2008.csv", header=TRUE, sep=",",
+    quote="",stringsAsFactors=FALSE,comment.char="",nrows=7009730,
     colClasses=colClasses))
 # 360 secs
 
@@ -260,7 +260,7 @@ fread(data, colClasses=list(character=2:4))     # same using column numbers
 
 # drop
 fread(data, colClasses=c("B"="NULL","C"="NULL"))   # as read.csv
-fread(data, colClasses=list(NULL=c("B","C")))      # 
+fread(data, colClasses=list(NULL=c("B","C")))      #
 fread(data, drop=c("B","C"))      # same but less typing, easier to read
 fread(data, drop=2:3)             # same using column numbers
 


### PR DESCRIPTION
As per NEWS item:  
> The large sample of rows throughout the file means that `fread` will be confident that the column really does just contain `0`s and `1`s, enabling and encouraging this convenient and efficient choice to save needing conversion afterwards or setting `colClasses` manually. In R, `logical` is `integer` anyway and can be treated as such in calculations.

In the tests needed to be changed, the choice made sense; e.g. `Cancelled` and `Delayed` columns are now logical by default,  but `Month` too because it happened to be all-January coded as a single integer 1.  The latter case is felt to be unusual and that the benefits on the whole outweigh any risks.  We don't think any existing code will break, as per NEWS item.