### PR TITLE
Various memory faults found thanks to enable-strict-barrier

### DIFF
--- a/CRAN_Release.cmd
+++ b/CRAN_Release.cmd
@@ -169,9 +169,9 @@ test.data.table()
 vi ~/.R/Makevars  # make the -O3 line active again
 
 
-###############################################
-#  R-devel with UBSAN and ASAN on too
-###############################################
+#####################################################
+#  R-devel with UBSAN, ASAN and strict-barrier on too
+#####################################################
 
 cd ~/build
 wget -N https://stat.ethz.ch/R/daily/R-devel.tar.gz
@@ -180,14 +180,13 @@ tar xvf R-devel.tar.gz
 cd R-devel
 # Following R-exts#4.3.3
 
-## 64bit (normal)
-./configure --without-recommended-packages --disable-byte-compiled-packages --disable-openmp CC="gcc -fsanitize=undefined,address -fno-sanitize=float-divide-by-zero -fno-omit-frame-pointer" CFLAGS="-O0 -g -Wall -pedantic" LIBS="-lpthread"
+./configure --without-recommended-packages --disable-byte-compiled-packages --disable-openmp --enable-strict-barrier CC="gcc -fsanitize=undefined,address -fno-sanitize=float-divide-by-zero -fno-omit-frame-pointer" CFLAGS="-O0 -g -Wall -pedantic" LIBS="-lpthread"
 # For ubsan, disabled openmp otherwise gcc fails in R's distance.c:256 error: ‘*.Lubsan_data0’ not specified in enclosing parallel
 # UBSAN gives direct line number under gcc but not clang it seems. clang-5.0 has been helpful too, though.
 # If use later gcc-8, add F77=gfortran-8
 # LIBS="-lpthread" otherwise ld error about DSO missing
 
-## 32bit on 64bit Ubuntu (for tracing any 32bit-only Rdevel-only problems)
+## Rarely needed: 32bit on 64bit Ubuntu for tracing any 32bit-only problems
 dpkg --add-architecture i386
 apt-get update
 apt-get install libc6:i386 libstdc++6:i386 gcc-multilib g++-multilib gfortran-multilib libbz2-dev:i386 liblzma-dev:i386 libpcre3-dev:i386 libcurl3-dev:i386 libstdc++-7-dev:i386

