### PR TITLE
Small leak

### DIFF
--- a/src/forder.c
+++ b/src/forder.c
@@ -24,17 +24,17 @@ static SEXP *cradix_xtmp = NULL; static int cradix_xtmp_alloc = 0;
 static int *csort_otmp=NULL; static int csort_otmp_alloc=0;
 static SEXP *ustr = NULL; static int ustr_alloc = 0; static int ustr_n = 0;
 
-#define Error(...) do {onexit(); error(__VA_ARGS__);} while(0)      // http://gcc.gnu.org/onlinedocs/cpp/Swallowing-the-Semicolon.html#Swallowing-the-Semicolon
+#define Error(...) do {cleanup(); error(__VA_ARGS__);} while(0)      // http://gcc.gnu.org/onlinedocs/cpp/Swallowing-the-Semicolon.html#Swallowing-the-Semicolon
 #undef warning
 #define warning(...) Do not use warning in this file                // since it can be turned to error via warn=2
 /* Using OS realloc() in this file to benefit from (often) in-place realloc() to save copy
  * We have to trap on exit anyway to call savetl_end().
  * NB: R_alloc() would be more convenient (fails within) and robust (auto free) but there is no R_realloc(). Implementing R_realloc() would be an alloc and copy, iiuc.
  *     Calloc/Realloc needs to be Free'd, even before error() [R-exts$6.1.2]. An oom within Calloc causes a previous Calloc to leak so Calloc would still needs to be trapped anyway.
- * Therefore, using <<if (!malloc()) Error("helpful context msg")>> approach to onexit() on error.
+ * Therefore, using <<if (!malloc()) Error("helpful context msg")>> approach to cleanup() on error.
  */
 
