### PR TITLE
Fixed bug with assignments like DT[,c('x', 'y') := 1:10]

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -117,6 +117,8 @@
 
 28. CJ() works with multiple empty vectors now [#2511](https://github.com/Rdatatable/data.table/issues/2511). Thanks to @MarkusBonsch for fixing.
 
+29. `:=` assignment of one vector to two or more columns, e.g. DT[, c("x", "y") := 1:10], caused a tricky error if `setnames` was called afterwards because the code failed to copy the vector. [#2540](https://github.com/Rdatatable/data.table/issues/2540). This is an old issue [#185](https://github.com/Rdatatable/data.table/issues/185) that had been fixed but reappeared when code was refactored. Thanks to @patrickhowerter for the report and the reproducible example and to @MarkusBonsch for fixing.
+
 
 #### NOTES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -117,7 +117,7 @@
 
 28. CJ() works with multiple empty vectors now [#2511](https://github.com/Rdatatable/data.table/issues/2511). Thanks to @MarkusBonsch for fixing.
 
-29. `:=` assignment of one vector to two or more columns, e.g. DT[, c("x", "y") := 1:10], caused a tricky error if `setnames` was called afterwards because the code failed to copy the vector. [#2540](https://github.com/Rdatatable/data.table/issues/2540). This is an old issue [#185](https://github.com/Rdatatable/data.table/issues/185) that had been fixed but reappeared when code was refactored. Thanks to @patrickhowerter for the report and the reproducible example and to @MarkusBonsch for fixing.
+29. `:=` assignment of one vector to two or more columns, e.g. `DT[, c("x", "y") := 1:10]`, failed to copy the `1:10` data causing errors later if and when those columns were updated by reference, [#2540](https://github.com/Rdatatable/data.table/issues/2540). This is an old issue ([#185](https://github.com/Rdatatable/data.table/issues/185)) that had been fixed but reappeared when code was refactored. Thanks to @patrickhowerter for the detailed report with reproducible example and to @MarkusBonsch for fixing and strengthening tests so it doesn't reappear again.
 
 
 #### NOTES

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -2151,6 +2151,7 @@ test(752, DT[,head(.SD,2)[,new:=1:.N],by=a], data.table(a=rep(1:3,each=2),b=c(1:
 # Test duplicate() of recycled plonking RHS, #2298
 DT = data.table(a=letters[3:1],x=1:3)
 test(753, setkey(DT[,c("x1","x2"):=x],a), data.table(a=letters[1:3],x=3:1,x1=3:1,x2=3:1,key="a"))
+test(753.1, DT[,c("x1","x2"):=3:1, verbose = TRUE], output = "RHS for item 2 has been duplicated")
 DT = data.table(a=letters[3:1],x=1:3,y=4:6)
 test(754, setkey(DT[,c("x1","y1","x2","y2"):=list(x,y)],a), data.table(a=letters[1:3],x=3:1,y=6:4,x1=3:1,y1=6:4,x2=3:1,y2=6:4,key="a"))
 # And non-recycling i.e. that a single column copy does copy the column

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -2151,7 +2151,9 @@ test(752, DT[,head(.SD,2)[,new:=1:.N],by=a], data.table(a=rep(1:3,each=2),b=c(1:
 # Test duplicate() of recycled plonking RHS, #2298
 DT = data.table(a=letters[3:1],x=1:3)
 test(753, setkey(DT[,c("x1","x2"):=x],a), data.table(a=letters[1:3],x=3:1,x1=3:1,x2=3:1,key="a"))
-test(753.1, DT[,c("x1","x2"):=3:1, verbose = TRUE], output = "RHS for item 2 has been duplicated")
+test(753.1, DT[,c("x1","x2"):=4:6, verbose = TRUE], data.table(a=letters[1:3],x=3:1,x1=4:6,x2=4:6,key="a"),
+            output = "RHS for item 2 has been duplicated")
+test(753.2, DT[2,x2:=7L], data.table(a=letters[1:3],x=3:1,x1=4:6,x2=c(4L,7L,6L),key="a"))
 DT = data.table(a=letters[3:1],x=1:3,y=4:6)
 test(754, setkey(DT[,c("x1","y1","x2","y2"):=list(x,y)],a), data.table(a=letters[1:3],x=3:1,y=6:4,x1=3:1,y1=6:4,x2=3:1,y2=6:4,key="a"))
 # And non-recycling i.e. that a single column copy does copy the column

--- a/src/assign.c
+++ b/src/assign.c
@@ -477,7 +477,9 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values, SEXP v
     vlen = length(thisvalue);
     if (length(rows)==0 && targetlen==vlen && (vlen>0 || nrow==0)) {
       if (  MAYBE_SHARED(thisvalue) ||  // set() protects the NAMED of atomic vectors from .Call setting arguments to 2 by wrapping with list
-         (TYPEOF(values)==VECSXP && i>LENGTH(values)-1)) { // recycled RHS would have columns pointing to others, #185.
+         (TYPEOF(values)==VECSXP && i>LENGTH(values)-1) || // recycled RHS would have columns pointing to others, #185.
+         (TYPEOF(values)!=VECSXP && i>0) // assigning the same values to a second column. Have to ensure a copy #2540
+         ) { 
         if (verbose) {
           if (length(values)==length(cols)) {
             // usual branch


### PR DESCRIPTION
Closes #2540 
Closes #185
assign.c is very careful, when the right hand side needs to be copied.
However, there was one loophole where it failed to copy the right hand side: if the right hand side is a factory fresh vector, where `MAYBE_SHARED` returns FALSE, that is assigned to multiple columns.
An example is `DT[, c('x', 'y') := 1:10]`
I fixed and added a test.