### PR TITLE
non-equi joins work as expected when x is 0-row dt. Fixes #1986.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -102,6 +102,8 @@
 
 21. The edge case `setnames(data.table(), character(0))` now works rather than error, [#2452](https://github.com/Rdatatable/data.table/issues/2452).
 
+23. Non-equi joins work as expected when `x` in `x[i, on=...]` is a 0-row data.table. Closes [#1986](https://github.com/Rdatatable/data.table/issues/1986).
+
 #### NOTES
 
 1. `?data.table` makes explicit the option of using a `logical` vector in `j` to select columns, [#1978](https://github.com/Rdatatable/data.table/issues/1978). Thanks @Henrik-P for the note and @MichaelChirico for filing.

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -584,7 +584,8 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
           if (verbose) {last.started.at=proc.time()[3];cat("  Generating non-equi group ids ... ");flush.console()}
           nqgrp = .Call(Cnestedid, x, rightcols[non_equi:length(rightcols)], xo, xg, resetlen, mult)
           if (verbose) {cat("done in", round(proc.time()[3]-last.started.at,3),"secs\n");flush.console}
-          if ( (nqmaxgrp <- max(nqgrp)) > 1L) { # got some non-equi join work to do
+          if (length(nqgrp)) nqmaxgrp = max(nqgrp) # fix for #1986, when 'x' is 0-row table max(.) returns -Inf.
+          if (nqmaxgrp > 1L) { # got some non-equi join work to do
             if ("_nqgrp_" %in% names(x)) stop("Column name '_nqgrp_' is reserved for non-equi joins.")
             if (verbose) {last.started.at=proc.time()[3];cat("  Recomputing forder with non-equi ids ... ");flush.console()}
             set(nqx<-shallow(x), j="_nqgrp_", value=nqgrp)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -11001,6 +11001,12 @@ test(1841, fread("A\n0.58E-2141\n"), data.table(A="0.58E-2141"))   # no ERANGE w
 DT = data.table()     # 2452
 test(1842, setnames(DT, character(0)), DT)
 
+# fix for non-equi join issue #1986, when d2 is 0-row data.table
+d1 <- data.table(a=1L, b=2L)
+d2 <- d1[0L]
+test(1844.1, d2[d1, on=.(a>a, b<b)], d1)
+test(1844.2, d2[d1, on=.(a>a)], data.table(a=1L, b=NA_integer_, i.b=2L))
+
 ##########################
 
 # TODO: Tests involving GForce functions needs to be run with optimisation level 1 and 2, so that both functions are tested all the time.


### PR DESCRIPTION
Closes #1986 