### PR TITLE
Sys.timezone might raise warning when it should not

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -11794,7 +11794,7 @@ setDTthreads(0)
 plat = paste0("endian==", .Platform$endian,
               ", sizeof(long double)==", .Machine$sizeof.longdouble,
               ", sizeof(pointer)==", .Machine$sizeof.pointer,
-              ", TZ=", Sys.timezone(),
+              ", TZ=", suppressWarnings(Sys.timezone()),
               ", locale='", Sys.getlocale(), "'")
 DT = head(timings[-1L][order(-time)],10)   # exclude id 1 as in dev that includes JIT
 if ((x<-timings[,sum(nTest)]) != ntest) warning("Timings count mismatch:",x,"vs",ntest)


### PR DESCRIPTION
documented in https://github.com/wch/r-source/commit/9866ac2ad1e2f1c4565ae829ba33b5b98a08d10d

actually this PR does not solve completely that issue:
```
suppressWarnings(Sys.timezone())
Failed to create bus connection: No such file or directory
[1] "Etc/UTC"
```
suppressing messages does not have any impact, so it seems to be printed to output independently. `capture.output`, and `sink` also. At least in this PR we can get rid of warning state as it should not be really a warning.