### PR TITLE
Closes #2986; fread:select was sorting integers incorrectly

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
 
 #### BUG FIXES
 
+1. `select` in `fread` respects the supplied order when it's given as an `integer`/`numeric`-as-integer, [#2986](https://github.com/Rdatatable/data.table/issues/2986). Thanks @privefl for raising the issue.
+
 #### NOTES
 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 
 #### BUG FIXES
 
-1. `select` in `fread` respects the supplied order when it's given as an `integer`/`numeric`-as-integer, [#2986](https://github.com/Rdatatable/data.table/issues/2986). Thanks @privefl for raising the issue.
+1. `fread` now respects the order of columns passed to `select=` when column numbers are used, [#2986](https://github.com/Rdatatable/data.table/issues/2986). It already respected the order when column names are used. Thanks @privefl for raising the issue.
 
 #### NOTES
 

--- a/R/fread.R
+++ b/R/fread.R
@@ -128,7 +128,7 @@ fread <- function(input="",file,sep="auto",sep2="auto",dec=".",quote="\"",nrows=
   if (!is.null(select)) {
     # fix for #1445
     if (is.numeric(select)) {
-      reorder = if (length(o <- forderv(select))) o else seq_along(select)
+      reorder = frank(select)
     } else {
       reorder = select[select %chin% names(ans)]
       # any missing columns are warning about in fread.c and skipped

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -11983,6 +11983,16 @@ test(1914.8, identical(dtGet(dt.comp, 1), dt[[1]]))
 test(1914.9, identical(dtGet(dt.comp, 'b'), dt$b))
 # END port of old testthat tests
 
+str = "Sepal.Length,Sepal.Width,Petal.Length,Petal.Width,Species
+5.1,3.5,1.4,0.2,setosa
+4.9,3,1.4,0.2,setosa
+4.7,3.2,1.3,0.2,setosa
+4.6,3.1,1.5,0.2,setosa
+5,3.6,1.4,0.2,setosa"
+test(1915, fread(str, select = c(5, 1, 3)),
+     data.table(Species = c("setosa", "setosa", "setosa", "setosa", "setosa"),
+                Sepal.Length = c(5.1, 4.9, 4.7, 4.6, 5),
+                Petal.Length = c(1.4, 1.4, 1.3, 1.5, 1.4)))
 
 ###################################
 #  Add new tests above this line  #


### PR DESCRIPTION
Tagging @arunsrinivasan since he filed the initial `select`-sorting fix.