### PR TITLE
Closes #2007 by adding a test to ensure explicit select = NULL works

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,7 +35,7 @@
 
 5. Improved auto-detection of `character` inputs' formats to `as.ITime` to mirror the logic in `as.POSIXlt.character`, [#1383](https://github.com/Rdatatable/data.table/issues/1383) Thanks @franknarf1 for identifying a discrepancy and @MichaelChirico for investigating.
 
-6. `setcolorder()` now accepts less than `ncol(DT)` columns to be moved to the front, [#592](https://github.com/Rdatatable/data.table/issues/592). Thanks @MichaelChirico for the PR. 
+6. `setcolorder()` now accepts less than `ncol(DT)` columns to be moved to the front, [#592](https://github.com/Rdatatable/data.table/issues/592). Thanks @MichaelChirico for the PR. This also incidentally fixed [#2007](https://github.com/Rdatatable/data.table/issues/2007) whereby explicitly setting `select = NULL` in `fread` errored; thanks to @rcapell for reporting that and @dselivanov and @MichaelChirico for investigating and providing a new test.
 
 7. Three new *Grouping Sets* functions: `rollup`, `cube` and `groupingsets`, [#1377](https://github.com/Rdatatable/data.table/issues/1377). Allows to aggregation on various grouping levels at once producing sub-totals and grand total.
 

--- a/R/fread.R
+++ b/R/fread.R
@@ -107,7 +107,8 @@ fread <- function(input="",file,sep="auto",sep2="auto",dec=".",quote="\"",nrows=
       cols = which(colClasses=="factor")
   }
   setfactor(ans, cols, verbose)
-  if (!missing(select)) {
+  # 2007: is.missing is not correct since default value of select is NULL
+  if (!is.null(select)) {
     # fix for #1445
     if (is.numeric(select)) {
       reorder = if (length(o <- forderv(select))) o else seq_along(select)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -10932,7 +10932,7 @@ unlink(f)
 
 # ensure explicitly setting select to default value doesn't error, #2007
 test(1833, fread('V1,V2\n1,2', select = NULL),
-     data.table(V1 = TRUE, V2 = 2))
+     data.table(V1 = TRUE, V2 = 2L))
 
 ##########################
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -10930,6 +10930,9 @@ DT = as.data.table(matrix(5L, nrow=10, ncol=60))
 test(1832.2, any(grepl("^Column writers.* [.][.][.] ", capture.output(fwrite(DT, f, verbose=TRUE)))))
 unlink(f)
 
+# ensure explicitly setting select to default value doesn't error, #2007
+test(1833, fread('V1,V2\n1,2', select = NULL),
+     data.table(V1 = TRUE, V2 = 2))
 
 ##########################
 


### PR DESCRIPTION
@st-pasha Alternatively, we could just remove the `select = NULL` default and continue with the code as it was before. I think this is preferred as it allows users to have a value to set explicitly in dynamic use cases.