### PR TITLE
32bit rdevel

### DIFF
--- a/CRAN_Release.cmd
+++ b/CRAN_Release.cmd
@@ -81,6 +81,11 @@ grep ScalarInteger *.c   # Check all Scalar* either PROTECTed, return-ed or pass
 grep ScalarLogical *.c   # Now we depend on 3.1.0, check ScalarLogical is NOT PROTECTed.
 grep ScalarString *.c
 
+# Inspect missing PROTECTs
+# To pass this grep is why we like SET_VECTOR_ELT(,,var=allocVector()) style on one line.
+# If a PROTECT is not needed then a comment is added explaining why and including "PROTECT" in the comment to pass this grep
+grep allocVector *.c | grep -v PROTECT | grep -v SET_VECTOR_ELT | grep -v setAttrib | grep -v return
+
 cd
 R
 cc(clean=TRUE)  # to compile with -pedandic. Also use very latest gcc (currently gcc-7) as CRAN does

--- a/CRAN_Release.cmd
+++ b/CRAN_Release.cmd
@@ -12,49 +12,53 @@ q("no")
 # Ensure latest version of R otherwise problems with CRAN not finding dependents that depend on latest R
 # e.g. mirror may have been disabled in sources.list when upgrading ubuntu
 
+rm ./src/*.so
+rm ./src/*.o
+rm -rf ./data.table.Rcheck
+
 # Ensure no non-ASCII, other than in README.md is ok
 # tests.Rraw in particular have failed CRAN Solaris (only) due to this.
-# No unicode either. Put these tests in DtNonAsciiTests package.
-grep -RI --exclude-dir=".git" --exclude="*.md" --exclude="*~" --color='auto' -P -n "[\x80-\xFF]" data.table/
-grep -RI --exclude-dir=".git" --exclude="*.md" --exclude="*~" --color='auto' -n "[\]u[0-9]" data.table/
+grep -RI --exclude-dir=".git" --exclude="*.md" --exclude="*~" --color='auto' -P -n "[\x80-\xFF]" ./
+
+# No unicode either?! Put these tests in DtNonAsciiTests package. Trying this again to see what happens now that Solaris is dead. Tests 1864.1 and 1864.2
+grep -RI --exclude-dir=".git" --exclude="*.md" --exclude="*~" --color='auto' -n "[\]u[0-9]" ./
 
 # Ensure no calls to omp_set_num_threads() [to avoid affecting other packages and base R]
-grep --exclude="data.table/src/openmp-utils.c" omp_set_num_threads data.table/src/*
+grep --exclude="./src/openmp-utils.c" omp_set_num_threads ./src/*
 
 # Ensure no calls to omp_get_max_threads() also since access should be via getDTthreads()
-grep --exclude="data.table/src/openmp-utils.c" omp_get_max_threads data.table/src/*
+grep --exclude="./src/openmp-utils.c" omp_get_max_threads ./src/*
 
 # Ensure all #pragama omp parallel directives include a num_threads() clause
-grep "pragma omp parallel" data.table/src/*.c
+grep "pragma omp parallel" ./src/*.c
 
 # Ensure all .Call's first argument are unquoted.  TODO - change to use INHERITS()
-grep "[.]Call(\"" data.table/R/*.R
+grep "[.]Call(\"" ./R/*.R
 
 # Ensure no Rprintf in init.c
-grep "Rprintf" data.table/src/init.c
+grep "Rprintf" ./src/init.c
 
 # workaround for IBM AIX - ensure no globals named 'nearest' or 'class'.
 # See https://github.com/Rdatatable/data.table/issues/1351
-grep "nearest *=" data.table/src/*.c  # none
-grep "class *=" data.table/src/*.c    # quite a few but none global
+grep "nearest *=" ./src/*.c  # none
+grep "class *=" ./src/*.c    # quite a few but none global
 
 # No undefined type punning of the form:  *(long long *)&REAL(column)[i]
 # Failed clang 3.9.1 -O3 due to this, I think.
-grep "&REAL" data.table/src/*.c
+grep "&REAL" ./src/*.c
 
 # No use of long long, instead use int64_t. TODO
-# grep "long long" data.table/src/*.c
+# grep "long long" ./src/*.c
 
-# No tabs in C or R code (sorry Richard Hendricks)
-grep -P "\t" data.table/R/*.R
-grep -P "\t" data.table/src/*.c
-
+# No tabs in C or R code (sorry, Richard Hendricks)
+grep -P "\t" ./R/*.R
+grep -P "\t" ./src/*.c
 
 # seal leak potential where two unprotected API calls are passed to the same
 # function call, usually involving install() or mkChar()
 # Greppable thanks to single lines and wide screens
 # See comments in init.c
-cd data.table/src
+cd ./src
 grep install.*alloc *.c   --exclude init.c
 grep install.*Scalar *.c
 grep alloc.*install *.c   --exclude init.c
@@ -71,10 +75,10 @@ grep "install(" *.c       --exclude init.c   # TODO: perhaps in future pre-insta
 
 # ScalarInteger and ScalarString allocate and must be PROTECTed unless i) returned (which protects),
 # or ii) passed to setAttrib (which protects, providing leak-seals above are ok)
-# ScalarLogical in R now returns R's global TRUE but from R 3.1.0; Apr 2014. Before that it allocates.
+# ScalarLogical in R now returns R's global TRUE from R 3.1.0; Apr 2014. Before that it allocated.
 # Aside: ScalarInteger may return globals for small integers in future version of R.
 grep ScalarInteger *.c   # Check all Scalar* either PROTECTed, return-ed or passed to setAttrib.
-grep ScalarLogical *.c   # When we move R dependency to 3.1.0+, no need to protect ScalarLogical
+grep ScalarLogical *.c   # Now we depend on 3.1.0, check ScalarLogical is NOT PROTECTed.
 grep ScalarString *.c
 
 cd

--- a/CRAN_Release.cmd
+++ b/CRAN_Release.cmd
@@ -216,8 +216,9 @@ install.packages("bit64")
 require(bit64)
 require(data.table)
 test.data.table()  # just quick re-check
-gctorture2(step=100)
-print(Sys.time()); try(test.data.table()); print(Sys.time())
+gctorture2(step=100)    # 1h 26m
+print(Sys.time()); started.at<-proc.time(); try(test.data.table()); print(Sys.time()); print(timetaken(started.at))
+# Running test id 1437.0331      Error : protect(): protection stack overflow
 
 
 ###############################################

--- a/R/timetaken.R
+++ b/R/timetaken.R
@@ -1,21 +1,17 @@
 timetaken <- function(started.at)
 {
-   if (inherits(started.at,"POSIXct")) {
-    # started.at was Sys.time(). Slower method due to POSIXt.
-    secs <- as.double(difftime(Sys.time(), started.at, units="secs"))
+   if (!inherits(started.at,"proc_time")) stop("Use started.at=proc.time() (faster) not Sys.time() (POSIXt and slow)")
+   secs = proc.time()[3L] - started.at[3L]
+   mins = as.integer(secs) %/% 60L
+   hrs = mins %/% 60L
+   days = hrs %/% 24L
+   mins = mins - hrs * 60L
+   hrs = hrs - days * 24L
+   if (secs > 60.0) {
+     res = if (days>=1L) paste0(days," day", if (days>1L) "s " else " ") else ""
+     paste0(res,sprintf("%02d:%02d:%02d", hrs, mins, as.integer(secs) %% 60L))
    } else {
-    # new faster method using started.at = proc.time()
-    secs = proc.time()[3L] - started.at[3L]
-   }
-   mins <- secs %/% 60
-   hrs <- mins %/% 60
-   days <- hrs %/% 24
-   mins = mins - hrs * 60
-   hrs = hrs - 24*days
-   if (secs >= 60) {
-     if (days >= 1) res = sprintf("%d days ", as.integer(days)) else res=""
-     paste(res,sprintf("%02.0f:%02.0f:%02.0f", hrs, mins, secs %% 60),sep="")
-   } else {
-     sprintf(if (secs>=10) "%.1fsec" else "%.3fsec", secs)
+     sprintf(if (secs >= 10.0) "%.1fsec" else "%.3fsec", secs)
    }
 }
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,11 +26,6 @@ environment:
 
   matrix:
 
-#  Temp off, see PR #2665
-#  - R_VERSION: devel
-#    R_ARCH: i386
-#    GCC_PATH: mingw_32
-
   - R_VERSION: release
     R_ARCH: i386
     GCC_PATH: mingw_32
@@ -43,6 +38,10 @@ environment:
     R_ARCH: x64
     GCC_PATH: mingw_64
 
+#  Temp off, see PR #2665. Put first when enabled again.
+#  - R_VERSION: devel
+#    R_ARCH: i386
+#    GCC_PATH: mingw_32
 
 build_script:
   - set _R_CHECK_FORCE_SUGGESTS_=false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,9 +26,10 @@ environment:
 
   matrix:
 
-  - R_VERSION: devel
-    R_ARCH: i386
-    GCC_PATH: mingw_32
+#  Temp off, see PR #2665
+#  - R_VERSION: devel
+#    R_ARCH: i386
+#    GCC_PATH: mingw_32
 
   - R_VERSION: release
     R_ARCH: i386

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,12 +20,15 @@ environment:
 # -no-multiarch so that 32bit tests run separately, otherwise both 32bit and 64bit tests run in one job.
 # Separating the jobs out so we can very easily see in AppVeyor status which one(s) failed. It speeds
 # up dev cycle if the first one returns quickly since once passing locally on Linux, we push to test on Windows.
+# Default GCC_PATH appears to be gcc-4.6.3 which is now unsupported as from Rtools.exe v3.4. So, set it
+#  explicitly even if it didn't need to be varied in matrix below.
+# 32bit r-devel first as that's the highest chance of failing. If that passes, it's unlikely the others will fail.
 
   matrix:
-  - R_VERSION: release
-    R_ARCH: x64
-    GCC_PATH: mingw_64
-# Default GCC_PATH appears to be gcc-4.6.3 which is now unsupported as from Rtools.exe v3.4
+
+  - R_VERSION: devel
+    R_ARCH: i386
+    GCC_PATH: mingw_32
 
   - R_VERSION: release
     R_ARCH: i386
@@ -35,9 +38,10 @@ environment:
     R_ARCH: x64
     GCC_PATH: mingw_64
 
-  - R_VERSION: devel
-    R_ARCH: i386
-    GCC_PATH: mingw_32
+  - R_VERSION: release
+    R_ARCH: x64
+    GCC_PATH: mingw_64
+
 
 build_script:
   - set _R_CHECK_FORCE_SUGGESTS_=false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,11 +35,9 @@ environment:
     R_ARCH: x64
     GCC_PATH: mingw_64
 
-#  - R_VERSION: devel
-#    R_ARCH: i386
-#    GCC_PATH: mingw_32
-# Temporarily disabled on 7 March 2018 so as not to hold up PR testing while I investigate this apparently 32bit-only/Windows-only R-devel change
-
+  - R_VERSION: devel
+    R_ARCH: i386
+    GCC_PATH: mingw_32
 
 build_script:
   - set _R_CHECK_FORCE_SUGGESTS_=false

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -4510,8 +4510,8 @@ test(1266, getNumericRounding(), 0L)
 setNumericRounding(old_rounding)
 
 # fread reading NA in logical columns, #4766
-DF = data.frame(I=1:3, L=c(T,F,NA), R=3.14)
-write.csv(DF,f<-tempfile(),row.names=F)
+DF = data.frame(I=1:3, L=c(TRUE,FALSE,NA), R=3.14)
+write.csv(DF,f<-tempfile(),row.names=FALSE)
 test(1267.1, fread(f)$L, c(TRUE, FALSE, NA))
 test(1267.2, fread(f), as.data.table(read.csv(f)))
 unlink(f)
@@ -4882,7 +4882,7 @@ set(DT,1L,"b",FALSE)  # passing 1L as i here is needed to avoid column plonk, so
 test(1297, as.integer(TRUE[1]), 1L)   # In R 3.1, TRUE[1] returns the global TRUE but TRUE doesn't yet (parses as new vector)
 test(1298, as.integer(TRUE), 1L)
 # orignal example, verbatim from James Sams :
-upc_table = data.table(upc=1:100000, upc_ver_uc=rep(c(1,2), times=50000), is_PL=rep(c(T, F, F, T), each=25000), product_module_code=rep(1:4, times=25000), ignore.column=2:100001)
+upc_table = data.table(upc=1:100000, upc_ver_uc=rep(c(1,2), times=50000), is_PL=rep(c(TRUE, FALSE, FALSE, TRUE), each=25000), product_module_code=rep(1:4, times=25000), ignore.column=2:100001)
 test(1299, upc_table[, .N, by=list(upc, upc_ver_uc)][,max(N)], 1L)  # all size 1 groups
 test(1300, upc_table[, list(is_PL, product_module_code), keyby=list(upc, upc_ver_uc)][,upc[1:3]], 1:3L)   # was warning "internal TRUE value has been modified"
 
@@ -6573,7 +6573,7 @@ test(1483.2, merge(x,y,all=TRUE), data.table(k=factor(c(NA,1,2,3)), v.x=c(0,1,2,
 
 x <- data.table(country="US")
 y <- data.table(country=factor("USA"))
-test(1483.3, merge(x,y,by="country",all=T), data.table(country=factor(c("US", "USA")), key="country"))
+test(1483.3, merge(x,y,by="country",all=TRUE), data.table(country=factor(c("US", "USA")), key="country"))
 setkey(y)
 test(1483.4, y[x], data.table(country=factor("US"), key="country"))
 
@@ -6718,8 +6718,8 @@ test(1497, DT[, .SD, .SDcols = !c("a", "c")], DT[, !c("a", "c"), with=FALSE])
 
 # Fix for #1060
 DT = data.table(x=1, y=2, z=3, a=4, b=5, c=6)
-test(1498.1, DT[, .SD, .SDcols=c(T,F)], DT[, c("x", "z", "b"), with=FALSE])
-test(1498.2, DT[, .SD, .SDcols=!c(T,F)], DT[, !c("x", "z", "b"), with=FALSE])
+test(1498.1, DT[, .SD, .SDcols=c(TRUE,FALSE)], DT[, c("x", "z", "b"), with=FALSE])
+test(1498.2, DT[, .SD, .SDcols=!c(TRUE,FALSE)], DT[, !c("x", "z", "b"), with=FALSE])
 
 # Fix for #1072
 dt <- data.table(group1 = "a", group2 = "z", value  = 1)
@@ -7307,9 +7307,9 @@ rm(DT)
 K = 10L
 nastrings = c('null', 'NULL', 'na', '_NA', 'NA', 'nan', 'Nan', 'NAN', 'NaN')
 DT = data.table(int = 1:K,
-                 char = sample(letters, size = K, replace = T),
+                 char = sample(letters, size = K, replace = TRUE),
                  float = 1:K + 0.1,
-                 bool = sample( c(T, F), K, replace = T))
+                 bool = sample( c(TRUE, FALSE), K, replace = TRUE))
 
 DT_NA = DT
 for (j in seq_len( ncol(DT) )) {
@@ -7944,7 +7944,7 @@ test(1603.1, rbindlist(list(d2, d1), fill=TRUE), rbindlist(list(d1,d2), fill=TRU
 # fix for #1440
 DT = data.table(a=1:3, b=4:6)
 myCol = "b"
-test(1604, DT[,.(myCol),with=F], error="When with=FALSE,")
+test(1604, DT[,.(myCol),with=FALSE], error="When with=FALSE,")
 
 # fix for segfault #1531
 DT = data.table(x=rep(c("b","a","c"),each=3), y=c(1,3,6), v=1:9)
@@ -8456,16 +8456,17 @@ B = data.table(x=c(10,20), y=c(100,200), key="x")
 test(1631, key(A[B, on="x"]), NULL)
 
 # fix for #1479, secondary keys are removed when necessary
-dt = data.table(a = rep(c(F,F,T,F,F,F,F,F,F), 3), b = c("x", "y", "z"))
+TFvec = c(FALSE,FALSE,TRUE,FALSE,FALSE,FALSE,FALSE,FALSE,FALSE)
+dt = data.table(a = rep(TFvec, 3), b = c("x", "y", "z"))
 setindex(dt, a)
 dt[, a := as.logical(sum(a)), by = b]
 test(1632.1, names(attributes(attr(dt, 'index'))), NULL)
-dt = data.table(a = rep(c(F,F,T,F,F,F,F,F,F), 3), b = c("x", "y", "z"))
+dt = data.table(a = rep(TFvec, 3), b = c("x", "y", "z"))
 setindex(dt, b)
 dt[, a := as.logical(sum(a)), by = b]
 test(1632.2, names(attributes(attr(dt, 'index'))), "__b")
-dt = data.table(a = rep(c(F,F,T,F,F,F,F,F,F), 3), b = c("x", "y", "z"))
-test(1632.3, copy(dt)[, c := !a, by=b], copy(dt)[, c := c(T,T,F,T,T,T,T,T,T)])
+dt = data.table(a = rep(TFvec, 3), b = c("x", "y", "z"))
+test(1632.3, copy(dt)[, c := !a, by=b], copy(dt)[, c := !TFvec])
 
 # by accepts colA:colB for interactive scenarios, #1395
 dt = data.table(x=rep(1,18), y=rep(1:2, each=9), z=rep(1:3,each=6), a=rep(1:6, each=3))[, b := 6]
@@ -9190,7 +9191,7 @@ test(1658.6, fwrite(data.table(a=c("foo", NA), b=c(1, NA)), na="NA", quote=TRUE)
             output='"a","b"\n"foo",1\nNA,NA')
 
 # no col.names
-test(1658.7, fwrite(data.table(a="foo", b="bar"), col.names=F, quote=TRUE),
+test(1658.7, fwrite(data.table(a="foo", b="bar"), col.names=FALSE, quote=TRUE),
             output='"foo","bar"')
 
 test(1658.8, fwrite(data.table(a=c(1:5), b=c(1:5)), quote=TRUE),
@@ -11014,7 +11015,7 @@ test(1808.8, fread("A,B\r1,3\r\r \r2,\r", blank.lines.skip=TRUE, fill=TRUE), dat
 test(1809, fread("A,B\n\r1,2\n\r3,4\n\r5,6"), data.table(A=c(1L,3L,5L), B=c(2L,4L,6L)))
 cat("A,B\n1,q\n2,w\n3,xyz", file=f<-tempfile()); test(1810, fread(f,verbose=TRUE), data.table(A=c(1L,2L,3L), B=c("q","w","xyz")), output="File ends abruptly with 'z'.*cow page"); unlink(f)
 test(1811, fread("A,B\n1,2\n3,4", skip="boo"), error="skip='boo' not found in input")
-test(1812, fread("A,B\n1,2\n3,4\n", skip="4", verbose=T), data.table(V1=3L, V2=4L), output="Found skip='4' on line 3")
+test(1812, fread("A,B\n1,2\n3,4\n", skip="4", verbose=TRUE), data.table(V1=3L, V2=4L), output="Found skip='4' on line 3")
 test(1813, fread("A,B\n1,2\n3,4", skip=10L), error="skip=10 but the input only has 3 lines")
 test(1814, fread("A,B\n1,2\n3,4\n   \n\t", skip=3L), error="skip has been set after the last non-whitespace")
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -31,7 +31,7 @@ nfail = ntest = lastnum = 0
 whichfail = NULL
 
 .timingtests = FALSE
-started.at = Sys.time()
+started.at = proc.time()
 
 # Test default values in case user set global option. These are restored
 # at the end of this file.

--- a/man/data.table.Rd
+++ b/man/data.table.Rd
@@ -409,10 +409,8 @@ dev.off()
 # using rleid, get max(y) and min of all cols in .SDcols for each consecutive run of 'v'
 DT[, c(.(y=max(y)), lapply(.SD, min)), by=rleid(v), .SDcols=v:b]
 
-# Follow r-help posting guide, SUPPORT is here (*not* r-help) :
-# http://stackoverflow.com/questions/tagged/data.table
-# or
-# datatable-help@lists.r-forge.r-project.org
+# Support guide and links:
+# https://github.com/Rdatatable/data.table/wiki/Support
 
 \dontrun{
 if (interactive()) {
@@ -423,13 +421,13 @@ if (interactive()) {
   vignette("datatable-reshape")
   vignette("datatable-faq")
 
-
-  test.data.table()          # over 5700 low level tests
+  test.data.table()          # over 6,000 low level tests
 
   # keep up to date with latest stable version on CRAN
   update.packages()
-  # get the latest devel (needs Rtools for windows, xcode for mac)
-  install.packages("data.table", repos = "https://Rdatatable.github.io/data.table", type = "source")
+
+  # get the latest devel version (compiled binary for Windows available -- no tools needed)
+  # https://github.com/Rdatatable/data.table/wiki/Installation
 }
 }}
 \keyword{ data }

--- a/man/setattr.Rd
+++ b/man/setattr.Rd
@@ -35,14 +35,16 @@ setnames(x,old,new)
 \examples{
 
 DF = data.frame(a=1:2,b=3:4)       # base data.frame to demo copies and syntax
-try(tracemem(DF))                  # try() for R sessions opted out of memory profiling
+if (capabilities()["profmem"])     # usually memory profiling is available but just in case
+  tracemem(DF)
 colnames(DF)[1] <- "A"             # 4 shallow copies (R >= 3.1, was 4 deep copies before)
 names(DF)[1] <- "A"                # 3 shallow copies
 names(DF) <- c("A", "b")           # 1 shallow copy
 `names<-`(DF,c("A","b"))           # 1 shallow copy
 
 DT = data.table(a=1:2,b=3:4,c=5:6) # compare to data.table
-try(tracemem(DT))                  # by reference, no deep or shallow copies
+if (capabilities()["profmem"])
+  tracemem(DT)                     # by reference, no deep or shallow copies
 setnames(DT,"b","B")               # by name, no match() needed (warning if "b" is missing)
 setnames(DT,3,"C")                 # by position with warning if 3 > ncol(DT)
 setnames(DT,2:3,c("D","E"))        # multiple

--- a/man/test.data.table.Rd
+++ b/man/test.data.table.Rd
@@ -20,7 +20,10 @@ When \code{silent} equals to \code{TRUE} it will return \code{TRUE} if all tests
 }
 \seealso{ \code{\link{data.table}} }
 \examples{
-if (interactive()) test.data.table()
+\dontrun{
+  library(data.table)
+  test.data.table()
+}
 }
 \keyword{ data }
 

--- a/src/bmerge.c
+++ b/src/bmerge.c
@@ -143,9 +143,8 @@ SEXP bmerge(SEXP iArg, SEXP xArg, SEXP icolsArg, SEXP xcolsArg, SEXP isorted, SE
   o = NULL;
   if (!LOGICAL(isorted)[0]) {
     SEXP order = PROTECT(int_vec_init(length(icolsArg), 1)); // rep(1L, length(icolsArg))
-    SEXP oSxp = PROTECT(forder(i, icolsArg, PROTECT(ScalarLogical(FALSE)),
-              PROTECT(ScalarLogical(TRUE)), order, PROTECT(ScalarLogical(FALSE))));
-    UNPROTECT(3); // The 3 logicals in line above. TODO - split head of forder into C-level callable
+    SEXP oSxp = PROTECT(forder(i, icolsArg, ScalarLogical(FALSE), ScalarLogical(TRUE), order, ScalarLogical(FALSE)));
+    // TODO - split head of forder into C-level callable
     protecti += 2;   // order and oSxp
     if (!LENGTH(oSxp)) o = NULL; else o = INTEGER(oSxp);
   }

--- a/src/fcast.c
+++ b/src/fcast.c
@@ -35,8 +35,7 @@ SEXP fcast(SEXP lhs, SEXP val, SEXP nrowArg, SEXP ncolArg, SEXP idxArg, SEXP fil
     switch (TYPEOF(thiscol)) {
     case INTSXP:
       for (j=0; j<ncols; j++) {
-        target = allocVector(TYPEOF(thiscol), nrows);
-        SET_VECTOR_ELT(ans, nlhs+j+i*ncols, target);
+        SET_VECTOR_ELT(ans, nlhs+j+i*ncols, target=allocVector(TYPEOF(thiscol), nrows) );
         copyMostAttrib(thiscol, target);
         for (k=0; k<nrows; k++) {
           thisidx = idx[k*ncols + j];
@@ -46,8 +45,7 @@ SEXP fcast(SEXP lhs, SEXP val, SEXP nrowArg, SEXP ncolArg, SEXP idxArg, SEXP fil
       break;
     case REALSXP:
       for (j=0; j<ncols; j++) {
-        target = allocVector(TYPEOF(thiscol), nrows);
-        SET_VECTOR_ELT(ans, nlhs+j+i*ncols, target);
+        SET_VECTOR_ELT(ans, nlhs+j+i*ncols, target=allocVector(TYPEOF(thiscol), nrows) );
         copyMostAttrib(thiscol, target);
         for (k=0; k<nrows; k++) {
           thisidx = idx[k*ncols + j];
@@ -57,8 +55,7 @@ SEXP fcast(SEXP lhs, SEXP val, SEXP nrowArg, SEXP ncolArg, SEXP idxArg, SEXP fil
       break;
     case LGLSXP:
       for (j=0; j<ncols; j++) {
-        target = allocVector(TYPEOF(thiscol), nrows);
-        SET_VECTOR_ELT(ans, nlhs+j+i*ncols, target);
+        SET_VECTOR_ELT(ans, nlhs+j+i*ncols, target=allocVector(TYPEOF(thiscol), nrows) );
         copyMostAttrib(thiscol, target);
         for (k=0; k<nrows; k++) {
           thisidx = idx[k*ncols + j];
@@ -68,8 +65,7 @@ SEXP fcast(SEXP lhs, SEXP val, SEXP nrowArg, SEXP ncolArg, SEXP idxArg, SEXP fil
       break;
     case STRSXP:
       for (j=0; j<ncols; j++) {
-        target = allocVector(TYPEOF(thiscol), nrows);
-        SET_VECTOR_ELT(ans, nlhs+j+i*ncols, target);
+        SET_VECTOR_ELT(ans, nlhs+j+i*ncols, target=allocVector(TYPEOF(thiscol), nrows) );
         copyMostAttrib(thiscol, target);
         for (k=0; k<nrows; k++) {
           thisidx = idx[k*ncols + j];
@@ -79,8 +75,7 @@ SEXP fcast(SEXP lhs, SEXP val, SEXP nrowArg, SEXP ncolArg, SEXP idxArg, SEXP fil
       break;
     case VECSXP:
       for (j=0; j<ncols; j++) {
-        target = allocVector(TYPEOF(thiscol), nrows);
-        SET_VECTOR_ELT(ans, nlhs+j+i*ncols, target);
+        SET_VECTOR_ELT(ans, nlhs+j+i*ncols, target=allocVector(TYPEOF(thiscol), nrows) );
         copyMostAttrib(thiscol, target);
         for (k=0; k<nrows; k++) {
           thisidx = idx[k*ncols + j];

--- a/src/fmelt.c
+++ b/src/fmelt.c
@@ -531,7 +531,9 @@ SEXP getvarcols(SEXP DT, SEXP dtnames, Rboolean varfactor, Rboolean verbose, str
       nlevels = data->lmax;
     }
   }
-  setAttrib(target, R_ClassSymbol, mkString("factor"));
+  SEXP tmp = PROTECT(mkString("factor"));
+  setAttrib(target, R_ClassSymbol, tmp);
+  UNPROTECT(1);  // tmp
   cnt = 0;
   if (data->lvalues == 1) {
     levels = PROTECT(allocVector(STRSXP, nlevels));
@@ -545,7 +547,9 @@ SEXP getvarcols(SEXP DT, SEXP dtnames, Rboolean varfactor, Rboolean verbose, str
   } else levels = PROTECT(coerceVector(seq_int(nlevels, 1), STRSXP)); // generate levels = 1:nlevels
   // base::unique is fast on vectors, and the levels on variable columns are usually small
   SEXP uniqueLangSxp = PROTECT(lang2(install("unique"), levels));
-  setAttrib(target, R_LevelsSymbol, eval(uniqueLangSxp, R_GlobalEnv));
+  tmp = PROTECT(eval(uniqueLangSxp, R_GlobalEnv));
+  setAttrib(target, R_LevelsSymbol, tmp);
+  UNPROTECT(1); // tmp
   UNPROTECT(2); // levels, uniqueLangSxp
   if (!varfactor) SET_VECTOR_ELT(ansvars, 0, asCharacterFactor(target));
   UNPROTECT(protecti);

--- a/src/fmelt.c
+++ b/src/fmelt.c
@@ -391,8 +391,7 @@ SEXP getvaluecols(SEXP DT, SEXP dtnames, Rboolean valfactor, Rboolean verbose, s
   ansvals = PROTECT(allocVector(VECSXP, data->lvalues)); protecti++;
   for (i=0; i<data->lvalues; i++) {
     thisvalfactor = (data->maxtype[i] == VECSXP) ? FALSE : valfactor;
-    target = allocVector(data->maxtype[i], data->totlen);
-    SET_VECTOR_ELT(ansvals, i, target);
+    SET_VECTOR_ELT(ansvals, i, target=allocVector(data->maxtype[i], data->totlen) );
     thisvaluecols = VECTOR_ELT(data->valuecols, i);
     counter = 0; copyattr = FALSE;
     for (j=0; j<data->lmax; j++) {
@@ -487,8 +486,7 @@ SEXP getvarcols(SEXP DT, SEXP dtnames, Rboolean varfactor, Rboolean verbose, str
   SEXP ansvars, thisvaluecols, levels, target, matchvals, thisnames;
 
   ansvars = PROTECT(allocVector(VECSXP, 1)); protecti++;
-  target = allocVector(INTSXP, data->totlen);
-  SET_VECTOR_ELT(ansvars, 0, target);
+  SET_VECTOR_ELT(ansvars, 0, target=allocVector(INTSXP, data->totlen) );
   if (data->lvalues == 1) {
     thisvaluecols = VECTOR_ELT(data->valuecols, 0);
     // tmp fix for #1055
@@ -566,8 +564,7 @@ SEXP getidcols(SEXP DT, SEXP dtnames, Rboolean verbose, struct processData *data
     counter = 0;
     thiscol = VECTOR_ELT(DT, INTEGER(data->idcols)[i]-1);
     size = SIZEOF(thiscol);
-    target = allocVector(TYPEOF(thiscol), data->totlen);
-    SET_VECTOR_ELT(ansids, i, target);
+    SET_VECTOR_ELT(ansids, i, target=allocVector(TYPEOF(thiscol), data->totlen) );
     copyMostAttrib(thiscol, target); // all but names,dim and dimnames. And if so, we want a copy here, not keepattr's SET_ATTRIB.
     switch(TYPEOF(thiscol)) {
     case REALSXP :

--- a/src/fmelt.c
+++ b/src/fmelt.c
@@ -676,7 +676,7 @@ SEXP fmelt(SEXP DT, SEXP id, SEXP measure, SEXP varfactor, SEXP valfactor, SEXP 
     ansids  = PROTECT(getidcols(DT, dtnames, verbose, &data)); protecti++;
 
     // populate 'ans'
-    ans = allocVector(VECSXP, data.lids+1+data.lvalues); // 1 is for variable column
+    ans = PROTECT(allocVector(VECSXP, data.lids+1+data.lvalues)); protecti++; // 1 is for variable column
     for (i=0; i<data.lids; i++) {
       SET_VECTOR_ELT(ans, i, VECTOR_ELT(ansids, i));
     }

--- a/src/freadR.c
+++ b/src/freadR.c
@@ -354,9 +354,9 @@ size_t allocateDT(int8_t *typeArg, int8_t *sizeArg, int ncolArg, int ndrop, size
     int typeChanged = (type[i] > 0) && (newDT || TYPEOF(col) != typeSxp[type[i]] || oldIsInt64 != newIsInt64);
     int nrowChanged = (allocNrow != dtnrows);
     if (typeChanged || nrowChanged) {
-      SEXP thiscol = typeChanged ? allocVector(typeSxp[type[i]], allocNrow)
+      SEXP thiscol = typeChanged ? allocVector(typeSxp[type[i]], allocNrow)  // no need to PROTECT, passed immediately to SET_VECTOR_ELT, see R-exts 5.9.1
                                  : growVector(col, allocNrow);
-      SET_VECTOR_ELT(DT,resi,thiscol);     // no need to PROTECT thiscol, see R-exts 5.9.1
+      SET_VECTOR_ELT(DT,resi,thiscol);
       if (type[i]==CT_INT64) {
         SEXP tt = PROTECT(ScalarString(char_integer64));
         setAttrib(thiscol, R_ClassSymbol, tt);

--- a/src/freadR.c
+++ b/src/freadR.c
@@ -327,8 +327,9 @@ size_t allocateDT(int8_t *typeArg, int8_t *sizeArg, int ncolArg, int ndrop, size
     if (ndrop==0) {
       setAttrib(DT,R_NamesSymbol,colNamesSxp);  // colNames mkChar'd in userOverride step
     } else {
-      SEXP tt;
-      setAttrib(DT, R_NamesSymbol, tt = allocVector(STRSXP, ncol-ndrop));
+      SEXP tt = PROTECT(allocVector(STRSXP, ncol-ndrop));
+      setAttrib(DT, R_NamesSymbol, tt);
+      UNPROTECT(1); // tt; now that it's safely a member of protected object
       for (int i=0,resi=0; i<ncol; i++) if (type[i]!=CT_DROP) {
         SET_STRING_ELT(tt,resi++,STRING_ELT(colNamesSxp,i));
       }
@@ -356,7 +357,11 @@ size_t allocateDT(int8_t *typeArg, int8_t *sizeArg, int ncolArg, int ndrop, size
       SEXP thiscol = typeChanged ? allocVector(typeSxp[type[i]], allocNrow)
                                  : growVector(col, allocNrow);
       SET_VECTOR_ELT(DT,resi,thiscol);     // no need to PROTECT thiscol, see R-exts 5.9.1
-      if (type[i]==CT_INT64) setAttrib(thiscol, R_ClassSymbol, ScalarString(char_integer64));
+      if (type[i]==CT_INT64) {
+        SEXP tt = PROTECT(ScalarString(char_integer64));
+        setAttrib(thiscol, R_ClassSymbol, tt);
+        UNPROTECT(1);
+      }
       SET_TRUELENGTH(thiscol, allocNrow);
       DTbytes += SIZEOF(thiscol)*allocNrow;
     }

--- a/src/fwriteR.c
+++ b/src/fwriteR.c
@@ -208,7 +208,8 @@ SEXP fwriteR(
   args.doRowNames = LOGICAL(rowNames_Arg)[0];
   args.rowNames = NULL;
   if (args.doRowNames) {
-    SEXP rn = getAttrib(DF, R_RowNamesSymbol);
+    SEXP rn = PROTECT(getAttrib(DF, R_RowNamesSymbol));
+    protecti++;
     args.rowNames = isString(rn) ? (void *)DATAPTR(rn) : NULL;
   }
 

--- a/src/ijoin.c
+++ b/src/ijoin.c
@@ -109,11 +109,9 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
   lookup = VECTOR_ELT(ux, uxcols-4);
   type_lookup = VECTOR_ELT(ux, uxcols-3);
   for (i=0; i<uxrows; i++) {
-    vv = allocVector(INTSXP, len1[i]);
-    SET_VECTOR_ELT(lookup, i, vv);
+    SET_VECTOR_ELT(lookup, i, vv=allocVector(INTSXP, len1[i]));
     if (type != WITHIN) {
-      vv = allocVector(INTSXP, len2[i]);
-      SET_VECTOR_ELT(type_lookup, i, vv);
+      SET_VECTOR_ELT(type_lookup, i, vv=allocVector(INTSXP, len2[i]));
     }
   }
   pass2 = clock() - start;
@@ -301,10 +299,8 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
   // ans[0] is the the position of 'query' and ans[1] is that of 'subject'
   // allocate f1__ and f2__ and assign 'nomatch' to f2__
   ans = PROTECT(allocVector(VECSXP, 2));
-  f1__ = allocVector(INTSXP, totlen);
-  SET_VECTOR_ELT(ans, 0, f1__);
-  f2__ = allocVector(INTSXP, totlen);
-  SET_VECTOR_ELT(ans, 1, f2__);
+  SET_VECTOR_ELT(ans, 0, f1__=allocVector(INTSXP, totlen));
+  SET_VECTOR_ELT(ans, 1, f2__=allocVector(INTSXP, totlen));
   thislen=0;
   start = clock();
 

--- a/src/rbindlist.c
+++ b/src/rbindlist.c
@@ -654,8 +654,8 @@ SEXP rbindlist(SEXP l, SEXP sexp_usenames, SEXP sexp_fill, SEXP idcol) {
   setAttrib(ans, R_NamesSymbol, fnames);
   lf = VECTOR_ELT(l, data.first);
   for(j=0; j<data.n_cols; j++) {
-    if (fill) target = allocNAVector(data.max_type[j], data.n_rows);
-    else target = allocVector(data.max_type[j], data.n_rows);
+    if (fill) target = allocNAVector(data.max_type[j], data.n_rows);  // no PROTECT needed as passed immediately to SET_VECTOR_ELT
+    else target = allocVector(data.max_type[j], data.n_rows);         // no PROTECT needed as passed immediately to SET_VECTOR_ELT
     SET_VECTOR_ELT(ans, j+isidcol, target);
 
     if (usenames) {
@@ -768,16 +768,14 @@ SEXP rbindlist(SEXP l, SEXP sexp_usenames, SEXP sexp_fill, SEXP idcol) {
     R_len_t runidx = 1, cntridx = 0;
     SEXP lnames = getAttrib(l, R_NamesSymbol);
     if (isNull(lnames)) {
-      target = allocVector(INTSXP, data.n_rows);
-      SET_VECTOR_ELT(ans, 0, target);
+      SET_VECTOR_ELT(ans, 0, target=allocVector(INTSXP, data.n_rows) );
       for (i=0; i<LENGTH(l); i++) {
         for (j=0; j<data.fn_rows[i]; j++)
           INTEGER(target)[cntridx++] = runidx;
         runidx++;
       }
     } else {
-      target = allocVector(STRSXP, data.n_rows);
-      SET_VECTOR_ELT(ans, 0, target);
+      SET_VECTOR_ELT(ans, 0, target=allocVector(STRSXP, data.n_rows) );
       for (i=0; i<LENGTH(l); i++) {
         for (j=0; j<data.fn_rows[i]; j++)
           SET_STRING_ELT(target, cntridx++, STRING_ELT(lnames, i));
@@ -882,8 +880,7 @@ static SEXP listlist(SEXP x) {
   for (i=0; i<length(xs); i++) {
     SET_STRING_ELT(ans0, i, STRING_ELT(x, INTEGER(xo)[INTEGER(xs)[i]-1]-1));
     nl = INTEGER(xl)[i];
-    tmp = allocVector(INTSXP, nl);
-    SET_VECTOR_ELT(ans1, i, tmp);
+    SET_VECTOR_ELT(ans1, i, tmp=allocVector(INTSXP, nl) );
     for (j=0; j<nl; j++) {
       INTEGER(tmp)[j] = INTEGER(xo)[k+j];
     }

--- a/src/shift.c
+++ b/src/shift.c
@@ -5,13 +5,13 @@
 SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
 
   size_t size;
-  R_len_t i=0, j, m, nx, nk, xrows, thisk;
+  R_len_t i=0, j, m, nx, nk, xrows, thisk, protecti=0;
   SEXP x, tmp=R_NilValue, this, ans, thisfill, class;
   unsigned long long *dthisfill;
   enum {LAG, LEAD} stype = LAG;
   if (!length(obj)) return(obj); // NULL, list()
   if (isVectorAtomic(obj)) {
-    x = allocVector(VECSXP, 1);
+    x = PROTECT(allocVector(VECSXP, 1)); protecti++;
     SET_VECTOR_ELT(x, 0, obj);
   } else x = obj;
   if (!isNewList(x))
@@ -32,7 +32,7 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
   while(i < nk && INTEGER(k)[i] >= 0) i++;
   if (i != nk)
     error("n must be non-negative integer values (>= 0)");
-  ans = PROTECT(allocVector(VECSXP, nk * nx));
+  ans = PROTECT(allocVector(VECSXP, nk * nx)); protecti++;
   if (stype == LAG) {
     for (i=0; i<nx; i++) {
       this  = VECTOR_ELT(x, i);
@@ -40,7 +40,7 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
       xrows = length(this);
       switch (TYPEOF(this)) {
       case INTSXP :
-        thisfill = PROTECT(coerceVector(fill, INTSXP));
+        thisfill = PROTECT(coerceVector(fill, INTSXP)); protecti++;
         for (j=0; j<nk; j++) {
           thisk = (xrows >= INTEGER(k)[j]) ? INTEGER(k)[j] : xrows;
           SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(INTSXP, xrows) );
@@ -59,13 +59,13 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
       case REALSXP :
         class = getAttrib(this, R_ClassSymbol);
         if (isString(class) && STRING_ELT(class, 0) == char_integer64) {
-          thisfill = PROTECT(allocVector(REALSXP, 1));
+          thisfill = PROTECT(allocVector(REALSXP, 1)); protecti++;
           dthisfill = (unsigned long long *)REAL(thisfill);
           if (INTEGER(fill)[0] == NA_INTEGER)
             dthisfill[0] = NA_INT64_LL;
           else dthisfill[0] = (unsigned long long)INTEGER(fill)[0];
         } else {
-          thisfill = PROTECT(coerceVector(fill, REALSXP));
+          thisfill = PROTECT(coerceVector(fill, REALSXP)); protecti++;
         }
         for (j=0; j<nk; j++) {
           thisk = (xrows >= INTEGER(k)[j]) ? INTEGER(k)[j] : xrows;
@@ -83,7 +83,7 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
         break;
 
       case LGLSXP :
-        thisfill = PROTECT(coerceVector(fill, LGLSXP));
+        thisfill = PROTECT(coerceVector(fill, LGLSXP)); protecti++;
         for (j=0; j<nk; j++) {
           thisk = (xrows >= INTEGER(k)[j]) ? INTEGER(k)[j] : xrows;
           SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(LGLSXP, xrows) );
@@ -98,7 +98,7 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
         break;
 
       case STRSXP :
-        thisfill = PROTECT(coerceVector(fill, STRSXP));
+        thisfill = PROTECT(coerceVector(fill, STRSXP)); protecti++;
         for (j=0; j<nk; j++) {
           SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(STRSXP, xrows) );
           for (m=0; m<xrows; m++)
@@ -108,7 +108,7 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
         break;
 
       case VECSXP :
-        thisfill = PROTECT(coerceVector(fill, VECSXP));
+        thisfill = PROTECT(coerceVector(fill, VECSXP)); protecti++;
         for (j=0; j<nk; j++) {
           SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(VECSXP, xrows) );
           for (m=0; m<xrows; m++)
@@ -123,7 +123,6 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
       copyMostAttrib(this, tmp);
       if (isFactor(this))
         setAttrib(tmp, R_LevelsSymbol, getAttrib(this, R_LevelsSymbol));
-      UNPROTECT(1);
     }
   } else if (stype == LEAD) {
     for (i=0; i<nx; i++) {
@@ -132,7 +131,7 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
       xrows = length(this);
       switch (TYPEOF(this)) {
       case INTSXP :
-        thisfill = PROTECT(coerceVector(fill, INTSXP));
+        thisfill = PROTECT(coerceVector(fill, INTSXP)); protecti++;
         for (j=0; j<nk; j++) {
           thisk = (xrows >= INTEGER(k)[j]) ? INTEGER(k)[j] : xrows;
           SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(INTSXP, xrows) );
@@ -151,13 +150,13 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
       case REALSXP :
         class = getAttrib(this, R_ClassSymbol);
         if (isString(class) && STRING_ELT(class, 0) == char_integer64) {
-          thisfill = PROTECT(allocVector(REALSXP, 1));
+          thisfill = PROTECT(allocVector(REALSXP, 1)); protecti++;
           dthisfill = (unsigned long long *)REAL(thisfill);
           if (INTEGER(fill)[0] == NA_INTEGER)
             dthisfill[0] = NA_INT64_LL;
           else dthisfill[0] = (unsigned long long)INTEGER(fill)[0];
         } else {
-          thisfill = PROTECT(coerceVector(fill, REALSXP));
+          thisfill = PROTECT(coerceVector(fill, REALSXP)); protecti++;
         }
         for (j=0; j<nk; j++) {
           thisk = (xrows >= INTEGER(k)[j]) ? INTEGER(k)[j] : xrows;
@@ -173,7 +172,7 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
         break;
 
       case LGLSXP :
-        thisfill = PROTECT(coerceVector(fill, LGLSXP));
+        thisfill = PROTECT(coerceVector(fill, LGLSXP)); protecti++;
         for (j=0; j<nk; j++) {
           thisk = (xrows >= INTEGER(k)[j]) ? INTEGER(k)[j] : xrows;
           SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(LGLSXP, xrows) );
@@ -188,7 +187,7 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
         break;
 
       case STRSXP :
-        thisfill = PROTECT(coerceVector(fill, STRSXP));
+        thisfill = PROTECT(coerceVector(fill, STRSXP)); protecti++;
         for (j=0; j<nk; j++) {
           SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(STRSXP, xrows) );
           for (m=0; m<xrows; m++)
@@ -198,7 +197,7 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
         break;
 
       case VECSXP :
-        thisfill = PROTECT(coerceVector(fill, VECSXP));
+        thisfill = PROTECT(coerceVector(fill, VECSXP)); protecti++;
         for (j=0; j<nk; j++) {
           SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(VECSXP, xrows) );
           for (m=0; m<xrows; m++)
@@ -210,12 +209,9 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
       default :
         error("Unsupported type '%s'", type2char(TYPEOF(this)));
       }
-      UNPROTECT(1);
     }
   }
-  UNPROTECT(1);
-  if (isVectorAtomic(obj) && length(ans) == 1)
-    return (VECTOR_ELT(ans, 0));
-  return(ans);
+  UNPROTECT(protecti);
+  return isVectorAtomic(obj) && length(ans) == 1 ? VECTOR_ELT(ans, 0) : ans;
 }
 

--- a/src/shift.c
+++ b/src/shift.c
@@ -43,8 +43,7 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
         thisfill = PROTECT(coerceVector(fill, INTSXP));
         for (j=0; j<nk; j++) {
           thisk = (xrows >= INTEGER(k)[j]) ? INTEGER(k)[j] : xrows;
-          tmp = allocVector(INTSXP, xrows);
-          SET_VECTOR_ELT(ans, i*nk+j, tmp);
+          SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(INTSXP, xrows) );
           if (xrows - INTEGER(k)[j] > 0)
             memcpy((char *)DATAPTR(tmp)+(INTEGER(k)[j]*size),
                  (char *)DATAPTR(this),
@@ -70,8 +69,7 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
         }
         for (j=0; j<nk; j++) {
           thisk = (xrows >= INTEGER(k)[j]) ? INTEGER(k)[j] : xrows;
-          tmp = allocVector(REALSXP, xrows);
-          SET_VECTOR_ELT(ans, i*nk+j, tmp);
+          SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(REALSXP, xrows) );
           if (xrows - INTEGER(k)[j] > 0) {
             memcpy((char *)DATAPTR(tmp)+(INTEGER(k)[j]*size),
                  (char *)DATAPTR(this),
@@ -88,8 +86,7 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
         thisfill = PROTECT(coerceVector(fill, LGLSXP));
         for (j=0; j<nk; j++) {
           thisk = (xrows >= INTEGER(k)[j]) ? INTEGER(k)[j] : xrows;
-          tmp = allocVector(LGLSXP, xrows);
-          SET_VECTOR_ELT(ans, i*nk+j, tmp);
+          SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(LGLSXP, xrows) );
           if (xrows - INTEGER(k)[j] > 0)
             memcpy((char *)DATAPTR(tmp)+(INTEGER(k)[j]*size),
                  (char *)DATAPTR(this),
@@ -103,8 +100,7 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
       case STRSXP :
         thisfill = PROTECT(coerceVector(fill, STRSXP));
         for (j=0; j<nk; j++) {
-          tmp = allocVector(STRSXP, xrows);
-          SET_VECTOR_ELT(ans, i*nk+j, tmp);
+          SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(STRSXP, xrows) );
           for (m=0; m<xrows; m++)
             SET_STRING_ELT(tmp, m, (m < INTEGER(k)[j]) ? STRING_ELT(thisfill, 0) : STRING_ELT(this, m - INTEGER(k)[j]));
           copyMostAttrib(this, tmp);
@@ -114,8 +110,7 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
       case VECSXP :
         thisfill = PROTECT(coerceVector(fill, VECSXP));
         for (j=0; j<nk; j++) {
-          tmp = allocVector(VECSXP, xrows);
-          SET_VECTOR_ELT(ans, i*nk+j, tmp);
+          SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(VECSXP, xrows) );
           for (m=0; m<xrows; m++)
             SET_VECTOR_ELT(tmp, m, (m < INTEGER(k)[j]) ? VECTOR_ELT(thisfill, 0) : VECTOR_ELT(this, m - INTEGER(k)[j]));
           copyMostAttrib(this, tmp);
@@ -140,8 +135,7 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
         thisfill = PROTECT(coerceVector(fill, INTSXP));
         for (j=0; j<nk; j++) {
           thisk = (xrows >= INTEGER(k)[j]) ? INTEGER(k)[j] : xrows;
-          tmp = allocVector(INTSXP, xrows);
-          SET_VECTOR_ELT(ans, i*nk+j, tmp);
+          SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(INTSXP, xrows) );
           if (xrows - INTEGER(k)[j] > 0)
             memcpy((char *)DATAPTR(tmp),
                  (char *)DATAPTR(this)+(INTEGER(k)[j]*size),
@@ -167,8 +161,7 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
         }
         for (j=0; j<nk; j++) {
           thisk = (xrows >= INTEGER(k)[j]) ? INTEGER(k)[j] : xrows;
-          tmp = allocVector(REALSXP, xrows);
-          SET_VECTOR_ELT(ans, i*nk+j, tmp);
+          SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(REALSXP, xrows));
           if (xrows - INTEGER(k)[j] > 0)
             memcpy((char *)DATAPTR(tmp),
                  (char *)DATAPTR(this)+(INTEGER(k)[j]*size),
@@ -183,8 +176,7 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
         thisfill = PROTECT(coerceVector(fill, LGLSXP));
         for (j=0; j<nk; j++) {
           thisk = (xrows >= INTEGER(k)[j]) ? INTEGER(k)[j] : xrows;
-          tmp = allocVector(LGLSXP, xrows);
-          SET_VECTOR_ELT(ans, i*nk+j, tmp);
+          SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(LGLSXP, xrows) );
           if (xrows - INTEGER(k)[j] > 0)
             memcpy((char *)DATAPTR(tmp),
                  (char *)DATAPTR(this)+(INTEGER(k)[j]*size),
@@ -198,8 +190,7 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
       case STRSXP :
         thisfill = PROTECT(coerceVector(fill, STRSXP));
         for (j=0; j<nk; j++) {
-          tmp = allocVector(STRSXP, xrows);
-          SET_VECTOR_ELT(ans, i*nk+j, tmp);
+          SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(STRSXP, xrows) );
           for (m=0; m<xrows; m++)
             SET_STRING_ELT(tmp, m, (xrows-m <= INTEGER(k)[j]) ? STRING_ELT(thisfill, 0) : STRING_ELT(this, m + INTEGER(k)[j]));
           copyMostAttrib(this, tmp);
@@ -209,8 +200,7 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
       case VECSXP :
         thisfill = PROTECT(coerceVector(fill, VECSXP));
         for (j=0; j<nk; j++) {
-          tmp = allocVector(VECSXP, xrows);
-          SET_VECTOR_ELT(ans, i*nk+j, tmp);
+          SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(VECSXP, xrows) );
           for (m=0; m<xrows; m++)
             SET_VECTOR_ELT(tmp, m, (xrows-m <= INTEGER(k)[j]) ? VECTOR_ELT(thisfill, 0) : VECTOR_ELT(this, m + INTEGER(k)[j]));
             copyMostAttrib(this, tmp);

--- a/src/transpose.c
+++ b/src/transpose.c
@@ -45,8 +45,7 @@ SEXP transpose(SEXP l, SEXP fill, SEXP ignoreArg) {
   ans = PROTECT(allocVector(VECSXP, maxlen));
   anslen = (!ignore) ? ln : (ln - zerolen);
   for (i=0; i<maxlen; i++) {
-    thisi = allocVector(maxtype, anslen);
-    SET_VECTOR_ELT(ans, i, thisi);
+    SET_VECTOR_ELT(ans, i, thisi=allocVector(maxtype, anslen) );
   }
 
   // transpose

--- a/src/wrappers.c
+++ b/src/wrappers.c
@@ -114,7 +114,7 @@ SEXP dim(SEXP x)
         type2char(TYPEOF(x)));
   }
 
-  SEXP ans = allocVector(INTSXP, 2);
+  SEXP ans = PROTECT(allocVector(INTSXP, 2));
   if(length(x) == 0) {
     INTEGER(ans)[0] = 0;
     INTEGER(ans)[1] = 0;
@@ -123,8 +123,7 @@ SEXP dim(SEXP x)
     INTEGER(ans)[0] = length(VECTOR_ELT(x, 0));
     INTEGER(ans)[1] = length(x);
   }
-
+  UNPROTECT(1);
   return ans;
 }
-
 


### PR DESCRIPTION
Currently, on day 2, I believe it's a memory problem on the data.table side that is just happening to show up on 32bit-only Windows-only r-devel-only by chance.   I do see a `protection stack overflow` locally on 64bit in `r-devel` under `gctorture(step=100)`.

One repex so far but likely red herring: https://bugs.r-project.org/bugzilla3/show_bug.cgi?id=17389

The type 31 errors (FREESXP) are now gone. So good chance that was indeed the 3 now-fixed missing protects. Those would have occurred on any platform under gc torture.

Next of multiple issues, then ...

Possibly related to empty join in data.table.
- #2658 
- https://www.r-project.org/nosvn/R.check/r-devel-windows-ix86+x86_64/batchtools-00check.html

This suggests CRAN release 1.10.4-3 triggers it too, on 32-bit Windows r-devel only.