### PR TITLE
validOps needs only list structure

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2813,9 +2813,9 @@ isReallyReal <- function(x) {
   if (!is.call(isub)) return(NULL)
   if (!is.null(attr(x, '.data.table.locked'))) return(NULL)  # fix for #958, don't create auto index on '.SD'.
   ## a list of all possible operators with their translations into the 'on' clause
-  validOps <- rbind(data.table(op = "==", on = "=="),
-                    data.table(op = "%in%", on = "=="),
-                    data.table(op = "%chin%", on = "=="))
+  validOps <- list(op = c("==", "%in%", "%chin%"),
+                   on = c("==", "==",   "=="))
+
   ## Determine, whether the nature of isub in general supports fast binary search
   remainingIsub <- isub
   i <- list()


### PR DESCRIPTION
The line that creates `validOps` calls the relatively expensive functions `rbind` and `data.table`, yet only requires a list structure, which is much faster to create:

```
Unit: relative
     expr      min       lq    mean   median      uq      max neval cld
  current 2530.482 1311.841 1543.11 680.0233 556.256 11819.48   100   a
 list_way    1.000    1.000    1.00   1.0000   1.000     1.00   100   a
```

(Currently, this object may not need to be created at all, as its only use as far as I can see is in `validOps$on[validOps$op == operator]` which is always `"=="`, but I understand that it may be useful when it is eventually extended.)

I noticed this when profiling code which calls a subset repeatedly. 

