### PR TITLE
trivial (temporary?) fix for confusing list column printing, related,…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,8 @@
     * gains `print.keys` argument, `FALSE` by default, which displays the keys and/or indices (secondary keys) of a `data.table`. Thanks @MichaelChirico for the PR, Yike Lu for the suggestion and Arun for honing that idea to its present form.
 
     * gains `col.names` argument, `"auto"` by default, which toggles which registers of column names to include in printed output. `"top"` forces `data.frame`-like behavior where column names are only ever included at the top of the output, as opposed to the default behavior which appends the column names below the output as well for longer (>20 rows) tables. `"none"` shuts down column name printing altogether. Thanks @MichaelChirico for the PR, Oleg Bondar for the suggestion, and Arun for guiding commentary.
+    
+    * Non-atomic column printing gets a fix to make it more obvious when truncation is happening, part of [#1523](https://github.com/Rdatatable/data.table/issues/1523). Thanks to @franknarf1 for drawing attention to an issue raised on StackOverflow by [TMOTTM](https://stackoverflow.com/q/47679701).
 
 10. setkeyv accelerated if key already exists [#2331](https://github.com/Rdatatable/data.table/issues/2331). Thanks to @MarkusBonsch for the PR.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -50,10 +50,10 @@
     * gains `print.keys` argument, `FALSE` by default, which displays the keys and/or indices (secondary keys) of a `data.table`. Thanks @MichaelChirico for the PR, Yike Lu for the suggestion and Arun for honing that idea to its present form.
 
     * gains `col.names` argument, `"auto"` by default, which toggles which registers of column names to include in printed output. `"top"` forces `data.frame`-like behavior where column names are only ever included at the top of the output, as opposed to the default behavior which appends the column names below the output as well for longer (>20 rows) tables. `"none"` shuts down column name printing altogether. Thanks @MichaelChirico for the PR, Oleg Bondar for the suggestion, and Arun for guiding commentary.
-    
-    * Non-atomic column printing gets a fix to make it more obvious when truncation is happening, part of [#1523](https://github.com/Rdatatable/data.table/issues/1523). Thanks to @franknarf1 for drawing attention to an issue raised on StackOverflow by [TMOTTM](https://stackoverflow.com/q/47679701).
 
-10. setkeyv accelerated if key already exists [#2331](https://github.com/Rdatatable/data.table/issues/2331). Thanks to @MarkusBonsch for the PR.
+    * list columns would print the first 6 items in each cell followed by a comma if there are more than 6 in that cell. Now it ends ",..." to make it clearer, part of [#1523](https://github.com/Rdatatable/data.table/issues/1523). Thanks to @franknarf1 for drawing attention to an issue raised on Stack Overflow by @TMOTTM [here](https://stackoverflow.com/q/47679701).
+
+10. `setkeyv` accelerated if key already exists [#2331](https://github.com/Rdatatable/data.table/issues/2331). Thanks to @MarkusBonsch for the PR.
 
 11. Keys and indexes are now partially retained up to the key column assigned to with ':=' [#2372](https://github.com/Rdatatable/data.table/issues/2372). They used to be dropped completely if any one of the columns was affected by `:=`. Tanks to @MarkusBonsch for the PR.
 

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -16,9 +16,6 @@ setPackageName("data.table",.global)
 # So even though .BY doesn't appear in this file, it should still be NULL here and exported because it's
 # defined in SDenv and can be used by users.
 
-# FR #2591 - format.data.table issue with columns of class "formula"
-is.formula <- function(x) class(x) == "formula"
-
 is.data.table <- function(x) inherits(x, "data.table")
 is.ff <- function(x) inherits(x, "ff")  # define this in data.table so that we don't have to require(ff), but if user is using ff we'd like it to work
 

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -111,9 +111,9 @@ format.data.table <- function (x, ..., justify="none") {
   }
   format.item <- function(x) {
     if (is.atomic(x) || is.formula(x)) # FR #2591 - format.data.table issue with columns of class "formula"
-      paste(c(format(head(x,6), justify=justify, ...), if(length(x)>6)""),collapse=",")  # fix for #5435 - format has to be added here...
+      paste(c(format(head(x, 6L), justify=justify, ...), if(length(x) > 6L) "..."), collapse=",")  # fix for #5435 - format has to be added here...
     else
-      paste("<",class(x)[1L],">",sep="")
+      paste("<", class(x)[1L], ">", sep="")
   }
   # FR #1091 for pretty printing of character
   # TODO: maybe instead of doing "this is...", we could do "this ... test"?
@@ -145,3 +145,6 @@ shouldPrint = function(x) {
 # for removing the head (column names) of matrix output entirely,
 #   as opposed to printing a blank line, for excluding col.names per PR #1483
 cut_top = function(x) cat(capture.output(x)[-1L], sep = '\n')
+
+# FR #2591 - format.data.table issue with columns of class "formula"
+is.formula <- function(x) class(x) == "formula"

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -110,8 +110,8 @@ format.data.table <- function (x, ..., justify="none") {
     stop("Internal structure doesn't seem to be a list. Possibly corrupt data.table.")
   }
   format.item <- function(x) {
-    if (is.atomic(x) || is.formula(x)) # FR #2591 - format.data.table issue with columns of class "formula"
-      paste(c(format(head(x, 6L), justify=justify, ...), if(length(x) > 6L) "..."), collapse=",")  # fix for #5435 - format has to be added here...
+    if (is.atomic(x) || inherits(x,"formula")) # FR #2591 - format.data.table issue with columns of class "formula"
+      paste(c(format(head(x, 6L), justify=justify, ...), if (length(x) > 6L) "..."), collapse=",")  # fix for #5435 - format has to be added here...
     else
       paste("<", class(x)[1L], ">", sep="")
   }
@@ -146,5 +146,3 @@ shouldPrint = function(x) {
 #   as opposed to printing a blank line, for excluding col.names per PR #1483
 cut_top = function(x) cat(capture.output(x)[-1L], sep = '\n')
 
-# FR #2591 - format.data.table issue with columns of class "formula"
-is.formula <- function(x) class(x) == "formula"

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -1654,16 +1654,9 @@ f = function(.SD) .SD[,z:=rnorm(1)]
 test(557, DT[, f(.SD), by=x], error="[.]SD is locked.*reserved for possible future use")
 
 # Test printing on nested data.table, bug #1803
-DT = data.table(
-  x=letters[1:3],
-  y=list(1:10, letters[1:4],
-         data.table(a=1:3,b=4:6))
-)
+DT = data.table(x=letters[1:3], y=list(1:10, letters[1:4], data.table(a=1:3,b=4:6)))
 test(558, capture.output(print(DT)),
-          c("   x               y",
-           "1: a 1,2,3,4,5,6,...",
-           "2: b         a,b,c,d",
-           "3: c    <data.table>"))
+          c("   x               y", "1: a 1,2,3,4,5,6,...", "2: b         a,b,c,d", "3: c    <data.table>"))
 test(559, setkey(DT,x)["a",y][[1]], 1:10)   # y is symbol representing list column, specially detected in dogroups
 
 # Test renaming of .N to N

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -1654,9 +1654,16 @@ f = function(.SD) .SD[,z:=rnorm(1)]
 test(557, DT[, f(.SD), by=x], error="[.]SD is locked.*reserved for possible future use")
 
 # Test printing on nested data.table, bug #1803
-DT = data.table(x=letters[1:3],y=list(1:10,letters[1:4],data.table(a=1:3,b=4:6)))
+DT = data.table(
+  x=letters[1:3],
+  y=list(1:10, letters[1:4],
+         data.table(a=1:3,b=4:6))
+)
 test(558, capture.output(print(DT)),
-          c("   x            y","1: a 1,2,3,4,5,6,","2: b      a,b,c,d","3: c <data.table>"))
+          c("   x               y",
+           "1: a 1,2,3,4,5,6,...",
+           "2: b         a,b,c,d",
+           "3: c    <data.table>"))
 test(559, setkey(DT,x)["a",y][[1]], 1:10)   # y is symbol representing list column, specially detected in dogroups
 
 # Test renaming of .N to N


### PR DESCRIPTION
… part of #1523

There's some more discussion on the merits of instead using `toString` here which I tend to like, see the discussion on #1523; filing this PR to jumpstart that convo & offer a temporary fix in any case since this was trivial to do.

Also brought `is.formula` into `print.data.table.R` since that's where it belongs. Side note -- shouldn't the function instead be `inherits(x, 'formula')`?