### PR TITLE
as.chron methods removed. Not sure why we had them anyway.

### DIFF
--- a/CRAN_Release.cmd
+++ b/CRAN_Release.cmd
@@ -216,7 +216,7 @@ Rdevel CMD INSTALL data.table_1.11.1.tar.gz
 # Check UBSAN and ASAN flags appear in compiler output above. Rdevel was compiled with
 # them so should be passed through to here
 Rdevel
-install.packages(c("bit64","xts","nanotime","chron"), repos="http://cloud.r-project.org")  # minimum packages needed to not skip any tests in test.data.table()
+install.packages(c("bit64","xts","nanotime"), repos="http://cloud.r-project.org")  # minimum packages needed to not skip any tests in test.data.table()
 require(data.table)
 test.data.table()     # slower than usual, naturally, due to UBSAN and ASAN. Too slow to run R CMD check.
 for (i in 1:10) test.data.table()  # last resort: try several runs; e.g a few tests generate data with a non-fixed random seed
@@ -303,7 +303,6 @@ R CMD build --no-build-vignettes data.table
 # R CMD check requires many packages in Suggests. Too long under emulation. Instead run data.table's test suite directly
 R
 options(repos = "http://cran.stat.ucla.edu")
-install.packages("chron")  # takes a minute or so to start download and install.
 install.packages("bit64")  # important to test data.table with integer64 on big endian
 q("no")
 R CMD INSTALL data.table_1.9.5.tar.gz

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Authors@R: c(
   person("Hugh","Parsonage",  role="ctb"))
 Depends: R (>= 3.1.0)
 Imports: methods
-Suggests: bit64, curl, knitr, xts, nanotime, zoo, chron, reshape2, testthat (>= 0.4)
+Suggests: bit64, curl, knitr, xts, nanotime, zoo, reshape2, testthat (>= 0.4)
 Description: Fast aggregation of large data (e.g. 100GB in RAM), fast ordered joins, fast add/modify/delete of columns by group using no copies at all, list columns, friendly and fast character-separated-value read/write. Offers a natural and flexible syntax, for faster development.
 License: MPL-2.0 | file LICENSE
 URL: http://r-datatable.com

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -112,7 +112,6 @@ S3method(na.omit, data.table)
 export(as.IDate,as.ITime,IDateTime)
 export(second,minute,hour,yday,wday,mday,week,isoweek,month,quarter,year)
 
-export(as.chron.IDate, as.chron.ITime)
 export(as.Date.IDate) # workaround for zoo bug, see #1500
 
 S3method("[", ITime)

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 
 #### NOTES
 
