### PR TITLE
Follow up on gc race

### DIFF
--- a/src/fsort.c
+++ b/src/fsort.c
@@ -112,6 +112,7 @@ SEXP fsort(SEXP x, SEXP verboseArg) {
   // TODO: not only detect if already sorted, but if it is, just return x to save the duplicate
 
   SEXP ansVec = PROTECT(allocVector(REALSXP, xlength(x)));
+  int nprotect = 1;
   double *ans = REAL(ansVec);
   // allocate early in case fails if not enough RAM
   // TODO: document this is much cheaper than a copy followed by in-place.
@@ -126,6 +127,8 @@ SEXP fsort(SEXP x, SEXP verboseArg) {
   R_xlen_t lastBatchSize = xlength(x) - (nBatch-1)*batchSize;
   // could be that lastBatchSize == batchSize when i) xlength(x) is multiple of nBatch
   // and ii) for small vectors with just one batch
+
+  if (ALTREP(x)) { x = PROTECT(duplicate(x)); nprotect++; }
 
   t[1] = wallclock();
   double mins[nBatch], maxs[nBatch];
@@ -305,8 +308,7 @@ SEXP fsort(SEXP x, SEXP verboseArg) {
     Rprintf("%d: %.3f (%4.1f%%)\n", i, t[i]-t[i-1], 100.*(t[i]-t[i-1])/tot);
   }
 
-  UNPROTECT(1);
+  UNPROTECT(nprotect);
   return(ansVec);
 }
-
 

--- a/src/subset.c
+++ b/src/subset.c
@@ -245,7 +245,7 @@ SEXP subsetDT(SEXP x, SEXP rows, SEXP cols) {
   SETLENGTH(ans, LENGTH(cols));
   for (int i=0; i<LENGTH(cols); i++) {
     SEXP source, target;
-    if (ALTREP(VECTOR_ELT(x, INTEGER(cols)[i]-1))) error("Internal error in subset.c: column %d is an ALTREP vector. Please see NEWS item 1 in v1.11.4 and report this as a bug.", INTEGER(cols)[i]);
+    if (ALTREP(VECTOR_ELT(x, INTEGER(cols)[i]-1))) error("Internal error in subset.c: column %d is an ALTREP vector. Please see NEWS item 2 in v1.11.4 and report this as a bug.", INTEGER(cols)[i]);
     target = PROTECT(allocVector(TYPEOF(source=VECTOR_ELT(x, INTEGER(cols)[i]-1)), ansn));
     SETLENGTH(target, ansn);
     SET_TRUELENGTH(target, ansn);


### PR DESCRIPTION
Follow up to PR #2882 
- [x] between.c
- [x] freadR.c (fread.c already free of R-API and the critical sections in freadR.c are ok in this respect)
- [x] fwriteR.c (DATAPTR usage is before parallel regions in R-API free fwrite.c)
- [x] fsort.c
- [x] reorder.c