### PR TITLE
fread Windows file mapping call fixed to pass 32bit Windows

### DIFF
--- a/src/fread.c
+++ b/src/fread.c
@@ -1098,9 +1098,7 @@ int freadMain(freadMainArgs _args) {
         DTPRINT("  File opened, size = %s.\n", filesize_to_str(fileSize));
         DTPRINT("  Memory mapping ... ");
       }
-      DWORD hi = (fileSize) >> 32;            // tried very very hard again on 26 & 27th April 2017 to over-map file by 1 byte
-      DWORD lo = (fileSize) & 0xFFFFFFFFull;  // on Windows for COW/FILE_MAP_COPY on read-only file, with no joy.
-      HANDLE hMap=CreateFileMapping(hFile, NULL, PAGE_WRITECOPY, hi, lo, NULL);
+      HANDLE hMap=CreateFileMapping(hFile, NULL, PAGE_WRITECOPY, 0, 0, NULL);
       if (hMap==NULL) { CloseHandle(hFile); STOP("This is Windows, CreateFileMapping returned error %d for file %s", GetLastError(), fnam); }
       mmp = MapViewOfFile(hMap,FILE_MAP_COPY,0,0,fileSize);  // fileSize must be <= hilo passed to CreateFileMapping above.
       CloseHandle(hMap);  // we don't need to keep the file open; the MapView keeps an internal reference;


### PR DESCRIPTION
The `>>32` failed on win-builder with : 

fread.c: In function 'freadMain':
fread.c:1101:7: warning: right shift count >= width of type
       DWORD hi = (fileSize) >> 32;

Now, `fileSize` is declared as `size_t`.  So I guess that win-builder runs on a 32-bit Windows machine where `size_t` is 32bit.
