### PR TITLE
Closes #2660, na.omit with invert = TRUE and nothing missing works as intended

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -63,7 +63,7 @@
 
 12. Faster `as.IDate` and `as.ITime` methods for `POSIXct` and `numeric`, [#1392](https://github.com/Rdatatable/data.table/issues/1392). Thanks to Jan Gorecki for the PR.
 
-13. `unique(DT)` now returns `DT` early when there are no duplicates to save RAM, [#2013](https://github.com/Rdatatable/data.table/issues/2013). Thanks to Michael Chirico for the PR.
+13. `unique(DT)` now returns `DT` early when there are no duplicates to save RAM, [#2013](https://github.com/Rdatatable/data.table/issues/2013). Thanks to Michael Chirico for the PR, and thanks to @mgahan for pointing out a reversion in `na.omit.data.table` before release, [#2660](https://github.com/Rdatatable/data.table/issues/2660#issuecomment-371027948).
 
 14. `uniqueN()` is now faster on logical vectors. Thanks to Hugh Parsonage for [PR#2648](https://github.com/Rdatatable/data.table/pull/2648).
     ```

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2189,10 +2189,16 @@ na.omit.data.table <- function (object, cols = seq_along(object), invert = FALSE
   }
   cols = as.integer(cols)
   ix = .Call(Cdt_na, object, cols)
-  if (any(ix))
-    .Call(CsubsetDT, object, which_(ix, bool = invert), seq_along(object))
-  else
-    object
+  # forgot about invert with no NA case, #2660
+  if (invert) {
+    if (all(ix)) object[0L]
+    else
+      .Call(CsubsetDT, object, which_(ix, bool = TRUE), seq_along(object))
+  } else {
+    if (any(ix))
+      .Call(CsubsetDT, object, which_(ix, bool = FALSE), seq_along(object))
+    else object
+  }
 }
 
 which_ <- function(x, bool = TRUE) {

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -11756,7 +11756,7 @@ test(1880.1, length(names(joined)), length(unique(names(joined))))
 test(1880.2, nrow(merge(parents, children, by.x="name", by.y="parent", suffixes=c("",""))), 3L,
              warning = "column names.*are duplicated in the result")
 joined = suppressWarnings(merge(parents, children, by.x="name", by.y="parent", no.dups=FALSE))
-test(1880.3, any(duplicated(names(joined))), TRUE)             
+test(1880.3, any(duplicated(names(joined))), TRUE)
 
 # out-of-sample quote rule bump, #2265
 DT = data.table(A=rep("abc", 10000), B="def")
@@ -11793,6 +11793,10 @@ test(1885.3, fread(txt, fill=TRUE), ans[c(1,2,NA,3),][3,1:2:=""])  # TODO when b
 # (TOOD: undoubling double quotes #1109, #1299) but otherwise, auto mode correct
 test(1886, fread(testDir("quoted_no_header.csv"))[c(1,.N),list(V1,V6)], data.table(V1=c("John","Joan \"\"the bone\"\", Anne"), V6=INT(8075,123)))
 
+# na.omit with invert & no NAs works
+DT = data.table(a = 1:5)
+DT_out = data.table(a = integer(0L))
+test(1887, na.omit(DT, invert = TRUE), DT_out)
 
 ###################################
 #  Add new tests above this line  #


### PR DESCRIPTION
@mattdowle was considering adding `invert` argument to C-level `dt_na`, worth it?