### PR TITLE
Fix length > 1 class()

### DIFF
--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -71,8 +71,7 @@ round.IDate <- function (x, digits=c("weeks", "months", "quarters", "years"), ..
     return(e1)
   if (inherits(e1, "difftime") || inherits(e2, "difftime"))
     stop("difftime objects may not be added to IDate. Use plain integer instead of difftime.")
-  if ( (storage.mode(e1)=="double" && isReallyReal(e1)) ||
-       (storage.mode(e2)=="double" && isReallyReal(e2)) ) {
+  if (isReallyReal(e1) || isReallyReal(e2)) {
     return(`+.Date`(e1,e2))
     # IDate doesn't support fractional days; revert to base Date
   }
@@ -90,7 +89,7 @@ round.IDate <- function (x, digits=c("weeks", "months", "quarters", "years"), ..
     stop("unary - is not defined for \"IDate\" objects")
   if (inherits(e2, "difftime"))
     stop("difftime objects may not be subtracted from IDate. Use plain integer instead of difftime.")
-  if ( storage.mode(e2)=="double" && isReallyReal(e2) ) {
+  if ( isReallyReal(e2) ) {
     return(`-.Date`(as.Date(e1),as.Date(e2)))
     # IDate doesn't support fractional days so revert to base Date
   }

--- a/R/as.data.table.R
+++ b/R/as.data.table.R
@@ -157,9 +157,10 @@ as.data.table.list <- function(x, keep.rownames=FALSE, ...) {
 # tests and as.data.table.data.frame) I've commented #527
 # for now. This addresses #1078 and #1128
 .resetclass <- function(x, class) {
+  if (length(class)!=1L) stop("class must be length 1")
   cx = class(x)
-  n  = chmatch(class, cx)
-  cx = unique( c("data.table", "data.frame", tail(cx, length(cx)-n)) )
+  n  = chmatch(class, cx)   # chmatch accepts legth(class)>1 but next line requires length(n)==1
+  unique( c("data.table", "data.frame", tail(cx, length(cx)-n)) )
 }
 
 as.data.table.data.frame <- function(x, keep.rownames=FALSE, ...) {

--- a/R/as.data.table.R
+++ b/R/as.data.table.R
@@ -157,7 +157,8 @@ as.data.table.list <- function(x, keep.rownames=FALSE, ...) {
 # tests and as.data.table.data.frame) I've commented #527
 # for now. This addresses #1078 and #1128
 .resetclass <- function(x, class) {
-  if (length(class)!=1L) stop("class must be length 1")
+  if (length(class)!=1L)
+    stop("class must be length 1") # nocov
   cx = class(x)
   n  = chmatch(class, cx)   # chmatch accepts legth(class)>1 but next line requires length(n)==1
   unique( c("data.table", "data.frame", tail(cx, length(cx)-n)) )

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2940,27 +2940,13 @@ isReallyReal <- function(x) {
       if (length(RHS) != nrow(x)) stop("RHS of ", operator, " is length ",length(RHS)," which is not 1 or nrow (",nrow(x),"). For robustness, no recycling is allowed (other than of length 1 RHS). Consider %in% instead.")
       return(NULL) # DT[colA == colB] regular element-wise vector scan
     }
-
-    # fringe cases, #1361.
-    # re-direct all non-matching mode cases to base R, as data.table's binary
-    # search based join is strict in types. #957 and #961.
-    if (is.integer(x[[col]]) && is.double(RHS) && isReallyReal(RHS)) {
+    if ( (is.integer(x[[col]]) && isReallyReal(RHS)) ||
+         (is.factor(x[[col]])+is.factor(RHS) == 1L) ||
+         (is.character(x[[col]])+is.character(RHS) == 1L) ) {
+      # re-direct all non-matching mode cases to base R, as data.table's binary
+      # search based join is strict in types. #957, #961 and #1361
       return(NULL)
     }
-    if (is.integer(RHS) && is.double(x[[col]]) && isReallyReal(x[[col]])) {
-      return(NULL)
-    }
-
-    if (XOR(is.factor(x[[col]]),
-            is.factor(RHS))) {
-      return(NULL)
-    }
-    if (XOR(is.character(x[[col]]),
-            is.character(RHS))) {
-      return(NULL)
-    }
-
-
     if(is.character(x[[col]]) && !operator %chin% c("==", "%in%", "%chin%")) return(NULL) ## base R allows for non-equi operators on character columns, but these can't be optimized.
     if (!operator %chin% c("%in%", "%chin%")) {
       # addional requirements for notjoin and NA values. Behaviour is different for %in%, %chin% compared to other operators

--- a/R/fcast.R
+++ b/R/fcast.R
@@ -19,7 +19,7 @@ dcast <- function(data, formula, fun.aggregate = NULL, ..., margins = NULL,
 
 check_formula <- function(formula, varnames, valnames) {
   if (is.character(formula)) formula = as.formula(formula)
-  if (class(formula) != "formula" || length(formula) != 3L)
+  if (!inherits(formula, "formula") || length(formula) != 3L)
     stop("Invalid formula. Cast formula should be of the form LHS ~ RHS, for e.g., a + b ~ c.")
   vars = all.vars(formula)
   vars = vars[!vars %chin% c(".", "...")]

--- a/R/fcast.R
+++ b/R/fcast.R
@@ -20,7 +20,7 @@ dcast <- function(data, formula, fun.aggregate = NULL, ..., margins = NULL,
 check_formula <- function(formula, varnames, valnames) {
   if (is.character(formula)) formula = as.formula(formula)
   if (!inherits(formula, "formula") || length(formula) != 3L)
-    stop("Invalid formula. Cast formula should be of the form LHS ~ RHS, for e.g., a + b ~ c.")
+    stop("Invalid formula. Cast formula should be of the form LHS ~ RHS, for e.g., a + b ~ c.")  # nocov; couldn't find a way to construct a test formula with length!=3L
   vars = all.vars(formula)
   vars = vars[!vars %chin% c(".", "...")]
   allvars = c(vars, valnames)

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -7,7 +7,7 @@
   # Commented as a character string so this message is retained and seen by anyone who types data.table:::.onLoad
   tt = base::cbind.data.frame
   ss = body(tt)
-  if (class(ss)!="{") ss = as.call(c(as.name("{"), ss))
+  if (class(ss)[1L]!="{") ss = as.call(c(as.name("{"), ss))
   prefix = if (!missing(pkgname)) "data.table::" else ""  # R provides the arguments when it calls .onLoad, I don't in dev/test
   if (!length(grep("data.table",ss[[2L]]))) {
     ss = ss[c(1L, NA, 2L:length(ss))]
@@ -19,7 +19,7 @@
   }
   tt = base::rbind.data.frame
   ss = body(tt)
-  if (class(ss)!="{") ss = as.call(c(as.name("{"), ss))
+  if (class(ss)[1L]!="{") ss = as.call(c(as.name("{"), ss))
   if (!length(grep("data.table",ss[[2L]]))) {
     ss = ss[c(1L, NA, 2L:length(ss))]
     ss[[2L]] = parse(text=paste0("for (x in list(...)) { if (inherits(x,'data.table')) return(",prefix,".rbind.data.table(...)) }"))[[1L]] # fix for #4995

--- a/R/setkey.R
+++ b/R/setkey.R
@@ -191,8 +191,8 @@ forderv <- function(x, by=seq_along(x), retGrp=FALSE, sort=TRUE, order=1L, na.la
       if (anyNA(w)) stop("'by' contains '",by[is.na(w)][1],"' which is not a column name")
       by = w
     }
-    else if (typeof(by)=="double" && isReallyReal(by)) {
-      stop("'by' is type 'double' but one or more items in it are not whole integers")
+    else if (isReallyReal(by)) {
+      stop("'by' is type 'double' and one or more items in it are not whole integers")
     }
     by = as.integer(by)
     if ( (length(order) != 1L && length(order) != length(by)) || any(!order %in% c(1L, -1L)) )

--- a/R/utils.R
+++ b/R/utils.R
@@ -86,6 +86,3 @@ name_dots <- function(...) {
   list(vnames=vnames, novname=novname)
 }
 
-XOR <- function(x, y) if (anyNA(x)) NA else if (x) !y else y
-
-

--- a/R/utils.R
+++ b/R/utils.R
@@ -64,3 +64,5 @@ vapply_1i <- function (x, fun, ..., use.names = TRUE) {
 
 more = function(f) system(paste("more",f))    # nocov  (just a dev helper)
 
+XOR <- function(x, y) if (anyNA(x)) NA else if (x) !y else y
+

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -6738,7 +6738,7 @@ x = runif(2)
 test(1514.6, isReallyReal(x), 1L)
 x = numeric()
 test(1514.7, isReallyReal(x), 0L)
-test(1514.8, isReallyReal(9L), error="x must be of type double")
+test(1514.8, isReallyReal(9L), 0L)
 
 # #1091
 old.option = getOption("datatable.prettyprint.char")

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -7683,6 +7683,11 @@ test(1587, fread(text, key="y"), setDT(fread(text), key="y"))
 dt = data.table(i=1:10, f=as.factor(1:10))
 test(1588.1, dt[f %in% 3:4], dt[3:4])
 test(1588.2, dt[f == 3], dt[3])
+test(1588.3, dt[3 == f], dt[3])
+test(1588.4, dt[i == 3], dt[3])
+# test for reallyReal RHS
+test(1588.5, dt[i == 3.5], dt[0L])
+test(1588.6, dt[2.4 == 3.5], dt[0L])
 
 # data.table operates consistently independent of locale, but it's R that changes and is sensitive to it.
 #   Because keys/indexes depend on a sort order. If a data.table is stored on disk with a key

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -2682,7 +2682,7 @@ test(989, unique(dt, by='C'), dt[!duplicated(df[, 'C'])])
 test(990, unique(dt, by=c('B', 'C')), dt[!duplicated(df[, c('B', 'C')])])
 test(991, unique(dt, by=NULL), dt[!duplicated(df)])
 test(991.1, unique(dt, by=4), error="'by' value 4 out of range.*1,3")
-test(991.2, unique(dt, by=c(1,3.1)), error="'by' is type 'double' but one or more items in it are not whole integers")
+test(991.2, unique(dt, by=c(1,3.1)), error="'by' is type 'double' and one or more items in it are not whole integers")
 test(991.3, unique(dt, by=2:3), dt[!duplicated(df[,c('B','C')])])
 test(991.4, unique(dt, by=c('C','D','E')), error="'by' contains 'D' which is not a column name")
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -7688,6 +7688,8 @@ test(1588.4, dt[i == 3], dt[3])
 # test for reallyReal RHS
 test(1588.5, dt[i == 3.5], dt[0L])
 test(1588.6, dt[2.4 == 3.5], dt[0L])
+dt = data.table(ch=letters[1:6])
+test(1588.7, dt[ch>"c"], dt[4:6])  # coverage of a return(NULL) in .prepareFastSubset
 
 # data.table operates consistently independent of locale, but it's R that changes and is sensitive to it.
 #   Because keys/indexes depend on a sort order. If a data.table is stored on disk with a key

--- a/src/forder.c
+++ b/src/forder.c
@@ -1445,18 +1445,20 @@ SEXP isOrderedSubset(SEXP x, SEXP nrow)
 */
 
 SEXP isReallyReal(SEXP x) {
-  int n, i=0;
-  SEXP ans;
-  if (!isReal(x))
-    error("x must be of type double.");
-  n = length(x);
-  ans = PROTECT(allocVector(INTSXP, 1));
-  while (i<n &&
-      ( ISNA(REAL(x)[i]) ||
-      ( R_FINITE(REAL(x)[i]) && REAL(x)[i] == (int)(REAL(x)[i])))) {
-    i++;
+  SEXP ans = PROTECT(allocVector(INTSXP, 1));
+  INTEGER(ans)[0] = 0;
+  // return 0 (FALSE) when not type double, or is type double but contains integers
+  // used to error if not passed type double but this needed extra is.double() calls in calling R code
+  // which needed a repeat of the argument. Hence simpler and more robust to return 0 when not type double.
+  if (isReal(x)) {
+    int n=length(x), i=0;
+    while (i<n &&
+        ( ISNA(REAL(x)[i]) ||
+        ( R_FINITE(REAL(x)[i]) && REAL(x)[i] == (int)(REAL(x)[i])))) {
+      i++;
+    }
+    if (i<n) INTEGER(ans)[0] = i+1;  // return the location of first element which is really real; i.e. not an integer
   }
-  INTEGER(ans)[0] = (i<n ? i+1 : 0);
   UNPROTECT(1);
   return(ans);
 }


### PR DESCRIPTION
Recent discussion on R-devel contemplated change to `&&` and `||` that we were relying on. In my view, best to harden than rely on this behaviour.

*[Rd] ROBUSTNESS: x || y and x && y to give warning/error if length(x) != 1 or length(y) != 1*
https://stat.ethz.ch/pipermail/r-devel/2018-August/076678.html