### PR TITLE
test.with.other.packages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,7 +55,7 @@ test-r-release: # R-release most comprehensive tests, force all suggests, also i
     _R_CHECK_CRAN_INCOMING_REMOTE_: "FALSE"
     _R_CHECK_FORCE_SUGGESTS_: "TRUE"
     OPENBLAS_MAIN_FREE: "1"
-    TEST_DATA_TABLE_WITH_OTHER_PACKAGES: TRUE
+    TEST_DATA_TABLE_WITH_OTHER_PACKAGES: "TRUE"
   image: docker.io/jangorecki/r-builder
   dependencies:
   - mirror-packages

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,8 +19,8 @@ mirror-packages:
   script:
     - mkdir -p bus/$CI_BUILD_NAME/cran/src/contrib
     # mirror R dependencies
-    - Rscript -e 'source(Sys.getenv("CI_TOOLS")); mirror.packages(packages.dcf(c("DESCRIPTION","inst/tests/tests-DESCRIPTION"), "all"), repos=c(Sys.getenv("CRAN_MIRROR"), Sys.getenv("BIOC_MIRROR")), repodir="bus/mirror-packages/cran")'
-    #- Rscript -e 'source(Sys.getenv("CI_TOOLS")); mirror.packages(type="win.binary", packages.dcf(c("DESCRIPTION","inst/tests/tests-DESCRIPTION"), "all"), repos=c(Sys.getenv("CRAN_MIRROR"), Sys.getenv("BIOC_MIRROR")), repodir="bus/mirror-packages/cran")'
+    - Rscript -e 'source(Sys.getenv("CI_TOOLS")); mirror.packages(packages.dcf(c("DESCRIPTION","inst/tests/tests-DESCRIPTION"), "all"), repos=c(Sys.getenv("CRAN_MIRROR"), Sys.getenv("BIOC_MIRROR"), repos.dcf("inst/tests/tests-DESCRIPTION")), repodir="bus/mirror-packages/cran")'
+    #- Rscript -e 'source(Sys.getenv("CI_TOOLS")); mirror.packages(type="win.binary", packages.dcf(c("DESCRIPTION","inst/tests/tests-DESCRIPTION"), "all"), repos=c(Sys.getenv("CRAN_MIRROR"), Sys.getenv("BIOC_MIRROR"), repos.dcf("inst/tests/tests-DESCRIPTION")), repodir="bus/mirror-packages/cran")'
   artifacts:
     expire_in: 2 weeks
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,8 +19,8 @@ mirror-packages:
   script:
     - mkdir -p bus/$CI_BUILD_NAME/cran/src/contrib
     # mirror R dependencies
-    - Rscript -e 'source(Sys.getenv("CI_TOOLS")); mirror.packages(packages.dcf("DESCRIPTION", "all"), repos=c(Sys.getenv("CRAN_MIRROR"), Sys.getenv("BIOC_MIRROR")), repodir="bus/mirror-packages/cran")'
-    #- Rscript -e 'source(Sys.getenv("CI_TOOLS")); mirror.packages(type="win.binary", packages.dcf("DESCRIPTION", "all"), repos=c(Sys.getenv("CRAN_MIRROR"), Sys.getenv("BIOC_MIRROR")), repodir="bus/mirror-packages/cran")'
+    - Rscript -e 'source(Sys.getenv("CI_TOOLS")); mirror.packages(packages.dcf(c("DESCRIPTION","inst/tests/tests-DESCRIPTION"), "all"), repos=c(Sys.getenv("CRAN_MIRROR"), Sys.getenv("BIOC_MIRROR")), repodir="bus/mirror-packages/cran")'
+    #- Rscript -e 'source(Sys.getenv("CI_TOOLS")); mirror.packages(type="win.binary", packages.dcf(c("DESCRIPTION","inst/tests/tests-DESCRIPTION"), "all"), repos=c(Sys.getenv("CRAN_MIRROR"), Sys.getenv("BIOC_MIRROR")), repodir="bus/mirror-packages/cran")'
   artifacts:
     expire_in: 2 weeks
     paths:
@@ -46,7 +46,7 @@ build:
     paths:
       - bus
 
