### PR TITLE
Fix unsafe use of snprintf in fread

### DIFF
--- a/src/fread.c
+++ b/src/fread.c
@@ -2193,9 +2193,12 @@ int freadMain(freadMainArgs _args) {
                     j+1, colNames[j].len, colNamesAnchor + colNames[j].off,
                     typeName[abs(joldType)], typeName[abs(thisType)],
                     (int)(tch-fieldStart), fieldStart, (llu)(ctx.DTi+myNrow));
-                  typeBumpMsg = (char*) realloc(typeBumpMsg, typeBumpMsgSize + (size_t)len + 1);
-                  strcpy(typeBumpMsg+typeBumpMsgSize, temp);
-                  typeBumpMsgSize += (size_t)len;
+                  if (len > 1000) len = 1000;
+                  if (len > 0) {
+                    typeBumpMsg = (char*) realloc(typeBumpMsg, typeBumpMsgSize + (size_t)len + 1);
+                    strcpy(typeBumpMsg+typeBumpMsgSize, temp);
+                    typeBumpMsgSize += (size_t)len;
+                  }
                 }
                 nTypeBump++;
                 if (joldType>0) nTypeBumpCols++;


### PR DESCRIPTION
The man page for `snprintf` states:
> ... If the output was truncated due to this limit then the return value is the number of characters (excluding the terminating null byte) which **would have been written** to the final string if enough space had been available. Thus, a return value of size or more means that the output was truncated. (See also below under NOTES.)
> If an output error is encountered, a negative value is returned.

Thus it is possible that `len` is bigger than the `temp` buffer size, and we're unnecessarily allocating `typeBumpMsg` of too large size. Note that it is quite feasible to overrun 1000-char limit because of the `<<%.*s>>` part in the format string, which may contain content of arbitrary size.

The overallocated `typeBumpMsg` will be problematic only if there is a second type-bump message, in which case the space between two messages will be filled with garbage bytes.

This issue was discovered because of #2859, however this issue appears to be a separate problem.

See https://access.redhat.com/blogs/766093/posts/1976193 for details on this snprintf exploit.