### PR TITLE
upgrade CI, less code repetition, publish more, windows binaries

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,6 +14,10 @@
 ^\.Rhistory$
 ^data\.table_.*\.tar\.gz$
 ^cc\.R$
+^ci\.R$
+^publish\.R$
 ^Makefile$
 ^NEWS.0.md$
-
+^bus$
+^Dockerfile$
+^Dockerfile\.in$

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,5 @@
 variables:
-  CI_TOOLS: "https://svn.r-project.org/R/branches/tools4pkgs/src/library/tools/R/packages.R"
   CRAN_MIRROR: "https://cloud.r-project.org"
-  BIOC_MIRROR: "https://bioconductor.org/packages/3.4/bioc"
   _R_CHECK_FORCE_SUGGESTS_: "FALSE"
 
 stages:
@@ -11,22 +9,33 @@ stages:
   - integration
   - deploy
 
-mirror-packages:
+.artifacts-template: &artifacts
+  artifacts:
+    expire_in: 2 weeks
+    when: always
+    paths:
+      - bus
+
+mirror-packages: # download all recursive dependencies of data.table suggests and integration suggests from inst/tests/tests-DESCRIPTION
   stage: dependencies
   tags:
     - linux
   image: registry.gitlab.com/jangorecki/dockerfiles/r-base-dev
-  script:
-    - mkdir -p bus/$CI_BUILD_NAME/cran/src/contrib
-    # mirror R dependencies
-    - Rscript -e 'source(Sys.getenv("CI_TOOLS")); mirror.packages(packages.dcf(c("DESCRIPTION","inst/tests/tests-DESCRIPTION"), "all"), repos=c(Sys.getenv("CRAN_MIRROR"), Sys.getenv("BIOC_MIRROR"), repos.dcf("inst/tests/tests-DESCRIPTION")), repodir="bus/mirror-packages/cran")'
-    #- Rscript -e 'source(Sys.getenv("CI_TOOLS")); mirror.packages(type="win.binary", packages.dcf(c("DESCRIPTION","inst/tests/tests-DESCRIPTION"), "all"), repos=c(Sys.getenv("CRAN_MIRROR"), Sys.getenv("BIOC_MIRROR"), repos.dcf("inst/tests/tests-DESCRIPTION")), repodir="bus/mirror-packages/cran")'
-  artifacts:
-    expire_in: 2 weeks
+  cache:
     paths:
-      - bus
+    - bus/$CI_BUILD_NAME/cran
+  variables:
+    R_BIN_VERSION: "3.5"
+    R_DEVEL_BIN_VERSION: "3.6"
+  script:
+    - echo 'source("ci.R")' >> .Rprofile
+    - mkdir -p bus/$CI_BUILD_NAME/cran/src/contrib
+    # mirror R dependencies: source, win.binary
+    - Rscript -e 'mirror.packages(dcf.dependencies(c("DESCRIPTION","inst/tests/tests-DESCRIPTION"), "all"), repos=c(Sys.getenv("CRAN_MIRROR"), dcf.repos("inst/tests/tests-DESCRIPTION")), repodir="bus/mirror-packages/cran")'
+    - Rscript -e 'sapply(simplify=FALSE, setNames(nm=Sys.getenv(c("R_BIN_VERSION","R_DEVEL_BIN_VERSION"))), function(binary.ver) mirror.packages(type="win.binary", dcf.dependencies("DESCRIPTION", "all"), repos=Sys.getenv("CRAN_MIRROR"), repodir="bus/mirror-packages/cran", binary.ver=binary.ver))'
+  <<: *artifacts
 
-build:
+build: # build data.table sources as tar.gz archive
   stage: build
   tags:
     - linux
@@ -40,159 +49,183 @@ build:
     - R CMD build .
     - mkdir -p bus/$CI_BUILD_NAME/cran/src/contrib
     - mv $(ls -1t data.table_*.tar.gz | head -n 1) bus/$CI_BUILD_NAME/cran/src/contrib/.
-    - Rscript -e 'tools::write_PACKAGES(contrib.url("bus/build/cran"), addFiles=TRUE, fields="Revision")'
-  artifacts:
-    expire_in: 2 weeks
-    paths:
-      - bus
+    - Rscript -e 'tools::write_PACKAGES(contrib.url("bus/build/cran"), fields="Revision", addFiles=TRUE)'
+  <<: *artifacts
 
-test-r-release: # R-release most comprehensive tests, force all suggests, also integration tests
+.test-copy-src: &copy-src
+  - &copy-src
+    cp $(ls -1t bus/build/cran/src/contrib/data.table_*.tar.gz | head -n 1) .
+
+.test-move-src: &move-src
+  - &move-src
+    mkdir -p bus/$CI_BUILD_NAME && mv $(ls -1t data.table_*.tar.gz | head -n 1) bus/$CI_BUILD_NAME
+
+.test-cleanup-src: &cleanup-src
+  - &cleanup-src
+    rm $(ls -1t data.table_*.tar.gz | head -n 1)
+
+.test-template: &test
   stage: test
+  dependencies:
+  - mirror-packages
+  - build
+  <<: *artifacts
+
+.test-linux-template: &test-linux
+  <<: *test
   tags:
     - linux
+
+.test-windows-template: &test-windows
+  <<: *test
+  tags:
+    - windows
+  before_script:
+    - export PATH="/c/$R_DIR/bin:/c/Rtools/bin:$PATH"
+    - rm -rf /tmp/$R_DIR/library && mkdir -p /tmp/$R_DIR/library
+    - export R_LIBS_USER="/tmp/$R_DIR/library"
+
+.test-macosx-template: &test-macosx
+  <<: *test
+  tags:
+    - macosx
+
+test-r-release: #  most comprehensive tests, force all suggests, also integration tests
+  <<: *test-linux
+  image: registry.gitlab.com/jangorecki/dockerfiles/r-builder
   variables: # unlike CRAN
     _R_CHECK_CRAN_INCOMING_: "FALSE"
     _R_CHECK_CRAN_INCOMING_REMOTE_: "FALSE"
     _R_CHECK_FORCE_SUGGESTS_: "TRUE"
     OPENBLAS_MAIN_FREE: "1"
     TEST_DATA_TABLE_WITH_OTHER_PACKAGES: "TRUE"
-    TEST_DATA_TABLE_MEMTEST: "TRUE"
-  image: registry.gitlab.com/jangorecki/dockerfiles/r-builder
-  dependencies:
-  - mirror-packages
-  - build
   script:
-    - mkdir -p bus/$CI_BUILD_NAME
-    - Rscript -e 'source(Sys.getenv("CI_TOOLS")); if (length(pkgs<-packages.dcf(c("DESCRIPTION","inst/tests/tests-DESCRIPTION"), "all"))) install.packages(pkgs, repos=file.path("file:",normalizePath("bus/mirror-packages/cran")))'
+    - Rscript -e 'source("ci.R"); install.packages(dcf.dependencies(c("DESCRIPTION","inst/tests/tests-DESCRIPTION"), which="all"))'
+    - *copy-src
+    - rm -r bus
+    - *move-src
     - cd bus/$CI_BUILD_NAME
-    - Rscript -e 'file.copy(download.packages("data.table", repos=file.path("file:",normalizePath("../build/cran")))[,2], ".")'
     - R CMD check $(ls -1t data.table_*.tar.gz | head -n 1)
-  artifacts:
-    expire_in: 2 weeks
-    when: always
-    paths:
-      - bus
+    - *cleanup-src
 
