### PR TITLE
Fixed optimization where CJ would fail because of too many rows.

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2887,8 +2887,13 @@ isReallyReal <- function(x) {
     ## loop continues with remainingIsub
   }
   if (length(i) == 0L) stop("Internal error in .isFastSubsettable. Please report to data.table developers")
-  ## convert i to data.table with all combinations in rows. Care is needed with names as we do
-  ## it with 'do.call' and this would cause problems if colNames were 'sorted' or 'unique'
+  ## convert i to data.table with all combinations in rows.
+  if(length(i) > 1 && prod(sapply(i, length)) > 1e4){
+    ## CJ would result in more than 1e4 rows. This would be inefficient, especially memory-wise #2635
+    return(NULL)
+  }
+  ## Care is needed with names as we construct i
+  ## with 'CJ' and 'do.call' and this would cause problems if colNames were 'sorted' or 'unique'
   ## as these two would be interpreted as args for CJ
   colNames <- names(i)
   names(i) <- NULL
@@ -2898,7 +2903,6 @@ isReallyReal <- function(x) {
   setnames(i, colNames)
   idx <- NULL
   if(is.null(idx)){
-      ## we are seeing an equi-join
       ## check whether key fits the columns in i.
       ## order of key columns makes no difference, as long as they are all upfront in the key, I believe.
       if (all(names(i) %chin% head(key(x), length(i)))){

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2888,7 +2888,7 @@ isReallyReal <- function(x) {
   }
   if (length(i) == 0L) stop("Internal error in .isFastSubsettable. Please report to data.table developers")
   ## convert i to data.table with all combinations in rows.
-  if(length(i) > 1 && prod(sapply(i, length)) > 1e4){
+  if(length(i) > 1L && prod(vapply(i, length, integer(1L))) > 1e4){
     ## CJ would result in more than 1e4 rows. This would be inefficient, especially memory-wise #2635
     return(NULL)
   }

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -6012,13 +6012,13 @@ DT[, a:= c("A", "Q", "W", "C", "X", "Q")]
 test(1437.9, DT[a %chin% c("A", "B"), verbose = TRUE], output = "Optimized subsetting")
 test(1437.11, DT[a %chin% c("A", "B") & x == 3 & y %in% c(1,2), verbose = TRUE], output = "Optimized subsetting")
 ## multiple selections on the same column are not optimized and yield correct result
-test(1437.12, DT[a %chin% c("A", "B") & a == "A", verbose = TRUE], output = "   x y          z a1: 1 1 -0.6264538 A")
+test(1437.12, DT[a %chin% c("A", "B") & a == "A", verbose = TRUE], output = "^   x y          z a1: 1 1 -0.6264538 A")
 test(1437.13, DT[a %chin% c("A", "B") & a == "C"], DT[0])
 ## queries with 'or' connection are not optimized and yield the correct result.
-test(1437.14, DT[a %chin% c("A", "B") | x == 2, verbose = TRUE], output = "   x y          z a1: 1 1 -0.6264538 A2: 2 2  1.5952808 C3: 2 3  0.3295078 X4: 2 3 -0.8204684 Q")
+test(1437.14, DT[a %chin% c("A", "B") | x == 2, verbose = TRUE], output = "^   x y          z a1: 1 1 -0.6264538 A2: 2 2  1.5952808 C3: 2 3  0.3295078 X4: 2 3 -0.8204684 Q")
 test(1437.15, DT[a %chin% c("A", "B") | x == 2], DT[c(1, 4, 5, 6)])
 ## notjoin queries with connection are not optimized and yield the correct result.
-test(1437.16, DT[!a %chin% c("A", "B") & x == 2, verbose = TRUE], output = "   x y          z a1: 2 2  1.5952808 C2: 2 3  0.3295078 X3: 2 3 -0.8204684 Q")
+test(1437.16, DT[!a %chin% c("A", "B") & x == 2, verbose = TRUE], output = "^   x y          z a1: 2 2  1.5952808 C2: 2 3  0.3295078 X3: 2 3 -0.8204684 Q")
 test(1437.17, DT[!a %chin% c("A", "B") & x == 2], DT[c(4, 5, 6)])
 ## queries with j are optimized (Correct results are tested extensively below)
 test(1437.18, DT[x == 2, .(test = x+y), verbose = TRUE], output = "Optimized subsetting")
@@ -6045,8 +6045,18 @@ test(1437.28, DT[x & y, verbose = TRUE], output = "Optimized subsetting")
 test(1437.29, DT[x & y], DT[2])
 ## subsets where just cols are given but columns are not logical are not optimized.
 DT <- data.table(x = c(1, 0, 2, 4), y = c(0, 2, 1, 3))
-test(1437.31, DT[x & y, verbose = TRUE], output = "   x y")
+test(1437.31, DT[x & y, verbose = TRUE], output = "^   x y")
 test(1437.32, DT[x & y], DT[3:4])
+## test that optimization is switched off if CJ would result in more than 1e4 rows of i (#2635)
+# single column query with more than 1e4 rows is optimized
+test(1437.33, DT[x %in% 0:1e5, verbose = TRUE], output = "Optimized subsetting")
+test(1437.34, DT[x %in% 0:1e5], DT)
+# multi column query with less than 1e4 rows in i is optimized
+test(1437.35, DT[x %in% 0:99 & y %in% 0:98, verbose = TRUE], output = "Optimized subsetting")
+test(1437.36, DT[x %in% 0:99 & y %in% 0:98], DT)
+# multi column query with more than 1e4 rows in i is not optimized
+test(1437.37, DT[x %in% 0:100 & y %in% 0:101, verbose = TRUE], output = "^   x y")
+test(1437.38, DT[x %in% 0:100 & y %in% 0:101], DT)
 ## do extensive tests of optimized vs non-optimized queries for identical results.
 ## very much inspired by the tests for non equi joins (1641ff)
 set.seed(13545)
@@ -6096,7 +6106,7 @@ jQueries <- c(".(test = intCol + doubleCol, test2 = paste0(boolCol, charCol))",
 ## define example 'by' values
 bys <- c("groupCol", character(0))
 ## test each query string
-test_no <- 1437.0033
+test_no <- 1437.0039
 for(t in seq_len(nrow(all))){
   ## test the query with missing j
   thisQuery <- all$query[t]


### PR DESCRIPTION
Progress on #2635.

In the optimization of compound queries (PR #2494), `CJ` is used to construct a `data.table` with all the combinations of right hand sides of the compound query. 
This can be inefficient or even impossible for large `%in%` queries, such as DT[x %in% 1:1e5 & y %in% 1:1e5]. The result of `CJ` would have `1e5 * 1e5 = 1e10` rows, which is not possible currently because of integer limitations. 
Therefore, this PR implements a threshold of `1e4` on the maximum number of rows after `CJ` call. If this number is exceeded, no "optimization" takes place. 
The threshold is arbitrary and is just meant as a safeguard against memory explosion. From my perspective, this is an edge case, since I believe that queries with `%in%` and large right hand sides are not very common. 
In order to obtain maximum performance on these queries, use ` DT[x %in% 1:1e5][y %in% 1:1e5]`