### PR TITLE
Correct vignette example

### DIFF
--- a/vignettes/datatable-importing.Rmd
+++ b/vignettes/datatable-importing.Rmd
@@ -132,7 +132,7 @@ Slightly more extended way which also ensure that installed data.table is in ver
 ```r
 my.write = function (x) {
   if(requireNamespace("data.table", quietly=TRUE) &&
-    (package_version("data.table") >= "1.9.8")) {
+    utils::packageVersion("data.table") >= package_version("1.9.8")) {
     data.table::fwrite(x, "data.csv")
   } else {
     write.table(x, "data.csv")


### PR DESCRIPTION
* `utils::packageVersion` takes a pkg name, `base::package_version` treats a string as a package version for comparison purposes