-test-r-release-cran: # R-release CRAN check
-  stage: test
-  tags:
-    - linux
+test-r-release-vanilla: # minimal installation, no suggested deps, no vignettes or manuals, measure memory
+  <<: *test-linux
+  image: registry.gitlab.com/jangorecki/dockerfiles/r-base-dev
+  variables:
+    TEST_DATA_TABLE_MEMTEST: "TRUE"
+  script:
+    - *copy-src
+    - rm -r bus
+    - *move-src
+    - cd bus/$CI_BUILD_NAME
+    - R CMD check --no-manual --ignore-vignettes $(ls -1t data.table_*.tar.gz | head -n 1)
+    - *cleanup-src
+
+test-r-release-cran: # as CRAN
+  <<: *test-linux
   image: registry.gitlab.com/jangorecki/dockerfiles/r-builder
   variables:
     _R_CHECK_CRAN_INCOMING_: "TRUE"
     _R_CHECK_CRAN_INCOMING_REMOTE_: "TRUE"
-  dependencies:
-  - mirror-packages
-  - build
   script:
-    - mkdir -p bus/$CI_BUILD_NAME
-    - Rscript -e 'source(Sys.getenv("CI_TOOLS")); if (length(pkgs<-packages.dcf("DESCRIPTION", "all"))) install.packages(pkgs, repos=file.path("file:",normalizePath("bus/mirror-packages/cran")))'
+    - Rscript -e 'source("ci.R"); install.packages(dcf.dependencies("DESCRIPTION", which="most"))'
+    - *copy-src
+    - rm -r bus
+    - *move-src
     - cd bus/$CI_BUILD_NAME
-    - Rscript -e 'file.copy(download.packages("data.table", repos=file.path("file:",normalizePath("../build/cran")))[,2], ".")'
     - R CMD check --as-cran $(ls -1t data.table_*.tar.gz | head -n 1)
-  artifacts:
-    expire_in: 2 weeks
-    when: always
-    paths:
-      - bus
+    - *cleanup-src
 
-test-r-devel-cran: # R-devel CRAN check
-  stage: test
-  tags:
-    - linux
+test-r-devel-cran: # R-devel as CRAN
+  <<: *test-linux
   image: registry.gitlab.com/jangorecki/dockerfiles/r-devel
+  allow_failure: true
   variables:
     _R_CHECK_CRAN_INCOMING_: "TRUE"
     _R_CHECK_CRAN_INCOMING_REMOTE_: "TRUE"
-  dependencies:
-  - mirror-packages
-  - build
   script:
-    - mkdir -p bus/$CI_BUILD_NAME
-    - Rscript -e 'source(Sys.getenv("CI_TOOLS")); if (length(pkgs<-packages.dcf("DESCRIPTION", "all"))) install.packages(pkgs, repos=file.path("file:",normalizePath("bus/mirror-packages/cran")))'
+    - Rscript -e 'source("ci.R"); install.packages(dcf.dependencies("DESCRIPTION", which="most"))'
+    - *copy-src
+    - rm -r bus
+    - *move-src
     - cd bus/$CI_BUILD_NAME
-    - Rscript -e 'file.copy(download.packages("data.table", repos=file.path("file:",normalizePath("../build/cran")))[,2], ".")'
-    - R CMD check --as-cran --ignore-vignettes --no-manual $(ls -1t data.table_*.tar.gz | head -n 1)
-  artifacts:
-    expire_in: 2 weeks
-    when: always
-    paths:
-      - bus
-  allow_failure: true
+    - R CMD check --as-cran $(ls -1t data.table_*.tar.gz | head -n 1)
+    - *cleanup-src
 
-test-r-release-vanilla: # check minimal installation, no suggested deps, no vignettes or manuals
-  stage: test
-  tags:
-    - linux
-  image: registry.gitlab.com/jangorecki/dockerfiles/r-base-dev
-  dependencies:
-  - mirror-packages
-  - build
-  variables:
-    TEST_DATA_TABLE_MEMTEST: "TRUE"
-  script:
-    - mkdir -p bus/$CI_BUILD_NAME
-    - Rscript -e 'source(Sys.getenv("CI_TOOLS")); if (length(pkgs<-packages.dcf("DESCRIPTION"))) install.packages(pkgs, repos=file.path("file:",normalizePath("bus/mirror-packages/cran")))'
-    - cd bus/$CI_BUILD_NAME
-    - Rscript -e 'file.copy(download.packages("data.table", repos=file.path("file:",normalizePath("../build/cran")))[,2], ".")'
-    - R CMD check --no-manual --ignore-vignettes $(ls -1t data.table_*.tar.gz | head -n 1)
-  artifacts:
-    expire_in: 2 weeks
-    when: always
-    paths:
-      - bus
-
-test-r-3.1.0-cran:
-  stage: test
-  tags:
-    - linux
+test-r-3.1.0-cran: # test stated dependency on R 3.1.0 as CRAN
+  <<: *test-linux
   image: registry.gitlab.com/jangorecki/dockerfiles/r-3.1.0
   variables:
     _R_CHECK_CRAN_INCOMING_: "TRUE"
     _R_CHECK_CRAN_INCOMING_REMOTE_: "TRUE"
-  dependencies:
-  - mirror-packages
-  - build
   script:
-    - mkdir -p bus/$CI_BUILD_NAME
-    - curl -O $CI_TOOLS
-    - Rscript -e 'source("packages.R"); if (length(pkgs<-packages.dcf("DESCRIPTION", "all"))) install.packages(pkgs, repos=file.path("file:",normalizePath("bus/mirror-packages/cran")))'
+    - Rscript -e 'source("ci.R"); install.packages(dcf.dependencies("DESCRIPTION", which="most"))'
+    - *copy-src
+    - rm -r bus
+    - *move-src
     - cd bus/$CI_BUILD_NAME
-    - Rscript -e 'file.copy(download.packages("data.table", repos=file.path("file:",normalizePath("../build/cran")))[,2], ".")'
-    - R CMD check --no-manual --as-cran $(ls -1t data.table_*.tar.gz | head -n 1)
-  artifacts:
-    expire_in: 2 weeks
-    when: always
-    paths:
-      - bus
+    - R CMD check --as-cran $(ls -1t data.table_*.tar.gz | head -n 1)
+    - *cleanup-src
 
-.test-r-release-windows:
-  stage: test
-  tags:
-    - windows # TODO provide machine
-  script: # TODO win scripts
-    - mkdir -p bus/$CI_BUILD_NAME
-    - Rscript -e 'source(Sys.getenv("CI_TOOLS")); if (length(pkgs<-packages.dcf("DESCRIPTION", "all"))) install.packages(pkgs, repos=file.path("file:",normalizePath("bus/mirror-packages/cran")))'
+test-r-release-windows: # windows test and build binaries
+  <<: *test-windows
+  variables:
+    R_BIN_VERSION: "3.5"
+    R_DIR: "R-3.5.0"
+  script:
+    - Rscript -e "source('ci.R'); install.packages(dcf.dependencies('DESCRIPTION', which='all'))"
+    - *copy-src
+    - rm -r bus
+    - *move-src
     - cd bus/$CI_BUILD_NAME
-    - Rscript -e 'file.copy(download.packages("data.table", repos=file.path("file:",normalizePath("../build/cran")))[,2], ".")'
-    - R CMD build --no-manual --no-build-vignettes .
-    - R CMD check --no-manual --ignore-vignettes data.table_X.zip
-    # build windows binaries
-    - R CMD INSTALL --build data.table_X.zip
-  artifacts:
-    expire_in: 2 weeks
-    when: always
-    paths:
-      - bus
+    - R CMD check --no-manual $(ls -1t data.table_*.tar.gz | head -n 1)
+    - R CMD INSTALL --build $(ls -1t data.table_*.tar.gz | head -n 1)
+    - mkdir -p cran/bin/windows/contrib/$R_BIN_VERSION
+    - mv $(ls -1t data.table_*.zip | head -n 1) cran/bin/windows/contrib/$R_BIN_VERSION
+    - *cleanup-src
 