-test-r-release: # R-release most comprehensive tests, force all suggests
+test-r-release: # R-release most comprehensive tests, force all suggests, also integration tests
   stage: test
   tags:
     - linux
@@ -55,13 +55,14 @@ test-r-release: # R-release most comprehensive tests, force all suggests
     _R_CHECK_CRAN_INCOMING_REMOTE_: "FALSE"
     _R_CHECK_FORCE_SUGGESTS_: "TRUE"
     OPENBLAS_MAIN_FREE: "1"
+    TEST_DATA_TABLE_WITH_OTHER_PACKAGES: TRUE
   image: docker.io/jangorecki/r-builder
   dependencies:
   - mirror-packages
   - build
   script:
     - mkdir -p bus/$CI_BUILD_NAME
-    - Rscript -e 'source(Sys.getenv("CI_TOOLS")); if (length(pkgs<-packages.dcf("DESCRIPTION", "all"))) install.packages(pkgs, repos=file.path("file:",normalizePath("bus/mirror-packages/cran")))'
+    - Rscript -e 'source(Sys.getenv("CI_TOOLS")); if (length(pkgs<-packages.dcf(c("DESCRIPTION","inst/tests/tests-DESCRIPTION"), "all"))) install.packages(pkgs, repos=file.path("file:",normalizePath("bus/mirror-packages/cran")))'
     - cd bus/$CI_BUILD_NAME
     - Rscript -e 'file.copy(download.packages("data.table", repos=file.path("file:",normalizePath("../build/cran")))[,2], ".")'
     - R CMD check $(ls -1t data.table_*.tar.gz | head -n 1)

--- a/inst/tests/other.Rraw
+++ b/inst/tests/other.Rraw
@@ -5,13 +5,13 @@ if (exists("test.data.table",.GlobalEnv,inherits=FALSE)) {
   warning("This is dev where with.other.packages should not be run. Instead, use a fresh R session with data.table installed. ",
           "Not doing so in dev can be the cause of both false errors and false passes.")
 }
-if (!"package:data.table" %in% search()) stop("data.table should be already attached, see usage header in inst/tests/other.Rraw")
+if (!"package:data.table" %in% search()) stop("data.table should be already attached. Usage: require(data.table); test.data.table(with.other.packages=TRUE)")
 
 test = data.table:::test
 INT = data.table:::INT
 
-pkgs = c("ggplot2", "hexbin", "plyr", "caret", "xts", "gdata", "zoo", "nlme", "bit64", "knitr", "plm", "parallel", "dtq")
-if (any(duplicated(pkgs))) stop("Internal error: pkgs has a dup")
+pkgs = c("ggplot2", "hexbin", "plyr", "caret", "xts", "gdata", "zoo", "nlme", "bit64", "knitr", "plm", "parallel")
+if (any(duplicated(pkgs))) stop("Packages defined to be loaded for integration tests in 'inst/tests/other.Rraw' contains duplicates.")
 for (s in pkgs) {
   assign(paste0("test_",s), loaded<-suppressWarnings(suppressMessages(require(s, character.only=TRUE))))
   if (!loaded) cat("\n**** Other package",s,"is not installed. Tests using it will be skipped.\n\n")
@@ -165,22 +165,6 @@ if (test_parallel) {
       test(12.2, getDTthreads()==2) # User returned to multi-threaded after fork.
     }
   }
-}
-
-if (test_dtq) {
-  set.seed(5)
-  op = options("dtq.log.include"="") # unnamed environment created for other.Rraw evaluation in test.data.table()
-  DT = data.table(a = 1:10, b = letters[1:5])
-  LKP = data.table(b = letters[1:5], ratio = rnorm(5), key = "b")
-  DT2 = DT[, .(a = sum(a)), b
-           ][a > median(a), .(b, a, adj_a = a * 1.1)]
-  LKP[DT2, .(b, a, adj2_a = adj_a * ratio)]
-  tmp = DT[, {Sys.sleep(0.1); .(a)}]
-  ans = dtl()
-  test(13.1, is.data.table(ans))
-  test(13.2, nrow(ans)>0L)
-  test(13.3, ans[nrow(ans), elapsed > 0.1])
-  options(op)
 }
 
 cat("\n",ntest-nfail,"out of",ntest,"tests passed.\n")

