### PR TITLE
keep git commit metadata in proper DESCRIPTION field

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,10 +36,11 @@ build:
   script:
     - Rscript -e 'install.packages("knitr", repos=file.path("file:",normalizePath("bus/mirror-packages/cran")))'
     - rm -r bus
+    - echo "Revision:" $CI_BUILD_REF >> ./DESCRIPTION
     - R CMD build .
     - mkdir -p bus/$CI_BUILD_NAME/cran/src/contrib
     - mv $(ls -1t data.table_*.tar.gz | head -n 1) bus/$CI_BUILD_NAME/cran/src/contrib/.
-    - Rscript -e 'tools::write_PACKAGES(contrib.url("bus/build/cran"), addFiles=TRUE)'
+    - Rscript -e 'tools::write_PACKAGES(contrib.url("bus/build/cran"), addFiles=TRUE, fields="Revision")'
   artifacts:
     expire_in: 2 weeks
     paths:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ r_packages:
   - covr
   - drat
 
+before_script:
+  - echo "Revision:" $TRAVIS_COMMIT >> ./DESCRIPTION
+
 after_success:
   - travis_wait Rscript -e 'library(covr);codecov()'
   - test $TRAVIS_REPO_SLUG == "Rdatatable/data.table" && test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && bash deploy.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ environment:
   - R_VERSION: devel
 
 before_build:
-  - cmd: ECHO Revision: %APPVEYOR_REPO_COMMIT%>>DESCRIPTION
+  - cmd: ECHO Revision: $Env:APPVEYOR_REPO_COMMIT>>DESCRIPTION
 
 build_script:
   - set _R_CHECK_FORCE_SUGGESTS_=false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ environment:
   - R_VERSION: devel
 
 before_build:
-  - cmd: ECHO Revision: $Env:APPVEYOR_REPO_COMMIT>>DESCRIPTION
+  - cmd: ECHO Revision: %APPVEYOR_REPO_COMMIT%>>DESCRIPTION
 
 build_script:
   - set _R_CHECK_FORCE_SUGGESTS_=false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,8 @@ environment:
   - R_VERSION: devel
 
 before_build:
-  - cmd: ECHO Revision: %APPVEYOR_REPO_COMMIT%>>DESCRIPTION
+  - cmd: ECHO no Revision metadata added to DESCRIPTION
+  #translate from unix: - cmd: ECHO "Revision:" $CI_BUILD_REF >> ./DESCRIPTION
 
 build_script:
   - set _R_CHECK_FORCE_SUGGESTS_=false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,9 @@ environment:
 
   - R_VERSION: devel
 
+before_build:
+  - cmd: ECHO no Revision metadata added to DESCRIPTION
+  #translate from unix: - cmd: ECHO "Revision:" $CI_BUILD_REF >> ./DESCRIPTION
 
 build_script:
   - set _R_CHECK_FORCE_SUGGESTS_=false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,8 +30,7 @@ environment:
   - R_VERSION: devel
 
 before_build:
-  - cmd: ECHO no Revision metadata added to DESCRIPTION
-  #translate from unix: - cmd: ECHO "Revision:" $CI_BUILD_REF >> ./DESCRIPTION
+  - cmd: ECHO Revision: %APPVEYOR_REPO_COMMIT%>>DESCRIPTION
 
 build_script:
   - set _R_CHECK_FORCE_SUGGESTS_=false

--- a/deploy.sh
+++ b/deploy.sh
@@ -22,7 +22,7 @@ addToDrat(){
   Rscript -e "drat::insertPackage('$PKG_REPO/$PKG_TARBALL', \
     repodir = '.', \
     commit='Travis publish data.table: build $TRAVIS_COMMIT', \
-    fields='Commit')"
+    addFiles=TRUE, fields='Revision')"
   git push --force upstream gh-pages 2>err.txt
   
 }


### PR DESCRIPTION
Previously we kept Commit field which was not valid in package check, we can use Revision field for that purpose. This PR will allow users to lookup exact git commit they are using.