-integration: # merging all artifacts so multiple deploy jobs can build same repo
+test-r-devel-windows: # R-devel on windows
+  <<: *test-windows
+  variables:
+    R_BIN_VERSION: "3.6"
+    R_DIR: "R-devel"
+    TEST_DATA_TABLE_MEMTEST: "TRUE"
+  allow_failure: true
+  script:
+    - Rscript -e "source('ci.R'); install.packages(dcf.dependencies('DESCRIPTION', which='all'))"
+    - *copy-src
+    - rm -r bus
+    - *move-src
+    - cd bus/$CI_BUILD_NAME
+    - R CMD check --no-manual --ignore-vignettes $(ls -1t data.table_*.tar.gz | head -n 1)
+    - R CMD INSTALL --build $(ls -1t data.table_*.tar.gz | head -n 1)
+    - mkdir -p cran/bin/windows/contrib/$R_BIN_VERSION
+    - mv $(ls -1t data.table_*.zip | head -n 1) cran/bin/windows/contrib/$R_BIN_VERSION
+    - *cleanup-src
+
+.test-r-release-macosx: # macosx test and build binaries
+  <<: *test-macosx
+  variables:
+    R_BIN_VERSION: "3.5"
+  script:
+    - Rscript -e 'source("ci.R"); install.packages(dcf.dependencies("DESCRIPTION", which="all"))'
+    - *copy-src
+    - rm -r bus
+    - *move-src
+    - cd bus/$CI_BUILD_NAME
+    - R CMD check $(ls -1t data.table_*.tar.gz | head -n 1)
+    - R CMD INSTALL --build $(ls -1t data.table_*.tar.gz | head -n 1)
+    - mkdir -p cran/bin/macosx/el-capitan/contrib/$R_BIN_VERSION
+    - mv $(ls -1t data.table_*.tgz | head -n 1) cran/bin/macosx/el-capitan/contrib/$R_BIN_VERSION
+    - *cleanup-src
+
+integration: # merging all artifacts to produce single R repository and summaries
   stage: integration
+  image: registry.gitlab.com/jangorecki/dockerfiles/r-builder
   tags:
     - linux
   only:
-    - gl-ci-upgrade
     - master
-  image: registry.gitlab.com/jangorecki/dockerfiles/r-builder
   dependencies:
   - mirror-packages
   - build
@@ -201,54 +234,126 @@ integration: # merging all artifacts so multiple deploy jobs can build same repo
   - test-r-devel-cran
   - test-r-release-vanilla
   - test-r-3.1.0-cran
+  - test-r-release-windows
+  - test-r-devel-windows
+  #- test-r-release-macosx
+  variables:
+    R_BIN_VERSION: "3.5"
+    R_DEVEL_BIN_VERSION: "3.6"
   script:
+    - echo 'source("ci.R"); source("publish.R")' >> .Rprofile
+    # list of available test-* jobs dynamically based on bus/test-* directories
+    - Rscript -e 'cat("\ntest.jobs <- c(\n"); cat(paste0("  \"",list.files("bus",pattern="^test-"),"\" = \"data.table\""), sep=",\n"); cat(")\n")' >> .Rprofile
+    - Rscript -e 'sapply(names(test.jobs), check.test, pkg="data.table", simplify=FALSE)'
     - mkdir -p bus/$CI_BUILD_NAME
-    # integration helpers, not in tools4pkgs branch, for multi pkgs use: pkg<-strsplit(job, "-", fixed=TRUE)[[1L]][2L]
-    - echo 'test.jobs<-c("test-r-release"="data.table","test-r-release-cran"="data.table","test-r-devel-cran"="data.table","test-r-release-vanilla"="data.table","test-r-3.1.0-cran"="data.table")' > integration.R
-    - echo 'lib.copy<-function(lib.from, repodir="bus/integration/cran"){ pkgs.from<-list.dirs(lib.from, recursive=FALSE); pkgs.to<-list.dirs(lib.to<-file.path(repodir,"library"), recursive=FALSE); pkg.copy<-function(pkg.from, lib.to){ pkg<-basename(pkg.from); dir.create(file.path(lib.to, pkg), recursive=TRUE); lib.dirs<-intersect(c("html","doc"), all.lib.dirs<-list.dirs(pkg.from, full.names=FALSE)); ans1<-setNames(file.copy(file.path(pkg.from, lib.dirs), file.path(lib.to, pkg), recursive=TRUE), lib.dirs); lib.files<-setdiff(list.files(pkg.from), all.lib.dirs); ans2<-setNames(file.copy(file.path(pkg.from, lib.files), file.path(lib.to, pkg)), lib.files); all(ans1, ans2)}; pkgs.from.new<-pkgs.from[!basename(pkgs.from) %in% basename(pkgs.to)]; setNames(sapply(pkgs.from.new, pkg.copy, lib.to=lib.to), basename(pkgs.from.new)) }' >> integration.R
-    - echo 'doc.copy<-function(repodir="bus/integration/cran"){ cp1<-c("COPYING","AUTHORS","THANKS"); ans1<-setNames(file.copy(file.path(R.home("doc"), cp1), file.path(repodir, "doc", cp1)), cp1); cp2<-c("html","manual"); ans2<-setNames(file.copy(file.path(R.home("doc"), cp2), file.path(repodir,"doc"), recursive=TRUE), cp2); c(ans1, ans2) }' >> integration.R
-    - echo 'check.copy<-function(job, repodir="bus/integration/cran"){ dir.create(job.checks<-file.path(repodir, "web", "checks", pkg<-"data.table", job), recursive=TRUE); all(file.copy(file.path("bus", sprintf("%s/%s.Rcheck", job, pkg), c("00install.out","00check.log")), job.checks)) }' >> integration.R
-    - echo 'pdf.copy<-function(job, repodir="bus/integration/cran"){ dir.create(pkg.to<-file.path(repodir,"web","packages",pkg<-"data.table"), recursive=TRUE); file.copy(file.path("bus", job, sprintf("%s.Rcheck", pkg), sprintf("%s-manual.pdf",pkg)), to=file.path(pkg.to, sprintf("%s.pdf",pkg))) }' >> integration.R
-    - echo 'check.test<-function(job) { check<-readLines(file.path("bus", job, sprintf("%s.Rcheck", pkg<-"data.table"), "00check.log")); check[length(check)] }' >> integration.R
-    #- echo '' >> integration.R
-    # TODO: testing CRAN check results raise error so deploy wont start if there are check issues
-    - Rscript -e 'source("integration.R"); sapply(names(test.jobs), check.test, simplify=FALSE)'
+    # delete any existing non-dev version of data.table
+    - rm -f bus/mirror-packages/cran/src/contrib/data.table_*.tar.gz
+    - rm -f bus/mirror-packages/cran/bin/windows/contrib/$R_BIN_VERSION/data.table_*.zip
+    - rm -f bus/mirror-packages/cran/bin/windows/contrib/$R_DEVEL_BIN_VERSION/data.table_*.zip
+    #- rm -f bus/mirror-packages/cran/bin/macosx/el-capitan/contrib/$R_BIN_VERSION/data.table_*.tgz
+    #- rm -f bus/mirror-packages/cran/bin/macosx/el-capitan/contrib/$R_DEVEL_BIN_VERSION/data.table_*.tgz
     # merge mirror-packages and R devel packages
