### PR TITLE
Test 1590 fixed on Windows-1252

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,8 +3,6 @@
 
 ### Changes in v1.11.3  (in development)
 
-#### BUG FIXES
-
 1. Empty RHS of `:=` is no longer an error when the `i` clause returns no rows to assign to anyway, [#2829](https://github.com/Rdatatable/data.table/issues/2829). Thanks to @cguill95 for reporting and to @MarkusBonsch for fixing.
 
 2. Fixed runaway memory usage with R-devel (R > 3.5.0), [#2882](https://github.com/Rdatatable/data.table/pull/2882). Thanks to many people but in particular to Paul Bailey for making the breakthrough reproducible example and Luke Tierney for then pinpointing the issue. It was caused by an interaction of two or more data.table threads operating on new compact vectors in the ALTREP framework, such as the sequence `1:n`. This interaction could result in R's garbage collector turning off, and hence the memory explosion. Problems may occur in R 3.5.0 too but we were only able to reproduce in R > 3.5.0. The R code in data.table's implementation benefits from ALTREP (`for` loops in R no longer allocate their range vector input, for example) but are not so appropriate as data.table columns. Sequences such as `1:n` are common in test data but not very common in real-world datasets. Therefore, there is no need for data.table to support columns which are ALTREP compact sequences. The `data.table()` function already expanded compact vectors (by happy accident) but `setDT()` did not (it now does). If, somehow, a compact vector still reaches the internal parallel regions, a helpful error will now be generated. If this happens, please report it as a bug.

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
 
 2. Fixed runaway memory usage with R-devel (R > 3.5.0), [#2882](https://github.com/Rdatatable/data.table/pull/2882). Thanks to many people but in particular to Paul Bailey for making the breakthrough reproducible example and Luke Tierney for then pinpointing the issue. It was caused by an interaction of two or more data.table threads operating on new compact vectors in the ALTREP framework, such as the sequence `1:n`. This interaction could result in R's garbage collector turning off, and hence the memory explosion. Problems may occur in R 3.5.0 too but we were only able to reproduce in R > 3.5.0. The R code in data.table's implementation benefits from ALTREP (`for` loops in R no longer allocate their range vector input, for example) but are not so appropriate as data.table columns. Sequences such as `1:n` are common in test data but not very common in real-world datasets. Therefore, there is no need for data.table to support columns which are ALTREP compact sequences. The `data.table()` function already expanded compact vectors (by happy accident) but `setDT()` did not (it now does). If, somehow, a compact vector still reaches the internal parallel regions, a helpful error will now be generated. If this happens, please report it as a bug.
 
+3. Tests 1590.3 & 1590.4 now pass when users run `test.data.table()` on Windows, [#2856](https://github.com/Rdatatable/data.table/pull/2856). Thanks to Avraham Adler for reporting. Those tests were passing on AppVeyor, win-builder and CRAN's Windows because `R CMD check` sets `LC_COLLATE=C` as documented in R-exts$1.3.1, whereas by default on Windows `LC_COLLATE` is usually a regional Windows-1252 dialect such as `English_United States.1252`.
+
 
 ### Changes in v1.11.2  (on CRAN 8 May 2018)
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -7674,48 +7674,53 @@ dt = data.table(i=1:10, f=as.factor(1:10))
 test(1588.1, dt[f %in% 3:4], dt[3:4])
 test(1588.2, dt[f == 3], dt[3])
 
-# data.table::forderv is encoding-aware and independent of locale
-# [ Aside: data.table needs to be independent of locale because keys/indexes depend on a sort order. If a data.table is stored on disk with a key
+# data.table operates consistently independent of locale, but it's R that changes and is sensitive to it.
+#   Because keys/indexes depend on a sort order. If a data.table is stored on disk with a key
 #   created in a locale-sensitive order and then loaded by another R session in a different locale, the ability to re-use existing sortedness
 #   will break because the order would depend on the locale. Which is why data.table is deliberately C-locale only. For consistency and simpler
 #   internals for robustness to reduce the change of errors and to avoid that class of bug. It would be possible to have locale-sensitive keys
-#   and indexes but we've, so far, decided not to, for those reasons. ]
-# base::order is encoding-aware and locale-sensitive, tested here
-# R is usually started in the regional non-C locale; e.g. en_US.UTF-8 for Matt and en_IN for Jan, #2771
-# This test 1590 tests both data.table and base R in the default locale and C locale too
-# Note that data.table operates consistently independent of locale, but it's R that changes and is sensitive to it.
+#   and indexes but we've, so far, decided not to, for those reasons.
+# R is usually started in the regional non-C locale; e.g. en_US.UTF-8 for Matt, en_IN for Jan (#2771) and English_United States.1252 on Windows in US (#2856)
 oldlocale = Sys.getlocale()
 ctype = Sys.getlocale("LC_CTYPE")
 collate = Sys.getlocale("LC_COLLATE")
-# We could use LC_ALL, too, but the idea was to focus on the minimal parts of LC_ALL directly.
-# The user may have changed locale from the default, so we desire here to precisely return these two
-# locale settings to their values before this test (which might feasibly not be the default).
-if (ctype==collate && ctype!="C") {
-  # normally true; e.g. R CMD check, CRAN etc, unless user manually started R in C-locale
-  x1 = "fa\xE7ile"
-  Encoding(x1) = "latin1"
-  x2 = iconv(x1, "latin1", "UTF-8")
-  test(1590.1, forderv(c(x2,x1,x1,x2)), integer())  # integer() means input is already sorted
-  test(1590.2, base::order(c(x2,x1,x1,x2)), 1:4)
-  Encoding(x2) = "unknown"
-  test(1590.3, forderv(c(x2,x1,x1,x2)), integer())
-  test(1590.4, base::order(c(x2,x1,x1,x2)), 1:4)
-}
 Sys.setlocale("LC_CTYPE","C")
 Sys.setlocale("LC_COLLATE","C")
 # Same as Set.locale("LC_ALL","C") but done like this because it's not possible to return LC_ALL to previous state (only to default)
-# Both LC_CTYPE and LC_COLLATE need to be set (as more normally done with LC_ALL) before base::order changes behaviour in test 1590.6 and 1590.8
+# Both LC_CTYPE and LC_COLLATE need to be set (as more normally done with LC_ALL) before base::order changes behaviour in test 1590.4 and 1590.7
 x1 = "fa\xE7ile"
 Encoding(x1) = "latin1"
 x2 = iconv(x1, "latin1", "UTF-8")
-test(1590.5, forderv(c(x2,x1,x1,x2)), integer())         # same consistent result from data.table (good for our needs)
-test(1590.6, base::order(c(x2,x1,x1,x2)), INT(1,4,2,3))  # different result in base R under C locale
+test(1590.1, identical(x1,x2))
+test(1590.2, x1==x2)
+test(1590.3, forderv(    c(x2,x1,x1,x2)), integer())     # desirable consistent result given data.table's needs
+test(1590.4, base::order(c(x2,x1,x1,x2)), INT(1,4,2,3))  # different result in base R under C locale even though identical(x1,x2)
 Encoding(x2) = "unknown"
-test(1590.7, forderv(c(x2,x1,x1,x2)), INT(1,4,2,3))      # same consistent result from data.table (good for our needs)
-test(1590.8, base::order(c(x2,x1,x1,x2)), INT(2,3,1,4))  # different result again; base R is encoding-sensitive when in C-locale
+test(1590.5, x1!=x2)
+test(1590.6, forderv(    c(x2,x1,x1,x2)), INT(1,4,2,3))  # consistent with Windows-1252 result, tested further below
+test(1590.7, base::order(c(x2,x1,x1,x2)), INT(2,3,1,4))  # different result; base R is encoding-sensitive in C-locale
 Sys.setlocale("LC_CTYPE", ctype)
 Sys.setlocale("LC_COLLATE", collate)
-test(1590.9, Sys.getlocale(), oldlocale)  # checked restored locale fully back to how it was before this test
+test(1590.8, Sys.getlocale(), oldlocale)  # checked restored locale fully back to how it was before this test
+# Now test default locale on all platforms: Windows-1252 on AppVeyor and win-builder, UTF-8 on Linux, and users running test.data.table() in their locale
+x1 = "fa\xE7ile"
+Encoding(x1) = "latin1"
+x2 = iconv(x1, "latin1", "UTF-8")
+test(1590.9, identical(x1,x2))
+test(1590.11, x1==x2)
+test(1590.12, forderv(    c(x2,x1,x1,x2)), integer())
+test(1590.13, base::order(c(x2,x1,x1,x2)), 1:4)
+Encoding(x2) = "unknown"
+if (x1==x2) {
+  # Linux and Mac where locale is usually UTF8
+  # NB: x1==x2 is a condition in base R, independent of data.table
+  test(1590.14, forderv(    c(x2,x1,x1,x2)), integer())
+  test(1590.15, base::order(c(x2,x1,x1,x2)), 1:4)
+} else {
+  # Windows-1252, #2856
+  test(1590.16, forderv(    c(x2,x1,x1,x2)), INT(1,4,2,3))
+  test(1590.17, base::order(c(x2,x1,x1,x2)), INT(1,4,2,3))
+}
 
 # #1432 test
 list_1 = list(a = c(44,47), dens = c(2331,1644))
@@ -11847,7 +11852,8 @@ plat = paste0("endian==", .Platform$endian,
               ", sizeof(long double)==", .Machine$sizeof.longdouble,
               ", sizeof(pointer)==", .Machine$sizeof.pointer,
               ", TZ=", suppressWarnings(Sys.timezone()),
-              ", locale='", Sys.getlocale(), "'")
+              ", locale='", Sys.getlocale(), "'",
+              ", l10n_info()='", paste0(names(l10n_info()), "=", l10n_info(), collapse="; "), "'")
 DT = head(timings[-1L][order(-time)],10)   # exclude id 1 as in dev that includes JIT
 if ((x<-timings[,sum(nTest)]) != ntest) warning("Timings count mismatch:",x,"vs",ntest)
 cat("\n10 longest running tests took ", as.integer(tt<-DT[, sum(time)]), "s (", as.integer(100*tt/(ss<-timings[,sum(time)])), "% of ", as.integer(ss), "s)\n", sep="")


### PR DESCRIPTION
Closes #2856 
There was no issue on CRAN, win-builder or AppVeyor,  for [this reason](https://github.com/Rdatatable/data.table/issues/2856#issuecomment-391900164).  That's fixed so it now runs on all platforms including those.
I was able to reproduce on Windows VM and confirmed fixed.