--- a/src/gsumm.c
+++ b/src/gsumm.c
@@ -33,7 +33,15 @@ SEXP gforce(SEXP env, SEXP jsub, SEXP o, SEXP f, SEXP l, SEXP irowsArg) {
   if (!isInteger(o)) error("o is not an integer vector");
   if (!isInteger(f)) error("f is not an integer vector");
   if (!isInteger(l)) error("l is not an integer vector");
-  if (!isInteger(irowsArg) && !isNull(irowsArg)) error("irowsArg is not an integer vector");
+  if (isNull(irowsArg)) {
+    irows = NULL;
+    irowslen = -1;
+  }
+  else if (isInteger(irowsArg)) {
+    irows = INTEGER(irowsArg);
+    irowslen = LENGTH(irowsArg);
+  }
+  else error("irowsArg is neither an integer vector nor NULL");
   ngrp = LENGTH(l);
   if (LENGTH(f) != ngrp) error("length(f)=%d != length(l)=%d", LENGTH(f), ngrp);
   grpn=0;
@@ -63,8 +71,6 @@ SEXP gforce(SEXP env, SEXP jsub, SEXP o, SEXP f, SEXP l, SEXP irowsArg) {
   if (length(tt) && INTEGER(tt)[0]!=maxgrpn) error("Internal error: o's maxgrpn mismatches recalculated maxgrpn");
   oo = INTEGER(o);
   ff = INTEGER(f);
-  irows = INTEGER(irowsArg);
-  if (!isNull(irowsArg)) irowslen = length(irowsArg);
 
   SEXP ans = PROTECT( eval(jsub, env) );
   // if this eval() fails with R error, R will release grp for us. Which is why we use R_alloc above.

--- a/src/rbindlist.c
+++ b/src/rbindlist.c
@@ -416,14 +416,15 @@ static SEXP fast_order(SEXP dt, R_len_t byArg, R_len_t handleSorted) {
 }
 
 static SEXP uniq_lengths(SEXP v, R_len_t n) {
-
-  R_len_t i, nv=length(v);
+  R_len_t nv=length(v);
   SEXP ans = PROTECT(allocVector(INTSXP, nv));
-  for (i=1; i<nv; i++) {
+  for (R_len_t i=1; i<nv; i++) {
     INTEGER(ans)[i-1] = INTEGER(v)[i] - INTEGER(v)[i-1];
   }
-  // last value
-  INTEGER(ans)[nv-1] = n - INTEGER(v)[nv-1] + 1;
+  if (nv>0) {
+    // last value
+    INTEGER(ans)[nv-1] = n - INTEGER(v)[nv-1] + 1;
+  }
   UNPROTECT(1);
   return(ans);
 }
@@ -631,7 +632,6 @@ SEXP rbindlist(SEXP l, SEXP sexp_usenames, SEXP sexp_fill, SEXP idcol) {
 
   // check for factor, get max types, and when usenames=TRUE get the answer 'names' and column indices for proper reordering.
   preprocess(l, usenames, fill, &data);
-  fnames   = VECTOR_ELT(data.ans_ptr, 0);
   if (usenames) findices = VECTOR_ELT(data.ans_ptr, 1);
   protecti = data.protecti;   // TODO very ugly and doesn't seem right. Assign items to list instead, perhaps.
   if (data.n_rows == 0 && data.n_cols == 0) {
@@ -642,6 +642,7 @@ SEXP rbindlist(SEXP l, SEXP sexp_usenames, SEXP sexp_fill, SEXP idcol) {
     error("Total rows in the list is %lld which is larger than the maximum number of rows, currently %d",
           (long long)data.n_rows, INT32_MAX);
   }
+  fnames = VECTOR_ELT(data.ans_ptr, 0);
   if (isidcol) {
     fnames = PROTECT(add_idcol(fnames, idcol, data.n_cols));
     protecti++;

--- a/src/uniqlist.c
+++ b/src/uniqlist.c
@@ -67,16 +67,15 @@ SEXP uniqlist(SEXP l, SEXP order)
 }
 
 SEXP uniqlengths(SEXP x, SEXP n) {
-  SEXP ans;
-  R_len_t i, len;
-  if (TYPEOF(x) != INTSXP || length(x) < 0) error("Input argument 'x' to 'uniqlengths' must be an integer vector of length >= 0");
+  // seems very similar to rbindlist.c:uniq_lengths. TODO: centralize into common function
+  if (TYPEOF(x) != INTSXP) error("Input argument 'x' to 'uniqlengths' must be an integer vector");
   if (TYPEOF(n) != INTSXP || length(n) != 1) error("Input argument 'n' to 'uniqlengths' must be an integer vector of length 1");
-  PROTECT(ans = allocVector(INTSXP, length(x)));
-  len = length(x);
-  for (i=1; i<len; i++) {
+  R_len_t len = length(x);
+  SEXP ans = PROTECT(allocVector(INTSXP, len));
+  for (R_len_t i=1; i<len; i++) {
     INTEGER(ans)[i-1] = INTEGER(x)[i] - INTEGER(x)[i-1];
   }
-  INTEGER(ans)[len-1] = INTEGER(n)[0] - INTEGER(x)[len-1] + 1;
+  if (len>0) INTEGER(ans)[len-1] = INTEGER(n)[0] - INTEGER(x)[len-1] + 1;
   UNPROTECT(1);
   return(ans);
 }


### PR DESCRIPTION
These faults fit with the sporadic fails that only show up on 32bit-only Windows-only R-devel-only so far. Need to be fixed anyway and we'll see if it's more stable from now on.
Likely thanks to new `CATCH_ZERO_LENGTH_ACCESS` under `enable-strict-barrier` that Luke Tierney added to R-devel recently.