-    - cp -R bus/mirror-packages/cran bus/$CI_BUILD_NAME/
+    - mv bus/mirror-packages/cran bus/$CI_BUILD_NAME/
+    # publish package sources
     - mkdir -p bus/$CI_BUILD_NAME/cran/library bus/$CI_BUILD_NAME/cran/doc
     - mv $(ls -1t bus/build/cran/src/contrib/data.table_*.tar.gz | head -n 1) bus/$CI_BUILD_NAME/cran/src/contrib
-    - Rscript -e 'tools::write_PACKAGES(contrib.url("bus/integration/cran"), fields="Revision", addFiles=TRUE)'
+    - Rscript -e 'tools::write_PACKAGES(contrib.url("bus/integration/cran", type="source"), type="source", fields="Revision", addFiles=TRUE)'
+    # publish binaries
+    - Rscript -e 'move.bin("test-r-release-windows", Sys.getenv("R_BIN_VERSION"), os.type="windows")'
+    - Rscript -e 'move.bin("test-r-devel-windows", Sys.getenv("R_DEVEL_BIN_VERSION"), os.type="windows", silent=TRUE)'
+    - Rscript -e 'tools::write_PACKAGES(contrib.url("bus/integration/cran", type="win.binary", ver=Sys.getenv("R_BIN_VERSION")), type="win.binary", fields="Revision", addFiles=TRUE)'
+    - Rscript -e 'tools::write_PACKAGES(contrib.url("bus/integration/cran", type="win.binary", ver=Sys.getenv("R_DEVEL_BIN_VERSION")), type="win.binary", fields="Revision", addFiles=TRUE)'
+    #- Rscript -e 'move.bin("test-r-release-macosx", Sys.getenv("R_BIN_VERSION"), os.type="macosx")'
+    #- Rscript -e 'move.bin("test-r-devel-macosx", Sys.getenv("R_DEVEL_BIN_VERSION"), os.type="macosx", silent=TRUE)'
+    #- Rscript -e 'tools::write_PACKAGES(contrib.url("bus/integration/cran", type="mac.binary.el-capitan", ver=Sys.getenv("R_BIN_VERSION")), type="mac.binary.el-capitan", fields="Revision", addFiles=TRUE)'
+    #- Rscript -e 'tools::write_PACKAGES(contrib.url("bus/integration/cran", type="mac.binary.el-capitan", ver=Sys.getenv("R_DEVEL_BIN_VERSION")), type="mac.binary.el-capitan", fields="Revision", addFiles=TRUE)'
     # install all pkgs to render html and double check successful installation of all devel packages
     - mkdir -p /tmp/opencran/library /tmp/opencran/doc/html
     - Rscript -e 'install.packages("data.table", dependencies=TRUE, lib="/tmp/opencran/library", repos=file.path("file:",normalizePath("bus/integration/cran")), INSTALL_opts="--html", quiet=TRUE)'
-    - Rscript -e 'sapply("data.table", packageVersion, lib.loc="/tmp/opencran/library", simplify=FALSE)'
+    - Rscript -e 'packageVersion("data.table", lib.loc="/tmp/opencran/library")'
+    # CRAN style web/CRAN_web.css
+    - wget -q -P bus/integration/cran/web https://cran.r-project.org/web/CRAN_web.css
+    # web/packages/$pkg/index.html
+    - Rscript -e 'sapply(rownames(installed.packages(lib.loc="/tmp/opencran/library", priority="NA")), package.index, lib.loc="/tmp/opencran/library")'
     # R docs, html, css, icons
-    - Rscript -e 'source("integration.R"); doc.copy(repodir="/tmp/opencran")'
+    - Rscript -e 'doc.copy(repodir="/tmp/opencran")'
     # Update packages.html, rewrite file:/ to relative path
     - Rscript -e 'setwd("/tmp/opencran/doc/html"); make.packages.html(lib.loc="../../library", docdir="/tmp/opencran/doc"); tmp<-readLines(f<-"/tmp/opencran/doc/html/packages.html"); writeLines(gsub("file:///../../library","../../library", tmp, fixed=TRUE), f)'
     - mv /tmp/opencran/doc bus/integration/cran/
-    # library
-    - Rscript -e 'source("integration.R"); lib.copy(lib.from="/tmp/opencran/library")'
-    # web/checks/$pkg/$job: 00install.out, 00check.log
-    - Rscript -e 'source("integration.R"); sapply(names(test.jobs), check.copy)'
-    # web/packages - here is only single package
-    #- Rscript -e 'source("integration.R"); sapply(sprintf("test-%s-r-release", unique(test.jobs)), pdf.copy)'
-    - Rscript -e 'source("integration.R"); pdf.copy("test-r-release")'
-    # TODO: web/checks/check_results_$pkg.html
-    # https://github.com/wch/r-source/blob/trunk/src/library/tools/R/CRANtools.R
-    # TODO: web/packages/$pkg/index.html
-  artifacts:
-    expire_in: 2 weeks
-    paths:
-      - bus
+    # library html manual, vignettes
+    - Rscript -e 'lib.copy(lib.from="/tmp/opencran/library")'
+    # web/checks/$pkg/$job: 00install.out, 00check.log, *.Rout, memtest.csv, memtest.png
+    - Rscript -e 'sapply(names(test.jobs), check.copy, simplify=FALSE)'
+    # web/packages/$pkg/$pkg.pdf
+    - Rscript -e 'pdf.copy("data.table", "test-r-release")'
+    # web/checks/check_results_$pkg.html
+    - Rscript -e 'check.index("data.table", names(test.jobs))'
+    # cleanup artifacts from other jobs
+    - mkdir tmpbus
+    - mv bus/$CI_BUILD_NAME tmpbus
+    - rm -r bus
+    - mv tmpbus bus
+  <<: *artifacts
 
-pages:
+.docker-template: &docker
+  stage: deploy
+  tags:
+    - linux
+  image: docker
+  services:
+  - docker:dind
+  dependencies:
+  - build
+  before_script:
+    - sed "s/SRC_IMAGE_NAME/$SRC_IMAGE_NAME/" < Dockerfile.in > Dockerfile
+    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
+  script:
+    - docker build --pull -t "$CI_REGISTRY_IMAGE/$IMAGE_NAME:$IMAGE_TAG" -f Dockerfile .
+    - docker run --rm "$CI_REGISTRY_IMAGE/$IMAGE_NAME:$IMAGE_TAG" Rscript -e 'cat(R.version.string, "\ndata.table revision", read.dcf(system.file("DESCRIPTION", package="data.table"), fields="Revision")[[1L]], "\n"); require(data.table); test.data.table()'
+    - docker push "$CI_REGISTRY_IMAGE/$IMAGE_NAME:$IMAGE_TAG"
+
+docker-r-release: # publish docker image of data.table on R-release
+  only:
+    - master
+  variables:
+    SRC_IMAGE_NAME: "r-base-dev"
+    IMAGE_NAME: "r-release"
+    IMAGE_TAG: "latest"
+  <<: *docker
+
+docker-r-release-builder: # publish on R-release and OS dependencies for building Rmd vignettes
+  only:
+    - master
+  variables:
+    SRC_IMAGE_NAME: "r-builder"
+    IMAGE_NAME: "r-release-builder"
+    IMAGE_TAG: "latest"
+  <<: *docker
+
+docker-r-devel: # publish docker image of data.table on R-devel
+  only:
+    - master
+  variables:
+    SRC_IMAGE_NAME: "r-devel"
+    IMAGE_NAME: "r-devel"
+    IMAGE_TAG: "latest"
+  <<: *docker
+
+docker-tags: # publish only on tagged commits, we use tags for version
+  only:
+    - tags
+  variables:
+    SRC_IMAGE_NAME: "r-base-dev"
+    IMAGE_NAME: "r-release"
+    IMAGE_TAG: $CI_COMMIT_TAG
+  <<: *docker
+
+pages: # publish R repository, test jobs summaries, html documentation of all packages in repo
   stage: deploy
   environment: production
   tags:
     - linux
   only:
