### PR TITLE
In writePOSIXct, use int64_t instead of int (#2995)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,7 +27,7 @@
 
 7. `as.ITime.times` was rounding fractional seconds while other methods were truncating, [#2870](https://github.com/Rdatatable/data.table/issues/2870). The `as.ITime` method gains `ms=` taking `"truncate"` (default), `"nearest"` and `"ceil"`. Thanks to @rossholmberg for reporting and Michael Chirico for fixing.
 
-8. Fix `fwrite` output for POSIXct datetimes, reported by @mdzorn in [#2995](https://github.com/Rdatatable/data.table/issues/2995). 
+8. `fwrite()` now writes POSIXct dates after 2038 correctly, [#2995](https://github.com/Rdatatable/data.table/issues/2995). Thanks to Manfred Zorn for reporting and Philippe Chataignon for the PR fixing it.
 
 #### NOTES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,8 @@
 
 6. `as.IDate.numeric` no longer ignores "origin", [#2880](https://github.com/Rdatatable/data.table/issues/2880). Thanks to David Arenburg for reporting and fixing.
 
+7. Fix `fwrite` output for POSIXct datetimes, reported by @mdzorn in [#2995](https://github.com/Rdatatable/data.table/issues/2995). 
+
 #### NOTES
 
 1. The type coercion warning message has been improved, [#2989](https://github.com/Rdatatable/data.table/pull/2989). Thanks to @sarahbeeysian on [Twitter](https://twitter.com/sarahbeeysian/status/1021359529789775872) for highlighting. For example, given the follow statements:

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -9140,6 +9140,10 @@ test(1658.29, fwrite(data.table(id=c("A","B","C"), v=c(1.1,0.0,9.9))), output="i
 # logical NA as "NA" when logical01=TRUE, instead of the default na="" which writes all types including <NA> in character column as ,, consistently.
 test(1658.30, fwrite(data.table(id=1:3,bool=c(TRUE,NA,FALSE)),na="NA",logical01=TRUE), output="\"id\",\"bool\"\n1,1\n2,NA\n3,0")
 
+# POSIXct 
+test(1658.31, fwrite(data.table(D = as.POSIXct(seq.Date(as.Date("2038-01-19"), as.Date("2038-01-20"), by = "day")))),
+    output="D\n2038-01-19T00:00:00Z\n2038-01-20T00:00:00Z")
+
 ## End fwrite tests
 
 # tests for #679, inrange(), FR #707

--- a/src/fwrite.c
+++ b/src/fwrite.c
@@ -387,18 +387,18 @@ void writePOSIXct(double *col, int64_t row, char **pch)
   if (!isfinite(x)) {
     write_chars(na, &ch);
   } else {
-    int xi, d, t;
+    int64_t xi, d, t;
     if (x>=0) {
-      xi = (int)x;
+      xi = floor(x);
       d = xi / 86400;
       t = xi % 86400;
     } else {
       // before 1970-01-01T00:00:00Z
-      xi = (int)floor(x);
+      xi = floor(x);
       d = (xi+1)/86400 - 1;
       t = xi - d*86400;  // xi and d are both negative here; t becomes the positive number of seconds into the day
     }
-    int m = (int)((x-xi)*10000000); // 7th digit used to round up if 9
+    int m = ((x-xi)*10000000); // 7th digit used to round up if 9
     m += (m%10);  // 9 is numerical accuracy, 8 or less then we truncate to last microsecond
     m /= 10;
     write_date(d, &ch);


### PR DESCRIPTION
Internal variables in writePOSIXct are defined as int. This commit
defined then as int64_t to avoid year 2038 bug as reported in
issue #2995.