### PR TITLE
Invalidly keyed result from join and warning in v1.11.6

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 
 #### BUG FIXES
 
-1. v1.11.6 introduced a bug where joining two keyed tables using `on=` to columns not forming a leading subset of `key(i)` could result in an invalidly keyed result. Subsequent queries on the result could then return incorrect results. A warning `longer object length is not a multiple of shorter object length` could also occur. Thanks to @renkun-ken for reporting and the PR.
+1. v1.11.6 introduced a bug where joining two keyed tables using `on=` to columns not forming a leading subset of `key(i)` could result in an invalidly keyed result, [#3061](https://github.com/Rdatatable/data.table/issues/3061). Subsequent queries on the result could then return incorrect results. A warning `longer object length is not a multiple of shorter object length` could also occur. Thanks to @renkun-ken for reporting and the PR.
 
 #### NOTES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
 
 #### BUG FIXES
 
+1. A bug that produces warnings in key checking when joining two data.tables is fixed, [#3061](https://github.com/Rdatatable/data.table/issues/3061). Thanks to @renkun-ken for reporting and the PR.
+
 #### NOTES
 
 1. The option `datatable.CJ.names` is now TRUE by default as per NEWS item 6 in v1.11.6 (see below). This option will be removed in v1.13.0.

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 
 #### BUG FIXES
 
-1. A bug that produces warnings in key checking when joining two data.tables is fixed, [#3061](https://github.com/Rdatatable/data.table/issues/3061). Thanks to @renkun-ken for reporting and the PR.
+1. v1.11.6 introduced a bug where joining two keyed tables using `on=` to columns not forming a leading subset of `key(i)` could result in an invalidly keyed result. Subsequent queries on the result could then return incorrect results. A warning `longer object length is not a multiple of shorter object length` could also occur. Thanks to @renkun-ken for reporting and the PR.
 
 #### NOTES
 

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1327,12 +1327,8 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
           keylen = if (!chk) len else 0L # fix for #1268
         }
         ## check key on i as well!
-        ichk = is.data.table(i) && haskey(i) ## make sure, i has key at all
-        if (ichk) {
-          ## make sure, i has the correct key
-          ichk = head(key(i), length(leftcols))
-          ichk = all(ichk == names(i)[leftcols][seq_along(ichk)]) # fix for #3061
-        }
+        ichk = is.data.table(i) && haskey(i) &&
+               identical(head(key(i), length(leftcols)), names(i)[leftcols]) # i has the correct key, #3061
         if (keylen && (ichk || is.logical(i) || (.Call(CisOrderedSubset, irows, nrow(x)) && ((roll == FALSE) || length(irows) == 1L)))) # see #1010. don't set key when i has no key, but irows is ordered and roll != FALSE
           setattr(ans,"sorted",head(key(x),keylen))
       }

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1328,7 +1328,11 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
         }
         ## check key on i as well!
         ichk = is.data.table(i) && haskey(i) ## make sure, i has key at all
