### PR TITLE
Slowdown with R 3.5.0

### DIFF
--- a/src/gsumm.c
+++ b/src/gsumm.c
@@ -54,14 +54,14 @@ SEXP gforce(SEXP env, SEXP jsub, SEXP o, SEXP f, SEXP l, SEXP irowsArg) {
   maxgrpn = 0;
   if (LENGTH(o)) {
     isunsorted = 1; // for gmedian
-    for (int g=0; g<ngrp; g++) {
-      int *this = INTEGER(o) + INTEGER(f)[g]-1;
+    for (int g=0, *od=INTEGER(o), *fd=INTEGER(f); g<ngrp; g++) {   // R API outside should help for very many small groups, pr#3045
+      int *this = od + fd[g]-1;
       for (int j=0; j<grpsize[g]; j++)  grp[ this[j]-1 ] = g;
       if (grpsize[g]>maxgrpn) maxgrpn = grpsize[g];  // recalculate (may as well since looping anyway) and check below
     }
   } else {
-    for (int g=0; g<ngrp; g++) {
-      int *this = grp + INTEGER(f)[g]-1;
+    for (int g=0, *fd=INTEGER(f); g<ngrp; g++) {
+      int *this = grp + fd[g]-1;
       for (int j=0; j<grpsize[g]; j++)  this[j] = g;
       if (grpsize[g]>maxgrpn) maxgrpn = grpsize[g];  // needed for #2046 and #2111 when maxgrpn attribute is not attached to empty o
     }


### PR DESCRIPTION
Towards #2962 
Taking R API calls like INTEGER(), REAL() and LOGICAL() outside loops needs to be done throughout whole project. These are no longer macros since R 3.5.0. That speedup had been one reason I had defined USE_RINTERNALS many years ago but they are now inline functions and a tiny bit heaver inside them too to deal with altrep. Taking R API calls outside loops was recommended by Luke T in any case, especially with respect to OpenMP parallel regions.   Once this work is applied to the whole project (658 for loops potentially) we might be able to remove USE_RINTERNALS which would be really great.
With this PR I get .585s down to .482s (recovers 20% slowdown) on the specific example in issue #2962.  Follow up PRs to come.