### PR TITLE
Clear rchk messages on CRAN

### DIFF
--- a/CRAN_Release.cmd
+++ b/CRAN_Release.cmd
@@ -262,6 +262,17 @@ There are some things to overcome to achieve compile without USE_RINTERNALS, tho
 ## test.data.table()
 ## q("no")
 
+########################################################################
+#  rchk : https://github.com/kalibera/rchk
+########################################################################
+cd ~/build/rchk/trunk
+echo 'install.packages("~/GitHub/data.table/data.table_1.11.5.tar.gz",repos=NULL)' | ./bin/R --slave
+../scripts/check_package.sh data.table
+cat packages/lib/data.table/libs/*check
+# keep running and rerunning locally until all problems cease.
+#   rchk has an internal stack which can exhaust. Clearing the current set of problems (e.g. as displayed
+#   on CRAN) is not sufficient because new problems can be found because it didn't get that far before.
+#   hence repeating locally until clear is necessary.
 
 ###############################################
 #  QEMU to emulate big endian

--- a/src/assign.c
+++ b/src/assign.c
@@ -35,7 +35,7 @@ void setselfref(SEXP x) {
   // Called from C only, not R level, so returns void.
   setAttrib(x, SelfRefSymbol, p=R_MakeExternalPtr(
     R_NilValue,                  // for identical() to return TRUE. identical() doesn't look at tag and prot
-    getAttrib(x, R_NamesSymbol), // to detect if names has been replaced and its tl lost, e.g. setattr(DT,"names",...)
+    PROTECT(getAttrib(x, R_NamesSymbol)),  // to detect if names has been replaced and its tl lost, e.g. setattr(DT,"names",...)
     PROTECT(R_MakeExternalPtr(   // to avoid an infinite loop in object.size(), if prot=x here
       x,                         // to know if this data.table has been copied by key<-, attr<-, names<-, etc.
       R_NilValue,                // this tag and prot currently unused
@@ -43,7 +43,7 @@ void setselfref(SEXP x) {
     ))
   ));
   R_RegisterCFinalizerEx(p, finalizer, FALSE);
-  UNPROTECT(1);  // The PROTECT above is needed by --enable-strict-barrier (it seems, iiuc)
+  UNPROTECT(2);
 
 /*
   *  base::identical doesn't check prot and tag of EXTPTR, just that the ptr itself is the

--- a/src/freadR.c
+++ b/src/freadR.c
@@ -224,7 +224,7 @@ _Bool userOverride(int8_t *type, lenOff *colNames, const char *anchor, int ncol)
     } else {
       if (!isNewList(colClassesSxp)) STOP("CfreadR: colClasses is not type list");
       if (!length(getAttrib(colClassesSxp, R_NamesSymbol))) STOP("CfreadR: colClasses is type list but has no names");
-      SEXP typeEnum_idx = PROTECT(chmatch(getAttrib(colClassesSxp, R_NamesSymbol), typeRName_sxp, NUT, FALSE));
+      SEXP typeEnum_idx = PROTECT(chmatch(PROTECT(getAttrib(colClassesSxp, R_NamesSymbol)), typeRName_sxp, NUT, FALSE));
       for (int i=0; i<LENGTH(colClassesSxp); i++) {
         SEXP items;
         signed char thisType = typeEnum[INTEGER(typeEnum_idx)[i]-1];
@@ -254,7 +254,7 @@ _Bool userOverride(int8_t *type, lenOff *colNames, const char *anchor, int ncol)
         UNPROTECT(1); // UNPROTECTing itemsInt inside loop to save protection stack
       }
       for (int i=0; i<ncol; i++) if (type[i]<0) type[i] *= -1;  // undo sign; was used to detect duplicates
-      UNPROTECT(1);  // typeEnum_idx
+      UNPROTECT(2);  // typeEnum_idx (+1 for its protect of getAttrib)
     }
     UNPROTECT(1);  // typeRName_sxp
   }

--- a/src/rbindlist.c
+++ b/src/rbindlist.c
@@ -804,34 +804,30 @@ SEXP rbindlist(SEXP l, SEXP sexp_usenames, SEXP sexp_fill, SEXP idcol) {
 SEXP chmatch2_old(SEXP x, SEXP table, SEXP nomatch) {
 
   R_len_t i, j, k, nx, li, si, oi;
-  SEXP dt, ans, order, start, lens, grpid, index;
   if (TYPEOF(nomatch) != INTSXP || length(nomatch) != 1) error("'nomatch' must be an integer of length 1");
   if (!length(x) || isNull(x)) return(allocVector(INTSXP, 0));
   if (TYPEOF(x) != STRSXP) error("'x' must be a character vector");
   nx=length(x);
   if (!length(table) || isNull(table)) {
-    ans = PROTECT(allocVector(INTSXP, nx));
+    SEXP ans = PROTECT(allocVector(INTSXP, nx));
     for (i=0; i<nx; i++) INTEGER(ans)[i] = INTEGER(nomatch)[0];
     UNPROTECT(1);
     return(ans);
   }
   if (TYPEOF(table) != STRSXP) error("'table' must be a character vector");
   // Done with special cases. On to the real deal.
-  {
-    // start new scope to ensure tt is used just here
-    SEXP tt = PROTECT(allocVector(VECSXP, 2));
-    SET_VECTOR_ELT(tt, 0, x);
-    SET_VECTOR_ELT(tt, 1, table);
-    dt = PROTECT(unlist2(tt));
-    UNPROTECT(1);
-  }
+
+  SEXP tt = PROTECT(allocVector(VECSXP, 2));
+  SET_VECTOR_ELT(tt, 0, x);
+  SET_VECTOR_ELT(tt, 1, table);
+  SEXP dt = PROTECT(unlist2(tt));
 
   // order - first time
-  order = PROTECT(fast_order(dt, 2, 1));
-  start = getAttrib(order, sym_starts);
-  lens  = PROTECT(uniq_lengths(start, length(order))); // length(order) = nrow(dt)
-  grpid = VECTOR_ELT(dt, 1);
-  index = VECTOR_ELT(dt, 2);
+  SEXP order = PROTECT(fast_order(dt, 2, 1));
+  SEXP start = getAttrib(order, sym_starts);
+  SEXP lens  = PROTECT(uniq_lengths(start, length(order))); // length(order) = nrow(dt)
+  SEXP grpid = VECTOR_ELT(dt, 1);
+  SEXP index = VECTOR_ELT(dt, 2);
 
   // replace dt[1], we don't need it anymore
   k=0;
@@ -842,12 +838,11 @@ SEXP chmatch2_old(SEXP x, SEXP table, SEXP nomatch) {
     k += j;
   }
   // order - again
-  UNPROTECT(2); // order, lens
   order = PROTECT(fast_order(dt, 2, 1));
   start = getAttrib(order, sym_starts);
   lens  = PROTECT(uniq_lengths(start, length(order)));
 
-  ans = PROTECT(allocVector(INTSXP, nx));
+  SEXP ans = PROTECT(allocVector(INTSXP, nx));
   k = 0;
   for (i=0; i<length(lens); i++) {
     li = INTEGER(lens)[i];
@@ -856,7 +851,7 @@ SEXP chmatch2_old(SEXP x, SEXP table, SEXP nomatch) {
     if (oi > nx-1) continue;
     INTEGER(ans)[oi] = (li == 2) ? INTEGER(index)[INTEGER(order)[si+1]-1]+1 : INTEGER(nomatch)[0];
   }
-  UNPROTECT(4); // order, lens, ans
+  UNPROTECT(7);
   return(ans);
 }
 

--- a/src/rbindlist.c
+++ b/src/rbindlist.c
@@ -804,7 +804,7 @@ SEXP rbindlist(SEXP l, SEXP sexp_usenames, SEXP sexp_fill, SEXP idcol) {
 SEXP chmatch2_old(SEXP x, SEXP table, SEXP nomatch) {
 
   R_len_t i, j, k, nx, li, si, oi;
-  SEXP dt, l, ans, order, start, lens, grpid, index;
+  SEXP dt, ans, order, start, lens, grpid, index;
   if (TYPEOF(nomatch) != INTSXP || length(nomatch) != 1) error("'nomatch' must be an integer of length 1");
   if (!length(x) || isNull(x)) return(allocVector(INTSXP, 0));
   if (TYPEOF(x) != STRSXP) error("'x' must be a character vector");
@@ -817,12 +817,14 @@ SEXP chmatch2_old(SEXP x, SEXP table, SEXP nomatch) {
   }
   if (TYPEOF(table) != STRSXP) error("'table' must be a character vector");
   // Done with special cases. On to the real deal.
-  l = PROTECT(allocVector(VECSXP, 2));
-  SET_VECTOR_ELT(l, 0, x);
-  SET_VECTOR_ELT(l, 1, table);
-
-  UNPROTECT(1); // l
-  dt = PROTECT(unlist2(l));
+  {
+    // start new scope to ensure tt is used just here
+    SEXP tt = PROTECT(allocVector(VECSXP, 2));
+    SET_VECTOR_ELT(tt, 0, x);
+    SET_VECTOR_ELT(tt, 1, table);
+    dt = PROTECT(unlist2(tt));
+    UNPROTECT(1);
+  }
 
   // order - first time
   order = PROTECT(fast_order(dt, 2, 1));

--- a/src/reorder.c
+++ b/src/reorder.c
@@ -37,7 +37,7 @@ SEXP reorder(SEXP x, SEXP order)
 
   R_len_t start = 0;
   while (start<nrow && INTEGER(order)[start] == start+1) start++;
-  if (start==nrow) return(R_NilValue);  // input is 1:n, nothing to do
+  if (start==nrow) { UNPROTECT(nprotect); return(R_NilValue); }  // input is 1:n, nothing to do
   R_len_t end = nrow-1;
   while (INTEGER(order)[end] == end+1) end--;
   for (R_len_t i=start; i<=end; i++) {


### PR DESCRIPTION
Current rchk messages on CRAN reproduced locally.
```
Package data.table version 1.11.4
Package built using 74847/R 3.6.0; x86_64-pc-linux-gnu; 2018-06-05 10:41:32 UTC; unix   
Checked with rchk version b882e37fb462917a8ab94e70394f3a797250b4e1
More information at https://github.com/kalibera/cran-checks/blob/master/rchk/PROTECT.md
```
- [x] Function chmatch2_old
  [UP] calling allocating function unlist2(V) with a fresh pointer (l <arg 1>) data.table/src/rbindlist.c:825

- [x] Function fmelt  [UP] unprotected variable dtnames while calling allocating function Rf_allocVector data.table/src/fmelt.c:663
  [UP] unprotected variable dtnames while calling allocating function preprocess(?,?,?,V,V,?,?,?) data.table/src/fmelt.c:664
  [UP] allocating function getvaluecols may destroy its unprotected argument (dtnames <arg 2>), which is later used. data.table/src/fmelt.c:670
  [UP] calling allocating function getvaluecols with a fresh pointer (dtnames <arg 2>) data.table/src/fmelt.c:670
  [UP] allocating function getvarcols may destroy its unprotected argument (dtnames <arg 2>), which is later used. data.table/src/fmelt.c:671
  [UP] calling allocating function getvarcols with a fresh pointer (dtnames <arg 2>) data.table/src/fmelt.c:671
  [UP] allocating function getidcols may destroy its unprotected argument (dtnames <arg 2>), which is later used. data.table/src/fmelt.c:672
  [UP] unprotected variable dtnames while calling allocating function Rf_allocVector data.table/src/fmelt.c:675
  [UP] unprotected variable dtnames while calling allocating function Rf_allocVector data.table/src/fmelt.c:684

- [x] Function gmax
  [UP] calling allocating function Rf_coerceVector(V,?) with a fresh pointer (ans <arg 1>) data.table/src/gsumm.c:391

- [x] Function gmin
  [UP] calling allocating function Rf_coerceVector(V,?) with a fresh pointer (ans <arg 1>) data.table/src/gsumm.c:260

- [x] Function reorder
  [PB] has possible protection stack imbalance data.table/src/reorder.c:109

- [x] Function setselfref
  [UP] calling allocating function R_MakeExternalPtr with argument allocated using Rf_getAttrib(?,S:names) data.table/src/assign.c:36

- [x] Function userOverride
  [UP] calling allocating function chmatch(?,V,?,?) with argument allocated using Rf_getAttrib(?,S:names) data.table/src/freadR.c:227