-        if(ichk) ichk = (head(key(i), length(leftcols)) == names(i)[leftcols]) ## make sure, i has the correct key
+        if (ichk) {
+          ## make sure, i has the correct key
+          ichk = head(key(i), length(leftcols))
+          ichk = all(ichk == names(i)[leftcols][seq_along(ichk)]) # fix for #3061
+        }
         if (keylen && (ichk || is.logical(i) || (.Call(CisOrderedSubset, irows, nrow(x)) && ((roll == FALSE) || length(irows) == 1L)))) # see #1010. don't set key when i has no key, but irows is ordered and roll != FALSE
           setattr(ans,"sorted",head(key(x),keylen))
       }

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -12206,23 +12206,21 @@ test(1942.11, DT[,sum(v),keyby=id1,verbose=TRUE], data.table(id1=c("D","A","C"),
 options(old)
 
 # merge warning: longer object length is not a multiple of shorter object length (#3061)
-d1 <- data.table(
-  S_INFO_WINDCODE = c("000001.SZ", "000001.SZ",
-    "000001.SZ", "000001.SZ", "000001.SZ"),
-  ANN_DT = c(19900321L, 19901231L, 19901231L, 19901231L, 19901231L),
-  REPORT_PERIOD = c(19891231L, 19891231L, 19900331L, 19900630L, 19900930L),
-  REPORT_YEAR = c(1989L, 1989L, 1990L, 1990L, 1990L),
-  REPORT_QUARTER = c(4L, 4L, 1L, 2L, 3L),
-  key = c("S_INFO_WINDCODE", "ANN_DT", "REPORT_PERIOD"))
-d2 <- data.table(
-  S_INFO_WINDCODE = c("000001.SZ", "000001.SZ",
-    "000001.SZ", "000001.SZ", "000001.SZ"),
-  ANN_DT = c(19900321L, 19901231L, 19901231L, 19901231L, 19901231L),
-  REPORT_PERIOD = c(19891231L, 19891231L, 19900331L, 19900630L, 19900930L),
-  REPORT_YEAR = c(1989L, 1989L, 1990L, 1990L, 1990L),
-  REPORT_QUARTER = c(4L, 4L, 1L, 2L, 3L),
-  key = c("S_INFO_WINDCODE", "ANN_DT", "REPORT_PERIOD"))
-test(1943.1, is.data.table(d1[d2, on = c("S_INFO_WINDCODE", "ANN_DT", "REPORT_PERIOD", "REPORT_YEAR", "REPORT_QUARTER")]))
+DT1 <- data.table(
+  id = c("A", "A", "A", "A", "A"),
+  date = c(19900321L, 19901231L, 19901231L, 19901231L, 19901231L),
+  period = c(19891231L, 19891231L, 19900331L, 19900630L, 19900930L),
+  year = c(1989L, 1989L, 1990L, 1990L, 1990L),
+  key = c("id", "date", "period"))
+DT2 <- data.table(
+  id = c("A", "A", "A", "A", "A"),
+  date = c(19900321L, 19901231L, 19901231L, 19901231L, 19901231L),
+  period = c(19891231L, 19891231L, 19900331L, 19900630L, 19900930L),
+  year = c(1989L, 1989L, 1990L, 1990L, 1990L),
+  key = c("id", "date", "period"))
+test(1943.1, (ans<-DT1[DT2])[,1:4], DT1)                         # ok before
+test(1943.2, DT1[DT2, on=c("id","date","period")], ans)          # ok before
+test(1943.3, DT1[DT2, on=c("id","date","period","year")], ans)   # no warning #3061 (longer object length is not a multiple)
 
 
 ###################################

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -12205,7 +12205,7 @@ options(datatable.use.index=FALSE)
 test(1942.11, DT[,sum(v),keyby=id1,verbose=TRUE], data.table(id1=c("D","A","C"), V1=INT(1,6,8), key="id1"), output="Finding groups using forderv")
 options(old)
 
-# merge warning: longer object length is not a multiple of shorter object length (#3061)
+# merge warning: longer object length is not a multiple of shorter object length, #3061
 DT1 <- data.table(
   id = c("A", "A", "A", "A", "A"),
   date = c(19900321L, 19901231L, 19901231L, 19901231L, 19901231L),
@@ -12220,7 +12220,11 @@ DT2 <- data.table(
   key = c("id", "date", "period"))
 test(1943.1, (ans<-DT1[DT2])[,1:4], DT1)                         # ok before
 test(1943.2, DT1[DT2, on=c("id","date","period")], ans)          # ok before
-test(1943.3, DT1[DT2, on=c("id","date","period","year")], ans)   # no warning #3061 (longer object length is not a multiple)
+test(1943.3, DT1[DT2, on=c("id","date","period","year")], ans)   # no warning (longer object length is not a multiple)
+DT1 = data.table(id=c("A","A","A"), date=1:3, val=7:9, key="id,date")
+DT2 = data.table(id=c("A","A","A"), date=1:3, date2=3:1, key="id,date")
+test(1943.4, DT1[DT2, on=c("id",date="date2")],
+             data.table(id="A", date=3:1, val=9:7, i.date=1:3))  # was invalidly keyed by id,date in 1.11.6
 
 
 ###################################

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -12220,7 +12220,7 @@ DT2 <- data.table(
   key = c("id", "date", "period"))
 test(1943.1, (ans<-DT1[DT2])[,1:4], DT1)                         # ok before
 test(1943.2, DT1[DT2, on=c("id","date","period")], ans)          # ok before
-test(1943.3, DT1[DT2, on=c("id","date","period","year")], ans)   # no warning (longer object length is not a multiple)
+test(1943.3, DT1[DT2, on=c("id","date","period","year")], ans[,1:4])  # no warning (longer object length is not a multiple)
 DT1 = data.table(id=c("A","A","A"), date=1:3, val=7:9, key="id,date")
 DT2 = data.table(id=c("A","A","A"), date=1:3, date2=3:1, key="id,date")
 test(1943.4, DT1[DT2, on=c("id",date="date2")],

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -12205,6 +12205,25 @@ options(datatable.use.index=FALSE)
 test(1942.11, DT[,sum(v),keyby=id1,verbose=TRUE], data.table(id1=c("D","A","C"), V1=INT(1,6,8), key="id1"), output="Finding groups using forderv")
 options(old)
 
+# merge warning: longer object length is not a multiple of shorter object length (#3061)
+d1 <- data.table(
+  S_INFO_WINDCODE = c("000001.SZ", "000001.SZ",
+    "000001.SZ", "000001.SZ", "000001.SZ"),
+  ANN_DT = c(19900321L, 19901231L, 19901231L, 19901231L, 19901231L),
+  REPORT_PERIOD = c(19891231L, 19891231L, 19900331L, 19900630L, 19900930L),
+  REPORT_YEAR = c(1989L, 1989L, 1990L, 1990L, 1990L),
+  REPORT_QUARTER = c(4L, 4L, 1L, 2L, 3L),
+  key = c("S_INFO_WINDCODE", "ANN_DT", "REPORT_PERIOD"))
+d2 <- data.table(
+  S_INFO_WINDCODE = c("000001.SZ", "000001.SZ",
+    "000001.SZ", "000001.SZ", "000001.SZ"),
+  ANN_DT = c(19900321L, 19901231L, 19901231L, 19901231L, 19901231L),
+  REPORT_PERIOD = c(19891231L, 19891231L, 19900331L, 19900630L, 19900930L),
+  REPORT_YEAR = c(1989L, 1989L, 1990L, 1990L, 1990L),
+  REPORT_QUARTER = c(4L, 4L, 1L, 2L, 3L),
+  key = c("S_INFO_WINDCODE", "ANN_DT", "REPORT_PERIOD"))
+test(1943.1, is.data.table(d1[d2, on = c("S_INFO_WINDCODE", "ANN_DT", "REPORT_PERIOD", "REPORT_YEAR", "REPORT_QUARTER")]))
+
 
 ###################################
 #  Add new tests above this line  #


### PR DESCRIPTION
This is a simple fix of #3061. I'm not fully sure if it fits the purpose of `ichk` but the code `ichk || is.logical(i) || ...` that follows looks also problematic with the original `ichk` since it produces a logical vector of element-wise string comparison yet the use of `||` only checks the first logical value.