-static void onexit() {
+static void cleanup() {
   free(gs[0]); gs[0] = NULL;
   free(gs[1]); gs[1] = NULL;
   flip = 0;
@@ -1359,7 +1359,7 @@ SEXP forder(SEXP DT, SEXP by, SEXP retGrp, SEXP sortStrArg, SEXP orderArg, SEXP 
     setAttrib(ans, sym_maxgrpn, ScalarInteger(gsmax[flip]));
   }
 
-  onexit();
+  cleanup();
   UNPROTECT(n_protect);
   return ans;
 }

--- a/src/forder.c
+++ b/src/forder.c
@@ -13,22 +13,60 @@ static int gsalloc[2] = {0};                                        // allocated
 static int gsngrp[2] = {0};                                         // used
 static int gsmax[2] = {0};                                          // max grpn so far
 static int gsmaxalloc = 0;                                          // max size of stack, set by forder to nrows
-static Rboolean stackgrps = TRUE;                                   // switched off for last column when not needed by setkey
-static Rboolean sortStr = TRUE;                                     // TRUE for setkey, FALSE for by=
+static void *xsub = NULL;                                           // allocated by forder; local function arguments named xsub point into it
 static int *newo = NULL;                                            // used by forder and [i|d|c]sort to reorder order. not needed if length(by)==1
+static int *otmp = NULL; static int otmp_alloc = 0;
+static void *xtmp = NULL; static int xtmp_alloc = 0;                // TO DO: save xtmp if possible, see allocs in forder
+static void *radix_xsub = NULL; static size_t radix_xsub_alloc = 0;
+static int *cradix_counts = NULL; static int cradix_counts_alloc = 0;
+static int maxlen = 1;
+static SEXP *cradix_xtmp = NULL; static int cradix_xtmp_alloc = 0;
+static int *csort_otmp=NULL; static int csort_otmp_alloc=0;
+static SEXP *ustr = NULL; static int ustr_alloc = 0; static int ustr_n = 0;
+
+#define Error(...) do {onexit(); error(__VA_ARGS__);} while(0)      // http://gcc.gnu.org/onlinedocs/cpp/Swallowing-the-Semicolon.html#Swallowing-the-Semicolon
+#undef warning
+#define warning(...) Do not use warning in this file                // since it can be turned to error via warn=2
+/* Using OS realloc() in this file to benefit from (often) in-place realloc() to save copy
+ * We have to trap on exit anyway to call savetl_end().
+ * NB: R_alloc() would be more convenient (fails within) and robust (auto free) but there is no R_realloc(). Implementing R_realloc() would be an alloc and copy, iiuc.
+ *     Calloc/Realloc needs to be Free'd, even before error() [R-exts$6.1.2]. An oom within Calloc causes a previous Calloc to leak so Calloc would still needs to be trapped anyway.
+ * Therefore, using <<if (!malloc()) Error("helpful context msg")>> approach to onexit() on error.
+ */
+
+static void onexit() {
+  free(gs[0]); gs[0] = NULL;
+  free(gs[1]); gs[1] = NULL;
+  flip = 0;
+  gsalloc[0] = gsalloc[1] = 0;
+  gsngrp[0] = gsngrp[1] = 0;
+  gsmax[0] = gsmax[1] = 0;
+  gsmaxalloc = 0;
+
+  free(xsub);             xsub=NULL;
+  free(newo);             newo=NULL;
+  free(otmp);             otmp=NULL;             otmp_alloc=0;
+  free(xtmp);             xtmp=NULL;             xtmp_alloc=0;
+  free(radix_xsub);       radix_xsub=NULL;       radix_xsub_alloc=0;
+  free(cradix_counts);    cradix_counts=NULL;    cradix_counts_alloc=0;
+  maxlen = 1;
+  free(cradix_xtmp);      cradix_xtmp=NULL;      cradix_xtmp_alloc=0;   // TO DO: reuse xtmp
+  free(csort_otmp);       csort_otmp=NULL;       csort_otmp_alloc=0;
+
+  for(int i=0; i<ustr_n; i++)
+    SET_TRUELENGTH(ustr[i],0);
+  free(ustr);             ustr=NULL;             ustr_alloc=0; ustr_n=0;
+  savetl_end();  // Restore R's own usage of tl. Must run after the for loop above since only CHARSXP which had tl>0 (R's usage) are stored there.
+}
 
 static int nalast = -1;                                             // =1, 0, -1 for TRUE, NA, FALSE respectively. Value rewritten inside forder().
                                                                     // note that na.last=NA (0) removes NAs, not retains them.
 static int order = 1;                                               // =1, -1 for ascending and descending order respectively
+static Rboolean stackgrps = TRUE;                                   // switched off for last column when not needed by setkey
+static Rboolean sortStr = TRUE;                                     // TRUE for setkey, FALSE for by=
 
 #define N_SMALL 200                                                 // replaced n < 200 with n < N_SMALL. Easier to change later
 #define N_RANGE 100000                                              // range limit for counting sort. UPDATE: should be less than INT_MAX (see setRange for details)
-
-#define Error(...) do {savetl_end(); error(__VA_ARGS__);} while(0)  // http://gcc.gnu.org/onlinedocs/cpp/Swallowing-the-Semicolon.html#Swallowing-the-Semicolon
-#undef warning
-#define warning(...) Do not use warning in this file                // since it can be turned to error via warn=2
-/* use malloc/realloc (not Calloc/Realloc) so we can trap errors
-and call savetl_end() before the error(). */
 
 static void growstack(int newlen) {
   if (newlen==0) newlen=100000;                                   // no link to icount range restriction, just 100,000 seems a good minimum at 0.4MB.
@@ -57,16 +95,6 @@ static void flipflop() {
   gsngrp[flip] = 0;
   gsmax[flip] = 0;
   if (gsalloc[flip] < gsalloc[1-flip]) growstack(gsalloc[1-flip]*2);
-}
-
-static void gsfree() {
-  free(gs[0]); free(gs[1]);
-  gs[0] = NULL; gs[1]= NULL;
-  flip = 0;
-  gsalloc[0] = gsalloc[1] = 0;
-  gsngrp[0] = gsngrp[1] = 0;
-  gsmax[0] = gsmax[1] = 0;
-  gsmaxalloc = 0;
 }
 
 #ifdef TIMING_ON
@@ -248,10 +276,7 @@ static unsigned int radixcounts[8][257] = {{0}};                            // 4
 static int skip[8];
 /* global because iradix and iradix_r interact and are called repetitively.
    counts are set back to 0 after each use, to benefit from skipped radix. */
-static void *radix_xsub=NULL;
-static size_t radix_xsuballoc=0;
 
-static int *otmp=NULL, otmp_alloc=0;
 static void alloc_otmp(int n) {
   if (otmp_alloc >= n) return;
   otmp = (int *)realloc(otmp, n * sizeof(int));
@@ -259,7 +284,6 @@ static void alloc_otmp(int n) {
   otmp_alloc = n;
 }
 
-static void *xtmp=NULL; int xtmp_alloc=0;                                   // TO DO: save xtmp if possible, see allocs in forder
 static void alloc_xtmp(int n) {                                             // TO DO: currently always the largest type (double) but
                                       // could be int if that's all that's needed
   if (xtmp_alloc >= n) return;
@@ -328,13 +352,13 @@ static void iradix(int *x, int *o, int n)
     o[--thiscounts[thisx]] = i+1;
   }
 
-  if (radix_xsuballoc < maxgrpn) {
+  if (radix_xsub_alloc < maxgrpn) {
     // The largest group according to the first non-skipped radix, so could be big (if radix is needed on first column)
     // TO DO: could include extra bits to divide the first radix up more. Often the MSD has groups in just 0-4 out of 256.
     // free'd at the end of forder once we're done calling iradix repetitively
     radix_xsub = (int *)realloc(radix_xsub, maxgrpn*sizeof(double));    // realloc(NULL) == malloc
     if (!radix_xsub) Error("Failed to realloc working memory %d*8bytes (xsub in iradix), radix=%d", maxgrpn, radix);
-    radix_xsuballoc = maxgrpn;
+    radix_xsub_alloc = maxgrpn;
   }
 
   alloc_otmp(maxgrpn);   // TO DO: can we leave this to forder and remove these calls??
@@ -577,13 +601,13 @@ static void dradix(unsigned char *x, int *o, int n)
     o[ --thiscounts[((unsigned char *)&thisx)[RADIX_BYTE]] ] = i+1;
   }
 
-  if (radix_xsuballoc < maxgrpn) {                                            // TO DO: centralize this alloc
+  if (radix_xsub_alloc < maxgrpn) {                                            // TO DO: centralize this alloc
     // The largest group according to the first non-skipped radix, so could be big (if radix is needed on first column)
     // TO DO: could include extra bits to divide the first radix up more. Often the MSD has groups in just 0-4 out of 256.
     // free'd at the end of forder once we're done calling iradix repetitively
     radix_xsub = (double *)realloc(radix_xsub, maxgrpn*sizeof(double));  // realloc(NULL) == malloc
     if (!radix_xsub) Error("Failed to realloc working memory %d*8bytes (xsub in dradix), radix=%d", maxgrpn, radix);
-    radix_xsuballoc = maxgrpn;
+    radix_xsub_alloc = maxgrpn;
   }
 
   alloc_otmp(maxgrpn);   // TO DO: leave to forder and remove these calls?
@@ -705,12 +729,6 @@ static void dradix_r(unsigned char *xsub, int *osub, int n, int radix)
 // TO DO?: dcount. Find step size, then range = (max-min)/step and proceed as icount. Many fixed precision floats (such as prices)
 // may be suitable. Fixed precision such as 1.10, 1.15, 1.20, 1.25, 1.30 ... do use all bits so dradix skipping may not help.
 
-static int *cradix_counts = NULL;
-static int cradix_counts_alloc = 0;
-static int maxlen = 1;
-static SEXP *cradix_xtmp = NULL;
-static int cradix_xtmp_alloc = 0;
-
 int StrCmp2(SEXP x, SEXP y) {    // same as StrCmp but also takes into account 'na.last' argument.
   if (x == y) return 0;                   // same cached pointer (including NA_STRING==NA_STRING)
   if (x == NA_STRING) return nalast;      // if x=NA, nalast=1 ? then x > y else x < y (Note: nalast == 0 is already taken care of in 'csorted', won't be 0 here)
@@ -794,9 +812,6 @@ static void cradix_r(SEXP *xsub, int n, int radix)
   if (itmp<n-1) cradix_r(xsub+itmp, n-itmp, radix+1);  // final group
 }
 
-static SEXP *ustr = NULL;
-static int ustr_alloc = 0, ustr_n = 0;
-
 static void cgroup(SEXP *x, int *o, int n)
 // As icount :
 //   Places the ordering into o directly, overwriting whatever was there
@@ -845,7 +860,6 @@ static void cgroup(SEXP *x, int *o, int n)
   ustr_n = 0;
 }
 
-static int *csort_otmp=NULL, csort_otmp_alloc=0;
 static void alloc_csort_otmp(int n) {
   if (csort_otmp_alloc >= n) return;
   csort_otmp = (int *)realloc(csort_otmp, n * sizeof(int));
@@ -1203,13 +1217,12 @@ SEXP forder(SEXP DT, SEXP by, SEXP retGrp, SEXP sortStrArg, SEXP orderArg, SEXP 
   TEND(0)
 
   int maxgrpn = gsmax[flip];   // biggest group in the first column
-  void *xsub = NULL;           // local to forder
   int (*f)(); void (*g)();
 
   if (length(by)>1 && gsngrp[flip]<n) {
     xsub = (void *)malloc(maxgrpn * sizeof(double));    // double is the largest type, 8
     if (xsub==NULL) Error("Couldn't allocate xsub in forder, requested %d * %d bytes.", maxgrpn, sizeof(double));
-    newo = (int *)malloc(maxgrpn * sizeof(int));        // global variable, used by isort, dsort, sort and cgroup
+    newo = (int *)malloc(maxgrpn * sizeof(int));        // used by isort, dsort, sort and cgroup
     if (newo==NULL) Error("Couldn't allocate newo in forder, requested %d * %d bytes.", maxgrpn, sizeof(int));
   }
   TEND(1)  // should be negligible time to malloc even large blocks, but time it anyway to be sure
@@ -1326,12 +1339,6 @@ SEXP forder(SEXP DT, SEXP by, SEXP retGrp, SEXP sortStrArg, SEXP orderArg, SEXP 
 #endif
 
   if (!sortStr && ustr_n!=0) Error("Internal error: at the end of forder sortStr==FALSE but ustr_n!=0 [%d]", ustr_n);
-  for(int i=0; i<ustr_n; i++)
-    SET_TRUELENGTH(ustr[i],0);
-  maxlen = 1;  // reset global. Minimum needed to count "" and NA
-  ustr_n = 0;
-  savetl_end();
-  free(ustr);                ustr=NULL;          ustr_alloc=0;
 
   if (isSorted) {
     // the o vector created earlier could be avoided in this case if we only create it when isSorted becomes FALSE
@@ -1352,16 +1359,7 @@ SEXP forder(SEXP DT, SEXP by, SEXP retGrp, SEXP sortStrArg, SEXP orderArg, SEXP 
     setAttrib(ans, sym_maxgrpn, ScalarInteger(gsmax[flip]));
   }
 
-  gsfree();
-  free(radix_xsub);          radix_xsub=NULL;    radix_xsuballoc=0;
-  free(xsub); free(newo);    xsub=newo=NULL;
-  free(xtmp);                xtmp=NULL;          xtmp_alloc=0;
-  free(otmp);                otmp=NULL;          otmp_alloc=0;
-  free(csort_otmp);          csort_otmp=NULL;    csort_otmp_alloc=0;
-
-  free(cradix_counts);       cradix_counts=NULL; cradix_counts_alloc=0;
-  free(cradix_xtmp);         cradix_xtmp=NULL;   cradix_xtmp_alloc=0;   // TO DO: use xtmp already got
-
+  onexit();
   UNPROTECT(n_protect);
   return ans;
 }


### PR DESCRIPTION
Closes #2812 
Moved all global variables into one section at the top. Previously they occurred just before the helper functions using them. That's good practice for local variables (to declare as local as possible), but not for globals, because the cleanup was harder.
Now the cleanup function immediately follows the globals and deals with them in the same order as they are declared to aid checking none are missed.
Moved the free's that were at the end of the main function (on success) into the cleanup function so that those get freed on error too. This resolves the leak.
This brings forder.c into line with fread.c which also has a single cleanup at the top doing everything.