### PR TITLE
Improved key handling when assigning with ':='

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -49,6 +49,8 @@
     
 10. setkeyv accelerated if key already exists [#2331](https://github.com/Rdatatable/data.table/issues/2331). Thanks to @MarkusBonsch for the PR.
 
+11. improved key handling when assigning with ':=' [#2372](https://github.com/Rdatatable/data.table/issues/2372). Keys and secondary indices used to be droopped completely if one of the columns was affected by ':='. Now, as much as possible of the remaining keys and indices is retained for re-use. Thanks to @MarkusBonsch for the PR.
+
 
 #### BUG FIXES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -49,7 +49,7 @@
     
 10. setkeyv accelerated if key already exists [#2331](https://github.com/Rdatatable/data.table/issues/2331). Thanks to @MarkusBonsch for the PR.
 
-11. improved key handling when assigning with ':=' [#2372](https://github.com/Rdatatable/data.table/issues/2372). Keys and secondary indices used to be droopped completely if one of the columns was affected by ':='. Now, as much as possible of the remaining keys and indices is retained for re-use. Thanks to @MarkusBonsch for the PR.
+11. improved key handling when assigning with ':=' [#2372](https://github.com/Rdatatable/data.table/issues/2372). Keys and secondary indices used to be dropped completely if one of the columns was affected by ':='. Now, as much as possible of the remaining keys and indices is retained for re-use. Thanks to @MarkusBonsch for the PR.
 
 
 #### BUG FIXES

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -40,6 +40,11 @@ started.at = Sys.time()
 oldalloccol = options(datatable.alloccol=1024L)
 
 if (!.devtesting) {
+    # Only ::: here so that when testing in dev we use the version in .GlobalEnv. If we used ::: in tests
+    # it would pick up the installed version and you'd have to reinstall every time in dev.
+    # Or, when :: is here, there should be a comment saying which package uses that name. That's so that
+    # test.data.table() works for users who have that other package installed.
+    # The string "data.table::" should exist nowhere else in this file other than here inside this branch.
     test = data.table:::test
     INT = data.table:::INT
     compactprint = data.table:::compactprint
@@ -58,16 +63,14 @@ if (!.devtesting) {
     .R.subassignCopiesOthers = data.table:::.R.subassignCopiesOthers
     .R.subassignCopiesVecsxp = data.table:::.R.subassignCopiesVecsxp
     setdiff_ = data.table:::setdiff_
-    frankv = data.table::frankv
     is_na = data.table:::is_na
     shallow = data.table:::shallow # until exported
     chmatch2 = data.table:::chmatch2
     which_ = data.table:::which_
-    shift = data.table::shift
     any_na = data.table:::any_na
     replace_dot_alias = data.table:::replace_dot_alias
     isReallyReal = data.table:::isReallyReal
-    between = data.table::between
+    between = data.table::between   # which package contains between?
     which.first = data.table:::which.first
     which.last = data.table:::which.last
     trim = data.table:::trim
@@ -3735,7 +3738,7 @@ if (.Machine$sizeof.longdouble == 16) {
 
   tol = 3.000214e-13
   x = c(8, NaN, Inf, -7.18918, 5.18909+0.07*tol, NA, -7.18918111, -Inf, NA, 5.18909, NaN, 5.18909-1.2*tol, 5.18909-0.04*tol)
-  # cat(data.table:::binary(x[c(5,10,12,13)]),sep="\n")
+  # cat(binary(x[c(5,10,12,13)]),sep="\n")
   # 0 10000000001 010011000001101000001100111100011000 00000000 11000000
   # 0 10000000001 010011000001101000001100111100011000 00000000 10101000
   # 0 10000000001 010011000001101000001100111100010111 11111111 00010011
@@ -5778,18 +5781,18 @@ thisDT <- copy(DT)[2, x1 := 3]
 test(1419.1, key(thisDT), NULL)
 thisDT <- copy(DT)[2, x2 := 3]
 test(1419.2, key(thisDT), "x1")
-test(1419.3, data.table:::forderv(thisDT, c("x1")), integer(0))
+test(1419.3, forderv(thisDT, c("x1")), integer(0))
 thisDT <- copy(DT)[2, x2 := 3]
 test(1419.4, key(thisDT), "x1")
-test(1419.5, data.table:::forderv(thisDT, c("x1")), integer(0))
+test(1419.5, forderv(thisDT, c("x1")), integer(0))
 thisDT <- copy(DT)[3, x3 := 3]
 test(1419.6, key(thisDT), c("x1", "x2"))
-test(1419.7, data.table:::forderv(thisDT, c("x1", "x2")), integer(0))
+test(1419.7, forderv(thisDT, c("x1", "x2")), integer(0))
 thisDT <- copy(DT)[3, c("x1", "x3") := .(3,3)]
 test(1419.8,key(thisDT), NULL)
 thisDT <- copy(DT)[3, c("x2", "x3") := .(3,3)]
 test(1419.9, key(thisDT), "x1")
-test(1419.10, data.table:::forderv(thisDT, c("x1")), integer(0))
+test(1419.10, forderv(thisDT, c("x1")), integer(0))
 setkey(DT, NULL)
 thisDT <- copy(DT)[3, x3 := 3]
 test(1419.11, key(thisDT), NULL)
@@ -5822,8 +5825,7 @@ allIndicesValid <- function(DT){
   for(idx in seq_along(indices(DT))){
     index <- attr(attr(DT, "index"), paste0("__", indices(DT)[idx], collapse = ""))
     if(!length(index)) index <- seq_len(nrow(DT))
-    if(length(data.table:::forderv(DT[index],
-                                   indices(DT, vectors = TRUE)[[idx]]))){
+    if(length(forderv(DT[index], indices(DT, vectors = TRUE)[[idx]]))){
       ## index is not properly ordered
       return(FALSE)
     }

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -40,11 +40,13 @@ started.at = Sys.time()
 oldalloccol = options(datatable.alloccol=1024L)
 
 if (!.devtesting) {
-    # Only ::: here so that when testing in dev we use the version in .GlobalEnv. If we used ::: in tests
-    # it would pick up the installed version and you'd have to reinstall every time in dev.
-    # Or, when :: is here, there should be a comment saying which package uses that name. That's so that
-    # test.data.table() works for users who have that other package installed.
-    # The string "data.table::" should exist nowhere else in this file other than here inside this branch.
+
+    # Make symbols to the installed version's ::: so that we can i) test internal-only not-exposed R functions
+    # in the test suite when user runs test.data.table() from installed package AND ii) so that in dev the same
+    # tests can be used but in dev they test the package in .GlobalEnv. If we used ::: throughout tests, that
+    # would pick up the installed version and in dev you'd have to reinstall every time which slows down dev.
+    # NB: The string "data.table:::" should exist nowhere else in this file other than here inside this branch.
+    
     test = data.table:::test
     INT = data.table:::INT
     compactprint = data.table:::compactprint
@@ -57,7 +59,6 @@ if (!.devtesting) {
     setrev = data.table:::setrev
     setreordervec = data.table:::setreordervec
     selfrefok = data.table:::selfrefok
-    setattr = data.table::setattr     # so as not to use bit::setattr
     .R.listCopiesNamed = data.table:::.R.listCopiesNamed
     .R.assignNamesCopiesAll = data.table:::.R.assignNamesCopiesAll
     .R.subassignCopiesOthers = data.table:::.R.subassignCopiesOthers
@@ -70,15 +71,24 @@ if (!.devtesting) {
     any_na = data.table:::any_na
     replace_dot_alias = data.table:::replace_dot_alias
     isReallyReal = data.table:::isReallyReal
-    between = data.table::between   # which package contains between?
     which.first = data.table:::which.first
     which.last = data.table:::which.last
     trim = data.table:::trim
     `%+%.default` = data.table:::`%+%.default`
     .shallow = data.table:::.shallow
     getdots = data.table:::getdots
-    second = data.table::second # avoid S4Vectors::second
     binary = data.table:::binary
+    
+    # Also, for functions that are masked by other packages, we need to map the data.table one. Or else, 
+    # the other package's function would be picked up. As above, we only need to do this because we desire
+    # to develop in .GlobalEnv with cc().
+    # NB: The string "data.table::" should exist nowhere else in this file other than here inside this branch.
+                                          # masked by which Suggests package?
+                                          # =================================
+    setattr = data.table::setattr         # bit
+    shift = data.table::shift             # IRanges, GenomicRanges
+    between = data.table::between         # plm
+    second = data.table::second           # S4Vectors
 }
 
 # test for covering tables.R 100%, we need to run tables() before creating any data.tables to return null data.table

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -5777,9 +5777,9 @@ test(1416, indices(DT), 'foo')
 setindex(DT,foo,bar,baz)
 test(1417, DT[2,baz:=10L,verbose=TRUE], output=".*Shortening index 'foo__bar__baz' to 'foo__bar' due to an update on a key column")  # test last
 setindex(DT,bar,baz)
-test(1418, DT[2,c("foo","bar"):=10L,verbose=TRUE], output=".*Dropping index.* due to an update on a key column")     # test 2nd to 1st
+test(1418.1, DT[2,c("foo","bar"):=10L,verbose=TRUE], output=".*Dropping index.* due to an update on a key column")     # test 2nd to 1st
 setindex(DT,bar,baz)
-test(1419, DT[2,c("foo","baz"):=10L,verbose=TRUE], output=".*Shortening index 'bar__baz' to 'bar' due to an update on a key column")     # test 2nd to 2nd
+test(1418.2, DT[2,c("foo","baz"):=10L,verbose=TRUE], output=".*Shortening index 'bar__baz' to 'bar' due to an update on a key column")     # test 2nd to 2nd
 
 ## testing key retainment on assign (#2372)
 DT <- data.table(x1 = c(1,1,1,1,1,2,2,2,2,2),
@@ -5802,28 +5802,29 @@ thisDT <- copy(DT)[3, c("x1", "x3") := .(3,3)]
 test(1419.8,key(thisDT), NULL)
 thisDT <- copy(DT)[3, c("x2", "x3") := .(3,3)]
 test(1419.9, key(thisDT), "x1")
-test(1419.10, forderv(thisDT, c("x1")), integer(0))
+# skip test numbers ending 0 because if 1419.10 fails, it prints as 1419.1 the same as 1419.1
+test(1419.11, forderv(thisDT, c("x1")), integer(0))
 setkey(DT, NULL)
 thisDT <- copy(DT)[3, x3 := 3]
-test(1419.11, key(thisDT), NULL)
+test(1419.12, key(thisDT), NULL)
 ## same tests for empty DT
 ## forderv tests can be skipped for empty DT
 DT <- DT[0]
 thisDT <- copy(DT)[, x3 := 3]
-test(1419.12, key(thisDT), NULL)
+test(1419.13, key(thisDT), NULL)
 setkeyv(DT, c("x1", "x2", "x3"))
 thisDT <- copy(DT)[, x1 := 3]
-test(1419.13, key(thisDT), NULL)
-thisDT <- copy(DT)[, x2 := 3]
-test(1419.14, key(thisDT), "x1")
+test(1419.14, key(thisDT), NULL)
 thisDT <- copy(DT)[, x2 := 3]
 test(1419.15, key(thisDT), "x1")
+thisDT <- copy(DT)[, x2 := 3]
+test(1419.16, key(thisDT), "x1")
 thisDT <- copy(DT)[, x3 := 3]
-test(1419.16, key(thisDT), c("x1", "x2"))
+test(1419.17, key(thisDT), c("x1", "x2"))
 thisDT <- copy(DT)[, c("x1", "x3") := .(3,3)]
-test(1419.17, key(thisDT), NULL)
+test(1419.18, key(thisDT), NULL)
 thisDT <- copy(DT)[, c("x2", "x3") := .(3,3)]
-test(1419.18, key(thisDT), "x1")
+test(1419.19, key(thisDT), "x1")
 
 ## testing secondary key retainment on assign (#2372)
 DT <- data.table(a = c(1,1,1,2,1,2,2,2,2,2),
@@ -5846,49 +5847,49 @@ allIndicesValid <- function(DT){
   }
   return(TRUE)
 }
-test(1419.19, indices(copy(DT)[1, a:=1]), NULL)
+test(1419.21, indices(copy(DT)[1, a:=1]), NULL)
 setindex(DT, a)
 setindex(DT, a, aaa)
 setindex(DT, ab, aaa)
 setindex(DT)
-test(1419.21, allIndicesValid(DT), TRUE)
+test(1419.22, allIndicesValid(DT), TRUE)
 thisDT <- copy(DT)[1, a:=1][, aaa := 1][, ab := 1]
-test(1419.22, indices(thisDT), NULL)
-test(1419.23, allIndicesValid(thisDT), TRUE)
+test(1419.23, indices(thisDT), NULL)
+test(1419.24, allIndicesValid(thisDT), TRUE)
 thisDT <- copy(DT)[, b := 2]
-test(1419.24, indices(thisDT), c("a", "a__aaa", "ab__aaa"))
-test(1419.25, allIndicesValid(thisDT), TRUE)
+test(1419.25, indices(thisDT), c("a", "a__aaa", "ab__aaa"))
+test(1419.26, allIndicesValid(thisDT), TRUE)
 thisDT <- copy(DT)[, ab := 2]
-test(1419.26, indices(thisDT), c("a", "a__aaa", "a__aaa__b"))
-test(1419.27, allIndicesValid(thisDT), TRUE)
+test(1419.27, indices(thisDT), c("a", "a__aaa", "a__aaa__b"))
+test(1419.28, allIndicesValid(thisDT), TRUE)
 thisDT <- copy(DT)[, aaa := 2]
-test(1419.28, indices(thisDT), c("a", "ab"))
-test(1419.29, allIndicesValid(thisDT), TRUE)
-thisDT <- copy(DT)[, c("aaa", "b") := 2]
-test(1419.30, indices(thisDT), c("a", "ab"))
+test(1419.29, indices(thisDT), c("a", "ab"))
 test(1419.31, allIndicesValid(thisDT), TRUE)
+thisDT <- copy(DT)[, c("aaa", "b") := 2]
+test(1419.32, indices(thisDT), c("a", "ab"))
+test(1419.33, allIndicesValid(thisDT), TRUE)
 ## same on empty DT
 DT <- DT[0]
 setindex(DT, a)
 setindex(DT, a, aaa)
 setindex(DT, ab, aaa)
 setindex(DT)
-test(1419.32, allIndicesValid(DT), TRUE)
+test(1419.34, allIndicesValid(DT), TRUE)
 thisDT <- copy(DT)[, a:=1][, aaa := 1][, ab := 1]
-test(1419.33, indices(thisDT), NULL)
-test(1419.34, allIndicesValid(thisDT), TRUE)
-thisDT <- copy(DT)[, b := 2]
-test(1419.35, indices(thisDT), c("a", "a__aaa", "ab__aaa"))
+test(1419.35, indices(thisDT), NULL)
 test(1419.36, allIndicesValid(thisDT), TRUE)
-thisDT <- copy(DT)[, ab := 2]
-test(1419.37, indices(thisDT), c("a", "a__aaa", "a__aaa__b"))
+thisDT <- copy(DT)[, b := 2]
+test(1419.37, indices(thisDT), c("a", "a__aaa", "ab__aaa"))
 test(1419.38, allIndicesValid(thisDT), TRUE)
+thisDT <- copy(DT)[, ab := 2]
+test(1419.39, indices(thisDT), c("a", "a__aaa", "a__aaa__b"))
+test(1419.41, allIndicesValid(thisDT), TRUE)
 thisDT <- copy(DT)[, aaa := 2]
-test(1419.39, indices(thisDT), c("a", "ab"))
-test(1419.40, allIndicesValid(thisDT), TRUE)
+test(1419.42, indices(thisDT), c("a", "ab"))
+test(1419.43, allIndicesValid(thisDT), TRUE)
 thisDT <- copy(DT)[, c("aaa", "b") := 2]
-test(1419.41, indices(thisDT), c("a", "ab"))
-test(1419.42, allIndicesValid(thisDT), TRUE)
+test(1419.44, indices(thisDT), c("a", "ab"))
+test(1419.45, allIndicesValid(thisDT), TRUE)
 
 
 # setnames updates secondary key

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -5738,14 +5738,14 @@ test(1396, DT[a==2, verbose=TRUE], DT[2], output="Creating new index 'a'")
 test(1397, DT[b==6, verbose=TRUE], DT[3], output="Creating new index 'b'")
 test(1398, DT[b==6, verbose=TRUE], DT[3], output="Using existing index 'b'")
 test(1399, indices(DT), c("a","b"))
-test(1400, DT[2, a:=4L, verbose=TRUE], data.table(a=c(1L,4L,3L),b=4:6), output="Dropping index 'a' due to update on 'a' (column 1)")
+test(1400, DT[2, a:=4L, verbose=TRUE], data.table(a=c(1L,4L,3L),b=4:6), output=".*Dropping index 'a' due to an update on a key column")
 test(1401, indices(DT), "b")
-test(1402, DT[,b:=NULL,verbose=TRUE], data.table(a=c(1L,4L,3L)), output="Dropping index 'b' due to delete of 'b' (column 2)")
+test(1402, DT[,b:=NULL,verbose=TRUE], data.table(a=c(1L,4L,3L)), output=".*Dropping index 'b' due to an update on a key column")
 test(1403, indices(DT), NULL)
 DT = data.table(x=1:5)
 test(1404, DT[, y := x <= 2L], data.table(x=1:5, y=c(TRUE,TRUE,FALSE,FALSE,FALSE)))
 test(1405, DT[y == TRUE, .N, verbose=TRUE], 2L, output="Creating new index")
-test(1406, DT[, y := x <= 3L, verbose=TRUE], data.table(x=1:5, y=c(TRUE,TRUE,TRUE,FALSE,FALSE)), output="Dropping index")
+test(1406, DT[, y := x <= 3L, verbose=TRUE], data.table(x=1:5, y=c(TRUE,TRUE,TRUE,FALSE,FALSE)), output=".*Dropping index")
 test(1407, DT[y == TRUE, .N], 3L)
 DT = data.table(x=1:5, y=10:6)
 test(1408, DT[x==3,verbose=TRUE], DT[3], output="Creating")
@@ -5759,14 +5759,125 @@ test(1413, DT[x==5], DT[1])
 DT = data.table(foo=1:3, bar=4:6, baz=9:7)
 setindex(DT,foo,bar,baz)
 test(1414, indices(DT), c("foo__bar__baz"))
-test(1415, DT[2,bar:=10L,verbose=TRUE], output="Dropping index 'foo__bar__baz' due to update on 'bar'")  # test middle
-test(1416, indices(DT), NULL)
+test(1415, DT[2,bar:=10L,verbose=TRUE], output=".*Shortening index 'foo__bar__baz' to 'foo' due to an update on a key column")  # test middle
+test(1416, indices(DT), 'foo')
 setindex(DT,foo,bar,baz)
-test(1417, DT[2,baz:=10L,verbose=TRUE], output="Dropping index 'foo__bar__baz' due to update on 'baz'")  # test last
+test(1417, DT[2,baz:=10L,verbose=TRUE], output=".*Shortening index 'foo__bar__baz' to 'foo__bar' due to an update on a key column")  # test last
 setindex(DT,bar,baz)
-test(1418, DT[2,c("foo","bar"):=10L,verbose=TRUE], output="Dropping index.* due to update on 'bar'")     # test 2nd to 1st
+test(1418, DT[2,c("foo","bar"):=10L,verbose=TRUE], output=".*Dropping index.* due to an update on a key column")     # test 2nd to 1st
 setindex(DT,bar,baz)
-test(1419, DT[2,c("foo","baz"):=10L,verbose=TRUE], output="Dropping index.* due to update on 'baz'")     # test 2nd to 2nd
+test(1419, DT[2,c("foo","baz"):=10L,verbose=TRUE], output=".*Shortening index 'bar__baz' to 'bar' due to an update on a key column")     # test 2nd to 2nd
+
+## testing key retainment on assign (#2372)
+DT <- data.table(x1 = c(1,1,1,1,1,2,2,2,2,2),
+                 x2 = c(1,1,2,2,2,1,1,2,2,2),
+                 x3 = c(1,2,1,1,2,1,1,1,1,2),
+                 y  = rnorm(10), 
+                 key = c("x1", "x2", "x3"))
+thisDT <- copy(DT)[2, x1 := 3]
+test(1419.1, key(thisDT), NULL)
+thisDT <- copy(DT)[2, x2 := 3]
+test(1419.2, key(thisDT), "x1")
+test(1419.3, data.table:::forderv(thisDT, c("x1")), integer(0))
+thisDT <- copy(DT)[2, x2 := 3]
+test(1419.4, key(thisDT), "x1")
+test(1419.5, data.table:::forderv(thisDT, c("x1")), integer(0))
+thisDT <- copy(DT)[3, x3 := 3]
+test(1419.6, key(thisDT), c("x1", "x2"))
+test(1419.7, data.table:::forderv(thisDT, c("x1", "x2")), integer(0))
+thisDT <- copy(DT)[3, c("x1", "x3") := .(3,3)]
+test(1419.8,key(thisDT), NULL)
+thisDT <- copy(DT)[3, c("x2", "x3") := .(3,3)]
+test(1419.9, key(thisDT), "x1")
+test(1419.10, data.table:::forderv(thisDT, c("x1")), integer(0))
+setkey(DT, NULL)
+thisDT <- copy(DT)[3, x3 := 3]
+test(1419.11, key(thisDT), NULL)
+## same tests for empty DT
+## forderv tests can be skipped for empty DT
+DT <- DT[0]
+thisDT <- copy(DT)[, x3 := 3]
+test(1419.12, key(thisDT), NULL)
+setkeyv(DT, c("x1", "x2", "x3"))
+thisDT <- copy(DT)[, x1 := 3]
+test(1419.13, key(thisDT), NULL)
+thisDT <- copy(DT)[, x2 := 3]
+test(1419.14, key(thisDT), "x1")
+thisDT <- copy(DT)[, x2 := 3]
+test(1419.15, key(thisDT), "x1")
+thisDT <- copy(DT)[, x3 := 3]
+test(1419.16, key(thisDT), c("x1", "x2"))
+thisDT <- copy(DT)[, c("x1", "x3") := .(3,3)]
+test(1419.17, key(thisDT), NULL)
+thisDT <- copy(DT)[, c("x2", "x3") := .(3,3)]
+test(1419.18, key(thisDT), "x1")
+
+## testing secondary key retainment on assign (#2372)
+DT <- data.table(a = c(1,1,1,2,1,2,2,2,2,2),
+                 aaa = c(2,1,2,2,2,1,1,2,2,2),
+                 b = c(1,2,1,1,2,1,1,1,1,2),
+                 ab  = rnorm(10))
+allIndicesValid <- function(DT){
+  ## checks that the order of all indices is correct
+  for(idx in seq_along(indices(DT))){
+    index <- attr(attr(DT, "index"), paste0("__", indices(DT)[idx], collapse = ""))
+    if(!length(index)) index <- seq_len(nrow(DT))
+    if(length(data.table:::forderv(DT[index],
+                                   indices(DT, vectors = TRUE)[[idx]]))){
+      ## index is not properly ordered
+      return(FALSE)
+    }
+    if(any(duplicated(names(attributes(attr(DT, "index")))))){
+      ## index names are not unique
+      return(FALSE)
+    }
+  }
+  return(TRUE)
+}
+test(1419.19, indices(copy(DT)[1, a:=1]), NULL)
+setindex(DT, a)
+setindex(DT, a, aaa)
+setindex(DT, ab, aaa)
+setindex(DT)
+test(1419.21, allIndicesValid(DT), TRUE)
+thisDT <- copy(DT)[1, a:=1][, aaa := 1][, ab := 1]
+test(1419.22, indices(thisDT), NULL)
+test(1419.23, allIndicesValid(thisDT), TRUE)
+thisDT <- copy(DT)[, b := 2]
+test(1419.24, indices(thisDT), c("a", "a__aaa", "ab__aaa"))
+test(1419.25, allIndicesValid(thisDT), TRUE)
+thisDT <- copy(DT)[, ab := 2]
+test(1419.26, indices(thisDT), c("a", "a__aaa", "a__aaa__b"))
+test(1419.27, allIndicesValid(thisDT), TRUE)
+thisDT <- copy(DT)[, aaa := 2]
+test(1419.28, indices(thisDT), c("a", "ab"))
+test(1419.29, allIndicesValid(thisDT), TRUE)
+thisDT <- copy(DT)[, c("aaa", "b") := 2]
+test(1419.30, indices(thisDT), c("a", "ab"))
+test(1419.31, allIndicesValid(thisDT), TRUE)
+## same on empty DT
+DT <- DT[0]
+setindex(DT, a)
+setindex(DT, a, aaa)
+setindex(DT, ab, aaa)
+setindex(DT)
+test(1419.32, allIndicesValid(DT), TRUE)
+thisDT <- copy(DT)[, a:=1][, aaa := 1][, ab := 1]
+test(1419.33, indices(thisDT), NULL)
+test(1419.34, allIndicesValid(thisDT), TRUE)
+thisDT <- copy(DT)[, b := 2]
+test(1419.35, indices(thisDT), c("a", "a__aaa", "ab__aaa"))
+test(1419.36, allIndicesValid(thisDT), TRUE)
+thisDT <- copy(DT)[, ab := 2]
+test(1419.37, indices(thisDT), c("a", "a__aaa", "a__aaa__b"))
+test(1419.38, allIndicesValid(thisDT), TRUE)
+thisDT <- copy(DT)[, aaa := 2]
+test(1419.39, indices(thisDT), c("a", "ab"))
+test(1419.40, allIndicesValid(thisDT), TRUE)
+thisDT <- copy(DT)[, c("aaa", "b") := 2]
+test(1419.41, indices(thisDT), c("a", "ab"))
+test(1419.42, allIndicesValid(thisDT), TRUE)
+
 
 # setnames updates secondary key
 DT = data.table(a=1:5,b=10:6)


### PR DESCRIPTION
This closes [#2372].

Now, when updating columns with :=, existing keys and indices are retained up to the first modified column (exclusive).
Example: key on x1, x2, x3 --> assignment on x2 --> key on x1.

The tests 1400 ff had to be modified since they were testing for the old behaviour.
Additional tests have been added to make sure, all cases are handled, also on empty data.tables.

I tested for C memory allocation problems with `R -d valgrind` and found no issues.
There is an issue with a segmentataion fault on unloading the package but I discovered that this is a problem of the master (issue [#2388])

A small benchmark (code at the end of this post) shows that there is no speed penalty associated with the new implementation:

| master | PR |
| --- | --- |
|  0.25 	ms | 0.27 ms |


```
library(data.table)
library(microbenchmark)

nrow <- 1
ncol <- 20
nindex <- 20
nassigncol <- 10

DT <- data.table(x1 = rnorm(nrow))
setindex(DT, x1)
index <- c("x1")
for(col in seq_len(ncol-1)){
  DT[, paste0("x", col + 1) := rnorm(nrow)]
  if(col < nindex){
    index <- c(index, paste0("x", col+1))
    setindexv(DT, index)
  }
}

test <- microbenchmark(assign = copy(DT)[, paste0("x", (ncol - nassigncol):ncol) := 1], 
                       times = 100, 
                       unit = "ms")

```
