### PR TITLE
Fixed subsetting / join bug with keys and factor to character coercion.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,8 @@
 
 4. `as.matrix(DT, rownames="id")` now works when `DT` has a single row, [#2930](https://github.com/Rdatatable/data.table/issues/2930). Thanks to @malcook for reporting and @sritchie73 for fixing. The root cause was the dual meaning of the `rownames=` argument: i) a single column name/number (most common), or ii) rowname values length 1 for the single row. For clarity and safety, `rownames.value=` has been added. Old usage (i.e. `length(rownames)>1`) continues to work for now but will issue a warning in a future release, and then error in a release after that.
 
+5. Fixed regression that was introduced by PR [#2389](https://github.com/Rdatatable/data.table/pull/2389). The PR introduced partial key retainment on := assigns. This broke the joining logic that assumed implicitely that assigning always destroys keys completely. As a result, join and subset results were wrong when matching character to factor columns with existing keys. [#2881](https://github.com/Rdatatable/data.table/issues/2881). Thanks to @ddong63 for reporting and to @MarkusBonsch for fixing.
+
 #### NOTES
 
 1. The type coercion warning message has been improved, [#2989](https://github.com/Rdatatable/data.table/pull/2989). Thanks to @sarahbeeysian on [Twitter](https://twitter.com/sarahbeeysian/status/1021359529789775872) for highlighting. For example, given the follow statements:
@@ -64,8 +66,6 @@ Warning message:
 3. Tests 1590.3 & 1590.4 now pass when users run `test.data.table()` on Windows, [#2856](https://github.com/Rdatatable/data.table/pull/2856). Thanks to Avraham Adler for reporting. Those tests were passing on AppVeyor, win-builder and CRAN's Windows because `R CMD check` sets `LC_COLLATE=C` as documented in R-exts$1.3.1, whereas by default on Windows `LC_COLLATE` is usually a regional Windows-1252 dialect such as `English_United States.1252`.
 
 4. Around 1 billion very small groups (of size 1 or 2 rows) could result in `"Failed to realloc working memory"` even when plenty of memory is available, [#2777](https://github.com/Rdatatable/data.table/issues/2777). Thanks once again to @jsams for the detailed report as a follow up to bug fix 40 in v1.11.0.
-
-5. Fixed regression that was introduced by PR [#2389](https://github.com/Rdatatable/data.table/pull/2389). The PR introduced partial key retainment on := assigns. This broke the joining logic that assumed implicitely that assigning always destroys keys completely. As a result, join and subset results were wrong when matching character to factor columns with existing keys. [#2881](https://github.com/Rdatatable/data.table/issues/2881). Thanks to @ddong63 for reporting and to @MarkusBonsch for fixing. 
 
 ### Changes in v1.11.2  (on CRAN 8 May 2018)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@
 
 4. Around 1 billion very small groups (of size 1 or 2 rows) could result in `"Failed to realloc working memory"` even when plenty of memory is available, [#2777](https://github.com/Rdatatable/data.table/issues/2777). Thanks once again to @jsams for the detailed report as a follow up to bug fix 40 in v1.11.0.
 
+5. Fixed regression that was introduced by PR [#2389](https://github.com/Rdatatable/data.table/pull/2389). The PR introduced partial key retainment on := assigns. This broke the joining logic that assumed implicitely that assigning always destroys keys completely. As a result, join and subset results were wrong when matching character to factor columns with existing keys. [#2881](https://github.com/Rdatatable/data.table/issues/2881). Thanks to @ddong63 for reporting and to @MarkusBonsch for fixing. 
 
 ### Changes in v1.11.2  (on CRAN 8 May 2018)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,7 @@
 
 4. `as.matrix(DT, rownames="id")` now works when `DT` has a single row, [#2930](https://github.com/Rdatatable/data.table/issues/2930). Thanks to @malcook for reporting and @sritchie73 for fixing. The root cause was the dual meaning of the `rownames=` argument: i) a single column name/number (most common), or ii) rowname values length 1 for the single row. For clarity and safety, `rownames.value=` has been added. Old usage (i.e. `length(rownames)>1`) continues to work for now but will issue a warning in a future release, and then error in a release after that.
 
-5. Fixed regression in v1.11.0 (May 2018) introduced by PR [#2389](https://github.com/Rdatatable/data.table/pull/2389) which introduced partial key retainment on `:=` assigns. This broke the joining logic that assumed implicitly that assigning always drops keys completely. Consequently, join and subset results could be wrong when matching character to factor columns with existing keys, [#2881](https://github.com/Rdatatable/data.table/issues/2881). Thanks to @ddong63 for reporting and to @MarkusBonsch for fixing. Missing test added to ensure this doesn't arise again.
+5. Fixed regression in v1.11.0 (May 2018) caused by PR [#2389](https://github.com/Rdatatable/data.table/pull/2389) which introduced partial key retainment on `:=` assigns. This broke the joining logic that assumed implicitly that assigning always drops keys completely. Consequently, join and subset results could be wrong when matching character to factor columns with existing keys, [#2881](https://github.com/Rdatatable/data.table/issues/2881). Thanks to @ddong63 for reporting and to @MarkusBonsch for fixing. Missing test added to ensure this doesn't arise again.
 
 #### NOTES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -67,6 +67,7 @@ Warning message:
 
 4. Around 1 billion very small groups (of size 1 or 2 rows) could result in `"Failed to realloc working memory"` even when plenty of memory is available, [#2777](https://github.com/Rdatatable/data.table/issues/2777). Thanks once again to @jsams for the detailed report as a follow up to bug fix 40 in v1.11.0.
 
+
 ### Changes in v1.11.2  (on CRAN 8 May 2018)
 
 1. `test.data.table()` created/overwrote variable `x` in `.GlobalEnv`, [#2828](https://github.com/Rdatatable/data.table/issues/2828); i.e. a modification of user's workspace which is not allowed. Thanks to @etienne-s for reporting.

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,7 @@
 
 4. `as.matrix(DT, rownames="id")` now works when `DT` has a single row, [#2930](https://github.com/Rdatatable/data.table/issues/2930). Thanks to @malcook for reporting and @sritchie73 for fixing. The root cause was the dual meaning of the `rownames=` argument: i) a single column name/number (most common), or ii) rowname values length 1 for the single row. For clarity and safety, `rownames.value=` has been added. Old usage (i.e. `length(rownames)>1`) continues to work for now but will issue a warning in a future release, and then error in a release after that.
 
-5. Fixed regression that was introduced by PR [#2389](https://github.com/Rdatatable/data.table/pull/2389). The PR introduced partial key retainment on := assigns. This broke the joining logic that assumed implicitely that assigning always destroys keys completely. As a result, join and subset results were wrong when matching character to factor columns with existing keys. [#2881](https://github.com/Rdatatable/data.table/issues/2881). Thanks to @ddong63 for reporting and to @MarkusBonsch for fixing.
+5. Fixed regression in v1.11.0 (May 2018) introduced by PR [#2389](https://github.com/Rdatatable/data.table/pull/2389) which introduced partial key retainment on `:=` assigns. This broke the joining logic that assumed implicitly that assigning always drops keys completely. Consequently, join and subset results could be wrong when matching character to factor columns with existing keys, [#2881](https://github.com/Rdatatable/data.table/issues/2881). Thanks to @ddong63 for reporting and to @MarkusBonsch for fixing. Missing test added to ensure this doesn't arise again.
 
 #### NOTES
 

--- a/R/between.R
+++ b/R/between.R
@@ -25,7 +25,7 @@ inrange <- function(x,lower,upper,incbounds=TRUE) {
   if (verbose) {last.started.at=proc.time();cat("forderv(query) took ... ");flush.console()}
   xo = forderv(query)
   if (verbose) {cat(timetaken(last.started.at),"\n"); flush.console()}
-  ans = bmerge(shallow(subject), query, 1L:2L, c(1L,1L), FALSE, xo,
+  ans = bmerge(shallow(subject), query, 1L:2L, c(1L,1L), xo,
       0, c(FALSE, TRUE), 0L, "all", ops, integer(0L),
       1L, verbose) # fix for #1819, turn on verbose messages
   options(datatable.verbose=FALSE)

--- a/R/bmerge.R
+++ b/R/bmerge.R
@@ -1,9 +1,8 @@
 
-bmerge <- function(i, x, leftcols, rightcols, io, xo, roll, rollends, nomatch, mult, ops, nqgrp, nqmaxgrp, verbose)
+bmerge <- function(i, x, leftcols, rightcols, xo, roll, rollends, nomatch, mult, ops, nqgrp, nqmaxgrp, verbose)
 {
   # TO DO: rename leftcols to icols, rightcols to xcols
-  # NB: io is currently just TRUE or FALSE for whether i is keyed
-  # TO DO: io and xo could be moved inside Cbmerge
+  # TO DO: xo could be moved inside Cbmerge
   # bmerge moved to be separate function now that list() doesn't copy in R
   # types of i join columns are promoted to match x's types (with warning or verbose)
 
@@ -89,9 +88,10 @@ bmerge <- function(i, x, leftcols, rightcols, io, xo, roll, rollends, nomatch, m
       set(i, j=lc, value=newval)
     }
   }
+  ## after all modifications of i, check if i has a proper key on all leftcols
+  io <- identical(leftcols, head(chmatch(key(i), names(i)), length(leftcols)))
   if (verbose) {last.started.at=proc.time();cat("Starting bmerge ...");flush.console()}
-  ans = .Call(Cbmerge, i, x, as.integer(leftcols), as.integer(rightcols), io<-haskey(i), xo, roll, rollends, nomatch, mult, ops, nqgrp, nqmaxgrp)
-  # NB: io<-haskey(i) necessary for test 579 where the := above change the factor to character and remove i's key
+  ans = .Call(Cbmerge, i, x, as.integer(leftcols), as.integer(rightcols), io, xo, roll, rollends, nomatch, mult, ops, nqgrp, nqmaxgrp)
   if (verbose) {cat("done in",timetaken(last.started.at),"\n"); flush.console()}
 
   # in the caller's shallow copy,  see comment at the top of this function for usage

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -591,9 +591,8 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
         setnames(i, orignames[leftcols])
         setattr(i, 'sorted', names(i)) # since 'x' has key set, this'll always be sorted
       }
-      io = if (missing(on)) haskey(i) else identical(unname(on), head(key(i), length(on)))
-      i = .shallow(i, retain.key = io)
-      ans = bmerge(i, x, leftcols, rightcols, io, xo, roll, rollends, nomatch, mult, ops, nqgrp, nqmaxgrp, verbose=verbose)
+      i = .shallow(i, retain.key = TRUE)
+      ans = bmerge(i, x, leftcols, rightcols, xo, roll, rollends, nomatch, mult, ops, nqgrp, nqmaxgrp, verbose=verbose)
       # temp fix for issue spotted by Jan, test #1653.1. TODO: avoid this
       # 'setorder', as there's another 'setorder' in generating 'irows' below...
       if (length(ans$indices)) setorder(setDT(ans[1L:3L]), indices)
@@ -1308,7 +1307,10 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
         if ( (keylen>len || chk) && !.Call(CisOrderedSubset, irows, nrow(x))) {
           keylen = if (!chk) len else 0L # fix for #1268
         }
-        if (keylen && ((is.data.table(i) && haskey(i)) || is.logical(i) || (.Call(CisOrderedSubset, irows, nrow(x)) && ((roll == FALSE) || length(irows) == 1L)))) # see #1010. don't set key when i has no key, but irows is ordered and roll != FALSE
+        ## check key on i as well!
+        ichk = is.data.table(i) && haskey(i) ## make sure, i has key at all
+        if(ichk) ichk = (head(key(i), length(leftcols)) == names(i)[leftcols]) ## make sure, i has the correct key
+        if (keylen && (ichk || is.logical(i) || (.Call(CisOrderedSubset, irows, nrow(x)) && ((roll == FALSE) || length(irows) == 1L)))) # see #1010. don't set key when i has no key, but irows is ordered and roll != FALSE
           setattr(ans,"sorted",head(key(x),keylen))
       }
       setattr(ans, "class", class(x)) # fix for #5296

--- a/R/foverlaps.R
+++ b/R/foverlaps.R
@@ -113,7 +113,7 @@ foverlaps <- function(x, y, by.x = if (!is.null(key(x))) key(x) else key(y), by.
   matches <- function(ii, xx, del, ...) {
     cols = setdiff(names(xx), del)
     xx = .shallow(xx, cols, retain.key = FALSE)
-    ans = bmerge(xx, ii, seq_along(xx), seq_along(xx), haskey(xx), integer(0), mult=mult, ops=rep(1L, length(xx)), integer(0), 1L, verbose=verbose, ...)
+    ans = bmerge(xx, ii, seq_along(xx), seq_along(xx), integer(0), mult=mult, ops=rep(1L, length(xx)), integer(0), 1L, verbose=verbose, ...)
     # vecseq part should never run here, but still...
     if (ans$allLen1) ans$starts else vecseq(ans$starts, ans$lens, NULL)
   }

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -11983,6 +11983,17 @@ test(1914.8, identical(dtGet(dt.comp, 1), dt[[1]]))
 test(1914.9, identical(dtGet(dt.comp, 'b'), dt$b))
 # END port of old testthat tests
 
+## Testing issue #2881: wrong bmerge result if 
+## - character gets coerced to factor and 
+## - i is keyed 
+## - and level order in i is different from x
+iris <- data.table(iris)
+iris$grp <- c('A', 'B')
+iris[, Species1 := factor(Species, levels = c('setosa', 'versicolor', 'virginica'), labels = c('setosa', 'versicolor', 'Virginica'))]
+iSorted = data.table(Species1 = c('setosa', 'Virginica'), grp = 'B', key = c("grp", "Species1"))
+i <- setkey(copy(iSorted),NULL)
+test(1915, iris[iSorted, on = c("grp==grp", 'Species1==Species1')],
+           iris[i, on = c("grp==grp", 'Species1==Species1')])
 
 ###################################
 #  Add new tests above this line  #


### PR DESCRIPTION
Closes #2881. 
Unfortunately, my PR #2389, that introduced partial key retainment when assigning to columns, introduced a regression in `bmerge.R`. 
`bmerge.R` assumed implicitely that any `set()` operation removes a key completely if it assigns to a key column. In contrast, the mentioned PR made it possible that a reduced key still exists when assigning to a key column.

I have done the following:
- adapted `bmerge.R` so that it checks internally if the key on `i` is correct, instead of using the `io` argument. This was also mentioned as a TODO in `bmerge.R` sourcecode. 
- It involved a changed bmerge interface (with removed `io` argument), so I changed all calls to `bmerge.R`. 
- Additionally, the logic that sets the `sorted` attribute at the end of `data.table.R` had to be modified. 

No existing tests were modified and a new test added.

This regression should occur very rarely, but if it does, it is very bad. Therefore, it might make sense to issue a quick bugfix release to CRAN rather soon?