### PR TITLE
R 3.1.0 passing again

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -446,7 +446,7 @@ test(166, suppressWarnings(split(DT,DT$grp)[[2]]), DT[grp==2])
 
 # and that plotting works
 test(167.1, DT[,plot(b,f)], NULL)
-test(167.2, DT[,hist(b)]$breaks, seq.int(10L,50L,by=5L))
+test(167.2, as.integer(DT[,hist(b)]$breaks), seq.int(10L,50L,by=5L)) # as.integer needed for R 3.1.0
 test(167.3, DT[,plot(b,f),by=.(grp)], data.table(grp=integer()))
 try(graphics.off(),silent=TRUE)
 

--- a/vignettes/datatable-benchmarking.Rmd
+++ b/vignettes/datatable-benchmarking.Rmd
@@ -2,7 +2,7 @@
 title: "Benchmarking data.table"
 date: "`r Sys.Date()`"
 output:
-  rmarkdown::html_vignette
+  rmarkdown::html_vignette:
     toc: true
     number_sections: true
 vignette: >
@@ -17,11 +17,11 @@ h2 {
 }
 </style>
 
-This document is meant to guide on measuring performance of data.table. Single place to documents best practices or traps to avoid.  
+This document is meant to guide on measuring performance of data.table. Single place to documents best practices or traps to avoid.
 
 ## fread: clear caches
 
-Ideally each `fread` call should be run in fresh session with the following commands preceding R execution. This clears OS cache file in RAM and HD cache.  
+Ideally each `fread` call should be run in fresh session with the following commands preceding R execution. This clears OS cache file in RAM and HD cache.
 
 ```sh
 free -g
@@ -32,11 +32,11 @@ sudo hdparm -t /dev/sda
 
 ## subset: index optimization switch off
 
-Index optimization will currently be turned off when doing subset using index and when cross product of elements provided to filter on exceeds > 1e4.  
+Index optimization will currently be turned off when doing subset using index and when cross product of elements provided to filter on exceeds > 1e4.
 
 ## subset: index aware benchmarking
 
-For convinience data.table automatically builds index on fields you are doing subset data. It will add some overhead to first subset on particular fields but greatly reduce time to query those columns in subsequent runs. When measuring speed best way is to measure index creation and query using index separately. Having such timings it is easy to decide what is the optimal strategy for your use case.  
+For convinience data.table automatically builds index on fields you are doing subset data. It will add some overhead to first subset on particular fields but greatly reduce time to query those columns in subsequent runs. When measuring speed best way is to measure index creation and query using index separately. Having such timings it is easy to decide what is the optimal strategy for your use case.
 To control usage of index use following options (see `?datatable.optimize` for more details):
 
 ```r
@@ -46,7 +46,7 @@ options(datatable.auto.index=TRUE)
 options(datatable.use.index=TRUE)
 ```
 `options(datatable.optimize=2L)` will turn off optimization of subsets completely, while `options(datatable.optimize=3L)` will switch it back on.
-`use.index=FALSE` will force query not to use index even if it exists, but existing keys are used for optimization. `auto.index=FALSE` only disables building index automatically when doing subset on non-indexed data.  
+`use.index=FALSE` will force query not to use index even if it exists, but existing keys are used for optimization. `auto.index=FALSE` only disables building index automatically when doing subset on non-indexed data.
 
 ## _by reference_ operations
 
@@ -57,7 +57,7 @@ Protecting your data.table from being updated by reference operations can be ach
 ## avoid `microbenchmark(, times=100)`
 
 Repeating benchmarking many times usually does not fit well for data processing tools. Of course it perfectly make sense for more atomic calculations. It does not well represent use case for common data processing tasks, which rather consists of batches sequentially provided transformations, each run once.
-Matt once said:  
+Matt once said:
 
 > I'm very wary of benchmarks measured in anything under 1 second. Much prefer 10 seconds or more for a single run, achieved by increasing data size. A repetition count of 500 is setting off alarm bells. 3-5 runs should be enough to convince on larger data. Call overhead and time to GC affect inferences at this very small scale.
 


### PR DESCRIPTION
Closes #2685.
Thanks to Jan for checking R 3.1.0 and finding that.

Also added a `:` to new benchmark vignette to avoid `R CMD build` error, locally-for-me-only it seems, since it had passed on Appveyor and Travis : 

    Scanner error: mapping values are not allowed in this context at line 5, column 8
