### PR TITLE
Fixing bug on assigning with 0 row matches

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 ### Changes in v1.11.3  (in development)
 
 #### BUG FIXES
+
 1. Empty RHS of := is no longer an error when the i clause returns no rows to assign to anyway, [#2829](https://github.com/Rdatatable/data.table/issues/2829). Thanks to @cguill95 for reporting and to @MarkusBonsch for fixing.
 
 #### NOTES

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,8 @@
 ### Changes in v1.11.3  (in development)
 
 #### BUG FIXES
-1. Fixed bug where assignment with 0 matching rows threw error [#2829](https://github.com/Rdatatable/data.table/issues/2829). Thanks to @cguill95 for reporting and to @MarkusBonsch for fixing.
+1. Empty RHS of := is no longer an error when the i clause returns no rows to assign to anyway, [#2829](https://github.com/Rdatatable/data.table/issues/2829). Thanks to @cguill95 for reporting and to @MarkusBonsch for fixing.
+
 #### NOTES
 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 ### Changes in v1.11.3  (in development)
 
 #### BUG FIXES
-
+1. Fixed bug where assignment with 0 matching rows threw error [#2829](https://github.com/Rdatatable/data.table/issues/2829). Thanks to @cguill95 for reporting and to @MarkusBonsch for fixing.
 #### NOTES
 
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -11790,9 +11790,12 @@ test(1910, DT[, v:=cumsum(x), by="y"], data.table(x=1:10, y=1:2, v=INT(1,2,4,6,9
 
 # testing issue #2829 (assigning to 0 rows)
 DT = data.table(COL_INT = 1L, COL_INT_2 = 5L)
-test(1911, 
+test(1911.1, 
      DT[COL_INT == 0L, c("COL_INT", "NEW_COL"):=list(COL_INT_2, "Test")],
      data.table(COL_INT = 1L, COL_INT_2 = 5L, NEW_COL = NA_character_))
+test(1911.2, 
+     DT[, COL_INT := integer(0)],
+     error = "RHS of assignment to existing column 'COL_INT' is zero length but not NULL.*")
 
 ###################################
 #  Add new tests above this line  #

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -11788,6 +11788,11 @@ test(1909.6, nchar(ans$V2), INT(3287,3287,3287))
 DT = data.table(x=1:10, y=1:2)
 test(1910, DT[, v:=cumsum(x), by="y"], data.table(x=1:10, y=1:2, v=INT(1,2,4,6,9,12,16,20,25,30)))
 
+# testing issue #2829 (assigning to 0 rows)
+DT = data.table(COL_INT = 1L, COL_INT_2 = 5L)
+test(1911, 
+     DT[COL_INT == 0L, c("COL_INT", "NEW_COL"):=list(COL_INT_2, "Test")],
+     data.table(COL_INT = 1L, COL_INT_2 = 5L, NEW_COL = NA_character_))
 
 ###################################
 #  Add new tests above this line  #

--- a/src/assign.c
+++ b/src/assign.c
@@ -409,11 +409,9 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values, SEXP v
     else colnam = STRING_ELT(newcolnames,coln-length(names));
     if (coln+1 <= oldncol && isNull(thisvalue)) continue;  // delete existing column(s) afterwards, near end of this function
     if (vlen<1 && nrow>0) {
-      if (coln+1 <= oldncol) { 
-        if(numToDo > 0){ //fixes #2829
+      if (coln+1 <= oldncol && numToDo > 0) { // numToDo > 0 fixes #2829, see test 1911
           error("RHS of assignment to existing column '%s' is zero length but not NULL. If you intend to delete the column use NULL. Otherwise, the RHS must have length > 0; e.g., NA_integer_. If you are trying to change the column type to be an empty list column then, as with all column type changes, provide a full length RHS vector such as vector('list',nrow(DT)); i.e., 'plonk' in the new column.", CHAR(STRING_ELT(names,coln)));
-        }
-      } else if (TYPEOF(thisvalue)!=VECSXP) {  // list() is ok for new columns
+      } else if (coln+1 > oldncol && TYPEOF(thisvalue)!=VECSXP) {  // list() is ok for new columns
         newcolnum = coln-length(names);
         if (newcolnum<0 || newcolnum>=length(newcolnames))
           error("Internal logical error. length(newcolnames)=%d, length(names)=%d, coln=%d", length(newcolnames), length(names), coln);

--- a/src/assign.c
+++ b/src/assign.c
@@ -410,7 +410,7 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values, SEXP v
     if (coln+1 <= oldncol && isNull(thisvalue)) continue;  // delete existing column(s) afterwards, near end of this function
     if (vlen<1 && nrow>0) {
       if (coln+1 <= oldncol && numToDo > 0) { // numToDo > 0 fixes #2829, see test 1911
-          error("RHS of assignment to existing column '%s' is zero length but not NULL. If you intend to delete the column use NULL. Otherwise, the RHS must have length > 0; e.g., NA_integer_. If you are trying to change the column type to be an empty list column then, as with all column type changes, provide a full length RHS vector such as vector('list',nrow(DT)); i.e., 'plonk' in the new column.", CHAR(STRING_ELT(names,coln)));
+        error("RHS of assignment to existing column '%s' is zero length but not NULL. If you intend to delete the column use NULL. Otherwise, the RHS must have length > 0; e.g., NA_integer_. If you are trying to change the column type to be an empty list column then, as with all column type changes, provide a full length RHS vector such as vector('list',nrow(DT)); i.e., 'plonk' in the new column.", CHAR(STRING_ELT(names,coln)));
       } else if (coln+1 > oldncol && TYPEOF(thisvalue)!=VECSXP) {  // list() is ok for new columns
         newcolnum = coln-length(names);
         if (newcolnum<0 || newcolnum>=length(newcolnames))


### PR DESCRIPTION
Closes #2829.
`assign.c` was modified to only throw error on 0 length RHS if `>0` rows are to be updated.
* No existing tests modified
* 1 test added
