### PR TITLE
Locking data.table tables

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2495,6 +2495,7 @@ setnames <- function(x,old,new) {
   # But also more convenient than names(DT)[i]="newname"  because we can also do setnames(DT,"oldname","newname")
   # without an onerous match() ourselves. old can be positions, too, but we encourage by name for robustness.
   if (!is.data.frame(x)) stop("x is not a data.table or data.frame")
+  if (!is.null(attr(x,".data.table.locked")) && attr(x,".data.table.locked")) stop("data.table is locked so names can't be updated")
   if (length(names(x)) != length(x)) stop("dt is length ",length(dt)," but its names are length ",length(names(x)))
   if (missing(new)) {
     # for setnames(DT,new); e.g., setnames(DT,c("A","B")) where ncol(DT)==2


### PR DESCRIPTION
There are many open issues (e.g. #778 and #1086 ) on Github and questions on StackOverflow asking for the ability to lock the contents of a data.table from all updates. One suggestion has been to use the attribute .data.table.locked which blocks some update (e.g. := ) to block all updates. Below is an example how setnames could be altered to to do this. I'm new to the data.table code, so I have a few questions:
1. Can the attribute .data.table.locked be used or does it currently have a specific other use?
2. Is there a deeper place in the code where we can block updates as opposed to updating all the R functions?
3. Should lockBinding(dt,env) be extended to set .data.table.locked?