### PR TITLE
Remove internal R v3.1.0 switches

### DIFF
--- a/CRAN_Release.cmd
+++ b/CRAN_Release.cmd
@@ -156,7 +156,7 @@ vi ~/.R/Makevars  # make the -O3 line active again
 ###############################################
 
 cd ~/build
-wget -N ftp://ftp.stat.math.ethz.ch/pub/Software/R/R-devel.tar.gz
+wget -N https://stat.ethz.ch/R/daily/R-devel.tar.gz
 rm -rf R-devel
 tar xvf R-devel.tar.gz
 cd R-devel

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -46,9 +46,8 @@ data.table <-function(..., keep.rownames=FALSE, check.names=FALSE, key=NULL, str
   # cbind directs to.  And the nested loops for recycling lend themselves to being C level.
 
   x <- list(...)   # doesn't copy named inputs as from R >= 3.1.0 (a very welcome change)
-  if (!.R.listCopiesNamed) .Call(CcopyNamedInList,x)   # to maintain the old behaviour going forwards, for now. See test 548.2.
-  # **TO DO** Something strange with NAMED on components of `...`. To investigate. Or just port data.table() to C. This is why
-  # it's switched, because extra copies would be introduced in R <= 3.1.0, iiuc.
+  .Call(CcopyNamedInList,x)   # to maintain pre-Rv3.1.0 behaviour, for now. See test 548.2. TODO: revist
+  # TODO Something strange with NAMED on components of `...` to investigate. Or, just port data.table() to C.
 
   # fix for #5377 - data.table(null list, data.frame and data.table) should return null data.table. Simple fix: check all scenarios here at the top.
   if (identical(x, list(NULL)) || identical(x, list(list())) ||
@@ -1986,11 +1985,7 @@ tail.data.table <- function(x, n=6L, ...) {
     # search for one other .Call to assign in [.data.table to see how it differs
   }
   verbose=getOption("datatable.verbose")
-  if (!.R.subassignCopiesOthers) {   # From 3.1.0, DF[2,"b"] = 7 no longer copies DF$a, but the VECSXP is copied (i.e. a shallow copy).
-    x = .Call(Cassign,copy(x),i,cols,newnames,value,verbose)
-  } else {
-    .Call(Cassign,x,i,cols,newnames,value,verbose)
-  }
+  x = .Call(Cassign,copy(x),i,cols,newnames,value,verbose) # From 3.1.0, DF[2,"b"] = 7 no longer copies DF$a (so in this [<-.data.table method we need to copy)
   alloc.col(x)  #  can maybe avoid this realloc, but this is (slow) [<- anyway, so just be safe.
   if (length(reinstatekey)) setkeyv(x,reinstatekey)
   invisible(x)
@@ -2050,7 +2045,6 @@ dimnames.data.table <- function(x) {
 "dimnames<-.data.table" = function (x, value)   # so that can do  colnames(dt)=<..>  as well as names(dt)=<..>
 {
   if (!cedta()) return(`dimnames<-.data.frame`(x,value))  # won't maintain key column (if any). Revisit if ever causes a compatibility problem but don't think it's likely that packages change column names using dimnames<-. See names<-.data.table below.
-  if (.R.assignNamesCopiesAll) warning("This is R<3.1.0 where dimnames(x)<-value syntax deep copies the entire table. Please upgrade to R>=3.1.0 and see ?setnames which allows you to change names by name with built-in checks and warnings.")
   if (!is.list(value) || length(value) != 2L) stop("attempting to assign invalid object to dimnames of a data.table")
   if (!is.null(value[[1L]])) stop("data.tables do not have rownames")
   if (ncol(x) != length(value[[2L]])) stop("can't assign",length(value[[2L]]),"colnames to a",ncol(x),"column data.table")
@@ -2060,14 +2054,9 @@ dimnames.data.table <- function(x) {
 
 "names<-.data.table" <- function(x,value)
 {
-  # When non data.table aware packages change names, we'd like to maintain the key, too.
+  # When non data.table aware packages change names, we'd like to maintain the key.
   # If call is names(DT)[2]="newname", R will call this names<-.data.table function (notice no i) with 'value' already prepared to be same length as ncol
-  caller = as.character(sys.call(-2L))[1L]
-  if ( ((tt<-identical(caller,"colnames<-")) && cedta(3L)) || cedta() ) {
-    if (.R.assignNamesCopiesAll)
-      warning("This is R<3.1.0 where ",if(tt)"col","names(x)<-value deep copies the entire table (several times). Please upgrade to R>=3.1.0 and see ?setnames which allows you to change names by name with built-in checks and warnings.")
-  }
-  x = shallow(x) # `names<-` should NOT modify by reference. Related to #1015, #476 and #825. Needed for R v3.1.0+.  TO DO: revisit
+  x = shallow(x) # `names<-` should not modify by reference. Related to #1015, #476 and #825. Needed for R v3.1.0+.  TO DO: revisit
   if (is.null(value))
     setattr(x,"names",NULL)   # e.g. plyr::melt() calls base::unname()
   else

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -91,17 +91,7 @@ test <- function(num,x,y=TRUE,error=NULL,warning=NULL,output=NULL) {
   # better than the dev-time-lost when it crashes and it actually crashed much later than the last test number visible.
 
   if (!missing(error) && !missing(y)) stop("Test ",num," is invalid: when error= is provided it does not make sense to pass y as well")
-  check_specials = function(string, type) {
-    # helper in dev to remind dev what might be wrong when changing or adding a new test
-    # nocov start
-    found = ""
-    if (length(grep("[^[\\]([(]|[)])", string))) found = "parenthesis"
-    else if (length(grep("[^[\\]([[]|[]])", string))) found = "square bracket"
-    else if (length(grep("[^\\]\\+", string))) found = "'+'"
-    else if (length(grep("[^\\]\\^", string))) found = "'^'"
-    if (found!="") stop("Likely due to the unescaped ",found," in the ",type,"= string. Please avoid it using .* or preceed it with double backslash.")
-    # nocov end
-  }
+
   string_match = function(x, y) {
     if (length(grep(x,y,fixed=TRUE)))  # try treating x as literal first; useful for most messages containing ()[]+ characters
       return(TRUE)
@@ -146,7 +136,6 @@ test <- function(num,x,y=TRUE,error=NULL,warning=NULL,output=NULL) {
         cat("Test",num,"didn't produce the correct warning:\n")
         cat("Expected: ", warning[i], "\n")
         cat("Observed: ", actual.warns[i], "\n")
-        check_specials(warning[i], "warning")
         fail = TRUE
         # nocov end
       }
@@ -165,7 +154,6 @@ test <- function(num,x,y=TRUE,error=NULL,warning=NULL,output=NULL) {
       cat("Test",num,"didn't produce the correct error:\n")
       cat("Expected: ", error, "\n")
       cat("Observed: ", actual.err, "\n")
-      check_specials(error, "error")
       fail = TRUE
       # nocov end
     }
@@ -180,7 +168,6 @@ test <- function(num,x,y=TRUE,error=NULL,warning=NULL,output=NULL) {
       cat("Test",num,"didn't produce correct output:\n")
       cat("Expected: <<",gsub("\n","\\\\n",output),">>\n",sep="")  # \n printed as '\\n' so the two lines of output can be compared vertically
       cat("Observed: <<",gsub("\n","\\\\n",out),">>\n",sep="")
-      check_specials(output, "output")
       fail = TRUE
       # nocov end
     }

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -93,11 +93,8 @@ test <- function(num,x,y=TRUE,error=NULL,warning=NULL,output=NULL) {
   if (!missing(error) && !missing(y)) stop("Test ",num," is invalid: when error= is provided it does not make sense to pass y as well")
 
   string_match = function(x, y) {
-    if (length(grep(x,y,fixed=TRUE)))  # try treating x as literal first; useful for most messages containing ()[]+ characters
-      return(TRUE)
-    if (length(tryCatch(grep(x,y), error=function(e)NULL)))  # otherwise try x as regexp; but just return FALSE if it's not a valid regexp
-      return(TRUE)
-    return(FALSE)                      # nocov
+    length(grep(x,y,fixed=TRUE)) ||                    # try treating x as literal first; useful for most messages containing ()[]+ characters
+    length(tryCatch(grep(x,y), error=function(e)NULL)) # otherwise try x as regexp
   }
 
   xsub = substitute(x)

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -95,7 +95,7 @@ test <- function(num,x,y=TRUE,error=NULL,warning=NULL,output=NULL) {
   string_match = function(x, y) {
     if (length(grep(x,y,fixed=TRUE)))  # try treating x as literal first; useful for most messages containing ()[]+ characters
       return(TRUE)
-    if (length(grep(x,y)))             # otherwise try regexp; commonly here when .* is used in x and if so, ()[]+ must then be escaped
+    if (length(tryCatch(grep(x,y), error=function(e)NULL)))  # otherwise try x as regexp; but just return FALSE if it's not a valid regexp
       return(TRUE)
     return(FALSE)                      # nocov
   }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,17 +15,23 @@ environment:
     CRAN: http://cloud.r-project.org/
     WARNINGS_ARE_ERRORS: 1
     USE_RTOOLS: true
-    GCC_PATH: mingw_64
-# Default GCC_PATH appears to be gcc-4.6.3 which is now unsupported as from Rtools.exe v3.4
-    R_CHECK_ARGS: --no-manual
-# R_CHECK_ARGS specified in order to turn off --as-cran as that can be slow
+    R_CHECK_ARGS: --no-manual --no-multiarch
+# R_CHECK_ARGS specified in order to turn off --as-cran (default) as that can be slow, and -no-multiarch so that 32bit tests run separately
 
   matrix:
   - R_VERSION: release
     R_ARCH: x64
-    
+    GCC_PATH: mingw_64
+# Default GCC_PATH appears to be gcc-4.6.3 which is now unsupported as from Rtools.exe v3.4
+
   - R_VERSION: devel
     R_ARCH: x64
+    GCC_PATH: mingw_64
+
+  - R_VERSION: devel
+    R_ARCH: i386
+    GCC_PATH: mingw_32
+
 
 build_script:
   - set _R_CHECK_FORCE_SUGGESTS_=false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,10 @@ environment:
     WARNINGS_ARE_ERRORS: 1
     USE_RTOOLS: true
     R_CHECK_ARGS: --no-manual --no-multiarch
-# R_CHECK_ARGS specified in order to turn off --as-cran (default) as that can be slow, and -no-multiarch so that 32bit tests run separately
+# R_CHECK_ARGS specified in order to turn off --as-cran (default) as that can be slow, and
+# -no-multiarch so that 32bit tests run separately, otherwise both 32bit and 64bit tests run in one job.
+# Separating the jobs out so we can very easily see in AppVeyor status which one(s) failed. It speeds
+# up dev cycle if the first one returns quickly since once passing locally on Linux, we push to test on Windows.
 
   matrix:
   - R_VERSION: release
@@ -24,13 +27,18 @@ environment:
     GCC_PATH: mingw_64
 # Default GCC_PATH appears to be gcc-4.6.3 which is now unsupported as from Rtools.exe v3.4
 
+  - R_VERSION: release
+    R_ARCH: i386
+    GCC_PATH: mingw_32
+
   - R_VERSION: devel
     R_ARCH: x64
     GCC_PATH: mingw_64
 
-  - R_VERSION: devel
-    R_ARCH: i386
-    GCC_PATH: mingw_32
+#  - R_VERSION: devel
+#    R_ARCH: i386
+#    GCC_PATH: mingw_32
+# Temporarily disabled on 7 March 2018 so as not to hold up PR testing while I investigate this apparently 32bit-only/Windows-only R-devel change
 
 
 build_script:

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -57,10 +57,6 @@ if (!.devtesting) {
     setrev = data.table:::setrev
     setreordervec = data.table:::setreordervec
     selfrefok = data.table:::selfrefok
-    .R.listCopiesNamed = data.table:::.R.listCopiesNamed
-    .R.assignNamesCopiesAll = data.table:::.R.assignNamesCopiesAll
-    .R.subassignCopiesOthers = data.table:::.R.subassignCopiesOthers
-    .R.subassignCopiesVecsxp = data.table:::.R.subassignCopiesVecsxp
     setdiff_ = data.table:::setdiff_
     is_na = data.table:::is_na
     shallow = data.table:::shallow # until exported
@@ -2371,8 +2367,7 @@ l = list(data.table(a=1:3), data.table(b=4:6))
 test(843, l[[2L]][,c:=7:9], data.table(b=4:6,c=7:9))
 test(844, l, list(data.table(a=1:3), data.table(b=4:6,c=7:9)))
 names(l) = c("foo","bar")   # R >= 3.1 no longer copies all the contents, yay
-test(845, l[["foo"]][2,d:=4L], data.table(a=1:3,d=c(NA,4L,NA)),
-    warning= if (!.R.assignNamesCopiesAll) NULL else "Invalid .internal.selfref detected and fixed")
+test(845, l[["foo"]][2,d:=4L], data.table(a=1:3,d=c(NA,4L,NA)))
 l = list(data.table(a=1:3), data.table(b=4:6))
 setattr(l,"names",c("foo","bar"))
 test(846, l[["foo"]][2,d:=4], data.table(a=1:3,d=c(NA,4,NA)))
@@ -2391,15 +2386,9 @@ options(old)
 DT1 = data.table(a=1:3, b=4:6)
 DT2 = data.table(c=7:9)
 l = list(DT1, DT2)
-if (!.R.listCopiesNamed) {
-    # From R>=3.1, list() no longer copies NAMED inputs (a very welcome change in Rdevel, r63767)
-    test(853, address(DT1) == address(l[[1L]]))
-    w = NULL
-} else {
-    test(853, address(DT1) != address(l[[1L]]))
-    w = "Invalid .internal.selfref detected and fixed.*R's list() used to copy named objects"
-}
-test(854, l[[1]][,d:=10:12], data.table(a=1:3,b=4:6,d=10:12), warning = w)
+# From R>=3.1, list() no longer copies NAMED inputs (a very welcome change in Rdevel, r63767)
+test(853, address(DT1) == address(l[[1L]]))
+test(854, l[[1]][,d:=10:12], data.table(a=1:3,b=4:6,d=10:12))
 test(855, l[[1]], data.table(a=1:3,b=4:6,d=10:12))
 
 # Test setnames on data.frame, #2273.
@@ -11756,7 +11745,7 @@ test(1880.1, length(names(joined)), length(unique(names(joined))))
 test(1880.2, nrow(merge(parents, children, by.x="name", by.y="parent", suffixes=c("",""))), 3L,
              warning = "column names.*are duplicated in the result")
 joined = suppressWarnings(merge(parents, children, by.x="name", by.y="parent", no.dups=FALSE))
-test(1880.3, any(duplicated(names(joined))), TRUE)             
+test(1880.3, any(duplicated(names(joined))), TRUE)
 
 # out-of-sample quote rule bump, #2265
 DT = data.table(A=rep("abc", 10000), B="def")

--- a/src/fread.c
+++ b/src/fread.c
@@ -2369,7 +2369,7 @@ int freadMain(freadMainArgs _args) {
     }
   }
   if (quoteRuleBumpedCh!=NULL && quoteRuleBumpedCh<headPos) {
-    DTWARN("Found and resolved improper quoting. First healed line %d: <<%s>>", quoteRuleBumpedLine, strlim(quoteRuleBumpedCh, 500));
+    DTWARN("Found and resolved improper quoting. First healed line %llu: <<%s>>", (llu)quoteRuleBumpedLine, strlim(quoteRuleBumpedCh, 500));
   }
 
   if (verbose) {

--- a/src/fread.c
+++ b/src/fread.c
@@ -2364,7 +2364,7 @@ int freadMain(freadMainArgs _args) {
         ch = headPos;
         int tt = countfields(&ch);
         DTWARN("Stopped early on line %llu. Expected %d fields but found %d. Consider fill=TRUE and comment.char=. First discarded non-empty line: <<%s>>",
-          DTi+row1line, ncol, tt, strlim(skippedFooter,500));
+          (llu)DTi+row1line, ncol, tt, strlim(skippedFooter,500));
       }
     }
   }


### PR DESCRIPTION
Closes #2498 

There were 3 used, all FALSE since R 3.1.0: 
```
.R.listCopiesNamed
.R.assignNamesCopiesAll
.R.subassignCopiesOthers
```

and 1 unused (TRUE) :  
```
.R.subassignCopiesVecsxp
```

These are all still checked, but now `stop()` in `.onLoad` so we know in future if anything changes in R-devel.