+1. `as.chron` methods for `IDate` and `ITime` have been removed, [#2825](https://github.com/Rdatatable/data.table/issues/2825). `as.chron` still works since `IDate` inherits from `Date`. We are not sure why we had specific methods in the first place. It may have been from a time when `IDate` did not inherit from `Date`, perhaps. Note that we don't use `chron` ourselves in our own work.
 
 ### Changes in v1.11.0  (on CRAN 1 May 2018)
 

--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -204,7 +204,7 @@ unique.ITime <- function(x, ...) {
 }
 
 # create a data.table with IDate and ITime columns
-#   should work for most date/time formats like chron or POSIXct
+#   should work for most date/time formats like POSIXct
 
 IDateTime <- function(x, ...) UseMethod("IDateTime")
 IDateTime.default <- function(x, ...) {
@@ -232,28 +232,6 @@ as.POSIXct.ITime <- function(x, tz = "UTC", date = as.Date(Sys.time()), ...) {
 
 as.POSIXlt.ITime <- function(x, ...) {
   as.POSIXlt(as.POSIXct(x, ...))
-}
-
-# chron support
-
-as.chron.IDate <- function(x, time = NULL, ...) {
-  if(!requireNamespace("chron", quietly = TRUE)) stop("Install suggested `chron` package to use `as.chron.IDate` function.") else {
-    if (!is.null(time)) {
-      chron::chron(dates. = chron::as.chron(as.Date(x)), times. = chron::as.chron(time))
-    } else {
-      chron::chron(dates. = chron::as.chron(as.Date(x)))
-    }
-  }
-}
-
-as.chron.ITime <- function(x, date = NULL, ...) {
-  if(!requireNamespace("chron", quietly = TRUE)) stop("Install suggested `chron` package to use `as.chron.ITime` function.") else {
-    if (!is.null(date)) {
-      chron::chron(dates. = chron::as.chron(as.Date(date)), times. = chron::as.chron(x))
-    } else {
-      chron::chron(times. = as.character(x))
-    }
-  }
 }
 
 as.ITime.times <- function(x, ...) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,6 @@ build_script:
   - travis-tool.sh r_install bit64
   - travis-tool.sh r_install xts
   - travis-tool.sh r_install nanotime
-  - travis-tool.sh r_install chron
 
 test_script:
   - travis-tool.sh run_tests

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -66,8 +66,7 @@ if (exists("test.data.table", .GlobalEnv, inherits=FALSE)) {
 sugg = c(
   "bit64",          # if big integers are detected in file, fread reads them as bit64::integer64 if installed (warning if not)
   "xts",            # we have xts methods in R/xts.R
-  "nanotime",       # fwrite looks for the 'nanotime' class name at C level (but we have our own writer in C, though)
-  "chron"           # we have chron methods in R/IDateTime.R
+  "nanotime"        # fwrite looks for the 'nanotime' class name at C level (but we have our own writer in C, though)
   # zoo             # In DESCRIPTION:Suggests otherwise R CMD check warning: '::' or ':::' import not declared from: 'zoo'; it is tested in other.Rraw though
   # reshape2        # In DESCRIPTION:Suggests otherwise same R CMD check warning. See fmelt.R line 1 refers to reshape2 depending on R 3.0.0, but now we do too,
 )                   # perhaps something can be improved now. dcast and melt methods for data.table are tested directly here in main without needing reshape2 loaded.
@@ -7799,17 +7798,6 @@ test(1601.2, tryCatch(merge(data.table(a=1),data.table(NULL), by="a"), warning =
 test(1601.3, tryCatch(merge(data.table(NULL),data.table(a=1), by="a"), warning = function(w) w$message), "You are trying to join data.tables where 'x' argument is 0 columns data.table.")
 test(1601.4, tryCatch(merge(data.table(NULL),data.table(NULL), by="a"), warning = function(w) w$message), "You are trying to join data.tables where 'x' and 'y' arguments are 0 columns data.table.")
 
-# migrate `chron` dependency to Suggests #1558
-dd = as.IDate("2016-02-28")
-tt = as.ITime("03:04:43")
-if (test_chron) {
-  test(1602.1, as.chron.IDate(dd), chron::as.chron(as.Date(dd)))
-  test(1602.2, class(as.chron.ITime(tt)), "times")
-} else {
-  test(1602.3, as.chron.IDate(dd), error = "Install suggested `chron` package to use `as.chron.IDate` function.")
-  test(1602.4, as.chron.ITime(tt), error = "Install suggested `chron` package to use `as.chron.ITime` function.")
-}
-
 # fix for #1549
 d1 <- data.table(v1=1:2,x=x)
 d2 <- data.table(v1=3:4)
@@ -11805,7 +11793,9 @@ options(oldOptions)  # set at top of this file
 setDTthreads(0)
 plat = paste0("endian==", .Platform$endian,
               ", sizeof(long double)==", .Machine$sizeof.longdouble,
-              ", sizeof(pointer)==", .Machine$sizeof.pointer)
+              ", sizeof(pointer)==", .Machine$sizeof.pointer,
+              ", TZ=", Sys.timezone(),
+              ", locale='", Sys.getlocale(), "'")
 DT = head(timings[-1L][order(-time)],10)   # exclude id 1 as in dev that includes JIT
 if ((x<-timings[,sum(nTest)]) != ntest) warning("Timings count mismatch:",x,"vs",ntest)
 cat("\n10 longest running tests took ", as.integer(tt<-DT[, sum(time)]), "s (", as.integer(100*tt/(ss<-timings[,sum(time)])), "% of ", as.integer(ss), "s)\n", sep="")

--- a/man/IDateTime.Rd
+++ b/man/IDateTime.Rd
@@ -5,8 +5,6 @@
 \alias{as.ITime}
 \alias{IDateTime}
 \alias{as.character.ITime}
-\alias{as.chron.IDate}
-\alias{as.chron.ITime}
 \alias{as.Date.IDate}
 \alias{as.IDate.Date}
 \alias{as.IDate.default}
@@ -54,13 +52,11 @@ as.IDate(x, ...)
 \method{as.IDate}{Date}(x, \dots)
 \method{as.Date}{IDate}(x, \dots)
 \method{as.POSIXct}{IDate}(x, tz = "UTC", time = 0, \dots)
-\method{as.chron}{IDate}(x, time = NULL, \dots)
 \method{round}{IDate}(x, digits = c("weeks", "months", "quarters","years"), \ldots)
 
 as.ITime(x, ...)
 \method{as.ITime}{default}(x, \dots)
 \method{as.POSIXct}{ITime}(x, tz = "UTC", date = as.Date(Sys.time()), \dots)
-\method{as.chron}{ITime}(x, date = NULL, \dots)
 \method{as.character}{ITime}(x, \dots)
 \method{format}{ITime}(x, \dots)
 
@@ -108,8 +104,7 @@ hours. Because \code{ITime} is stored in seconds, you can add it to a
 \code{POSIXct} object, but you should not add it to a \code{Date}
 object.
 
-Conversions to and from \code{Date}, \code{POSIXct}, and \code{chron}
-formats are provided.
+Conversions to and from \code{Date} and \code{POSIXct} formats are provided.
 
 \code{ITime} does not account for time zones. When converting
 \code{ITime} and \code{IDate} to POSIXct with \code{as.POSIXct}, a time
@@ -219,16 +214,6 @@ as.POSIXct(af$itime) # uses today's date
 (seqdates <- seq(as.IDate("2001-01-01"), as.IDate("2001-08-03"), by = "3 weeks"))
 round(seqdates, "months")
 
-if (require(chron)) {
-    as.chron(as.IDate("2000-01-01"))
-    as.chron(as.ITime("10:45"))
-    as.chron(as.IDate("2000-01-01"), as.ITime("10:45"))
-    as.chron(as.ITime("10:45"), as.IDate("2000-01-01"))
-    as.ITime(chron(times = "11:01:01"))
-    IDateTime(chron("12/31/98","10:45:00"))
-}
-
 }
 \keyword{utilities}
-\keyword{chron}
 


### PR DESCRIPTION
Closes #2825 

NEWS item : 
> `as.chron` methods for `IDate` and `ITime` have been removed, [#2825](https://github.com/Rdatatable/data.table/issues/2825). `as.chron` still works since `IDate` inherits from `Date`. We are not sure why we had specific methods in the first place. It may have been from a time when `IDate` did not inherit from `Date`, perhaps. Note that we don't use `chron` ourselves in our own work.

I'll rerun rev dep checks before release. If there's any impact I'll think again.