### PR TITLE
Add `all` to `fsetequal()` for consistency with other set operators

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,8 @@
 
 7. `as.ITime.times` was rounding fractional seconds while other methods were truncating, [#2870](https://github.com/Rdatatable/data.table/issues/2870). The `as.ITime` method gains `ms=` taking `"truncate"` (default), `"nearest"` and `"ceil"`. Thanks to @rossholmberg for reporting and Michael Chirico for fixing.
 
+8. `fsetequal` gains the `all` argument to make it consistent with the other set operator functions `funion`, `fsetdiff` and `fintersect` [#2968](https://github.com/Rdatatable/data.table/issues/2968). When `all = FALSE` `fsetequal` will treat rows as elements in a set when checking whether two `data.tables` are equal (i.e. duplicate rows will be ignored). For now the default value is `all = TRUE` for backwards compatibility, but this will be changed to `all = FALSE` in a future release to make it consistent with the other set operation functions. Thanks to @franknarf1 for reporting and @sritchie73 for fixing.
+
 #### NOTES
 
 1. The type coercion warning message has been improved, [#2989](https://github.com/Rdatatable/data.table/pull/2989). Thanks to @sarahbeeysian on [Twitter](https://twitter.com/sarahbeeysian/status/1021359529789775872) for highlighting. For example, given the follow statements:

--- a/R/setops.R
+++ b/R/setops.R
@@ -105,13 +105,17 @@ funion <- function(x, y, all=FALSE) {
   ans
 }
 
-fsetequal <- function(x, y) {
+fsetequal <- function(x, y, all=TRUE) {
   if (!is.data.table(x) || !is.data.table(y)) stop("x and y must be both data.tables")
   if (!identical(sort(names(x)), sort(names(y)))) stop("x and y must have same column names")
   if (!identical(names(x), names(y))) stop("x and y must have same column order")
   bad.type = setNames(c("raw","complex","list") %chin% c(vapply(x, typeof, FUN.VALUE = ""), vapply(y, typeof, FUN.VALUE = "")), c("raw","complex","list"))
   if (any(bad.type)) stop(sprintf("x and y must not have unsupported column types: %s", paste(names(bad.type)[bad.type], collapse=", ")))
   if (!identical(lapply(x, class), lapply(y, class))) stop("x and y must have same column classes")
+  if (!all) {
+    x = funique(x)
+    y = funique(y)
+  } 
   isTRUE(all.equal.data.table(x, y, check.attributes = FALSE, ignore.row.order = TRUE))
 }
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -8247,6 +8247,12 @@ if (test_bit64) {
   test(1626.75, fsetequal(x, y), FALSE)
   test(1626.76, fsetequal(dt[c(2:3,3L)], dt[c(2:3,3L)]), TRUE)
 }
+# fix for #2968 fsetequal with all = FALSE should treat rows as set elements
+x = data.table(c(1,2,2,2,3,4,4), c(1,1,1,3,3,3,3))
+x2 = unique(x)
+y = data.table(c(2,3,4,4,4,5), c(1,1,2,3,3,3))
+test(1626.77, fsetequal(x, x2, all = FALSE), TRUE)
+test(1626.78, fsetequal(x, y, all = FALSE), FALSE)
 
 # fix for #1087 and #1465
 test(1627, charToRaw(names(fread(testDir("issue_1087_utf8_bom.csv")))[1L]), as.raw(97L))

--- a/man/setops.Rd
+++ b/man/setops.Rd
@@ -20,7 +20,7 @@
 fintersect(x, y, all = FALSE)
 fsetdiff(x, y, all = FALSE)
 funion(x, y, all = FALSE)
-fsetequal(x, y)
+fsetequal(x, y, all = TRUE)
 }
 \arguments{
 	\item{x,y}{\code{data.table}s.}
@@ -31,8 +31,11 @@ fsetequal(x, y)
 
 			\item{\code{fsetdiff} will return \code{max(0, xn-yn)} copies of that row.}
 
-			\item{\code{funion} will return \code{xn+yn} copies of that row.}}
+			\item{\code{funion} will return \code{xn+yn} copies of that row.}
+			
+			\item{\code{fsetequal} will return \code{FALSE} unless \code{xn == yn}.}
 		}
+	}
 }
 \details{
   Columns of type \code{complex} and \code{list} are not supported except for \code{funion}.
@@ -47,6 +50,7 @@ fsetequal(x, y)
 }
 \examples{
 x = data.table(c(1,2,2,2,3,4,4))
+x2 = data.table(c(1,2,3,4)) # same set of rows as x
 y = data.table(c(2,3,4,4,4,5))
 fintersect(x, y)            # intersect
 fintersect(x, y, all=TRUE)  # intersect all
@@ -54,6 +58,7 @@ fsetdiff(x, y)              # except
 fsetdiff(x, y, all=TRUE)    # except all
 funion(x, y)                # union
 funion(x, y, all=TRUE)      # union all
-fsetequal(x, y)             # setequal
+fsetequal(x, x2, all=FALSE) # setequal
+fsetequal(x, x2)            # setequal all
 }
 \keyword{ data }

--- a/man/setops.Rd
+++ b/man/setops.Rd
@@ -31,7 +31,7 @@ fsetequal(x, y)
 
 			\item{\code{fsetdiff} will return \code{max(0, xn-yn)} copies of that row.}
 
-			\item{\code{funion} will return xn+yn copies of that row.}}
+			\item{\code{funion} will return \code{xn+yn} copies of that row.}}
 		}
 }
 \details{


### PR DESCRIPTION
Closes #2968 

Currently `fsetequal()` will check whether two data.tables have the same rows.

With the addition of the `all` argument, setting `all = FALSE` will make `fsetequal()` treat the rows of each data.table as the elements of a set, i.e. so that duplicate rows within each data.table are ignored when comparing them.

This PR makes `fsetequal` consistent with the other set operator functions, which already have the `all` argument.

I've set the default to be `all = TRUE` in `fsetequal()` for backwards compatibility, but envision this default changing to `FALSE` in a future release to bring `fsetequal()` in line with the other set operator functions.  