### PR TITLE
Faster by=key(DT)[1] and keyby= index

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,7 +17,7 @@
 
 6. New `options(datatable.CJ.names=TRUE)` changes `CJ()` to auto-name its inputs exactly as `data.table()` does, [#1596](https://github.com/Rdatatable/data.table/issues/1596). Thanks @franknarf1 for the suggestion. Current default is `FALSE`; i.e. no change. The option's default will be changed to `TRUE` in v1.12.0 and then eventually the option will be removed. Any code that depends on `CJ(x,y)$V1` will need to be changed to `CJ(x,y)$x` and is more akin to a bug fix due to the inconsistency with `data.table()`.
 
-7. If an appropriate index exists, `keyby=` will now use it. For example, given `setindex(DT,colA,colB)`, both `DT[,j,keyby=colA]` (a leading subset of the index columns) and `DT[,j,keyby=.(colA,colB)]` will use it but not `DT[,j,keyby=.(colB,colA)]`. The option `options(datatable.use.index=FALSE)` will turn this feature off. Please always use `keyby=` unless you wish to retain the order of groups by first-appearance order (in which case use `by=`).
+7. If an appropriate index exists, `keyby=` will now use it. For example, given `setindex(DT,colA,colB)`, both `DT[,j,keyby=colA]` (a leading subset of the index columns) and `DT[,j,keyby=.(colA,colB)]` will use the index, but not `DT[,j,keyby=.(colB,colA)]`. The option `options(datatable.use.index=FALSE)` will turn this feature off. Please always use `keyby=` unless you wish to retain the order of groups by first-appearance order (in which case use `by=`). Also, both `keyby=` and `by=` already used the key where possible but are now faster when using just the first column of the key. As usual, setting `verbose=TRUE` either per-query or globally using `options(datatable.verbose=TRUE)` will report what's being done internally.
 
 #### BUG FIXES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,8 @@
 
 11. Compilation fails in AIX because NAN and INFINITY macros definition in AIX make them not constant literals, [#3043](https://github.com/Rdatatable/data.table/pull/3043). Thanks to Ayappan for reporting and fixing.
 
+12. The introduction of altrep in R 3.5.0 caused some performance regressions of about 20% in some cases, [#2962](https://github.com/Rdatatable/data.table/issues/2962). Investigating this led to some improvements to grouping which are faster than before R 3.5.0 in some cases. Thanks to Nikolay S. for reporting. The work to accomodate altrep is not complete but it is better and it is highly recommended to upgrade to this update.
+
 #### NOTES
 
 1. The type coercion warning message has been improved, [#2989](https://github.com/Rdatatable/data.table/pull/2989). Thanks to @sarahbeeysian on [Twitter](https://twitter.com/sarahbeeysian/status/1021359529789775872) for highlighting. For example, given the follow statements:

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,8 @@
 
 6. New `options(datatable.CJ.names=TRUE)` changes `CJ()` to auto-name its inputs exactly as `data.table()` does, [#1596](https://github.com/Rdatatable/data.table/issues/1596). Thanks @franknarf1 for the suggestion. Current default is `FALSE`; i.e. no change. The option's default will be changed to `TRUE` in v1.12.0 and then eventually the option will be removed. Any code that depends on `CJ(x,y)$V1` will need to be changed to `CJ(x,y)$x` and is more akin to a bug fix due to the inconsistency with `data.table()`.
 
+7. If an appropriate index exists, `keyby=` will now use it. For example, given `setindex(DT,colA,colB)`, both `DT[,j,keyby=colA]` (a leading subset of the index columns) and `DT[,j,keyby=.(colA,colB)]` will use it but not `DT[,j,keyby=.(colB,colA)]`. The option `options(datatable.use.index=FALSE)` will turn this feature off. Please always use `keyby=` unless you wish to retain the order of groups by first-appearance order (in which case use `by=`).
+
 #### BUG FIXES
 
 1. `fread` now respects the order of columns passed to `select=` when column numbers are used, [#2986](https://github.com/Rdatatable/data.table/issues/2986). It already respected the order when column names are used. Thanks @privefl for raising the issue.

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -566,8 +566,7 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
             if (verbose) cat("on= matches existing key, using key\n")
           } else {
             if (isTRUE(getOption("datatable.use.index"))) {
-              idxName = paste0("__", names(on), collapse="")
-              xo = attr(attr(x, 'index'), idxName, exact = TRUE)
+              xo = getindex(x, names(on))
               if (verbose && !is.null(xo)) cat("on= matches existing index, using index\n")
             }
             if (is.null(xo)) {
@@ -879,10 +878,23 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
           bysubl = as.list.default(bysub)
         }
         allbyvars = intersect(all.vars(bysub),names(x))
+        orderedirows = .Call(CisOrderedSubset, irows, nrow(x))  # TRUE when irows is NULL (i.e. no i clause). Similar but better than is.sorted(f__)
+        bysameorder = byindex = FALSE
+        if (all(vapply_1b(bysubl, is.name))) {
+          bysameorder = orderedirows && haskey(x) && length(allbyvars) && identical(allbyvars,head(key(x),length(allbyvars)))
+          if (!bysameorder && !missing(keyby) && isTRUE(getOption("datatable.use.index"))) {
+            tt = paste0(allbyvars, collapse="__")
+            w = which.first(substring(indices(x),1L,nchar(tt)) == tt)  # substring to avoid the overhead of grep
+            if (!is.na(w)) {
+              byindex = indices(x)[w]
+              if (!length(getindex(x, byindex))) {
+                if (verbose) cat("by index '", byindex, "' but that index has 0 length. Ignoring.\n", sep="")
+                byindex=FALSE
+              }
+            }
+          }
+        }
 
-        orderedirows = .Call(CisOrderedSubset, irows, nrow(x))  # TRUE when irows is NULL (i.e. no i clause)
-        # orderedirows = is.sorted(f__)
-        bysameorder = orderedirows && haskey(x) && all(vapply_1b(bysubl,is.name)) && length(allbyvars) && identical(allbyvars,head(key(x),length(allbyvars)))
         if (is.null(irows))
           if (is.call(bysub) && length(bysub) == 3L && bysub[[1L]] == ":" && is.name(bysub[[2L]]) && is.name(bysub[[3L]])) {
             byval = eval(bysub, setattr(as.list(seq_along(x)), 'names', names(x)), parent.frame())
@@ -1463,7 +1475,7 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
     if (missing(by)) stop("Internal error, by is missing")
 
     if (length(byval) && length(byval[[1L]])) {
-      if (!bysameorder) {
+      if (!bysameorder && identical(byindex,FALSE)) {
         if (verbose) {last.started.at=proc.time();cat("Finding groups using forderv ... ");flush.console()}
         o__ = forderv(byval, sort=!missing(keyby), retGrp=TRUE)
         # The sort= argument is called sortStr at C level. It's just about saving the sort of unique strings at
@@ -1494,8 +1506,17 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
         }
         if (!orderedirows && !length(o__)) o__ = seq_len(xnrow)  # temp fix.  TODO: revist orderedirows
       } else {
-        if (verbose) {last.started.at=proc.time();cat("Finding groups using uniqlist ... ");flush.console()}
-        f__ = uniqlist(byval)
+        if (verbose) last.started.at=proc.time();
+        if (bysameorder) {
+          if (verbose) {cat("Finding groups using uniqlist on key ... ");flush.console()}
+          f__ = uniqlist(byval)
+        } else {
+          if (!is.character(byindex) || length(byindex)!=1L) stop("Internal error: byindex not the index name")
+          if (verbose) {cat("Finding groups using uniqlist on index '", byindex, "' ... ", sep="");flush.console()}
+          o__ = getindex(x, byindex)
+          if (is.null(o__)) stop("Internal error: byindex not found")
+          f__ = uniqlist(byval, order=o__)
+        }
         if (verbose) {
           cat(timetaken(last.started.at),"\n")
           last.started.at=proc.time()

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1472,7 +1472,7 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
 
   } else {
     # Find the groups, using 'byval' ...
-    if (missing(by)) stop("Internal error, by is missing")
+    if (missing(by)) stop("Internal error: by= is missing")   # nocov
 
     if (length(byval) && length(byval[[1L]])) {
       if (!bysameorder && identical(byindex,FALSE)) {

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1511,10 +1511,10 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
           if (verbose) {cat("Finding groups using uniqlist on key ... ");flush.console()}
           f__ = uniqlist(byval)
         } else {
-          if (!is.character(byindex) || length(byindex)!=1L) stop("Internal error: byindex not the index name")
+          if (!is.character(byindex) || length(byindex)!=1L) stop("Internal error: byindex not the index name")  # nocov
           if (verbose) {cat("Finding groups using uniqlist on index '", byindex, "' ... ", sep="");flush.console()}
           o__ = getindex(x, byindex)
-          if (is.null(o__)) stop("Internal error: byindex not found")
+          if (is.null(o__)) stop("Internal error: byindex not found")  # nocov
           f__ = uniqlist(byval, order=o__)
         }
         if (verbose) {

--- a/R/setkey.R
+++ b/R/setkey.R
@@ -111,9 +111,18 @@ key <- function(x) attr(x,"sorted",exact=TRUE)
 indices <- function(x, vectors = FALSE) {
   ans = names(attributes(attr(x,"index",exact=TRUE)))
   if (is.null(ans)) return(ans) # otherwise character() gets returned by next line
-  ans <- gsub("^__","",ans)
+  ans <- gsub("^__","",ans)     # the leading __ is internal only, so remove that in result
   if (isTRUE(vectors))
     ans <- strsplit(ans, "__", fixed = TRUE)
+  ans
+}
+
+getindex <- function(x, name) {
+  # name can be "col", or "col1__col2", or c("col1","col2")
+  ans = attr(attr(x, 'index'), paste0("__",name,collapse=""), exact=TRUE)
+  if (!is.null(ans) && (!is.integer(ans) || (length(ans)!=nrow(x) && length(ans)!=0L))) {
+    stop("Internal error: index '",name,"' exists but is invalid")
+  }
   ans
 }
 

--- a/R/setkey.R
+++ b/R/setkey.R
@@ -121,7 +121,7 @@ getindex <- function(x, name) {
   # name can be "col", or "col1__col2", or c("col1","col2")
   ans = attr(attr(x, 'index'), paste0("__",name,collapse=""), exact=TRUE)
   if (!is.null(ans) && (!is.integer(ans) || (length(ans)!=nrow(x) && length(ans)!=0L))) {
-    stop("Internal error: index '",name,"' exists but is invalid")
+    stop("Internal error: index '",name,"' exists but is invalid")   # nocov
   }
   ans
 }

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -12188,16 +12188,22 @@ test(1942.2, DT[,sum(v),keyby=id1,verbose=TRUE], data.table(id1=c("D","A","C"), 
 setindex(DT,id2)
 test(1942.3, DT[,sum(v),keyby=id2,verbose=TRUE], data.table(id2=INT(3,9,2), V1=INT(6,6,3), key="id2"), output="Finding groups using uniqlist on index 'id2")
 setindex(DT,id3)
+oldnr = getNumericRounding()  # TODO: return old
+setNumericRounding(0)
 test(1942.4, DT[,sum(v),keyby=id3,verbose=TRUE], data.table(id3=c(3.4, 9.1, 3.3), V1=INT(4,7,4), key="id3"), output="Finding groups using uniqlist on index 'id3'")
+setNumericRounding(1)
+test(1942.5, DT[,sum(v),keyby=id3,verbose=TRUE], data.table(id3=c(3.4, 9.1, 3.3), V1=INT(4,7,4), key="id3"), output="Finding groups using uniqlist on index 'id3'")
+setNumericRounding(oldnr)
 setindex(DT, NULL)
-test(1942.5, indices(DT), NULL)
+test(1942.6, indices(DT), NULL)
 setindex(DT,id1,id2)
-test(1942.6, DT[,sum(v),keyby=id1,verbose=TRUE], data.table(id1=c("D","A","C"), V1=INT(1,6,8), key="id1"), output="Finding groups using uniqlist on index 'id1__id2'")
-test(1942.7, DT[,sum(v),keyby=.(id1,id2),verbose=TRUE], data.table(id1=c("A","C","C","D"), id2=INT(9,2,3,3), V1=INT(6,3,5,1), key="id1,id2"), output="Finding groups using uniqlist on index 'id1__id2'")
-test(1942.8, DT[,sum(v),keyby=.(id2,id1),verbose=TRUE], data.table(id2=INT(2,3,3,9), id1=c("C","C","D","A"), V1=INT(3,5,1,6), key="id2,id1"), output="Finding groups using forderv")
+test(1942.7, DT[,sum(v),keyby=id1,verbose=TRUE], data.table(id1=c("D","A","C"), V1=INT(1,6,8), key="id1"), output="Finding groups using uniqlist on index 'id1__id2'")
+test(1942.8, DT[,sum(v),keyby=.(id1,id2),verbose=TRUE], data.table(id1=c("A","C","C","D"), id2=INT(9,2,3,3), V1=INT(6,3,5,1), key="id1,id2"), output="Finding groups using uniqlist on index 'id1__id2'")
+test(1942.9, DT[,sum(v),keyby=.(id2,id1),verbose=TRUE], data.table(id2=INT(2,3,3,9), id1=c("C","C","D","A"), V1=INT(3,5,1,6), key="id2,id1"), output="Finding groups using forderv")
 options(datatable.use.index=FALSE)
-test(1942.9, DT[,sum(v),keyby=id1,verbose=TRUE], data.table(id1=c("D","A","C"), V1=INT(1,6,8), key="id1"), output="Finding groups using forderv")
+test(1942.11, DT[,sum(v),keyby=id1,verbose=TRUE], data.table(id1=c("D","A","C"), V1=INT(1,6,8), key="id1"), output="Finding groups using forderv")
 options(old)
+
 
 ###################################
 #  Add new tests above this line  #

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -12177,6 +12177,27 @@ test(1940, data.table(A=1:3, .SD=4:6), error=".SD.*has special meaning")
 test(1941.1, fintersect(data.table(y=1), data.table(y=2)), data.table(y=numeric()))
 test(1941.2, fintersect(data.table(y=1), data.table(y=1)), data.table(y=1))
 
+# by= and keyby= using uniqlist on key,  keyby= using index and passing it to uniqlist
+DT = data.table(id=c("D","A","C","A","C"), v=1:5)
+setkey(DT,id)
+test(1942.1, DT[,sum(v),by=id,verbose=TRUE], data.table(id=c("A","C","D"), V1=INT(6,8,1), key="id"), output="Finding groups using uniqlist on key")
+DT = data.table(id1=c("D","A","C","A","C"), id2=INT(3,9,2,9,3), id3=c(3.4, 9.1, 3.4, 3.3, 9.1), v=1:5)
+setindex(DT,id1)
+old = options(datatable.use.index=TRUE)
+test(1942.2, DT[,sum(v),keyby=id1,verbose=TRUE], data.table(id1=c("D","A","C"), V1=INT(1,6,8), key="id1"), output="Finding groups using uniqlist on index 'id1'")
+setindex(DT,id2)
+test(1942.3, DT[,sum(v),keyby=id2,verbose=TRUE], data.table(id2=INT(3,9,2), V1=INT(6,6,3), key="id2"), output="Finding groups using uniqlist on index 'id2")
+setindex(DT,id3)
+test(1942.4, DT[,sum(v),keyby=id3,verbose=TRUE], data.table(id3=c(3.4, 9.1, 3.3), V1=INT(4,7,4), key="id3"), output="Finding groups using uniqlist on index 'id3'")
+setindex(DT, NULL)
+test(1942.5, indices(DT), NULL)
+setindex(DT,id1,id2)
+test(1942.6, DT[,sum(v),keyby=id1,verbose=TRUE], data.table(id1=c("D","A","C"), V1=INT(1,6,8), key="id1"), output="Finding groups using uniqlist on index 'id1__id2'")
+test(1942.7, DT[,sum(v),keyby=.(id1,id2),verbose=TRUE], data.table(id1=c("A","C","C","D"), id2=INT(9,2,3,3), V1=INT(6,3,5,1), key="id1,id2"), output="Finding groups using uniqlist on index 'id1__id2'")
+test(1942.8, DT[,sum(v),keyby=.(id2,id1),verbose=TRUE], data.table(id2=INT(2,3,3,9), id1=c("C","C","D","A"), V1=INT(3,5,1,6), key="id2,id1"), output="Finding groups using forderv")
+options(datatable.use.index=FALSE)
+test(1942.9, DT[,sum(v),keyby=id1,verbose=TRUE], data.table(id1=c("D","A","C"), V1=INT(1,6,8), key="id1"), output="Finding groups using forderv")
+options(old)
 
 ###################################
 #  Add new tests above this line  #

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -96,6 +96,7 @@ unsigned long long (*twiddle)(void *, int, int);
 SEXP forder(SEXP DT, SEXP by, SEXP retGrp, SEXP sortStrArg, SEXP orderArg, SEXP naArg);
 bool need2utf8(SEXP x, int n);
 SEXP isReallyReal(SEXP);
+int getNumericRounding_C();
 
 // reorder.c
 SEXP reorder(SEXP x, SEXP order);

--- a/src/forder.c
+++ b/src/forder.c
@@ -455,7 +455,7 @@ SEXP setNumericRounding(SEXP droundArg)
 // init.c has initial call with default of 2
 {
   if (!isInteger(droundArg) || LENGTH(droundArg)!=1) error("Must an integer or numeric vector length 1");
-  if (INTEGER(droundArg)[0] < 0 || INTEGER(droundArg)[0] > 2) error("Must be 2 (default) or 1 or 0");
+  if (INTEGER(droundArg)[0] < 0 || INTEGER(droundArg)[0] > 2) error("Must be 2, 1 or 0");
   dround = INTEGER(droundArg)[0];
   dmask1 = dround ? 1 << (8*dround-1) : 0;
   dmask2 = 0xffffffffffffffff << dround*8;
@@ -465,6 +465,12 @@ SEXP setNumericRounding(SEXP droundArg)
 SEXP getNumericRounding()
 {
   return ScalarInteger(dround);
+}
+
+int getNumericRounding_C()
+// for use in uniqlist.c
+{
+  return dround;
 }
 
 static union {

--- a/src/uniqlist.c
+++ b/src/uniqlist.c
@@ -50,11 +50,15 @@ SEXP uniqlist(SEXP l, SEXP order)
     } break;
     case STRSXP : {
       SEXP *vd=DATAPTR(v), prev, this;
-      COMPARE1 && ENC2UTF8(this)!=ENC2UTF8(prev) COMPARE2   // but most of the time there are equal, so ENC2UTF8 doesn't need to be called
+      COMPARE1 && ENC2UTF8(this)!=ENC2UTF8(prev) COMPARE2   // but most of the time they are equal, so ENC2UTF8 doesn't need to be called
     } break;
     case REALSXP : {
       uint64_t *vd=(uint64_t *)REAL(v), prev, this;
-      COMPARE1 COMPARE2
+      if (getNumericRounding_C()==0 /*default*/ || inherits(v, "integer64")) {
+        COMPARE1 COMPARE2
+      } else {
+        COMPARE1 && dtwiddle(&this, 0, 1)!=dtwiddle(&prev, 0, 1) COMPARE2
+      }
     } break;
     default :
       error("Type '%s' not supported", type2char(TYPEOF(v)));


### PR DESCRIPTION
```
N = 5e8
set.seed(1)
DT = data.table(
  id = sample(LETTERS[1:6], N, replace=TRUE),
  val = sample(10, N, replace=TRUE)
)
setkey(DT,id)
```

Before this PR : 
```
> system.time(DT[,sum(val),by=id,verbose=TRUE]) 
Detected that j uses these columns: val 
Finding groups using uniqlist ... 6.924sec 
Finding group sizes from the positions (can be avoided to save RAM) ... 0.002sec 
lapply optimization is on, j unchanged as 'sum(val)'
GForce optimized j to 'gsum(val)'
Making each group and running j (GForce TRUE) ... 3.156sec 
   user  system elapsed 
 10.567   0.601  11.168 
```

With this PR : 
```
> system.time(DT[,sum(val),by=id,verbose=TRUE]) 
Detected that j uses these columns: val 
Finding groups using uniqlist ... 0.373sec 
Finding group sizes from the positions (can be avoided to save RAM) ... 0.002sec 
lapply optimization is on, j unchanged as 'sum(val)'
GForce optimized j to 'gsum(val)'
Making each group and running j (GForce TRUE) ... 3.190sec 
   user  system elapsed 
  4.046   0.615   4.662 
```

The `uniqlist` part reduces from 6.9s to 0.4s.

ToDo:

- [x] ~add missing test of by=key(DT)[1] where that is integer64~  wasn't missing.
- [x] numeric rounding to pass test 1196.2

Found as a result of investigating and thanks to #2962.