### PR TITLE
RHS NULL in prepareFastSubset

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2934,6 +2934,7 @@ isReallyReal <- function(x) {
     if(col %chin% names(i)) return(NULL) ## repeated appearance of the same column not suported (e.g. DT[x < 3 & x < 5])
     ## now check the RHS of stub
     RHS = eval(stub[[3L]], x, enclos)
+    if (is.null(RHS)) return(NULL)
     # fix for #961
     if (is.list(RHS)) RHS = as.character(RHS)
     if (length(RHS) != 1 && !operator %chin% c("%in%", "%chin%")){


### PR DESCRIPTION
In rev dep checking I found that data.table broke CRAN package `eplusr`.  Not bad really to have just one breakage in an edge case.
The one-line addition in this PR makes it pass.
Please check ok @MarkusBonsch and is there a way to create a test for this?
Since `mode(NULL)=="NULL"` it might be to do with the `mode()!=mode()` that Hugh and I recently removed in PR #3026.