### PR TITLE
Fix typos in documentation.

### DIFF
--- a/man/copy.Rd
+++ b/man/copy.Rd
@@ -2,7 +2,7 @@
 \alias{copy}
 \title{ Copy an entire object }
 \description{
-  In \code{data.table} parlance, all \code{set*} functions change their input \emph{by reference}. That is, no copy is made at all, other than temporary working memory, which is as large as one column.. The only other \code{data.table} operator that modifies input by reference is \code{\link{:=}}. Check out the \code{See Also} section below for other \code{set*} function \code{data.table} provides.
+  In \code{data.table} parlance, all \code{set*} functions change their input \emph{by reference}. That is, no copy is made at all, other than temporary working memory, which is as large as one column. The only other \code{data.table} operator that modifies input by reference is \code{\link{:=}}. Check out the \code{See Also} section below for other \code{set*} function \code{data.table} provides.
 
   \code{copy()} copies an entire object.
 }

--- a/man/setDF.Rd
+++ b/man/setDF.Rd
@@ -2,7 +2,7 @@
 \alias{setDF}
 \title{Coerce a data.table to data.frame by reference}
 \description{
-  In \code{data.table} parlance, all \code{set*} functions change their input \emph{by reference}. That is, no copy is made at all, other than temporary working memory, which is as large as one column.. The only other \code{data.table} operator that modifies input by reference is \code{\link{:=}}. Check out the \code{See Also} section below for other \code{set*} function \code{data.table} provides.
+  In \code{data.table} parlance, all \code{set*} functions change their input \emph{by reference}. That is, no copy is made at all, other than temporary working memory, which is as large as one column. The only other \code{data.table} operator that modifies input by reference is \code{\link{:=}}. Check out the \code{See Also} section below for other \code{set*} function \code{data.table} provides.
 
   A helper function to convert a \code{data.table} or \code{list} of equal length to \code{data.frame} by reference.
 }
@@ -21,7 +21,7 @@ setDF(x, rownames=NULL)
 }
 
 \value{
-    The input \code{data.table} is modified by reference to a \code{data.frame} and returned (invisibly). If you require a copy, take a copy first (using \code{DT2 = copy(DT)}). See \code{?copy}..
+    The input \code{data.table} is modified by reference to a \code{data.frame} and returned (invisibly). If you require a copy, take a copy first (using \code{DT2 = copy(DT)}). See \code{?copy}.
 }
 
 \seealso{ \code{\link{data.table}}, \code{\link{as.data.table}}, \code{\link{setDT}}, \code{\link{copy}}, \code{\link{setkey}}, \code{\link{setcolorder}}, \code{\link{setattr}}, \code{\link{setnames}}, \code{\link{set}}, \code{\link{:=}}, \code{\link{setorder}}

--- a/man/setcolorder.Rd
+++ b/man/setcolorder.Rd
@@ -3,7 +3,7 @@
 
 \title{Fast column reordering of a data.table by reference}
 \description{
-  In \code{data.table} parlance, all \code{set*} functions change their input \emph{by reference}. That is, no copy is made at all, other than temporary working memory, which is as large as one column.. The only other \code{data.table} operator that modifies input by reference is \code{\link{:=}}. Check out the \code{See Also} section below for other \code{set*} function \code{data.table} provides.
+  In \code{data.table} parlance, all \code{set*} functions change their input \emph{by reference}. That is, no copy is made at all, other than temporary working memory, which is as large as one column. The only other \code{data.table} operator that modifies input by reference is \code{\link{:=}}. Check out the \code{See Also} section below for other \code{set*} function \code{data.table} provides.
 
   \code{setcolorder} reorders the columns of data.table, \emph{by reference}, to the new order provided.
 }

--- a/man/setkey.Rd
+++ b/man/setkey.Rd
@@ -14,7 +14,7 @@
 \description{
 In \code{data.table} parlance, all \code{set*} functions change their input
 \emph{by reference}. That is, no copy is made at all, other than temporary
-working memory, which is as large as one column.. The only other \code{data.table}
+working memory, which is as large as one column. The only other \code{data.table}
 operator that modifies input by reference is \code{\link{:=}}. Check out the
 \code{See Also} section below for other \code{set*} function \code{data.table}
 provides.

--- a/man/setorder.Rd
+++ b/man/setorder.Rd
@@ -9,7 +9,7 @@
 \description{
 In \code{data.table} parlance, all \code{set*} functions change their input
 \emph{by reference}. That is, no copy is made at all, other than temporary
-working memory, which is as large as one column.. The only other
+working memory, which is as large as one column. The only other
 \code{data.table} operator that modifies input by reference is \code{\link{:=}}.
 Check out the \code{See Also} section below for other \code{set*} function
 \code{data.table} provides.


### PR DESCRIPTION
This corrects cases in which sentences ended with '..' instead of '.'.