### PR TITLE
Measuring memory usage in test.data.table, reduce mem usage in some tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -127,6 +127,8 @@ test-r-release-vanilla: # check minimal installation, no suggested deps, no vign
   dependencies:
   - mirror-packages
   - build
+  variables:
+    TEST_DATA_TABLE_MEMTEST: "TRUE"
   script:
     - mkdir -p bus/$CI_BUILD_NAME
     - Rscript -e 'source(Sys.getenv("CI_TOOLS")); if (length(pkgs<-packages.dcf("DESCRIPTION"))) install.packages(pkgs, repos=file.path("file:",normalizePath("bus/mirror-packages/cran")))'

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -72,18 +72,22 @@ compactprint <- function(DT, topn=2L) {
 INT = function(...) { as.integer(c(...)) }   # utility used in tests.Rraw
 
 ps_mem = function() {
+  # nocov start
   cmd = sprintf("ps -o rss %s | tail -1", Sys.getpid())
   ans = tryCatch(as.numeric(system(cmd, intern=TRUE)), error=function(e) NA_real_)
   stopifnot(length(ans)==1L) # extra check if other OSes would not handle 'tail -1' properly for some reason
   # returns RSS memory occupied by current R process in MB rounded to 1 decimal places (as in gc), ps already returns KB
   c("PS_rss"=round(ans / 1024, 1))
+  # nocov end
 }
 
 gc_mem = function() {
+  # nocov start
   # gc reported memory in MB
   m = apply(gc()[, c(2L, 4L, 6L)], 2L, sum)
   names(m) = c("GC_used", "GC_gc_trigger", "GC_max_used")
   m
+  # nocov end
 }
 
 test <- function(num,x,y=TRUE,error=NULL,warning=NULL,output=NULL) {
@@ -147,7 +151,7 @@ test <- function(num,x,y=TRUE,error=NULL,warning=NULL,output=NULL) {
     e
   }
   if (memtest) {
-    timestamp = as.numeric(Sys.time())
+    timestamp = as.numeric(Sys.time())   # nocov
   }
   if (is.null(output)) {
     x = tryCatch(withCallingHandlers(x, warning=wHandler), error=eHandler)
@@ -156,8 +160,8 @@ test <- function(num,x,y=TRUE,error=NULL,warning=NULL,output=NULL) {
     out = capture.output(print(x <<- tryCatch(withCallingHandlers(x, warning=wHandler), error=eHandler)))
   }
   if (memtest) {
-    mem = as.list(c(inittime=inittime, timestamp=timestamp, test=num, ps_mem(), gc_mem()))
-    fwrite(mem, "memtest.csv", append=TRUE)
+    mem = as.list(c(inittime=inittime, timestamp=timestamp, test=num, ps_mem(), gc_mem()))   # nocov
+    fwrite(mem, "memtest.csv", append=TRUE)                                                  # nocov
   }
   fail = FALSE
   if (length(warning) != length(actual.warns)) {

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -71,8 +71,8 @@ compactprint <- function(DT, topn=2L) {
 INT = function(...) { as.integer(c(...)) }   # utility used in tests.Rraw
 
 memory_usage = function() {
-  # returns RSS memory occupied by current R process in MB rounded to 2 decimale places
-  round(as.numeric(system(sprintf("ps -o rss %s | tail -1", Sys.getpid()), intern=TRUE)) / (1024^2), 2)
+  # returns RSS memory occupied by current R process in MB rounded to 2 decimale places, ps already returns KB
+  round(as.numeric(system(sprintf("ps -o rss %s | tail -1", Sys.getpid()), intern=TRUE)) / 1024, 2)
 }
 
 test <- function(num,x,y=TRUE,error=NULL,warning=NULL,output=NULL) {

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -36,7 +36,7 @@ test.data.table <- function(verbose=FALSE, pkg="pkg", silent=FALSE, with.other.p
   assign("lasttime", proc.time()[3L], envir=env)  # used by test() to attribute time inbetween tests to the next test
   assign("timings", data.table( ID = seq_len(3000L), time=0.0, nTest=0L ), envir=env)   # test timings aggregated to integer id
   assign("memtest", as.logical(Sys.getenv("TEST_DATA_TABLE_MEMTEST", "FALSE")), envir=env)
-  assign("inittime", as.integer(Sys.time), envir=env) # keep measures from various test.data.table runs
+  assign("inittime", as.integer(Sys.time()), envir=env) # keep measures from various test.data.table runs
   # It doesn't matter that 3000L is far larger than needed for other and benchmark.
   if(isTRUE(silent)){
     try(sys.source(fn,envir=env), silent=silent)  # nocov

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -144,12 +144,15 @@ test <- function(num,x,y=TRUE,error=NULL,warning=NULL,output=NULL) {
     out = capture.output(print(x <<- tryCatch(withCallingHandlers(x, warning=wHandler), error=eHandler)))
   }
   if (memtest) {
+    # workaround for test 432.1: options(datatable.alloccol=NULL)
+    if (trick.null.alloccol<-is.null(getOption("datatable.alloccol"))) old.alloccol=options(datatable.alloccol=1024L)
     psmem = memory_usage()
     dtmem = as.data.table(gc(), keep.rownames=TRUE)
     setnames(dtmem, c("cells","used","usedmb","gctrigger","gctriggermb","maxused","maxusedmb"))
     dtmem = dcast(dtmem, . ~ cells, value.var=setdiff(names(dtmem), "cells"))
     dtmem[, c("testtimestamp","testnum","psmem",".") := list(timestamp, num, psmem, NULL)]
     fwrite(dtmem, "memtest.csv", append=TRUE) # allow to compare with historical runs
+    if (trick.null.alloccol) options(old.alloccol)
   }
   fail = FALSE
   if (length(warning) != length(actual.warns)) {

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -7639,6 +7639,7 @@ test(1588.1, dt[f %in% 3:4], dt[3:4])
 test(1588.2, dt[f == 3], dt[3])
 
 # encoding issue in forder
+# test escaped when memory statistics are collected due to #2746
 if (!memtest) {
   x <- "fa\xE7ile"
   Encoding(x)
@@ -11651,15 +11652,19 @@ if (memtest) {
   ..inittime = inittime
   m = fread("memtest.csv")[inittime==..inittime]
   if (nrow(m)) {
+    ps_na = all(is.na(m[["PS_rss"]])) # OS with no 'ps -o rss R' support
     png("memtest.png")
-    p = par(mfrow=c(3,2))
-    m[, plot(test, PS_rss, pch=18, xlab="test num", ylab="mem MB", main="ps -o rss R")]
-    m[, plot(timestamp, PS_rss, type="l", xlab="timestamp", ylab="mem MB", main="ps -o rss R")]
+    p = par(mfrow=c(if (ps_na) 2 else 3, 2))
+    if (!ps_na) {
+      m[, plot(test, PS_rss, pch=18, xlab="test num", ylab="mem MB", main="ps -o rss R")]
+      m[, plot(timestamp, PS_rss, type="l", xlab="timestamp", ylab="mem MB", main="ps -o rss R")]
+    }
     m[, plot(test, GC_used, pch=18, xlab="test num", ylab="mem MB", main="gc used")]
     m[, plot(timestamp, GC_used, type="l", xlab="timestamp", ylab="mem MB", main="gc used")]
     m[, plot(test, GC_max_used, pch=18, xlab="test num", ylab="mem MB", main="gc max used")]
     m[, plot(timestamp, GC_max_used, type="l", xlab="timestamp", ylab="mem MB", main="gc max used")]
     par(p)
+    dev.off()
   } else {
     warning("test.data.table runs with memory testing but did not collect any memory statistics.")
   }

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -10650,11 +10650,10 @@ test(1779.2, uniqueN(lt)==1L)
 # some random 1e6 timestamps old defaults vs new methods UTC
 intpx = function(x) as.integer(as.POSIXct(x, origin = "1970-01-01", tz = "UTC"))
 set.seed(1)
-i = sample(intpx("2015-10-12")-intpx("2014-10-12"), 1e6, TRUE) + intpx("2014-10-12")
+i = sample(intpx("2015-10-12")-intpx("2014-10-12"), 1e5, TRUE) + intpx("2014-10-12")
 p = as.POSIXct(i, origin = "1970-01-01", tz = "UTC")
 test(1779.3, identical(as.ITime.default(p), as.ITime(p)))
 test(1779.4, identical(as.IDate.default(p), as.IDate(p)))
-
 # test for non-UTC
 p = as.POSIXct(i, origin = "1970-01-01", tz = "Asia/Hong_Kong")
 test(1779.5, identical(as.ITime.default(p), as.ITime(p)))

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -2912,7 +2912,7 @@ test(1034, as.data.table(x<-as.character(sample(letters, 5))), data.table(V1=x))
 
   # segfault of unprotected var caught with the help of address sanitizer
   set.seed(1)
-  val = sample(c(1:5, NA), 1e5L, TRUE)
+  val = sample(c(1:5, NA), 1e4L, TRUE)
   dt <- setDT(replicate(100L, val, simplify=FALSE))
   ## to ensure there's no segfault...
   ans <- melt(dt, measure.vars=names(dt), na.rm=TRUE)
@@ -3627,7 +3627,7 @@ test(1149.2, forderv(numeric(0)), integer(0))
 
 # test uniqlengths
 set.seed(45)
-x <- sample(c(NA_integer_, 1:1e5), 1e7, TRUE)
+x <- sample(c(NA_integer_, 1:1e4), 1e6, TRUE)
 ox <- forderv(x)
 o1 <- uniqlist(list(x), ox)
 test(1151.1, c(diff(o1), length(x)-tail(o1, 1L)+1L), uniqlengths(o1, length(x)))
@@ -7120,8 +7120,8 @@ test(1548.1, unique(unlist(lapply(ans1, Encoding))), "unknown")
 test(1548.2, unique(unlist(lapply(ans2, Encoding))), "UTF-8")
 
 # #1167 print.data.table row id in non-scientific notation
-DT <- data.table(a = rep(1:5,3*1e6), b = rep(letters[1:3],5*1e6))
-test(1549, capture.output(print(DT)), c("          a b", "       1: 1 a", "       2: 2 b", "       3: 3 c", "       4: 4 a", "       5: 5 b", "      ---    ", "14999996: 1 b", "14999997: 2 c", "14999998: 3 a", "14999999: 4 b", "15000000: 5 c"))
+DT <- data.table(a = rep(1:5,3*1e5), b = rep(letters[1:3],5*1e5))
+test(1549, capture.output(print(DT)), c("         a b", "      1: 1 a", "      2: 2 b", "      3: 3 c", "      4: 4 a", "      5: 5 b", "     ---    ", "1499996: 1 b", "1499997: 2 c", "1499998: 3 a", "1499999: 4 b", "1500000: 5 c"))
 rm(DT)
 
 # PR by @dselivanov
@@ -10650,7 +10650,7 @@ test(1779.2, uniqueN(lt)==1L)
 # some random 1e6 timestamps old defaults vs new methods UTC
 intpx = function(x) as.integer(as.POSIXct(x, origin = "1970-01-01", tz = "UTC"))
 set.seed(1)
-i = sample(seq(intpx("2014-10-12"), intpx("2015-10-12")), 1e6, TRUE)
+i = sample(seq(intpx("2014-10-12"), intpx("2015-10-12")), 1e5, TRUE)
 p = as.POSIXct(i, origin = "1970-01-01", tz = "UTC")
 test(1779.3, identical(as.ITime.default(p), as.ITime(p)))
 test(1779.4, identical(as.IDate.default(p), as.IDate(p)))

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -7639,17 +7639,19 @@ test(1588.1, dt[f %in% 3:4], dt[3:4])
 test(1588.2, dt[f == 3], dt[3])
 
 # encoding issue in forder
-x <- "fa\xE7ile"
-Encoding(x)
-Encoding(x) <- "latin1"
-xx <- iconv(x, "latin1", "UTF-8")
-y = sample(c(x,xx), 10, TRUE)
-oy = if (length(oy <- forderv(y))) oy else seq_along(y)
-test(1590.4, oy, order(y))
-Encoding(xx) = "unknown"
-y = sample(c(x,xx), 10, TRUE)
-oy = if (length(oy <- forderv(y))) oy else seq_along(y)
-test(1590.5, oy, order(y))
+if (!memtest) {
+  x <- "fa\xE7ile"
+  Encoding(x)
+  Encoding(x) <- "latin1"
+  xx <- iconv(x, "latin1", "UTF-8")
+  y = sample(c(x,xx), 10, TRUE)
+  oy = if (length(oy <- forderv(y))) oy else seq_along(y)
+  test(1590.4, oy, order(y))
+  Encoding(xx) = "unknown"
+  y = sample(c(x,xx), 10, TRUE)
+  oy = if (length(oy <- forderv(y))) oy else seq_along(y)
+  test(1590.5, oy, order(y))
+}
 
 # #1432 test
 list_1 = list(a = c(44,47), dens = c(2331,1644))

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -10650,10 +10650,11 @@ test(1779.2, uniqueN(lt)==1L)
 # some random 1e6 timestamps old defaults vs new methods UTC
 intpx = function(x) as.integer(as.POSIXct(x, origin = "1970-01-01", tz = "UTC"))
 set.seed(1)
-i = sample(seq(intpx("2014-10-12"), intpx("2015-10-12")), 1e5, TRUE)
+i = sample(intpx("2015-10-12")-intpx("2014-10-12"), 1e6, TRUE) + intpx("2014-10-12")
 p = as.POSIXct(i, origin = "1970-01-01", tz = "UTC")
 test(1779.3, identical(as.ITime.default(p), as.ITime(p)))
 test(1779.4, identical(as.IDate.default(p), as.IDate(p)))
+
 # test for non-UTC
 p = as.POSIXct(i, origin = "1970-01-01", tz = "Asia/Hong_Kong")
 test(1779.5, identical(as.ITime.default(p), as.ITime(p)))
@@ -11647,6 +11648,23 @@ DT = head(timings[-1L][order(-time)],10)   # exclude id 1 as in dev that include
 if ((x<-timings[,sum(nTest)]) != ntest) warning("Timings count mismatch:",x,"vs",ntest)
 cat("\n10 longest running tests took ", as.integer(tt<-DT[, sum(time)]), "s (", as.integer(100*tt/(ss<-timings[,sum(time)])), "% of ", as.integer(ss), "s)\n", sep="")
 print(DT, class=FALSE)
+if (memtest) {
+  ..inittime = inittime
+  m = fread("memtest.csv")[inittime==..inittime]
+  if (nrow(m)) {
+    png("memtest.png")
+    p = par(mfrow=c(3,2))
+    m[, plot(test, PS_rss, pch=18, xlab="test num", ylab="mem MB", main="ps -o rss R")]
+    m[, plot(timestamp, PS_rss, type="l", xlab="timestamp", ylab="mem MB", main="ps -o rss R")]
+    m[, plot(test, GC_used, pch=18, xlab="test num", ylab="mem MB", main="gc used")]
+    m[, plot(timestamp, GC_used, type="l", xlab="timestamp", ylab="mem MB", main="gc used")]
+    m[, plot(test, GC_max_used, pch=18, xlab="test num", ylab="mem MB", main="gc max used")]
+    m[, plot(timestamp, GC_max_used, type="l", xlab="timestamp", ylab="mem MB", main="gc max used")]
+    par(p)
+  } else {
+    warning("test.data.table runs with memory testing but did not collect any memory statistics.")
+  }
+}
 if (nfail > 0) {
   if (nfail>1) {s1="s";s2="s: "} else {s1="";s2=" "}
   cat("\r")


### PR DESCRIPTION
Closes #2739
More comments inline.
Setting `TEST_DATA_TABLE_MEMTEST=TRUE` and running `test.data.table` will produce `memtest.csv` and following plot. On Linux of course.
![memtest](https://user-images.githubusercontent.com/3627377/38690275-5a9048e0-3e9b-11e8-96e9-c4ad6e303bb6.png)
