### PR TITLE
Closes #2407, fixes bug in calculation of ISO week number

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -90,6 +90,8 @@
 16. Integer values that are too large to fit in `int64` will now be read as strings [#2250](https://github.com/Rdatatable/data.table/issues/2250).
 
 17. Internal-only `.shallow` now retains keys correctly, [#2336](https://github.com/Rdatatable/data.table/issues/2336). Thanks to @MarkusBonsch for reporting, fixing ([PR #2337](https://github.com/Rdatatable/data.table/pull/2337)) and adding 37 tests. This much advances the journey towards exporting `shallow()`, [#2323](https://github.com/Rdatatable/data.table/issues/2323).
+
+18. `isoweek` calculation is correct regardless of local timezone setting (`Sys.timezone()`), [#2407](https://github.com/Rdatatable/data.table/issues/2407). Thanks to @MoebiusAV and @SimonCoulombe for reporting and @MichaelChirico for fixing.
     
 #### NOTES
 

--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -293,7 +293,8 @@ isoweek <- function(x) {
   #  subtract 1 and re-divide; also, POSIXlt increment by seconds
   nearest_thurs <- xlt + (3 - ((xlt$wday - 1) %% 7)) * 86400
 
-  year_start <- as.POSIXct(paste0(as.POSIXlt(nearest_thurs)$year + 1900L, "-01-01"))
+  #as.POSIXct here caused time zone issues, #2407
+  year_start <- as.Date(format(nearest_thurs, '%Y-01-01'))
 
   as.integer(1 + unclass(difftime(nearest_thurs, year_start, units = "days")) %/% 7)
 }

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -9482,17 +9482,25 @@ test(1701.7, dt[dt, .(xa=x.a, ia=i.a), .EACHI, on="a"], data.table(a=1L, xa=1L, 
 
 # ISO 8601-consistent week numbering, #1765
 #  test cases via https://en.wikipedia.org/wiki/ISO_week_date
+#  as well as specified in relation to #2407
 test_cases <- c("2005-01-01", "2005-01-02", "2005-12-31",
                 "2007-01-01", "2007-12-30", "2007-12-31",
                 "2008-01-01", "2008-12-28", "2008-12-29",
                 "2008-12-30", "2008-12-31", "2009-01-01",
                 "2009-12-31", "2010-01-01",
-                "2010-01-02", "2010-01-03")
+                "2010-01-02", "2010-01-03",
+                #see https://stackoverflow.com/questions/43944430 & #2407
+                "2014-12-29", "2014-12-22", "2015-02-02")
 
 test_values <- c(53L, 53L, 52L, 1L, 52L, 1L, 1L,
-                 52L, 1L, 1L, 1L, 1L, 53L, 53L, 53L, 53L)
+                 52L, 1L, 1L, 1L, 1L, 53L, 53L, 53L, 53L,
+                 1L, 52L, 6L)
 
-test(1702, isoweek(test_cases), test_values)
+test(1702.1, isoweek(test_cases), test_values)
+# calculating via character skirts timezone issues,
+#   but calculating from Date brings these into play, #2407
+test(1702.2, isoweek(as.Date(test_cases)), test_values)
+test(1702.3, isoweek(as.POSIXct(test_cases)), test_values)
 
 # fread, ensure no shell commands #1702
 if (.Platform$OS.type=="unix") {


### PR DESCRIPTION
@mattdowle this shouldn't matter for the whitespace PR, as the changes conform to the new standard