-    - gl-ci-upgrade
     - master
   image: ubuntu
   dependencies:
@@ -257,7 +362,7 @@ pages:
     - mkdir -p public
     - cp -r bus/integration/cran/* public
     - cat public/src/contrib/PACKAGES
-  artifacts:
+  artifacts: # publish when no failure
     expire_in: 2 weeks
     paths:
       - public

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,0 +1,9 @@
+FROM registry.gitlab.com/jangorecki/dockerfiles/SRC_IMAGE_NAME
+
+MAINTAINER Jan Gorecki j.gorecki@wit.edu.pl
+
+COPY bus/build/cran/ /cran/
+
+RUN Rscript -e 'install.packages("data.table", repos=file.path("file:","cran"))'
+
+CMD ["R"]

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -75,7 +75,7 @@ INT = function(...) { as.integer(c(...)) }   # utility used in tests.Rraw
 ps_mem = function() {
   # nocov start
   cmd = sprintf("ps -o rss %s | tail -1", Sys.getpid())
-  ans = tryCatch(as.numeric(system(cmd, intern=TRUE)), error=function(e) NA_real_)
+  ans = tryCatch(as.numeric(system(cmd, intern=TRUE, ignore.stderr=TRUE)), warning=function(w) NA_real_, error=function(e) NA_real_)
   stopifnot(length(ans)==1L) # extra check if other OSes would not handle 'tail -1' properly for some reason
   # returns RSS memory occupied by current R process in MB rounded to 1 decimal places (as in gc), ps already returns KB
   c("PS_rss"=round(ans / 1024, 1))

--- a/ci.R
+++ b/ci.R
@@ -1,0 +1,184 @@
+## most of functions from R tools4pkgs branch
+## https://github.com/wch/r-source/tree/tools4pkgs
+## https://svn.r-project.org/R/branches/tools4pkgs/src/library/tools/R/packages.R
+
+## added ver argument to produce R version independent urls
+## https://bugs.r-project.org/bugzilla3/show_bug.cgi?id=17420
+contrib.url <-
+function (repos, type = getOption("pkgType"), ver) 
+{
+  type <- utils:::resolvePkgType(type)
+  if (is.null(repos)) 
+    return(NULL)
+  if ("@CRAN@" %in% repos && interactive()) {
+    cat(gettext("--- Please select a CRAN mirror for use in this session ---"), "\n", sep = "")
+    flush.console()
+    chooseCRANmirror()
+    m <- match("@CRAN@", repos)
+    nm <- names(repos)
+    repos[m] <- getOption("repos")["CRAN"]
+    if (is.null(nm)) 
+      nm <- rep("", length(repos))
+    nm[m] <- "CRAN"
+    names(repos) <- nm
+  }
+  if ("@CRAN@" %in% repos) 
+    stop("trying to use CRAN without setting a mirror")
+  if(missing(ver)) {
+    ver <- paste(R.version$major, strsplit(R.version$minor, ".", fixed=TRUE)[[1L]][1L], sep = ".")
+  } else {
+    stopifnot(is.character(ver), length(ver)>0L, !is.na(ver))
+  }
+  mac.path <- "macosx"
+  if (substr(type, 1L, 11L) == "mac.binary.") {
+    mac.path <- paste(mac.path, substring(type, 12L), sep = "/")
+    type <- "mac.binary"
+  }
+  res <- switch(
+    type,
+    source = paste(gsub("/$", "", repos), "src", "contrib", sep = "/"),
+    mac.binary = paste(gsub("/$", "", repos), "bin", mac.path, "contrib", ver, sep = "/"), 
+    win.binary = paste(gsub("/$", "", repos), "bin", "windows", "contrib", ver, sep = "/")
+  )
+  res
+}
+
+## returns dependencies for a package based on its DESCRIPTION file
+dcf.dependencies <-
+function(file = "DESCRIPTION", 
+         which = NA,
+         except.priority = "base") {
+  if (!is.character(file) || !length(file) || !all(file.exists(file)))
+    stop("file argument must be character of filepath(s) to existing DESCRIPTION file(s)")
+  if (!is.character(except.priority))
+    stop("except.priority should be character vector")
+  if (!(all(except.priority %in% c("base","recommended")) || identical(except.priority, character(0))))
+    stop("except.priority accept 'base', 'recommended', both or empty character vector")
+  which_all <- c("Depends", "Imports", "LinkingTo", "Suggests", "Enhances")
+  if (is.na(which))
+    which = c("Depends", "Imports", "LinkingTo")
+  else if (identical(which, "all"))
+    which <- which_all
+  else if (identical(which, "most"))
+    which <- c("Depends", "Imports", "LinkingTo", "Suggests")
+  if (!is.character(which) || !length(which) || !all(which %in% which_all))
+    stop("which argument accept only valid dependency relation: ", paste(which_all, collapse=", "))
+  x <- unlist(lapply(file, function(f, which) {
+      dcf <- tryCatch(read.dcf(f, fields = which), error = identity)
+      if (inherits(dcf, "error") || !length(dcf))
+          warning(gettextf("error reading file '%s'", f), domain = NA, call. = FALSE)
+      else dcf[!is.na(dcf)]
+  }, which = which), use.names = FALSE)
+  local.extract_dependency_package_names = function (x) {
+    ## do not filter out R like tools:::.extract_dependency_package_names, used for web/$pkg/index.html
+    if (is.na(x)) 
+      return(character())
+    x <- unlist(strsplit(x, ",[[:space:]]*"))
+    x <- sub("[[:space:]]*([[:alnum:].]+).*", "\\1", x)
+    x[nzchar(x)]
+  }
+  x <- unlist(lapply(x, local.extract_dependency_package_names))
+  except <- if (length(except.priority)) c("R", unlist(tools:::.get_standard_package_names()[except.priority], use.names = FALSE))
+  setdiff(x, except)
+}
+
+## returns additional repositories for dependency packages based on its DESCRIPTION file
+dcf.repos <-
+function(file = "DESCRIPTION") {
+  if (!is.character(file) || !length(file) || !all(file.exists(file)))
+    stop("file argument must be character of filepath(s) to existing DESCRIPTION file(s)")
+  x <- unlist(lapply(file, function(f) {
+    dcf <- tryCatch(read.dcf(f, fields = "Additional_repositories"), error = identity)
+    if (inherits(dcf, "error") || !length(dcf))
+      warning(gettextf("error reading file '%s'", f), domain = NA, call. = FALSE)
+    else dcf[!is.na(dcf)]
+  }), use.names = FALSE)
+  x <- trimws(unlist(strsplit(trimws(x), ",", fixed = TRUE), use.names = FALSE))
+  unique(x)
+}
+
+## Mirror subset of CRAN
+## download dependencies recursively for provided packages
+## put all downloaded packages into local repository
+mirror.packages <-
+function(pkgs, 
+         which = c("Depends", "Imports", "LinkingTo"), 
+         repos = getOption("repos"), 
+         type = c("source", "mac.binary", "win.binary"), 
+         repodir, 
+         except.repodir = repodir, 
+         except.priority = "base", 
+         method,
+         quiet = TRUE,
+         binary.ver,
+         ...) {
+  if (!length(pkgs)) # edge case friendly
+    return(NULL)
+  if (!is.character(pkgs))
+    stop("pkgs argument must be character vector of packages to mirror from repository")
+  if (missing(repodir) || !is.character(repodir) || length(repodir)!=1L)
+    stop("repodir argument must be non-missing scalar character, local path to repo mirror")
+  if (!dir.exists(repodir) && !dir.create(repodir, recursive = TRUE, showWarnings = FALSE))
+    stop("Path provided in 'repodir' argument does not exists and could not be created")
+  if (missing(type) && .Platform$OS.type == "windows")
+    type <- "win.binary"
+  type <- match.arg(type)
+  if (!missing(binary.ver)) {
+    if (!is.character(binary.ver) || length(binary.ver)!=1L || is.na(binary.ver))
+      stop("binary.ver must be non-NA scalar character of type '3.5' so path to arbitrary binaries version can be resolved")
+  } else binary.ver <- paste(R.version$major, strsplit(R.version$minor, ".", fixed=TRUE)[[1L]][1L], sep = ".")
+  destdir <- contrib.url(repodir, type = type, ver = binary.ver)
+  if (!dir.exists(destdir) && !dir.create(destdir, recursive = TRUE, showWarnings = FALSE))
+    stop(sprintf("Your repo directory provided in 'repodir' exists, but does not have '%s' dir tree and it could not be created", destdir))
+  if (length(except.repodir) && (!is.character(except.repodir) || length(except.repodir)!=1L || !dir.exists(except.repodir)))
+    stop("except.repodir argument must be non-missing scalar character, local path to existing directory")
+  if (!is.character(except.priority) || !length(except.priority) || !all(except.priority %in% c("base","recommended")))
+    stop("except.priority accept 'base', 'recommended', both")
+  if (!is.logical(quiet) || length(quiet)!=1L || is.na(quiet))
+    stop("quiet argument must be TRUE or FALSE")
+  which_all <- c("Depends", "Imports", "LinkingTo", "Suggests", "Enhances")
+  if (identical(which, "all"))
+    which <- which_all
+  else if (identical(which, "most"))
+    which <- c("Depends", "Imports", "LinkingTo", "Suggests")
+  if (!is.character(which) || !length(which) || !all(which %in% which_all))
+    stop("which argument accept only valid dependency relations: ", paste(which_all, collapse=", "))
+  ## possible interactive CRAN menu
+  repos.url <- contrib.url(repos, type = type, ver = binary.ver)
+  db <- utils::available.packages(repos.url, type = type)
+  allpkgs <- c(pkgs, unlist(tools::package_dependencies(unique(pkgs), db, which, recursive = TRUE), use.names = FALSE))
+  except <- c("R", unlist(tools:::.get_standard_package_names()[except.priority], use.names = FALSE))
+  ## do not re-download existing packages, ignore version
+  if (length(except.repodir) && file.exists(file.path(contrib.url(except.repodir, type = type, ver = binary.ver), "PACKAGES"))) {
+    except.curl <- contrib.url(file.path("file:", normalizePath(except.repodir)), type = type, ver = binary.ver)
+    except <- c(except, rownames(utils::available.packages(except.curl, type = type, fields = "Package")))
+  }
+  newpkgs <- setdiff(allpkgs, except)
+  if (!all(availpkgs<-newpkgs %in% rownames(db))) {
+    ## source packages are considered mandatory due to _R_CHECK_FORCE_SUGGESTS_=true policy
+    if (type=="source")
+      stop(sprintf("Packages sources could not be found in provided repositories: %s", paste(newpkgs[!availpkgs], collapse = ", ")))
+    warning(sprintf("Packages binaries could not be found in provided reposistories for R version %s: %s", binary.ver, paste(newpkgs[!availpkgs], collapse = ", ")))
+    newpkgs <- newpkgs[availpkgs]
+  }
+  
+  pkgsext <- switch(type,
+                    "source" = "tar.gz",
+                    "mac.binary" = "tgz",
+                    "win.binary" = "zip")
+  pkgsver <- db[db[, "Package"] %in% newpkgs, c("Package", "Version"), drop=FALSE]
+  dlfiles <- file.path(destdir, sprintf("%s_%s.%s", pkgsver[,"Package"], pkgsver[,"Version"], pkgsext))
+  unlink(dlfiles[file.exists(dlfiles)])
+  ## repos argument is not used in download.packages, only as default for contriburl argument
+  ## we provide contriburl to avoid interactive CRAN menu popup twice in mirror.packages
+  dp <- utils::download.packages(pkgs = newpkgs, destdir = destdir, 
+                                 available = db, contriburl = repos.url, 
+                                 type = type, method = method, quiet = quiet)
+  tools::write_PACKAGES(dir = destdir, type = type, ...)
+  dp
+}
+
+## set repositories for CI tests
+if (as.logical(Sys.getenv("GITLAB_CI","false"))) {
+  options("repos" = if (.Platform$OS.type == "windows") file.path("file://",getwd(),"bus/mirror-packages/cran") else file.path("file:", normalizePath("bus/mirror-packages/cran", mustWork=FALSE)))
+}

--- a/publish.R
+++ b/publish.R
@@ -1,0 +1,253 @@
+format.deps <- function(file, which) {
+  deps.raw = read.dcf(file, fields=which)[[1L]]
+  if (all(is.na(deps.raw))) return(character())
+  deps.full = trimws(strsplit(deps.raw, ", ", fixed=TRUE)[[1L]])
+  deps = trimws(sapply(strsplit(deps.full, "(", fixed=TRUE), `[[`, 1L))
+  names(deps.full) <- deps
+  base.deps = c("R", unlist(tools:::.get_standard_package_names(), use.names = FALSE))
+  ans = sapply(deps, function(x) {
+    if (x %in% base.deps) deps.full[[x]]
+    else sprintf("<a href=\"../%s/index.html\">%s</a>", x, deps.full[[x]])
+  })
+  sprintf("<tr><td>%s:</td><td>%s</td></tr>", which, paste(ans, collapse=", "))
+}
+
+format.bins <- function(ver, bin_ver, cran.home, os.type, pkg, version, repodir) {
+  if (os.type=="windows") {
+    ext = "zip"
+    plat.path = "windows"
+  } else if (os.type=="macosx") {
+    ext = "tgz"
+    plat.path = "macosx/el-capitan"
+  } else stop("format.bins only valid for 'windows' or 'macosx' os.type")
+  file = sprintf("bin/%s/contrib/%s/%s_%s.%s", plat.path, bin_ver, pkg, version, ext)
+  fe = file.exists(file.path(repodir, file))
+  ans = sprintf("%s: <a href=\"%s/%s\">%s_%s.%s</a>", ver, cran.home, file, pkg, version, ext)
+  paste(ans[fe], collapse=", ")
+}
+
+package.index <- function(package, lib.loc, repodir="bus/integration/cran") {
+  file = system.file("DESCRIPTION", package=package, lib.loc=lib.loc)
+  dcf = read.dcf(file)
+  pkg = dcf[,"Package"]
+  version = dcf[,"Version"]
+  if (!"Revision" %in% colnames(dcf)) dcf = cbind(dcf, Revision = NA_character_)
+  tbl = c(
+    sprintf("<tr><td>Version:</td><td>%s</td></tr>", version),
+    sprintf("<tr><td>Revision:</td><td>%s</td></tr>", dcf[,"Revision"]), # some non data.table pkgs might have revision
+    format.deps(file, "Depends"),
+    format.deps(file, "Imports"),
+    format.deps(file, "LinkingTo"),
+    format.deps(file, "Suggests"),
+    format.deps(file, "Enhances"),
+    if (pkg=="data.table") sprintf("<tr><td>Checks:</td><td><a href=\"../../checks/check_results_%s.html\">%s results</a></td></tr>", pkg, pkg)
+  )
+  vign = tools::getVignetteInfo(pkg, lib.loc=lib.loc)
+  r_bin_ver = Sys.getenv("R_BIN_VERSION")
+  r_devel_bin_ver = Sys.getenv("R_DEVEL_BIN_VERSION")
+  stopifnot(nzchar(r_bin_ver), nzchar(r_devel_bin_ver))
+  cran.home = "../../.."
+  tbl.dl = c(
+    sprintf("<tr><td> Reference manual: </td><td> <a href=\"%s.pdf\">%s.pdf</a>, <a href=\"%s/library/%s/html/00Index.html\">00Index.html</a> </td></tr>", pkg, pkg, cran.home, pkg),
+    if (nrow(vign)) sprintf("<tr><td>Vignettes:</td><td>%s</td></tr>", paste(sprintf("<a href=\"%s/library/data.table/doc/%s\">%s</a><br/>", cran.home, vign[,"PDF"], vign[,"Title"]), collapse="\n")), # location unline cran web/pkg/vignettes to not duplicate content, documentation is in ../../../library
+    sprintf("<tr><td> Package source: </td><td> <a href=\"%s/src/contrib/%s_%s.tar.gz\"> %s_%s.tar.gz </a> </td></tr>", cran.home,pkg, version, pkg, version),
+    sprintf("<tr><td> Windows binaries: </td><td> %s </td></tr>", format.bins(ver=c("r-devel","r-release"), bin_ver=c(r_devel_bin_ver,r_bin_ver), cran.home=cran.home, os.type="windows", pkg=pkg, version=version, repodir=repodir)),
+    sprintf("<tr><td> OS X binaries: </td><td> %s </td></tr>", format.bins(ver=c("r-devel","r-release"), bin_ver=c(r_devel_bin_ver, r_bin_ver), cran.home=cran.home, os.type="macosx", pkg=pkg, version=version, repodir=repodir))
+  )
+  if (pkg=="data.table") {
+    registry = Sys.getenv("CI_REGISTRY", "registry.gitlab.com")
+    namespace = Sys.getenv("CI_PROJECT_NAMESPACE", "Rdatatable")
+    project = Sys.getenv("CI_PROJECT_NAME", "data.table")
+    images = c("r-release","r-devel","r-release-builder")
+    images.title = c("Base R release", "Base R development", "R release package builder")
+    tags = rep("latest", 3)
+    docker.dl = sprintf("<tr><td> %s: </td><td> <pre><code>docker pull %s/%s/%s/%s:%s</code></pre> </td></tr>", images.title, registry, namespace, project, images, tags)
+  }
+  index.file = file.path(repodir, "web/packages", pkg, "index.html")
+  if (!dir.exists(dirname(index.file))) dir.create(dirname(index.file), recursive=TRUE)
+  writeLines(c(
+    "<html>",
+    "<head>",
+    sprintf("<title>Package %s</title>", pkg),
+    "<link rel=\"stylesheet\" type=\"text/css\" href=\"../../CRAN_web.css\" />",
+    "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\" />",
+    "<style type=\"text/css\">table td { vertical-align: top; }</style>",
+    "</head>",
+    "<body>",
+    sprintf("<h2>%s</h2>", dcf[,"Title"]),
+    sprintf("<p>%s</p>", dcf[,"Description"]),
+    sprintf("<table summary=\"Package %s summary\">", pkg),
+    tbl,
+    "</table>",
+    "<h4>Downloads:</h4>",
+    sprintf("<table summary=\"Package %s downloads\">", pkg),
+    tbl.dl,
+    "</table>",
+    if (pkg=="data.table")
+      c("<h4>Docker images:</h4>",
+        sprintf("<table summary=\"Package %s docker images\">", pkg),
+        docker.dl,
+        "</table>"),
+    "</body>",
+    "</html>"
+  ), index.file)
+  file.exists(index.file)
+}
+
+lib.copy <- function(lib.from, repodir="bus/integration/cran"){
+  pkgs.from<-list.dirs(lib.from, recursive=FALSE)
+  pkgs.to<-list.dirs(lib.to<-file.path(repodir,"library"), recursive=FALSE)
+  pkg.copy <- function(pkg.from, lib.to) {
+    pkg<-basename(pkg.from);
+    dir.create(file.path(lib.to, pkg), recursive=TRUE)
+    lib.dirs<-intersect(c("html","doc"), all.lib.dirs<-list.dirs(pkg.from, full.names=FALSE))
+    ans1<-setNames(file.copy(file.path(pkg.from, lib.dirs), file.path(lib.to, pkg), recursive=TRUE), lib.dirs)
+    lib.files<-setdiff(list.files(pkg.from), all.lib.dirs)
+    ans2<-setNames(file.copy(file.path(pkg.from, lib.files), file.path(lib.to, pkg)), lib.files)
+    all(ans1, ans2)
+  }
+  pkgs.from.new<-pkgs.from[!basename(pkgs.from) %in% basename(pkgs.to)]
+  setNames(sapply(pkgs.from.new, pkg.copy, lib.to=lib.to), basename(pkgs.from.new))
+}
+
+doc.copy <- function(repodir="bus/integration/cran"){
+  cp1<-c("COPYING","AUTHORS","THANKS");
+  ans1<-setNames(file.copy(file.path(R.home("doc"), cp1), file.path(repodir, "doc", cp1)), cp1); cp2<-c("html","manual");
+  ans2<-setNames(file.copy(file.path(R.home("doc"), cp2), file.path(repodir,"doc"), recursive=TRUE), cp2);
+  c(ans1, ans2)
+}
+
+plat <- function(x) if (grepl("^.*windows", x)) "Windows" else if (grepl("^.*macosx", x)) "Mac OS X" else "Linux"
+
+check.copy <- function(job, repodir="bus/integration/cran"){
+  dir.create(job.checks<-file.path(repodir, "web", "checks", pkg<-"data.table", job), recursive=TRUE);
+  os = plat(job)
+  from = file.path("bus", sprintf("%s/%s.Rcheck", job, pkg))
+  current.rout = c("main.Rout","main.Rout.fail","testthat.Rout","testthat.Rout.fail","knitr.Rout","knitr.Rout.fail","memtest.csv","memtest.png")
+  if (os=="Windows") {
+    dir.create(file.path(job.checks, "tests_i386"), showWarnings=FALSE)
+    dir.create(file.path(job.checks, "tests_x64"), showWarnings=FALSE)
+    rout32 = file.path("tests_i386", current.rout)
+    rout64 = file.path("tests_x64", current.rout)
+    file.copy(file.path(from, rout32)[file.exists(file.path(from, rout32))], file.path(job.checks, "tests_i386"))
+    file.copy(file.path(from, rout64)[file.exists(file.path(from, rout64))], file.path(job.checks, "tests_x64"))
+    routs = c(rout32, rout64)
+  } else if (os=="Mac OS X") {
+    dir.create(file.path(job.checks, "tests"), showWarnings=FALSE)
+    routs = file.path("tests", current.rout)
+    file.copy(file.path(from, routs)[file.exists(file.path(from, routs))], file.path(job.checks, "tests"))
+  } else {
+    dir.create(file.path(job.checks, "tests"), showWarnings=FALSE)
+    routs = file.path("tests", current.rout)
+    file.copy(file.path(from, routs)[file.exists(file.path(from, routs))], file.path(job.checks, "tests"))
+  }
+  inst.check.files = file.path(from, inst.check<-c("00install.out","00check.log"))
+  file.copy(inst.check.files[file.exists(inst.check.files)], job.checks)
+  setNames(file.exists(file.path(job.checks, c(inst.check, routs))), c(inst.check, routs))
+}
+
+check.index <- function(pkg, jobs, repodir="bus/integration/cran") {
+  status = function(x) if (grepl("^.*ERROR", x)) "ERROR" else if (grepl("^.*WARNING", x)) "WARNING" else if (grepl("^.*NOTE", x)) "NOTE" else if (grepl("^.*OK", x)) "OK" else NA_character_
+  test.files = function(job, files, trim.name=FALSE, trim.exts=0L, pkg="data.table") {
+    stopifnot(trim.name + as.logical(trim.exts) < 2L) # cannot use both
+    links = sapply(files, function(file) {
+      if (!file.exists(file.path(repodir, "web/checks", pkg, job, file))) return(NA_character_)
+      dir = if (!identical(d<-dirname(file), ".")) d
+      sprintf("<a href=\"%s/%s/%s\">%s</a>", pkg, job, file,
+              if (trim.name) paste(c(dir, tools::file_ext(file)), collapse="/") else if (trim.exts) { for (i in 1:trim.exts) { file<-tools::file_path_sans_ext(file) }; file } else file)
+    })
+    paste(na.omit(links), collapse=", ")
+  }
+  routs = lapply(jobs, function(job) {
+    current.rout = c("main.Rout.fail","testthat.Rout.fail","knitr.Rout.fail")
+    os = plat(job)
+    if (os=="Windows") {
+      rout32 = file.path("tests_i386", current.rout)
+      rout64 = file.path("tests_x64", current.rout)
+      routs = c(rout32, rout64)
+    } else if (os=="Mac OS X") {
+      routs = file.path("tests", current.rout)
+    } else {
+      routs = file.path("tests", current.rout)
+    }
+    routs
+  })
+  memouts = lapply(jobs, function(job) {
+    current.memout = c("memtest.csv","memtest.png")
+    os = plat(job)
+    if (os=="Windows") {
+      mem32 = file.path("tests_i386", current.memout)
+      mem64 = file.path("tests_x64", current.memout)
+      memouts = c(mem32, mem64)
+    } else if (os=="Mac OS X") {
+      memouts = file.path("tests", current.memout)
+    } else {
+      memouts = file.path("tests", current.memout)
+    }
+    memouts
+  })
+  tbl = sprintf("<tr><td>%s</td><td>%s</td><td><a href=\"%s/%s/00install.out\">out</a></td><td><a href=\"%s/%s/00check.log\">%s</a></td><td>%s</td><td>%s</td></tr>",
+                sub("test-", "", jobs, fixed=TRUE),
+                sapply(jobs, plat),
+                pkg, jobs,
+                pkg, jobs, sapply(sapply(jobs, check.test, pkg="data.table"), status),
+                mapply(test.files, jobs, routs, trim.exts=2L), # 1st fail, 2nd Rout, keep just: tests_x64/main
+                mapply(test.files, jobs, memouts, trim.name=TRUE))
+  file = file.path(repodir, "web/checks", sprintf("check_results_%s.html", pkg))
+  writeLines(c("<html>",
+               "<head>",
+               sprintf("<title>Package Check Results for Package %s</title>", pkg),
+               "<link rel=\"stylesheet\" type=\"text/css\" href=\"../CRAN_web.css\"/>",
+               "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"/>",
+               "</head>",
+               "<body lang=\"en\">",
+               sprintf("<h2>Package Check Results for Package <a href=\"../packages/%s/index.html\"> %s </a> </h2>", pkg, pkg),
+               sprintf("<p>Last updated on %s.</p>", format(Sys.time(), usetz=TRUE)),
+               sprintf("<table border=\"1\" summary=\"CRAN check results for package %s\">", pkg),
+               "<tr><th>Test job</th><th>OS type</th><th>Install</th><th>Check</th><th>Rout.fail</th><th>Memtest</th></tr>",
+               tbl,
+               "</table>",
+               "</body>",
+               "</html>"),
+             file)
+  setNames(file.exists(file), file)
+}
+
+pdf.copy <- function(pkg, job, repodir="bus/integration/cran") {
+  if (!dir.exists(pkg.to<-file.path(repodir,"web","packages",pkg))) dir.create(pkg.to, recursive=TRUE);
+  file.copy(file.path("bus", job, sprintf("%s.Rcheck", pkg), sprintf("%s-manual.pdf",pkg)), to=pdf.to<-file.path(pkg.to, sprintf("%s.pdf",pkg)))
+  setNames(file.exists(pdf.to), pdf.to)
+}
+
+check.test <- function(job, pkg) {
+  file = file.path("bus", job, sprintf("%s.Rcheck", pkg), "00check.log")
+  if (!file.exists(file)) return(NA_character_)
+  check = readLines(file)
+  check[length(check)]
+}
+
+move.bin <- function(job, bin.version, os.type, file="DESCRIPTION", silent=FALSE) {
+  if (os.type=="unix") {
+    stop("publish of linux binaries not supported")
+  } else if (os.type=="windows") {
+    plat.path = "windows"
+    extension = "zip"
+  } else if (os.type=="macosx") {
+    plat.path = "macosx/el-capitan"
+    extension = "tgz"
+  }
+  dcf = read.dcf(file)
+  pkg = dcf[,"Package"][[1L]]
+  version = dcf[,"Version"][[1L]]
+  src.path = file.path("bus",job,"cran/bin",plat.path,"contrib",bin.version)
+  if (!silent && !dir.exists(src.path)) stop(sprintf("expected directory does not exists %s", src.path))
+  bin.file = sprintf("%s_%s.%s", pkg, version, extension)
+  tgt.path = file.path("bus/integration/cran/bin",plat.path,"contrib",bin.version)
+  if (!file.exists(file.path(src.path, bin.file))) {
+    if (!silent) stop(sprintf("expected binaries does not exists %s", file.path(src.path, bin.file)))
+  } else {
+    if (!dir.exists(tgt.path)) dir.create(tgt.path, recursive=TRUE)
+    file.rename(file.path(src.path,bin.file), file.path(tgt.path,bin.file))
+  }
+  setNames(file.exists(file.path(tgt.path,bin.file)), file.path(tgt.path,bin.file))
+}


### PR DESCRIPTION
This PR is significant change to GitLab CI

- yaml file now uses inline templates, this allows to not repeat same chunks of script in different places, precisely `<<: *template-name` and `  - *inline-template-name`.
- simple helpers for mirroring packages and accessing packages dependencies has been moved from sourcing online [R/branches/tools4pkgs/src/library/tools/R/packages.R](https://svn.r-project.org/R/branches/tools4pkgs/src/library/tools/R/packages.R) to locally stored `ci.R` file, and extended.
- functions producing artifacts (in `integration` post-tests job) has been moved from inline `Rscript -e ...` calls into `publish.R` file, and extended.
- checks on windows machine has been added for r-release and r-devel.
- binaries for windows r-release and r-devel are being published to CRAN-like repo.
- three simple docker images are being pushed to docker registry.
- artifacts published as html website now includes references to memtest reports and eventually Rout.fail

I will follow up here after merging this PR to show where reports, like memtest, Rout.fail, etc. can be found.