### PR TITLE
test_xts turned back on

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -6214,11 +6214,12 @@ test(1464.13, rleidv(DT, 1:2), ans<-INT(1,2,3,4,5,6,6,6,7,8,8,9,10,11,12,13,14,1
 test(1464.14, rleidv(DT, 2:1), ans)
 test(1464.15, rleidv(DT, c(3,1)), INT(1,1,2,2,3,4,5,5,6,7,8,9,10,11,12,13,14,15,16,17))
 
-if (test_xts &&
-     # package xts also has an issue with a && clause.  To avoid the tests failing due to this
-     # package we only test xts when not checking OR if the package version has incremented
-     # (either because my diagnosis was incorrect or the bug was fixed)
-    {!nzchar(Sys.getenv("_R_CHECK_LENGTH_1_LOGIC2_")) || packageVersion("xts") > "0.11-1"}) {
+if (test_xts) {
+
+  Sys.unsetenv("_R_CHECK_LENGTH_1_LOGIC2_")
+  # package xts has an issue with an && clause (https://github.com/joshuaulrich/xts/pull/269). When that is fixed in xts and released to CRAN, we can remove this Sys.unsetenv
+  # Sys.setenv is called again at the end of this xts branch. The original env variable value was stored at the top of this file and restored at the end.
+
   # data.table-xts conversion #882
   # Date index
   dt = data.table(index = as.Date((as.Date("2014-12-12")-49):as.Date("2014-12-12"),origin="1970-01-01"),quantity = as.numeric(rep(c(1:5),10)),value = rep(c(1:10)*100,5))
@@ -6276,6 +6277,8 @@ if (test_xts &&
                    key = "date")
   dt.xts <- as.xts.data.table(dt)
   test(1663, dt.xts[1L], xts::xts(data.table(nav=100), order.by=as.Date("2014-12-31")))
+
+  Sys.setenv("_R_CHECK_LENGTH_1_LOGIC2_" = TRUE)
 }
 
 


### PR DESCRIPTION
Just after merging #3067 I realized `test_xts` should not be off.   By restoring the previous value of the env variable at the end of tests.Rraw,  Hugh enabled a much simpler way to deal with test_xts.
* _R_CHECK_LENGTH_1_LOGIC2_ is now undefined at the beginning of test_xts.  So that xts's error under the new check doesn't cause data.table tests to error
* test xts now always runs again,  whereas before (i.e. with #3067 merged) it was turned off until xts >  "0.11-1"
* removed assumption that xts will meet new stronger check in release after 0.11-1
* added link to the xts issue so that we can turn the stricter check back on for test_xts whenever xts passes it
* recovers lost coverage

@HughParsonage if you're around, please check and review.  I barely overlap Jan's timezone.  So I can start release procedures of 1.11.8 today,  I'll go ahead and merge.  Merging will submit master to Jan's strict pipelines too.  I can see coverage has indeed increased.