### PR TITLE
Subset by bug

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -203,9 +203,7 @@ Thanks to @sritchie73 for reporting and fixing [PR#2631](https://github.com/Rdat
 
 38. Fixed a bug on Windows that `data.table` may break if the garbage collecting was triggered when sorting a large number of non-ASCII characters. Thanks to @shrektan for reporting and fixing [PR#2678](https://github.com/Rdatatable/data.table/pull/2678),  [#2674](https://github.com/Rdatatable/data.table/issues/2674).
 
-39. Internal aliasing of `.` to `list` was over-aggressive in applying `list` even when `.` was intended within `bquote`, [#1912](https://github.com/Rdatatable/data.table/issues/1912). Thanks @MichaelChirico for reporting/filing and @ecoRoland for suggesting and testing a fix. 
-
-40. Using 'by' when joining is now returning the correct result, where it used to return wrong entries in the grouping column(s) [#2591](https://github.com/Rdatatable/data.table/issues/2591). Thanks to @sritchie73 and @cathine for reporting and to @MarkusBonsch for fixing.
+39. Internal aliasing of `.` to `list` was over-aggressive in applying `list` even when `.` was intended within `bquote`, [#1912](https://github.com/Rdatatable/data.table/issues/1912). Thanks @MichaelChirico for reporting/filing and @ecoRoland for suggesting and testing a fix.
 
 #### NOTES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -205,6 +205,8 @@ Thanks to @sritchie73 for reporting and fixing [PR#2631](https://github.com/Rdat
 
 39. Internal aliasing of `.` to `list` was over-aggressive in applying `list` even when `.` was intended within `bquote`, [#1912](https://github.com/Rdatatable/data.table/issues/1912). Thanks @MichaelChirico for reporting/filing and @ecoRoland for suggesting and testing a fix. 
 
+40. Using 'by' when joining is now returning the correct result, where it used to return wrong entries in the grouping column(s) [#2591](https://github.com/Rdatatable/data.table/issues/2591). Thanks to @sritchie73 and @cathine for reporting and to @MarkusBonsch for fixing.
+
 #### NOTES
 
 0. The license has been changed from GPL to MPL (Mozilla Public License). All contributors were consulted and approved. [PR#2456](https://github.com/Rdatatable/data.table/pull/2456) details the reasons for the change.

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -5878,8 +5878,8 @@ DT <- data.table(intCol    = sample(c(1:3, NA), n, replace = TRUE),
                  doubleCol = sample(c(1.86, 1000.345, 2.346, NA, NaN), n, replace = TRUE),
                  boolCol   = sample(c(TRUE, FALSE, NA), n, replace = TRUE),
                  charCol   = sample(c(LETTERS[1:3], NA), n, replace = TRUE),
-                 groupCol  = sort(sample(c("a", "b", "c"), n, replace = TRUE)) ## sort is important to test #2713
-                 )
+                 groupCol  = sample(c("a", "b", "c"), n, replace = TRUE),
+                 sortedGroupCol = c(rep(1L, floor(n/3)), rep(2L, floor(n/3)), rep(3L, ceiling(n/3)))) ## sorted grouping column is important to test #2713
 if (test_bit64) DT[, int64Col := as.integer64(sample(1:3, n, replace = TRUE))]
 ## get list with unique values excluding NA
 vals <- lapply(DT, function(x) {out <- unique(x); out[!is.na(out)]})
@@ -5916,7 +5916,7 @@ all[, query := gsub("&missing$", "", gsub("missing&", "", query))]
 jQueries <- c(".(test = intCol + doubleCol, test2 = paste0(boolCol, charCol))",
               "c('test1', 'test2') := list(pmax(intCol, doubleCol), !boolCol)")
 ## define example 'by' values
-bys <- c("groupCol", character(0))
+bys <- c("groupCol", "sortedGroupCol", character(0))
 ## test each query string
 test_no <- 1437.0039
 for(t in seq_len(nrow(all))){

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -5878,7 +5878,8 @@ DT <- data.table(intCol    = sample(c(1:3, NA), n, replace = TRUE),
                  doubleCol = sample(c(1.86, 1000.345, 2.346, NA, NaN), n, replace = TRUE),
                  boolCol   = sample(c(TRUE, FALSE, NA), n, replace = TRUE),
                  charCol   = sample(c(LETTERS[1:3], NA), n, replace = TRUE),
-                 groupCol  = sample(c("a", "b", "c"), n, replace = TRUE))
+                 groupCol  = sort(sample(c("a", "b", "c"), n, replace = TRUE)) ## sort is important to test #2713
+                 )
 if (test_bit64) DT[, int64Col := as.integer64(sample(1:3, n, replace = TRUE))]
 ## get list with unique values excluding NA
 vals <- lapply(DT, function(x) {out <- unique(x); out[!is.na(out)]})

--- a/src/dogroups.c
+++ b/src/dogroups.c
@@ -132,10 +132,10 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
              (char *)DATAPTR(VECTOR_ELT(groups,INTEGER(jiscols)[j]-1))+i*size,
              size);
     }
-    if (LOGICAL(on)[0])
-      igrp = (length(grporder) && isNull(jiscols)) ? INTEGER(grporder)[INTEGER(starts)[i]-1]-1 : i;
-    else
-      igrp = (length(grporder)) ? INTEGER(grporder)[INTEGER(starts)[i]-1]-1 : (isNull(jiscols) ? INTEGER(starts)[i]-1 : i);
+    // igrp determines the start of the current group in rows of dt (0 based).
+    // if jiscols is not null, we have a by = .EACHI, so the start is exactly i.
+    // Otherwise, igrp needs to be determined from starts, potentially taking care about the order if present.
+    igrp = !isNull(jiscols) ? i : (length(grporder) ? INTEGER(grporder)[INTEGER(starts)[i]-1]-1 : INTEGER(starts)[i]-1);
     if (igrp>=0 && nrowgroups) for (j=0; j<length(BY); j++) {    // igrp can be -1 so 'if' is important, otherwise memcpy crash
       size = SIZEOF(VECTOR_ELT(BY,j));
       memcpy((char *)DATAPTR(VECTOR_ELT(BY,j)),  // ok use of memcpy size 1. Loop'd through columns not rows


### PR DESCRIPTION
Closes #2713 and #2591:

I fixed a bug in `src/dogroups.c` that caused wrong entries in the grouping column if:
* `by` was used during a join
* `on=` was used to specify the join columns
* The grouping column was sorted and contained groups longer than 1 row.

The following example from issue #2713 works correctly now:

```
library(data.table)
DT = data.table(
    id = c("a","a","a","b","b","c","c","d","d"),
    group = c(1,1,1,1,1,2,2,2,2),
    num = 1)
#    group V1
# 1:  1     2
# 2:  2     2
```

I updated tests and added a comment that explains the reasoning for my change into the source code.