### PR TITLE
Test 1158 fail on win-builder

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ environment:
 
   - R_VERSION: release  # the single Windows.zip binary (both 32bit/64bit) that users following dev version of installation instructions should click
 
-#  - R_VERSION: devel
+  - R_VERSION: devel
 
 before_build:
   - cmd: ECHO no Revision metadata added to DESCRIPTION

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -3684,12 +3684,13 @@ after = gc()["Vcells",2]
 test(1157, after < before+3)  # +3 = 3MB
 # Before the patch, Vcells grew dramatically from 6MB to 60MB. Now stable at 6MB. Increase 50 to 1000 and it grew to over 1GB for this case.
 
-# Similar for when dogroups writes less rows than allocated, #2648.
-DT = data.table(k = 1:50, g = 1:20, val = rnorm(1e4))
-before = gc()["Vcells",2]
-for (i in 1:50) DT[ , unlist(.SD), by = 'k']
-after = gc()["Vcells",2]
-test(1158, after < before+3)  # 177.6MB => 179.2MB. Needs to be +3 now from v1.9.8 with alloccol up from 100 to 1024
+# Similar for when dogroups writes less rows than allocated, #2648
+# Matt turned this off on 7th May 2018 as he saw it fail on win-builder R-devel (both 32bit and 64bit), potentially related to #2767
+# DT = data.table(k = 1:50, g = 1:20, val = rnorm(1e4))
+# before = gc()["Vcells",2]
+# for (i in 1:50) DT[ , unlist(.SD), by = 'k']
+# after = gc()["Vcells",2]
+# test(1158, after < before+3)  # 177.6MB => 179.2MB. Needs to be +3 now from v1.9.8 with alloccol up from 100 to 1024
 
 # tests for 'setDT' - convert list, DF to DT without copy
 x <- data.frame(a=1:4, b=5:8)


