### PR TITLE
fread coerce-down error downgraded to ignore & verbose

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -2597,8 +2597,9 @@ test(955, fread(input, colClasses=list(character="C",double="A")), data.table(A=
 test(956, fread(input, colClasses=list(character=2:3,double="A")), data.table(A=c(1.0,2.0),B=c("foo","bar"),C=c("3.140","6.28000")))
 test(957, fread(input, colClasses=list(character=1:3)), data.table(A=c("01","002"),B=c("foo","bar"),C=c("3.140","6.28000")))
 test(958, fread(input, colClasses="character"), data.table(A=c("01","002"),B=c("foo","bar"),C=c("3.140","6.28000")))
-test(959.1, fread(input, colClasses=c("character","double","numeric")),
-            error = "Attempt.*column 2 <<B>>.*inherent.*'string'.*down to.*'float64'")
+test(959.1, fread(input, colClasses=c("character","double","numeric"), verbose=TRUE),
+            data.table(A=c("01","002"), B=c("foo","bar"), C=c(3.14,6.28)),
+            output = "Attempt.*column 2 <<B>>.*inherent.*'string'.*down to.*'float64'")
 test(959.2, fread(input, colClasses=c("character",NA,"numeric")),
             data.table(A=c("01","002"),B=c("foo","bar"),C=c(3.14,6.28)))
 test(960, fread(input, colClasses=c("character","double")),

--- a/src/fread.c
+++ b/src/fread.c
@@ -1895,10 +1895,12 @@ int freadMain(freadMainArgs _args) {
     rowSize4 += (size[j] & 4);
     rowSize8 += (size[j] & 8);
     if (type[j]==CT_DROP) { ndrop++; continue; }
-    if (type[j]<tmpType[j])
-      STOP("Attempt to override column %d <<%.*s>> of inherent type '%s' down to '%s' which will lose accuracy. " \
+    if (type[j]<tmpType[j]) {
+      if (verbose) DTPRINT("Attempt to override column %d <<%.*s>> of inherent type '%s' down to '%s' which will lose accuracy. " \
            "If this was intended, please coerce to the lower type afterwards. Only overrides to a higher type are permitted.",
            j+1, colNames[j].len, colNamesAnchor+colNames[j].off, typeName[tmpType[j]], typeName[type[j]]);
+      type[j] = tmpType[j];
+    }
     nUserBumped += type[j]>tmpType[j];
     if (type[j] == CT_STRING) nStringCols++; else nNonStringCols++;
   }


### PR DESCRIPTION

To avoid breakage to `tstools`. But ignore & verbose seems better anyway. 
See v1.11.0 rev dep status [here](https://github.com/Rdatatable/data.table/issues/2779#issuecomment-383403641).

Breakage was as follows (due to colClasses="numeric" applying to all columns) :  
```
  adding: tmp/Rtmp1qxRZX/test_ts_2018_04_28.json (deflated 82%)
── 1. Error: imports work (@testWriteTimeseries.R#252)  ────────────────────────
Attempt to override column 1 <<date>> of inherent type 'string' down to 'float64' which will lose accuracy. If this was intended, please coerce to the lower type afterwards. Only overrides to a higher type are permitted.
1: expect_equal(ts, read_ts(csv_wide_name)) at testthat/testWriteTimeseries.R:252
2: quasi_label(enquo(expected), expected.label)
3: eval_bare(get_expr(quo), get_env(quo))
4: read_ts(csv_wide_name)
5: read_ts.csv(file)
6: fread(file, sep = sep, stringsAsFactors = FALSE, colClasses = "numeric")
```

That error is now a verbose message and the request to coerce down is ignored.