--- a/inst/tests/other.Rraw
+++ b/inst/tests/other.Rraw
@@ -16,7 +16,13 @@ if (any(duplicated(pkgs))) stop("Packages defined to be loaded for integration t
 is.require = function(pkg) suppressWarnings(suppressMessages(isTRUE(require(pkg, character.only=TRUE, quietly=TRUE, warn.conflicts=FALSE))))
 loaded = sapply(pkgs, is.require)
 
-if (sum(!loaded)) invisible(sapply(names(loaded)[!loaded], function(s) cat("\n**** Other package",s,"is not installed. Tests using it will be skipped.\n")))
+if (sum(!loaded)) {
+  if (as.logical(Sys.getenv("_R_CHECK_FORCE_SUGGESTS_", "TRUE"))) {
+    stop(sprintf("Package suggested but not available: %s\n\nThe suggested packages are required for a complete check of data.table integration tests.\nChecking can be attempted without them by setting the environment variable _R_CHECK_FORCE_SUGGESTS_ to a false value.", paste("'", names(loaded)[!loaded], "'", sep="", collapse=", ")))
+  } else {
+    invisible(sapply(names(loaded)[!loaded], function(s) cat("\n**** Other package",s,"is not installed. Tests using it will be skipped.\n")))
+  }
+}
 
 cat("\n")
 print(data.table(pkg=pkgs, loaded)[loaded==TRUE, version:=as.character(sapply(pkg, function(p) format(packageVersion(p))))][])

--- a/inst/tests/other.Rraw
+++ b/inst/tests/other.Rraw
@@ -85,7 +85,7 @@ if (loaded[["xts"]]) {
 }
 
 if (loaded[["gdata"]]) {
-  if (!test_xts) warning("The gdata test expects xts loaded as well since all 3 have a last() function.")
+  if (!loaded[["xts"]]) warning("The gdata test expects xts loaded as well since all 3 have a last() function.")
   x = list("a",1:2,89)
   test(6.1, xts::last(x), list(89))   # would prefer 89 here like data.table does, since "last" means the last one (never more than one) so why retain the one-item list() level?
   test(6.2, gdata::last(x), list(89))

--- a/inst/tests/other.Rraw
+++ b/inst/tests/other.Rraw
@@ -15,7 +15,10 @@ if (any(duplicated(pkgs))) stop("Packages defined to be loaded for integration t
 
 is.require = function(pkg) suppressWarnings(suppressMessages(isTRUE(require(pkg, character.only=TRUE, quietly=TRUE, warn.conflicts=FALSE))))
 loaded = sapply(pkgs, is.require)
-cat("\nPackages to be tested:\n\n")
+
+if (sum(!loaded)) invisible(sapply(names(loaded)[!loaded], function(s) cat("\n**** Other package",s,"is not installed. Tests using it will be skipped.\n")))
+
+cat("\n")
 print(data.table(pkg=pkgs, loaded)[loaded==TRUE, version:=as.character(sapply(pkg, function(p) format(packageVersion(p))))][])
 cat("\n")
 print(sessionInfo())

--- a/inst/tests/other.Rraw
+++ b/inst/tests/other.Rraw
@@ -168,6 +168,7 @@ if (test_parallel) {
 
 if (test_dtq) {
   set.seed(5)
+  op = options("dtq.log.include"="data.table") # `[` from data.table namespace are by default excluded
   DT = data.table(a = 1:10, b = letters[1:5])
   LKP = data.table(b = letters[1:5], ratio = rnorm(5), key = "b")
   DT2 = DT[, .(a = sum(a)), b
@@ -178,6 +179,7 @@ if (test_dtq) {
   test(13.1, is.data.table(ans))
   test(13.2, nrow(ans)>0L)
   test(13.3, ans[nrow(ans), elapsed > 0.1])
+  options(op)
 }
 
 cat("\n",ntest-nfail,"out of",ntest,"tests passed.\n")

--- a/inst/tests/other.Rraw
+++ b/inst/tests/other.Rraw
@@ -5,6 +5,7 @@ if (exists("test.data.table",.GlobalEnv,inherits=FALSE)) {
   warning("This is dev where with.other.packages should not be run. Instead, use a fresh R session with data.table installed. ",
           "Not doing so in dev can be the cause of both false errors and false passes.")
 }
+if (!"package:data.table" %in% search()) stop("data.table should be already attached, see usage header in inst/tests/other.Rraw")
 
 test = data.table:::test
 INT = data.table:::INT
@@ -168,7 +169,7 @@ if (test_parallel) {
 
 if (test_dtq) {
   set.seed(5)
-  op = options("dtq.log.include"="data.table") # `[` from data.table namespace are by default excluded
+  op = options("dtq.log.include"="") # unnamed environment created for other.Rraw evaluation in test.data.table()
   DT = data.table(a = 1:10, b = letters[1:5])
   LKP = data.table(b = letters[1:5], ratio = rnorm(5), key = "b")
   DT2 = DT[, .(a = sum(a)), b

--- a/inst/tests/other.Rraw
+++ b/inst/tests/other.Rraw
@@ -12,20 +12,24 @@ INT = data.table:::INT
 
 pkgs = c("ggplot2", "hexbin", "plyr", "caret", "xts", "gdata", "zoo", "nlme", "bit64", "knitr", "plm", "parallel")
 if (any(duplicated(pkgs))) stop("Packages defined to be loaded for integration tests in 'inst/tests/other.Rraw' contains duplicates.")
-for (s in pkgs) {
-  assign(paste0("test_",s), loaded<-suppressWarnings(suppressMessages(require(s, character.only=TRUE))))
-  if (!loaded) cat("\n**** Other package",s,"is not installed. Tests using it will be skipped.\n\n")
-}
+
+is.require = function(pkg) suppressWarnings(suppressMessages(isTRUE(require(pkg, character.only=TRUE, quietly=TRUE, warn.conflicts=FALSE))))
+loaded = sapply(pkgs, is.require)
+cat("\nPackages to be tested:\n\n")
+print(data.table(pkg=pkgs, loaded)[loaded==TRUE, version:=as.character(sapply(pkg, function(p) format(packageVersion(p))))][])
+cat("\n")
+print(sessionInfo())
+cat("\n")
 
 if (all(c("package:reshape","package:reshape2") %in% search())) {
   warning("Packages 'reshape' and 'reshape2' are both loaded. There have been problems before when you don't use the :: namespace prefix to disambiguate. Probably best to either remove.packages('reshape') and use reshape2 instead, or always use :: when packages mask non-generic names.")
 }
 
-if (test_ggplot2) {
+if (loaded[["ggplot2"]]) {
   DT = data.table( a=1:5, b=11:50, d=c("A","B","C","D"), f=1:5, grp=1:5 )
   test(1.1, names(print(ggplot(DT,aes(b,f))+geom_point()))[c(1,3)], c("data","plot"))
   test(1.2, DT[,print(ggplot(.SD,aes(b,f))+geom_point()),by=list(grp%%2L)],data.table(grp=integer()))  # %%2 to reduce time needed for ggplot2 to plot
-  if (test_hexbin) {
+  if (loaded[["hexbin"]]) {
     # Test reported by C Neff on 11 Oct 2011
     test(1.3, names(print(ggplot(DT) + geom_hex(aes(b, f)) + facet_wrap(~grp)))[c(1,3)], c("data","plot"))
   }
@@ -38,13 +42,13 @@ if (test_ggplot2) {
   try(graphics.off(),silent=TRUE)
 }
 
-if (test_plyr) {
+if (loaded[["plyr"]]) {
   # Test key is dropped when non-dt-aware packages (here, plyr) reorders rows of data.table.
   DT = data.table(a=1:10,b=1:2,key="a")
   test(2, arrange(DT,b), data.table(a=INT(1,3,5,7,9,2,4,6,8,10),b=INT(1,1,1,1,1,2,2,2,2,2), key=NULL))
 }
 
-if (FALSE) {  # test_reshape
+if (FALSE) {  # loaded[["reshape"]]
   # Fix for #825
   # The bug was that names(DT) changed, hence testing DT here not ans. Same fix tested next with caret, so we now just rely on the caret test.
   # When running this test on 13 Mar 2018, I noticed that reshape::cast doesn't retain the Date class and returns just numbers. So I copied
@@ -54,7 +58,7 @@ if (FALSE) {  # test_reshape
   test(3, names(DT), c("ID", "DATUM", "N", "rank"))
 }
 
-if (test_caret) {
+if (loaded[["caret"]]) {
   # Fix for #476
   # caret seems heavy (plyr, reshape2 and withr). win-builder halts at this point consistently, but we pass on Travis and locally.
   # So I put the win-builder fail down to resource issues and moved this test into test.data.table(with.other.packages=TRUE).
@@ -64,7 +68,7 @@ if (test_caret) {
   test(4, names(DT), c("x", "y"))
 }
 
-if (test_xts) {
+if (loaded[["xts"]]) {
   # xts's last returns a one row data.table ok (setDT is needed to pass strict selfrefok(), but if not, no matter, the first subsequent := heals it (if any).
   # Not true when DT is a one column data.table/data.frame, see below.
   # Potentially, we could unload and reload xts in different orders.
@@ -80,7 +84,7 @@ if (test_xts) {
   # Which was the main thrust of bug#2312 fixed in v1.8.3
 }
 
-if (test_gdata) {
+if (loaded[["gdata"]]) {
   if (!test_xts) warning("The gdata test expects xts loaded as well since all 3 have a last() function.")
   x = list("a",1:2,89)
   test(6.1, xts::last(x), list(89))   # would prefer 89 here like data.table does, since "last" means the last one (never more than one) so why retain the one-item list() level?
@@ -91,13 +95,13 @@ if (test_gdata) {
   test(6.5, data.table::last(DT), DT[3L])
 }
 
-if (test_zoo) {
+if (loaded[["zoo"]]) {
   # as.Date.IDate won't change the class if xts package loaded #1500
   x = as.IDate("2016-01-15")
   test(6, class(as.Date(x)), "Date")
 }
 
-if (test_nlme) {
+if (loaded[["nlme"]]) {
   # commented out to be consistent with base R, as #1078 and #1128 are more common cases..
   # until we can find a workaround for this, Arun disabled this one.
   # Search for "Fix for #1078" for the tests..
@@ -108,7 +112,7 @@ if (test_nlme) {
             {x=as.data.table(iris);tt=groupedData( Sepal.Length ~ Sepal.Width | Species, data=x);attr(tt,"class")=NULL;attr(tt,"FUN")=NULL;attr(tt,".internal.selfref")=NULL;tt})
 }
 
-if (test_bit64) {
+if (loaded[["bit64"]]) {
   # these don't pass UBSAN/USAN because of the overflow, so just here in other.Rraw
   test(8.1, as.character((as.integer64(2^62)-1)*2+1), "9223372036854775807")
   test(8.2, as.character((as.integer64(2^62)-1)*2+2), NA_character_, warning="integer64 overflow")
@@ -116,14 +120,14 @@ if (test_bit64) {
   test(8.4, as.character(-(as.integer64(2^62)-1)*2-2), NA_character_, warning="integer64.*flow")
 }
 
-if (test_gdata) {
+if (loaded[["gdata"]]) {
   # fix for bug #5069
   DT <- data.table(a = c('asdfasdf','asdf','asdgasdgasdgasdg','sdg'), b = runif(4,0,1))
   test(9, write.fwf(DT, f<-tempfile()), NULL)
   unlink(f)
 }
 
-if (test_knitr) {
+if (loaded[["knitr"]]) {
   # That data.table-unaware code in packages like knitr still work
   # kable in knitr v1.6 uses DF[...] syntax inside it but the user might have passed a data.table.
   # Which is fine and works thanks to cedta().
@@ -132,7 +136,7 @@ if (test_knitr) {
 }
 
 # for plm package
-if (test_plm) {
+if (loaded[["plm"]]) {
   set.seed(45L)
   x  = data.table(V1=c(1L,2L), V2=LETTERS[1:3], V3=round(rnorm(4),4), V4=1:12)
   px = pdata.frame(x, index=c("V2", "V4"), drop.index=FALSE, row.names=TRUE)
@@ -140,7 +144,7 @@ if (test_plm) {
   test(11.2, class(setDT(px)), class(x))
 }
 
-if (test_parallel) {
+if (loaded[["parallel"]]) {
   #1745 and #1727
   if (.Platform$OS.type=="windows") {
     warning("This test of auto fallback to single threaded mode when data.table is used from package parallel, does not run on Windows because 'mc.cores'>1 is not supported on Windows; i.e., parallel package isn't parallel on Windows, IIUC. Whereas data.table is parallel built-in on Windows for some functions (fwrite/fread/fsort and expanding) using OpenMP.")
@@ -168,4 +172,3 @@ if (test_parallel) {
 }
 
 cat("\n",ntest-nfail,"out of",ntest,"tests passed.\n")
-

--- a/inst/tests/tests-DESCRIPTION
+++ b/inst/tests/tests-DESCRIPTION
@@ -4,5 +4,5 @@ Type: Backend
 Title: List of data.table dependencies used in integration tests
 Authors@R: c(person("data.table team", role = c("aut", "cre", "cph"), email="mattjdowle@gmail.com"))
 Description: Standalone R DESCRIPTION file which defines R dependencies for integration tests of data.table package.
-Suggests: ggplot2 (>= 0.9.0), reshape, hexbin, fastmatch, nlme, gdata, caret, plm, rmarkdown, parallel, dtq
+Suggests: ggplot2 (>= 0.9.0), reshape, hexbin, fastmatch, nlme, gdata, caret, plm, rmarkdown, parallel, dtq (>= 0.1.6)
 Additional_repositories: https://jangorecki.gitlab.io/dtq

--- a/inst/tests/tests-DESCRIPTION
+++ b/inst/tests/tests-DESCRIPTION
@@ -1,0 +1,8 @@
+Package: test.data.table
+Version: 0.1
+Type: Backend
+Title: List of data.table dependencies used in integration tests
+Authors@R: c(person("data.table team", role = c("aut", "cre", "cph"), email="mattjdowle@gmail.com"))
+Description: Standalone R DESCRIPTION file which defines R dependencies for integration tests of data.table package.
+Suggests: ggplot2 (>= 0.9.0), reshape, hexbin, fastmatch, nlme, gdata, caret, plm, rmarkdown, parallel, dtq
+Additional_repositories: https://jangorecki.gitlab.io/dtq

--- a/inst/tests/tests-DESCRIPTION
+++ b/inst/tests/tests-DESCRIPTION
@@ -4,5 +4,4 @@ Type: Backend
 Title: List of data.table dependencies used in integration tests
 Authors@R: c(person("data.table team", role = c("aut", "cre", "cph"), email="mattjdowle@gmail.com"))
 Description: Standalone R DESCRIPTION file which defines R dependencies for integration tests of data.table package.
-Suggests: ggplot2 (>= 0.9.0), reshape, hexbin, fastmatch, nlme, gdata, caret, plm, rmarkdown, parallel, dtq (>= 0.1.6)
-Additional_repositories: https://jangorecki.gitlab.io/dtq
+Suggests: ggplot2 (>= 0.9.0), reshape, hexbin, fastmatch, nlme, gdata, caret, plm, rmarkdown, parallel

--- a/tests/main.R
+++ b/tests/main.R
@@ -1,6 +1,11 @@
 require(data.table)
 test.data.table()  # runs the main test suite of 5,000+ tests in /inst/tests/tests.Rraw
 
+# integration tests for packages excluded from Suggests in 1.10.5
+# for list of used packages see inst/tests/tests-DESCRIPTION
+with.other.packages = as.logical(Sys.getenv("TEST_DATA_TABLE_WITH_OTHER_PACKAGES","FALSE"))
+if (with.other.packages) test.data.table(with.other.packages=with.other.packages)
+
 # Turn off verbose repeat to save time (particularly Travis, but also CRAN) :
 # test.data.table(verbose=TRUE)
 # Calling it again in the past revealed some memory bugs but also verbose mode checks the verbose messages run ok


### PR DESCRIPTION
Closes #2696

Just setting env var will invoke second call to `test.data.table` doing integration tests only.
```
TEST_DATA_TABLE_WITH_OTHER_PACKAGES: "TRUE"
```
IMO better would be to have that inside single `test.data.table` call but capability to run multiple Rraw files has just been removed from there.