### PR TITLE
Tidied writeInt32 and writeInt64

### DIFF
--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -78,12 +78,14 @@ test <- function(num,x,y,error=NULL,warning=NULL,output=NULL) {
     all.equal.result = TRUE
     assign("ntest", get("ntest", parent.frame()) + 1, parent.frame(), inherits=TRUE)   # bump number of tests run
     assign("lastnum", num, parent.frame(), inherits=TRUE)
-    v = getOption("datatable.verbose")
-    i = interactive()   # exists(".devtesting",parent.frame()) && get(".devtesting", parent.frame())
-    if (v || i) {
-        cat(if (i) "\r" else "\n\n", "Running test id ", num, "     ",sep="")
-    }
-    # TO DO: every line that could possibly fail should ideally be inside test()
+
+    cat("\rRunning test id", num, "     ")
+    flush.console()
+    # This flush is for Windows to make sure last test number is written to file in CRAN and win-builder output where
+    # console output is captured. \r seems especially prone to not being auto flushed. The downside is that the last 13
+    # lines output are filled with the last 13 "running test num" lines rather than the last error output, but that's
+    # better than the dev-time-lost when it crashes and it actually crashed much later than the last test number visible.
+
     xsub = substitute(x)
     ysub = substitute(y)
     if (is.null(output)) err <<- try(x,TRUE)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -9269,7 +9269,7 @@ test(1695.13, x %between% c(3, 7), logical(0))
 old_opt = getOption("datatable.verbose")
 options(datatable.verbose = TRUE)
 x = data.table(A = 10:17)
-test(1696.0, any(grepl("bmerge", capture.output(x[A %inrange% 13:14]))), TRUE)
+test(1696.0, x[A %inrange% 13:14], output="bmerge")
 # restore verbosity
 options(datatable.verbose = old_opt)
 
@@ -10693,7 +10693,6 @@ test(1830.8, identical(
   fread("G\n0.000000000000000000000000000000000000000000000000000000000000449548\n"),
   data.table(G=c(4.49548e-61))))
 
-
 # Test that integers just above 128 or 256 characters in length parse as strings, not as integers/floats
 # This guards against potential overflows in the count of digits
 src1 = paste0(rep("1234567890", 13), collapse="")  # length = 130, slightly above 128
@@ -10703,6 +10702,12 @@ test(1831.2, fread(paste0("A\n", src2)), data.table(A=src2))
 test(1831.3, fread(paste0("A\n", src2, ".33")), data.table(A=paste0(src2, ".33")))
 test(1831.4, fread(paste0("A\n", "1.", src2)), data.table(A=paste0("1.", src2)))
 
+DT = as.data.table(matrix(5L, nrow=10, ncol=10))
+test(1832.1, fwrite(DT, f<-tempfile(), verbose=TRUE), output="Column writers")
+DT = as.data.table(matrix(5L, nrow=10, ncol=60))
+# Using capture.output directly to look for the "..." because test(,output=) intercepts [] for convenience elsewhere
+test(1832.2, any(grepl("^Column writers.* [.][.][.] ", capture.output(fwrite(DT, f, verbose=TRUE)))))
+unlink(f)
 
 
 ##########################

--- a/src/fread.c
+++ b/src/fread.c
@@ -1010,7 +1010,7 @@ int freadMain(freadMainArgs _args) {
       else
         DTPRINT("  None of the NAstrings look like numbers.\n");
     }
-    if (args.skipNrow) DTPRINT("  skip num lines = %lld\n", args.skipNrow);
+    if (args.skipNrow) DTPRINT("  skip num lines = %llu\n", (llu)args.skipNrow);
     if (args.skipString) DTPRINT("  skip to string = <<%s>>\n", args.skipString);
     DTPRINT("  show progress = %d\n", args.showProgress);
     DTPRINT("  0/1 column will be read as %s\n", args.logical01? "boolean" : "integer");
@@ -1244,14 +1244,14 @@ int freadMain(freadMainArgs _args) {
     pos = ch;
     ch = sof;
     while (ch<pos) line+=(*ch++=='\n');
-    if (verbose) DTPRINT("Found skip='%s' on line %d. Taking this to be header row or first row of data.\n",
-                         args.skipString, line);
+    if (verbose) DTPRINT("Found skip='%s' on line %llu. Taking this to be header row or first row of data.\n",
+                         args.skipString, (llu)line);
     ch = pos;
   }
   // Skip the first `skipNrow` lines of input.
   else if (args.skipNrow>0) {
     while (ch<eof && line<=args.skipNrow) line+=(*ch++=='\n');
-    if (ch>=eof) STOP("skip=%d but the input only has %d line%s", args.skipNrow, line, line>1?"s":"");
+    if (ch>=eof) STOP("skip=%llu but the input only has %llu line%s", (llu)args.skipNrow, (llu)line, line>1?"s":"");
     pos = ch;
   }
 

--- a/src/fwriteR.c
+++ b/src/fwriteR.c
@@ -15,12 +15,12 @@ static const char *sep2start, *sep2end;
 
 // Non-agnostic helpers ...
 
-const char *getString(SEXP *col, int row) {   // TODO: inline for use in fwrite.c
+const char *getString(SEXP *col, int64_t row) {   // TODO: inline for use in fwrite.c
   SEXP x = col[row];
   return x==NA_STRING ? NULL : CHAR(x);
 }
 
-const char *getCategString(SEXP col, int row) {
+const char *getCategString(SEXP col, int64_t row) {
   // the only writer that needs to have the header of the SEXP column, to get to the levels
   int x = INTEGER(col)[row];
   return x==NA_INTEGER ? NULL : CHAR(STRING_ELT(getAttrib(col, R_LevelsSymbol), x-1));


### PR DESCRIPTION
Removed `write_positive_int` and replaced with simpler `reverse`.
Saved a branch by not testing `==0` in both writeInt32 and writeInt64.  (Still to do, when `na=""` as is true by default, then can save another branch with new writers, like the now branch-free `writeBool8`).
writeInt32 faster by not casting to int64 just to call `write_positive_int`.
Fixes win32 crashes due to int/int64 type differences (in function arguments and in an error message construction),  now passes win-builder r-devel.
More robust test number printing with flush.console for Windows.
Two commits which I won't squash.