### PR TITLE
Closes #2475 -- setnames on a table with NA names works as expected

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -110,6 +110,8 @@
 
 25. `by=.EACHI` works now when `list` columns are being returned and some join values are missing, [#2300](https://github.com/Rdatatable/data.table/issues/2300). Thanks to @jangorecki and @franknarf1 for the reproducible examples which have been added to the test suite.
 
+26. `setnames` of whole table when original table had `NA` names skipped replacing those, [#2475](https://github.com/Rdatatable/data.table/issues/2475). Thanks to @franknarf1 and [BenoitLondon on StackOverflow](https://stackoverflow.com/questions/47228836/) for the report and @MichaelChirico for fixing.
+
 
 #### NOTES
 

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2460,8 +2460,7 @@ setnames <- function(x,old,new) {
     nx <- names(x)
     # note that duplicate names are permitted to be created in this usage only
     if (anyNA(nx)) {
-      # 2475 -- if x somehow got NA names,
-      #   which will skip logical NA values
+      # if x somehow has some NA names, which() needs help to return them, #2475
       w = which((nx != old) | (is.na(nx) & !is.na(old)))
     } else {
       w = which(nx != old)

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2457,8 +2457,15 @@ setnames <- function(x,old,new) {
     # for setnames(DT,new); e.g., setnames(DT,c("A","B")) where ncol(DT)==2
     if (!is.character(old)) stop("Passed a vector of type '",typeof(old),"'. Needs to be type 'character'.")
     if (length(old) != ncol(x)) stop("Can't assign ",length(old)," names to a ",ncol(x)," column data.table")
+    nx <- names(x)
     # note that duplicate names are permitted to be created in this usage only
-    w = which(names(x) != old)
+    if (anyNA(nx)) {
+      # 2475 -- if x somehow got NA names,
+      #   which will skip logical NA values
+      w = which((nx != old) | (is.na(nx) & !is.na(old)))
+    } else {
+      w = which(nx != old)
+    }
     if (!length(w)) return(invisible(x))  # no changes
     new = old[w]
     i = w

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -11135,6 +11135,10 @@ test(1851.1, dt[dt2, .SD, by=.EACHI, on="a", .SDcols="b"],
 test(1851.2, data.table(a = 1:2, b = list("yo", NULL))[.(1:3), on=.(a), x.b, by = .EACHI],
              data.table(a = 1:3, x.b = list("yo", NULL, NULL)))
 
+# NA column names and missing new argument to setnames, #2475
+DT = setNames(data.frame(a = 1, b = 2, c = 3, d = 4), c(NA, "b", "c", NA))
+setnames(DT, c('a', 'b', 'c', 'd'))
+test(1852, names(DT), c('a', 'b', 'c', 'd'))
 
 ##########################
 


### PR DESCRIPTION
Other option would be something like `which(!vapply(seq_along(old), function(ii) nx[ii] == old[ii], logical(1L)))`. Looks ugly and efficiency gain (if any) probably trivial