### PR TITLE
Updated NEWS and tests to reflect improved row ordering when joining.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -116,7 +116,7 @@
 
 25. `by=.EACHI` works now when `list` columns are being returned and some join values are missing, [#2300](https://github.com/Rdatatable/data.table/issues/2300). Thanks to @jangorecki and @franknarf1 for the reproducible examples which have been added to the test suite.
 
-26. Indices are now retrieved by exact name, [#2465](https://github.com/Rdatatable/data.table/issues/2465). Thanks to @pannnda for reporting and providing a reproducible example and to @MarkusBonsch for fixing.
+26. Indices are now retrieved by exact name, [#2465](https://github.com/Rdatatable/data.table/issues/2465). This prevents usage of wrong indices as well as unexpected row reordering in join results. Thanks to @pannnda for reporting and providing a reproducible example and to @MarkusBonsch for fixing.
 
 27. `setnames` of whole table when original table had `NA` names skipped replacing those, [#2475](https://github.com/Rdatatable/data.table/issues/2475). Thanks to @franknarf1 and [BenoitLondon on StackOverflow](https://stackoverflow.com/questions/47228836/) for the report and @MichaelChirico for fixing.
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -11185,6 +11185,10 @@ DT1[colname_with_suffix == "not found", ]  # automatically creates index on coln
 target <- data.table(colname = c("test1", "test2", "test2", "test3"), colname_with_suffix = c("other", "test", "includes test within", "other"), lookup_result = c(1,2,2,3))
 target[colname_with_suffix == "not found", ]
 test(1852, DT1[DT2, lookup_result := i.lookup_result, on=c("colname"="lookup")], target)
+# test that joins don't change row order when there is an index with additional columns present, #2559
+dt <- data.table(x = c(1,1), y = c(2,1))
+setindex(dt, x, y)
+test(1852.1, dt[J(x=1), on = "x==x"], setindex(dt, NULL))
 
 # NA column names and missing new argument to setnames, #2475
 DT = setNames(data.frame(a = 1, b = 2, c = 3, d = 4), c(NA, "b", "c", NA))


### PR DESCRIPTION
Closes #2559.
in 1.10.4, the row order after joins was unsexpected sometimes. This has been (accidentally) fixed with PR #2476. Here, we just add a test and a more informative news entry.