### PR TITLE
test use less memory, pass on 2GB ram machine

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -2912,7 +2912,7 @@ test(1034, as.data.table(x<-as.character(sample(letters, 5))), data.table(V1=x))
 
   # segfault of unprotected var caught with the help of address sanitizer
   set.seed(1)
-  val = sample(c(1:5, NA), 1e6L, TRUE)
+  val = sample(c(1:5, NA), 1e5L, TRUE)
   dt <- setDT(replicate(100L, val, simplify=FALSE))
   ## to ensure there's no segfault...
   ans <- melt(dt, measure.vars=names(dt), na.rm=TRUE)


### PR DESCRIPTION
Test which was added in https://github.com/Rdatatable/data.table/commit/6c654e9bd2cf00396b6be15dc1a0e850915bbb26 uses quite a lot memory and often fail on machine with 2GB ram.
Using parent commit of the above https://github.com/Rdatatable/data.table/commit/b49ac6be7911e01b8fa10b996d9a82b256a608ef I was able to reproduce issue using smaller size of data, thus we can safely use smaller data in this test.