### PR TITLE
If column '..x' exists (including prefix in name), it takes precedence for now for backwards compatibility

### DIFF
--- a/CRAN_Release.cmd
+++ b/CRAN_Release.cmd
@@ -359,7 +359,7 @@ R
 .libPaths()   # should be just 2 items: revdeplib and the base R package library
 update.packages(ask=FALSE)
 # if package not found on mirror, try manually a different one:
-install.packages("MIAmaxent", repos="http://cloud.r-project.org/")
+install.packages("<pkg>", repos="http://cloud.r-project.org/")
 update.packages(ask=FALSE)   # a repeat sometimes does more, keep repeating until none
 
 # Follow: https://bioconductor.org/install/#troubleshoot-biocinstaller

--- a/NEWS.md
+++ b/NEWS.md
@@ -133,7 +133,7 @@ Thanks to @MichaelChirico for reporting and to @MarkusBonsch for the implementat
     DT[, c(..cols, "colC")]   # same as DT[, .(colB,colC)]
     DT[, -..cols]             # all columns other than colB
     ```
-    Thus, `with=` should no longer be needed in any cases. Please change to using the `..` prefix and in a few years we will start to formally deprecate and remove the `with=` parameter.  If this is well received, the `..` prefix could be expanded to symbols appearing in `i=` and `by=`, too.
+    Thus, `with=` should no longer be needed in any cases. Please change to using the `..` prefix and over the next few years we will start to formally deprecate and remove the `with=` parameter.  If this is well received, the `..` prefix could be expanded to symbols appearing in `i=` and `by=`, too. Note that column names should not now start with `..`. If a symbol `..var` is used in `j=` but `..var` exists as a column name, the column still takes precendence, for backwards compatibility. Over the next few years, data.table will start issuing warnings/errors when it sees column names starting with `..`. This affects one CRAN package out of 475 using data.table, so we do not believe this restriction to be unreasonable. Our main focus here which we believe `..` achieves is to resolve the more common ambiguity when `var` is in calling scope and `var` is a column name, too.
 
 19. `setindexv` can now assign multiple (separate) indices by accepting a `list` in the `cols` argument.
 

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1236,9 +1236,13 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
   syms = syms[ substring(syms,1L,2L)==".." ]
   syms = syms[ substring(syms,3L,3L)!="." ]  # exclude ellipsis
   for (sym in syms) {
+    if (sym %chin% names(x)) {
+      # if "..x" exists as column name, use column, for backwards compatibility; e.g. package socialmixr in rev dep checks #2779
+      next
+      # TODO in future, as warned in NEWS item for v1.11.0 :
+      # warning(sym," in j is looking for ",getName," in calling scope, but a column '", sym, "' exists. Column names should not start with ..")
+    }
     getName = substring(sym, 3L)
-    if (sym %chin% names(x))
-      stop(sym," in j is looking for ",getName," in calling scope, but a column '", sym, "' exists. Column names should not start with ..")
     if (!exists(getName, parent.frame()))
       stop("Variable '",getName,"' is not found in calling scope. Looking in calling scope because this symbol was prefixed with .. in the j= parameter.")
     assign(sym, get(getName, parent.frame()), SDenv)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -11594,7 +11594,9 @@ test(1894.9, DT[, sum(z)*..z], error="Variable 'z' is not found in calling scope
 z = 3L
 test(1894.11, DT[, sum(z)*..z], 72L)
 setnames(DT, "z", "..z")
-test(1894.12, DT[, sum(y)*..z], error="..z in j is looking for z in calling scope, but a column '..z' exists. Column names should not start with ..")
+test(1894.12, DT[, sum(y)*..z], INT(105,120,135))  # TODO warning/error in future as per NEWS item in v1.11.0
+rm(z)
+test(1894.13, DT[, sum(y)*..z], INT(105,120,135))  # TODO warning/error in future as per NEWS item in v1.11.0
 
 test(1895, getDTthreads(verbose=TRUE), output="omp_get_max_threads.*omp_get_thread_limit.*DTthreads")
 


### PR DESCRIPTION
To avoid breaking `socialmixr` and several other Bioc packages.
See v1.11.0 rev dep status [here](https://github.com/Rdatatable/data.table/issues/2779#issuecomment-383403641).

Breakage was : 
```
Error: processing vignette 'introduction.Rmd' failed with diagnostics:
..original.lower.age.limit in j is looking for original.lower.age.limit in calling scope,
but a column '..original.lower.age.limit' exists. Column names should not start with ..
```