### PR TITLE
Indices are now identified by exact name

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -110,6 +110,8 @@
 
 25. `by=.EACHI` works now when `list` columns are being returned and some join values are missing, [#2300](https://github.com/Rdatatable/data.table/issues/2300). Thanks to @jangorecki and @franknarf1 for the reproducible examples which have been added to the test suite.
 
+26. Indices are now retrieved by exact name, [#2465] (https://github.com/Rdatatable/data.table/issues/2465). Thanks to @pannnda for reporting and providing a reproducible example and to @MarkusBonsch for fixing.
+
 
 #### NOTES
 

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -602,7 +602,7 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
           } else {
             if (isTRUE(getOption("datatable.use.index"))) {
               idxName = paste0("__", names(on), sep="", collapse="")  # TODO: wrong, no sep!
-              xo = attr(attr(x, 'index'), idxName)
+              xo = attr(attr(x, 'index'), idxName, exact = TRUE)
               if (verbose && !is.null(xo)) cat("on= matches existing index, using index\n")
             }
             if (is.null(xo)) {

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -11135,6 +11135,13 @@ test(1851.1, dt[dt2, .SD, by=.EACHI, on="a", .SDcols="b"],
 test(1851.2, data.table(a = 1:2, b = list("yo", NULL))[.(1:3), on=.(a), x.b, by = .EACHI],
              data.table(a = 1:3, x.b = list("yo", NULL, NULL)))
 
+# test that indices are only used on exact name match, #2465
+DT1 <- data.table(colname=c("test1","test2","test2","test3"), colname_with_suffix=c("other","test","includes test within","other"))
+DT2 <- data.table(lookup=c("test1","test2","test3"), lookup_result=c(1,2,3))
+DT1[colname_with_suffix == "not found", ]  # automatically creates index on colname_with_suffix
+target <- data.table(colname = c("test1", "test2", "test2", "test3"), colname_with_suffix = c("other", "test", "includes test within", "other"), lookup_result = c(1,2,2,3))
+target[colname_with_suffix == "not found", ]
+test(1852.1, DT1[DT2, lookup_result := i.lookup_result, on=c("colname"="lookup")], target)
 
 ##########################
 


### PR DESCRIPTION
Closes #2465.

Simply added the `exact = TRUE` to
the line where indices are identified:
`xo = attr(attr(x, 'index'), idxName, exact = TRUE)`
This prevents an index `test` being used for column `test_col`.