### PR TITLE
Fsort fix

### DIFF
--- a/R/setkey.R
+++ b/R/setkey.R
@@ -249,8 +249,13 @@ fsort <- function(x, decreasing = FALSE, na.last = FALSE, internal=FALSE, verbos
     # fsort is now exported for testing. Trying to head off complaints "it's slow on integer"
     # The only places internally we use fsort internally (3 calls, all on integer) have had internal=TRUE added for now.
     # TODO: implement integer and character in Cfsort and remove this branch and warning
-    if (!internal) warning("Input is not a vector of type double. New parallel sort has only been done for double vectors so far. Invoking relatively inefficient sort using order first.")
-    o = forderv(x, order=!decreasing, na.last=na.last)
+    if (!internal){
+      if(typeof(x) != "double") warning("Input is not a vector of type double. New parallel sort has only been done for double vectors so far. Invoking relatively inefficient sort using order first.")
+      if(decreasing) warning("New parallel sort has not been implemented for decreasing=TRUE so far. Invoking relatively inefficient sort using order first.")
+      if(na.last)    warning("New parallel sort has not been implemented for na.last=TRUE so far. Invoking relatively inefficient sort using order first.")
+    }
+    orderArg = if(decreasing) -1 else 1
+    o = forderv(x, order=orderArg, na.last=na.last)
     return( if (length(o)) x[o] else x )   # TO DO: document this shortcut for already-sorted
   }
 }

--- a/R/setkey.R
+++ b/R/setkey.R
@@ -242,17 +242,22 @@ forder <- function(x, ..., na.last=TRUE, decreasing=FALSE)
 
 fsort <- function(x, decreasing = FALSE, na.last = FALSE, internal=FALSE, verbose=FALSE, ...)
 {
-  if (typeof(x)=="double" && !decreasing && !na.last) {
-    if (internal) stop("Internal code should not be being called on type double")
-    return(.Call(Cfsort, x, verbose))
-  } else {
+  containsNAs <- FALSE
+  if (typeof(x)=="double" && !decreasing) {
+    containsNAs <- anyNA(x) ## just do this if all other conditions are met since it is relatively expensive
+  }
+  if(typeof(x)=="double" && !decreasing && !containsNAs){
+      if (internal) stop("Internal code should not be being called on type double")
+      return(.Call(Cfsort, x, verbose))
+  }
+  else {
     # fsort is now exported for testing. Trying to head off complaints "it's slow on integer"
     # The only places internally we use fsort internally (3 calls, all on integer) have had internal=TRUE added for now.
     # TODO: implement integer and character in Cfsort and remove this branch and warning
     if (!internal){
       if(typeof(x) != "double") warning("Input is not a vector of type double. New parallel sort has only been done for double vectors so far. Invoking relatively inefficient sort using order first.")
-      if(decreasing) warning("New parallel sort has not been implemented for decreasing=TRUE so far. Invoking relatively inefficient sort using order first.")
-      if(na.last)    warning("New parallel sort has not been implemented for na.last=TRUE so far. Invoking relatively inefficient sort using order first.")
+      if(decreasing)  warning("New parallel sort has not been implemented for decreasing=TRUE so far. Invoking relatively inefficient sort using order first.")
+      if(containsNAs) warning("New parallel sort has not been implemented for vectors containing NA values so far. Invoking relatively inefficient sort using order first.")
     }
     orderArg = if(decreasing) -1 else 1
     o = forderv(x, order=orderArg, na.last=na.last)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -11500,6 +11500,19 @@ test(1887, na.omit(DT, invert = TRUE), DT_out)
 
 x = runif(1e4)
 test(1888, fsort(x), base::sort(x))
+test(1888.1, fsort(x, decreasing = TRUE), base::sort(x, decreasing = TRUE),
+             warning = "New parallel sort has not been implemented for decreasing=TRUE so far. Invoking relatively inefficient sort using order first.")
+x <- c(x, NA_real_)
+test(1888.2, fsort(x, na.last = TRUE), base::sort(x, na.last = TRUE),
+             warning = "New parallel sort has not been implemented for na.last=TRUE so far. Invoking relatively inefficient sort using order first.")
+test(1888.3, fsort(x, na.last = FALSE), base::sort(x, na.last = FALSE))
+test(1888.4, fsort(x, decreasing = TRUE, na.last = TRUE), base::sort(x, decreasing = TRUE, na.last = TRUE),
+             warning = c("New parallel sort has not been implemented for decreasing=TRUE so far. Invoking relatively inefficient sort using order first.",
+             "New parallel sort has not been implemented for na.last=TRUE so far. Invoking relatively inefficient sort using order first."))
+x <- as.integer(x)
+test(1888.5, fsort(x), base::sort(x, na.last = FALSE),
+             warning = "Input is not a vector of type double. New parallel sort has only been done for double vectors so far. Invoking relatively inefficient sort using order first.")
+
 
 # doubling of savetl buffer (currently starts with 100)
 x = as.character(as.hexmode(1:1000))

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -11504,11 +11504,11 @@ test(1888.1, fsort(x, decreasing = TRUE), base::sort(x, decreasing = TRUE),
              warning = "New parallel sort has not been implemented for decreasing=TRUE so far. Invoking relatively inefficient sort using order first.")
 x <- c(x, NA_real_)
 test(1888.2, fsort(x, na.last = TRUE), base::sort(x, na.last = TRUE),
-             warning = "New parallel sort has not been implemented for na.last=TRUE so far. Invoking relatively inefficient sort using order first.")
-test(1888.3, fsort(x, na.last = FALSE), base::sort(x, na.last = FALSE))
+             warning = "New parallel sort has not been implemented for vectors containing NA values so far. Invoking relatively inefficient sort using order first.")
+test(1888.3, fsort(x, na.last = FALSE), base::sort(x, na.last = FALSE),
+             warning = "New parallel sort has not been implemented for vectors containing NA values so far. Invoking relatively inefficient sort using order first.")
 test(1888.4, fsort(x, decreasing = TRUE, na.last = TRUE), base::sort(x, decreasing = TRUE, na.last = TRUE),
-             warning = c("New parallel sort has not been implemented for decreasing=TRUE so far. Invoking relatively inefficient sort using order first.",
-             "New parallel sort has not been implemented for na.last=TRUE so far. Invoking relatively inefficient sort using order first."))
+             warning = "New parallel sort has not been implemented for decreasing=TRUE so far. Invoking relatively inefficient sort using order first.")
 x <- as.integer(x)
 test(1888.5, fsort(x), base::sort(x, na.last = FALSE),
              warning = "Input is not a vector of type double. New parallel sort has only been done for double vectors so far. Invoking relatively inefficient sort using order first.")


### PR DESCRIPTION
Closes #2772 and closes #2760 

Following changes:
1. `fsort` now tests if `x` contains NAs. If so, it falls back to `forderv` since `Cfsort` can't handle NAs so far.
2. Fixed bug where `fsort` failed with `decreasing = TRUE` argument.
3. More informative warnings. Before, `fsort` would always warn about x being integer if it fell back to `forderv`. Now it issues proper warnings if it falls back because of `decreasing = TRUE` or NA values in x.
4. Added tests for the above mentioned changes.