### PR DESCRIPTION
Just saw a fail on win-builder with R-devel in a test related to `gc()`.  1158 is between 896 and 1253 which fits with [this comment](https://github.com/Rdatatable/data.table/issues/2841#issuecomment-386853315).

<details><summary>Log</summary>

```
* using log directory 'd:/RCompile/CRANguest/R-devel/data.table.Rcheck'
* using R Under development (unstable) (2018-05-05 r74699)
* using platform: x86_64-w64-mingw32 (64-bit)
* using session charset: ISO8859-1
* checking for file 'data.table/DESCRIPTION' ... OK
* this is package 'data.table' version '1.11.1'
* checking CRAN incoming feasibility ... NOTE
Maintainer: 'Matt Dowle <mattjdowle@gmail.com>'

Days since last update: 6
* checking package namespace information ... OK
* checking package dependencies ... OK
* checking if this is a source package ... OK
* checking if there is a namespace ... OK
* checking for hidden files and directories ... OK
* checking for portable file names ... OK
* checking serialization versions ... OK
* checking whether package 'data.table' can be installed ... OK
* checking installed package size ... OK
* checking package directory ... OK
* checking 'build' directory ... OK
* checking DESCRIPTION meta-information ... OK
* checking top-level files ... OK
* checking for left-over files ... OK
* checking index information ... OK
* checking package subdirectories ... OK
* checking R files for non-ASCII characters ... OK
* checking R files for syntax errors ... OK
* loading checks for arch 'i386'
** checking whether the package can be loaded ... OK
** checking whether the package can be loaded with stated dependencies ... OK
** checking whether the package can be unloaded cleanly ... OK
** checking whether the namespace can be loaded with stated dependencies ... OK
** checking whether the namespace can be unloaded cleanly ... OK
** checking loading without being on the library search path ... OK
** checking use of S3 registration ... OK
* loading checks for arch 'x64'
** checking whether the package can be loaded ... OK
** checking whether the package can be loaded with stated dependencies ... OK
** checking whether the package can be unloaded cleanly ... OK
** checking whether the namespace can be loaded with stated dependencies ... OK
** checking whether the namespace can be unloaded cleanly ... OK
** checking loading without being on the library search path ... OK
** checking use of S3 registration ... OK
* checking dependencies in R code ... OK
* checking S3 generic/method consistency ... OK
* checking replacement functions ... OK
* checking foreign function calls ... OK
* checking R code for possible problems ... [21s] OK
* checking Rd files ... OK
* checking Rd metadata ... OK
* checking Rd line widths ... OK
* checking Rd cross-references ... OK
* checking for missing documentation entries ... OK
* checking for code/documentation mismatches ... OK
* checking Rd \usage sections ... OK
* checking Rd contents ... OK
* checking for unstated dependencies in examples ... OK
* checking line endings in C/C++/Fortran sources/headers ... OK
* checking line endings in Makefiles ... OK
* checking compilation flags in Makevars ... OK
* checking for GNU extensions in Makefiles ... OK
* checking for portable use of $(BLAS_LIBS) and $(LAPACK_LIBS) ... OK
* checking include directives in Makefiles ... OK
* checking pragmas in C/C++ headers and code ... OK
* checking compiled code ... OK
* checking installed files from 'inst/doc' ... OK
* checking files in 'vignettes' ... OK
* checking examples ...
** running examples for arch 'i386' ... [4s] OK
** running examples for arch 'x64' ... [5s] OK
* checking for unstated dependencies in 'tests' ... OK
* checking tests ...
** running tests for arch 'i386' ... [57s] ERROR
  Running 'autoprint.R' [1s]
  Comparing 'autoprint.Rout' to 'autoprint.Rout.save' ... OK
  Running 'knitr.R' [1s]
  Comparing 'knitr.Rout' to 'knitr.Rout.save' ... OK
  Running 'main.R' [54s]
  Running 'testthat.R' [2s]
Running the tests in 'tests/main.R' failed.
Complete output:
  > require(data.table)
  Loading required package: data.table
  > test.data.table()  # runs the main test suite of 5,000+ tests in /inst/tests/tests.Rraw
  Running D:/temp/Rtmpu2zJRl/RLIBS_ed8497746e6/data.table/tests/tests.Rraw 
  
  Running test id 1.1      
  Running test id 1.2      
[..snip..]
  Running test id 1155.3      
  Running test id 1155.4      
  Running test id 1155.5      
  Running test id 1157      
  Running test id 1158      Test 1158 ran without errors but failed check that x equals y:
  > x = after < before + 3 
  First 6 of 1 (type 'logical'): [1] FALSE
  > y = TRUE 
  First 6 of 1 (type 'logical'): [1] TRUE
  1 element mismatch
  
  Running test id 1159.1      
  Running test id 1159.2      
  Running test id 1159.3      
[..snip..]
  Running test id 1909.5      
  Running test id 1909.6      
  Running test id 1910      
  10 longest running tests took 26s (50% of 52s)
        ID time nTest
   1: 1739 5.30     5
   2: 1835 4.57     1
   3: 1874 4.01     5
   4: 1848 3.06     1
   5: 1253 1.87   485
   6:  861 1.83     1
   7:  863 1.53     1
   8: 1223 1.46   728
   9: 1639 1.27   141
  10: 1875 1.19     1
  
  Error in eval(exprs[i], envir) : 
    1 error out of 6327 in 52.0sec on Mon May 07 21:12:10 2018. [endian==little, sizeof(long double)==12, sizeof(pointer)==4, TZ=Europe/Berlin, locale='LC_COLLATE=C;LC_CTYPE=German_Germany.1252;LC_MONETARY=C;LC_NUMERIC=C;LC_TIME=C']. Search inst/tests/tests.Rraw for test number 1158.
  Calls: test.data.table -> sys.source -> eval -> eval
  Execution halted
** running tests for arch 'x64' ... [102s] ERROR
  Running 'autoprint.R' [1s]
  Comparing 'autoprint.Rout' to 'autoprint.Rout.save' ... OK
  Running 'knitr.R' [1s]
  Comparing 'knitr.Rout' to 'knitr.Rout.save' ... OK
  Running 'main.R' [99s]
  Running 'testthat.R' [2s]
Running the tests in 'tests/main.R' failed.
Complete output:
  > require(data.table)
  Loading required package: data.table
  > test.data.table()  # runs the main test suite of 5,000+ tests in /inst/tests/tests.Rraw
  Running D:/temp/Rtmpu2zJRl/RLIBS_ed8497746e6/data.table/tests/tests.Rraw 
  
  Running test id 1.1      
  Running test id 1.2      
[..snip..]
  Running test id 1155.2      
  Running test id 1155.3      
  Running test id 1155.4      
  Running test id 1155.5      
  Running test id 1157      
  Running test id 1158      Test 1158 ran without errors but failed check that x equals y:
  > x = after < before + 3 
  First 6 of 1 (type 'logical'): [1] FALSE
  > y = TRUE 
  First 6 of 1 (type 'logical'): [1] TRUE
  1 element mismatch
  
  Running test id 1159.1      
  Running test id 1159.2      
  Running test id 1159.3      
[..snip..]
  Running test id 1909.4      
  Running test id 1909.5      
  Running test id 1909.6      
  Running test id 1910      
  10 longest running tests took 47s (50% of 94s)
        ID time nTest
   1: 1438 6.82   738
   2: 1648 6.21    91
   3: 1650 5.95    91
   4: 1739 5.52     5
   5: 1652 5.43    91
   6: 1835 4.16     1
   7: 1644 3.68    91
   8: 1848 3.23     1
   9: 1874 3.16     5
  10: 1646 3.01    91
  
  Error in eval(exprs[i], envir) : 
    1 error out of 7703 in 00:01:34 on Mon May 07 21:13:50 2018. [endian==little, sizeof(long double)==16, sizeof(pointer)==8, TZ=Europe/Berlin, locale='LC_COLLATE=C;LC_CTYPE=German_Germany.1252;LC_MONETARY=C;LC_NUMERIC=C;LC_TIME=C']. Search inst/tests/tests.Rraw for test number 1158.
  Calls: test.data.table -> sys.source -> eval -> eval
  Execution halted
* checking for unstated dependencies in vignettes ... OK
* checking package vignettes in 'inst/doc' ... OK
* checking re-building of vignette outputs ... [20s] OK
* checking PDF version of manual ... OK
* DONE
Status: 2 ERRORs, 1 NOTE
```
</details>
<br>
First step: turned off 1158 to see if AppVeyor starts passing. Result: still fails with `mem exhausted` at 1253.