### PR TITLE
Fix AIX compilation issue with NAN and INFINITY

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,8 @@
 
 10. `fintersect` failed on tables with a column called `y`, [#3034](https://github.com/Rdatatable/data.table/issues/3034). Thanks to Maxim Nazarov for reporting.
 
+11. Compilation fails in AIX because NAN and INFINITY macros definition in AIX make them not constant literals, [#3043](https://github.com/Rdatatable/data.table/pull/3043). Thanks to Ayappan for reporting and fixing.
+
 #### NOTES
 
 1. The type coercion warning message has been improved, [#2989](https://github.com/Rdatatable/data.table/pull/2989). Thanks to @sarahbeeysian on [Twitter](https://twitter.com/sarahbeeysian/status/1021359529789775872) for highlighting. For example, given the follow statements:

--- a/src/fread.c
+++ b/src/fread.c
@@ -75,10 +75,12 @@ static freadMainArgs args;  // global for use by DTPRINT
 const char typeName[NUMTYPE][10] = {"drop", "bool8", "bool8", "bool8", "bool8", "int32", "int64", "float64", "float64", "float64", "string"};
 int8_t     typeSize[NUMTYPE]     = { 0,      1,       1,       1,       1,       4,       8,       8,         8,         8,         8      };
 
-// NAN and INFINITY constants are float, so cast to double once up front.
+// In AIX, NAN and INFINITY don't qualify as constant literals. Refer: PR #3043
+// So we assign them through below init function.
 static double NAND;
 static double INFD;
 
+// NAN and INFINITY constants are float, so cast to double once up front.
 void init() {
   NAND = (double)NAN;
   INFD = (double)INFINITY;

--- a/src/fread.c
+++ b/src/fread.c
@@ -76,8 +76,13 @@ const char typeName[NUMTYPE][10] = {"drop", "bool8", "bool8", "bool8", "bool8", 
 int8_t     typeSize[NUMTYPE]     = { 0,      1,       1,       1,       1,       4,       8,       8,         8,         8,         8      };
 
 // NAN and INFINITY constants are float, so cast to double once up front.
-static const double NAND = (double)NAN;
-static const double INFD = (double)INFINITY;
+static double NAND;
+static double INFD;
+
+void init() {
+  NAND = (double)NAN;
+  INFD = (double)INFINITY;
+}
 
 typedef struct FieldParseContext {
   // Pointer to the current parsing location
@@ -787,6 +792,7 @@ static void parse_double_extended(FieldParseContext *ctx)
   const char *ch = *(ctx->ch);
   double *target = (double*) ctx->targets[sizeof(double)];
   bool neg, quoted;
+  init();
   ch += (quoted = (*ch=='"'));
   ch += (neg = (*ch=='-')) + (*ch=='+');
 
@@ -871,6 +877,7 @@ static void parse_double_hexadecimal(FieldParseContext *ctx)
   double *target = (double*) ctx->targets[sizeof(double)];
   uint64_t neg;
   bool Eneg, subnormal = 0;
+  init();
   ch += (neg = (*ch=='-')) + (*ch=='+');
 
   if (ch[0]=='0' && (ch[1]=='x' || ch[1]=='X') &&


### PR DESCRIPTION
We have recently ported R to AIX .
https://www.ibm.com/developerworks/aix/library/aix-toolbox/alpha.html#R
When trying to install data.table, there is a compilation issue with NAN and INFINITY. 

fread.c:79:28: error: initializer element is not constant
 static const double NAND = (double)NAN;
                            ^
fread.c:80:28: error: initializer element is not constant
 static const double INFD = (double)INFINITY;
                            ^
With gcc -E option , we see this

static const unsigned int _SINFINITY = 0x7f800000;
static const unsigned int _SQNAN = 0x7fc00000;


static const double NAND = (double)
 79 "fread.c" 3 4
                                  (*((float *)(&_SQNAN)))
 79 "fread.c"
                                     ;
static const double INFD = (double)
 80 "fread.c" 3 4
                                  (*((float *)(&_SINFINITY)))
 80 "fread.c"

So they don't seem to qualify as constant literals hence the compilation issue. 
I have tested the fix in Linux as well. 