### PR TITLE
helper to keep dev data.table up to date, closes #2681

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -101,6 +101,8 @@ export(dcast.data.table)
 S3method(dcast, data.table)
 
 import(utils)
+S3method(update, dev.pkg)
+export(update.dev.pkg)
 S3method(tail, data.table)
 S3method(head, data.table)
 import(stats)

--- a/NEWS.md
+++ b/NEWS.md
@@ -101,6 +101,8 @@ Thanks to @MichaelChirico for reporting and to @MarkusBonsch for the implementat
 
 16. `melt.data.table` now offers friendlier functionality for providing `value.name` for `list` input to `measure.vars`, [#1547](https://github.com/Rdatatable/data.table/issues/1547). Thanks @MichaelChirico and @franknarf1 for the suggestion and use cases, @jangorecki and @mrdwab for implementation feedback, and @MichaelChirico for ultimate implementation.
 
+17. `update.dev.pkg` is new function to update package from development repository, it will download package sources only when newer commit is available in repository. `data.table::update.dev.pkg()` defaults updates `data.table`, but any package can be used.
+
 #### BUG FIXES
 
 1. The new quote rules handles this single field `"Our Stock Screen Delivers an Israeli Software Company (MNDO, CTCH)<\/a> SmallCapInvestor.com - Thu, May 19, 2011 10:02 AM EDT<\/cite><\/div>Yesterday in \""Google, But for Finding

--- a/R/onAttach.R
+++ b/R/onAttach.R
@@ -4,26 +4,63 @@
   # Runs when attached to search() path such as by library() or require()
   if (interactive()) {
   v = packageVersion("data.table")
-  d = read.dcf(system.file("DESCRIPTION", package="data.table"), fields = c("Packaged", "Built"))
+  d = read.dcf(system.file("DESCRIPTION", package="data.table"), fields = c("Packaged", "Built", "Revision"))
   if (is.na(d[1L])) {
     if (is.na(d[2L])) {
-      return() #neither field exists
+      return() # Packaged, Built fields does not exists
     } else {
       d = unlist(strsplit(d[2L], split="; "))[3L]
+      g = if (is.na(d[3L])) "" else paste0(" (",d[3L],")")
     }
   } else {
-    d = d[1L]
+      d = d[1L]
+      g = ""
   }
   dev = as.integer(v[1L, 3L]) %% 2L == 1L  # version number odd => dev
-  packageStartupMessage("data.table ", v, if(dev) paste0(" IN DEVELOPMENT built ", d))
+  packageStartupMessage(sprintf("data.table %s%s", v,
+                                if(dev) sprintf(" IN DEVELOPMENT built %s%s", d, g) else ""))
   if (dev && (Sys.Date() - as.Date(d))>28)
-    packageStartupMessage("**********\nThis development version of data.table was built more than 4 weeks ago. Please update.\n**********")
+    packageStartupMessage("**********\nThis development version of data.table was built more than 4 weeks ago. Please update: data.table::update.dev.pkg()\n**********")
   if (!.Call(ChasOpenMP))
     packageStartupMessage("**********\nThis installation of data.table has not detected OpenMP support. It should still work but in single-threaded mode. If this is a Mac, please ensure you are using R>=3.4.0 and have installed the MacOS binary package from CRAN: see ?install.packages, the 'type=' argument and the 'Binary packages' section. If you compiled from source, please reinstall and precisely follow the installation instructions on the data.table homepage. This warning message should not occur on Windows or Linux. If it does and you've followed the installation instructions on the data.table homepage, please file a GitHub issue.\n**********")
   packageStartupMessage('  The fastest way to learn (by data.table authors): https://www.datacamp.com/courses/data-analysis-the-data-table-way')
   packageStartupMessage('  Documentation: ?data.table, example(data.table) and browseVignettes("data.table")')
   packageStartupMessage('  Release notes, videos and slides: http://r-datatable.com')
   }
+}
+
+dcf.lib = function(pkg, field){
+  # get DESCRIPTION metadata field from local library
+  stopifnot(is.character(pkg), is.character(field), length(pkg)==1L, length(field)==1L)
+  dcf = system.file("DESCRIPTION", package=pkg)
+  if (nchar(dcf)) read.dcf(dcf, fields=field)[1L] else NA_character_
+}
+
+dcf.repo = function(pkg, repo, field){
+  # get DESCRIPTION metadata field from remote PACKAGES file
+  stopifnot(is.character(pkg), is.character(field), length(pkg)==1L, length(field)==1L, is.character(repo), length(repo)==1L, field!="Package")
+  idx = file(file.path(contrib.url(repo),"PACKAGES"))
+  on.exit(close(idx))
+  dcf = read.dcf(idx, fields=c("Package",field))
+  if (!pkg %in% dcf[,"Package"]) stop(sprintf("There is no %s package in provided repository.", pkg))
+  dcf[dcf[,"Package"]==pkg, field][[1L]]
+}
+
+update.dev.pkg = function(object="data.table", repo="https://Rdatatable.github.io/data.table", field="Revision", ...){
+  pkg = object
+  # perform package upgrade when new Revision present
+  stopifnot(is.character(pkg), length(pkg)==1L, !is.na(pkg),
+            is.character(repo), length(repo)==1L, !is.na(repo),
+            is.character(field), length(field)==1L, !is.na(field))
+  una = is.na(ups<-dcf.repo(pkg, repo, field))
+  upg = una | !identical(ups, dcf.lib(pkg, field))
+  if (upg) utils::install.packages(pkg, repos=repo, ...)
+  if (una) cat(sprintf("No commit information found in DESCRIPTION file for %s package. Unsure '%s' is correct field name in PACKAGES file in your devel repository '%s'.\n", pkg, field, file.path(repo, "src","contrib","PACKAGES")))
+  cat(sprintf("R %s package %s %s (%s)\n",
+              pkg,
+              c("is up-to-date at","has been updated to")[upg+1L],
+              dcf.lib(pkg, field),
+              utils::packageVersion(pkg)))
 }
 
 # nocov end

--- a/R/onAttach.R
+++ b/R/onAttach.R
@@ -33,7 +33,7 @@ dcf.lib = function(pkg, field){
   # get DESCRIPTION metadata field from local library
   stopifnot(is.character(pkg), is.character(field), length(pkg)==1L, length(field)==1L)
   dcf = system.file("DESCRIPTION", package=pkg)
-  if (nchar(dcf)) read.dcf(dcf, fields=field)[1L] else NA_character_
+  if (nzchar(dcf)) read.dcf(dcf, fields=field)[1L] else NA_character_
 }
 
 dcf.repo = function(pkg, repo, field){

--- a/man/update.dev.pkg.Rd
+++ b/man/update.dev.pkg.Rd
@@ -1,0 +1,37 @@
+\name{update.dev.pkg}
+\alias{update}
+\alias{update.dev.pkg}
+\title{Perform update of development version of a package}
+\description{
+  It will download and install package from devel repository only when new commit is
+  available there, otherwise only PACKAGES file is transferred. Defaults are set to update \code{data.table}, other
+  packages can be used. Their repository has to include git commit
+  information in PACKAGES file.
+}
+
+\usage{\method{update}{dev.pkg}(object="data.table",
+repo="https://Rdatatable.github.io/data.table", field="Revision", \dots)
+}
+\arguments{
+  \item{object}{ character scalar, package name. }
+  \item{repo}{ character scalar, url of package devel repository. }
+  \item{field}{ character scalar, metadata field to use in PACKAGES file and
+    DESCRIPTION file, default \code{"Revision"}. }
+  \item{\dots}{ passed to \code{\link[utils]{install.packages}}. }
+}
+\details{
+  In case if devel repository does not provide package binaries user has
+  have development tools installed for package compilation to use
+  this function.
+}
+\value{
+  NULL.
+}
+\examples{
+  # data.table::update.dev.pkg()
+}
+\seealso{
+  \code{\link{data.table}}
+}
+\keyword{ data }
+


### PR DESCRIPTION
Closes #2681 
New function to efficiently update dev data.table to latest version. Before downloading package it checks commit revision of currently installed data.table, and if new commit revision is available in our drat repository then package is downloaded and installed. Such function can be called on startup of R process if it is desired to stay up to date with devel version. It was used before in h2o benchmarks of data.table in https://github.com/h2oai/db-benchmark/blob/0922840dd7bc768aa11f937128bd066fc1246986/helpers.R#L97-L118
Function works for any drat repo as long as drat has commit information in PACKAGES file. Function defaults are set for updating data.table.
