### PR TITLE
Let print.data.table return invisible(x)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -225,7 +225,7 @@ Thanks to @sritchie73 for reporting and fixing [PR#2631](https://github.com/Rdat
 
 40. Attempt to allocate a wildly large amount of RAM (16EB) when grouping by key and there are close to 2 billion 1-row groups, [#2777](https://github.com/Rdatatable/data.table/issues/2777). Thanks to @jsams for the detailed report.
 
-41. Fix a bug that `print(dt, class=TRUE)` shows only `topn - 1` rows. Thanks to @heavywatal for reporting [#2803]((https://github.com/Rdatatable/data.table/issues/2803) and filing [PR#2804]((https://github.com/Rdatatable/data.table/pull/2804).
+41. Fix a bug that `print(dt, class=TRUE)` shows only `topn - 1` rows. Thanks to @heavywatal for reporting [#2803](https://github.com/Rdatatable/data.table/issues/2803) and filing [PR#2804](https://github.com/Rdatatable/data.table/pull/2804).
 
 
 #### NOTES
@@ -258,7 +258,9 @@ Was warning: set2key() will be deprecated in the next relase. Please use setinde
 Now error: set2key() is now deprecated. Please use setindex() instead.
 ```
 
-12. The option `datatable.showProgress` is no longer set to a default value when the package is loaded. Instead, the `default=` argument of `getOption` is used by both `fwrite` and `fread`. The default is the result of `interactive()` at the time of the call. Using `getOption` in this way is intended to be more helpful to users looking at `args(fread)` and `?fread`. 
+12. The option `datatable.showProgress` is no longer set to a default value when the package is loaded. Instead, the `default=` argument of `getOption` is used by both `fwrite` and `fread`. The default is the result of `interactive()` at the time of the call. Using `getOption` in this way is intended to be more helpful to users looking at `args(fread)` and `?fread`.
+
+13. `print.data.table()` invisibly returns its first argument instead of `NULL`. This behavior is compatible with the standard `print.data.frame()` and tibble's `print.tbl_df()`. Thanks to @heavywatal for [PR#2807](https://github.com/Rdatatable/data.table/pull/2807)
 
 
 ### Changes in v1.10.4-3  (on CRAN 20 Oct 2017)

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -25,13 +25,13 @@ print.data.table <- function(x, topn=getOption("datatable.print.topn"),
     if (length(SYS) <= 2L ||  # "> DT" auto-print or "> print(DT)" explicit print (cannot distinguish from R 3.2.0 but that's ok)
         ( length(SYS) > 3L && is.symbol(thisSYS <- SYS[[length(SYS)-3L]][[1L]]) &&
           as.character(thisSYS) %chin% mimicsAutoPrint ) )  {
-      return(invisible())
+      return(invisible(x))
       # is.symbol() temp fix for #1758.
     }
   }
   if (!is.numeric(nrows)) nrows = 100L
   if (!is.infinite(nrows)) nrows = as.integer(nrows)
-  if (nrows <= 0L) return(invisible())   # ability to turn off printing
+  if (nrows <= 0L) return(invisible(x))   # ability to turn off printing
   if (!is.numeric(topn)) topn = 5L
   topnmiss = missing(topn)
   topn = max(as.integer(topn),1L)
@@ -47,7 +47,7 @@ print.data.table <- function(x, topn=getOption("datatable.print.topn"),
        cat("Null data.table (0 rows and 0 cols)\n")  # See FAQ 2.5 and NEWS item in v1.8.9
     else
        cat("Empty data.table (0 rows) of ",length(x)," col",if(length(x)>1L)"s",": ",paste(head(names(x),6L),collapse=","),if(ncol(x)>6L)"...","\n",sep="")
-    return(invisible())
+    return(invisible(x))
   }
   if ((topn*2+1)<nrow(x) && (nrow(x)>nrows || !topnmiss)) {
     toprint = rbind(head(x, topn), tail(x, topn))
@@ -91,7 +91,7 @@ print.data.table <- function(x, topn=getOption("datatable.print.topn"),
     } else {
       print(toprint, right=TRUE, quote=quote)
     }
-    return(invisible())
+    return(invisible(x))
   }
   if (nrow(toprint)>20L && col.names == "auto")
     # repeat colnames at the bottom if over 20 rows so you don't have to scroll up to see them
@@ -102,7 +102,7 @@ print.data.table <- function(x, topn=getOption("datatable.print.topn"),
   } else {
     print(toprint, right=TRUE, quote=quote)
   }
-  invisible()
+  invisible(x)
 }
 
 format.data.table <- function (x, ..., justify="none") {


### PR DESCRIPTION
`print.data.table` should invisibly return its first argument instead of `NULL`. It is compatible with the standard `print.data.frame` and [tibble's `print.tbl_df`](https://github.com/tidyverse/tibble/blob/master/R/tbl-df.r), and supports pipe-style coding:

```
head_iris = iris %>%
  as.data.table() %>%
  print() %>%
  head(3L) %>%
  print()
```

I would be happy to add a bullet on the NEWS if this PR is accepted. Maybe NOTES section? Thanks.