### PR TITLE
Remove RVersion.h as a dependency

### DIFF
--- a/src/assign.c
+++ b/src/assign.c
@@ -1,7 +1,6 @@
 #include "data.table.h"
 #include <Rdefines.h>
 #include <Rmath.h>
-#include <Rversion.h>
 
 static SEXP *saveds=NULL;
 static R_len_t *savedtl=NULL, nalloc=0, nsaved=0;
@@ -657,7 +656,7 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values, SEXP v
     }
     s = ATTRIB(index); // reset to first element
     indexNo = 0;
-    while(s != R_NilValue) { 
+    while(s != R_NilValue) {
       a = TAG(s);
       indexLength = xlength(CAR(s));
       tc1 = c1 = CHAR(PRINTNAME(a));  // the index name; e.g. "__col1__col2"

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -1,7 +1,6 @@
 #include <R.h>
 #define USE_RINTERNALS
 #include <Rinternals.h>
-#include <Rversion.h>
 #ifdef _OPENMP
   #include <omp.h>
 #else // so it still compiles on machines with compilers void of openmp support
@@ -12,10 +11,12 @@
 // raise(SIGINT);
 #include <stdint.h> // for uint64_t rather than unsigned long long
 
+#define RVersion(major, minor, micro)  ((major<<16) + (minor<<8) + (micro))
+
 // Fixes R-Forge #5150, and #1641
-// a simple check for R version to decide if the type should be R_len_t or 
+// a simple check for R version to decide if the type should be R_len_t or
 // R_xlen_t long vector support was added in R 3.0.0
-#if defined(R_VERSION) && R_VERSION >= R_Version(3, 0, 0)
+#if defined(R_VERSION) && R_VERSION >= RVersion(3, 0, 0)
   typedef R_xlen_t RLEN;
 #else
   typedef R_len_t RLEN;
@@ -58,7 +59,7 @@ SEXP sym_BY;
 SEXP sym_starts, char_starts;
 SEXP sym_maxgrpn;
 Rboolean INHERITS(SEXP x, SEXP char_);
-long long DtoLL(double x); 
+long long DtoLL(double x);
 double LLtoD(long long x);
 double NA_INT64_D;
 long long NA_INT64_LL;
@@ -113,14 +114,14 @@ SEXP alloccol(SEXP dt, R_len_t n, Rboolean verbose);
 void memrecycle(SEXP target, SEXP where, int r, int len, SEXP source);
 SEXP shallowwrapper(SEXP dt, SEXP cols);
 
-SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, 
-                SEXP xjiscols, SEXP grporder, SEXP order, SEXP starts, 
-                SEXP lens, SEXP jexp, SEXP env, SEXP lhs, SEXP newnames, 
+SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols,
+                SEXP xjiscols, SEXP grporder, SEXP order, SEXP starts,
+                SEXP lens, SEXP jexp, SEXP env, SEXP lhs, SEXP newnames,
                 SEXP on, SEXP verbose);
 
 // bmerge.c
-SEXP bmerge(SEXP iArg, SEXP xArg, SEXP icolsArg, SEXP xcolsArg, SEXP isorted, 
-                SEXP xoArg, SEXP rollarg, SEXP rollendsArg, SEXP nomatchArg, 
+SEXP bmerge(SEXP iArg, SEXP xArg, SEXP icolsArg, SEXP xcolsArg, SEXP isorted,
+                SEXP xoArg, SEXP rollarg, SEXP rollendsArg, SEXP nomatchArg,
                 SEXP multArg, SEXP opArg, SEXP nqgrpArg, SEXP nqmaxgrpArg);
 SEXP ENC2UTF8(SEXP s);
 

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -11,16 +11,12 @@
 // raise(SIGINT);
 #include <stdint.h> // for uint64_t rather than unsigned long long
 
-#define RVersion(major, minor, micro)  ((major<<16) + (minor<<8) + (micro))
-
-// Fixes R-Forge #5150, and #1641
-// a simple check for R version to decide if the type should be R_len_t or
-// R_xlen_t long vector support was added in R 3.0.0
-#if defined(R_VERSION) && R_VERSION >= RVersion(3, 0, 0)
-  typedef R_xlen_t RLEN;
-#else
-  typedef R_len_t RLEN;
-#endif
+// data.table depends on R>=3.0.0 when R_xlen_t was introduced
+// Before R 3.0.0, RLEN used to be switched to R_len_t as R_xlen_t wasn't available.
+// We could now replace all RLEN with R_xlen_t directly. Or keep RLEN for the shorter
+// name so as not to have to check closely one letter difference R_xlen_t/R_len_t. We
+// might also undefine R_len_t to ensure not to use it.
+typedef R_xlen_t RLEN;
 
 #define IS_UTF8(x)  (LEVELS(x) & 8)
 #define IS_ASCII(x) (LEVELS(x) & 64)
@@ -138,5 +134,4 @@ double wallclock();
 // openmp-utils.c
 int getDTthreads();
 void avoid_openmp_hang_within_fork();
-
 

--- a/src/dogroups.c
+++ b/src/dogroups.c
@@ -1,7 +1,5 @@
 #include "data.table.h"
 #include <Rdefines.h>
-//#include <sys/mman.h>
-#include <Rversion.h>
 #include <fcntl.h>
 #include <time.h>
 

--- a/src/quickselect.c
+++ b/src/quickselect.c
@@ -1,7 +1,5 @@
 #include "data.table.h"
 #include <Rdefines.h>
-//#include <sys/mman.h>
-#include <Rversion.h>
 #include <fcntl.h>
 #include <time.h>
 


### PR DESCRIPTION
Due to unclear license status of "Rversion.h", I think we'd be better-off not including it (especially since we barely use it at all).