### PR TITLE
Remove reshape2 suggest

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Authors@R: c(
   person("Hugh","Parsonage",  role="ctb"))
 Depends: R (>= 3.1.0)
 Imports: methods
-Suggests: bit64, curl, knitr, xts, nanotime, zoo, reshape2
+Suggests: bit64, curl, knitr, xts, nanotime, zoo
 Description: Fast aggregation of large data (e.g. 100GB in RAM), fast ordered joins, fast add/modify/delete of columns by group using no copies at all, list columns, friendly and fast character-separated-value read/write. Offers a natural and flexible syntax, for faster development.
 License: MPL-2.0 | file LICENSE
 URL: http://r-datatable.com

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -29,8 +29,6 @@ export(rleid)
 export(rleidv)
 export(rowid)
 export(rowidv)
-export(as.xts.data.table)
-if(getRversion() >= "3.6.0") S3method(xts::as.xts, data.table)
 export(uniqueN)
 export(setDTthreads, getDTthreads)
 # set operators
@@ -69,7 +67,6 @@ S3method(as.data.table, ordered)
 S3method(as.data.table, Date)
 S3method(as.data.table, ITime)
 S3method(as.data.table, table)
-S3method(as.data.table, xts)
 S3method(as.data.table, default)
 S3method(as.data.frame, data.table)
 S3method(as.list, data.table)
@@ -90,16 +87,12 @@ S3method(within, data.table)
 S3method(is.na, data.table)
 S3method(format, data.table)
 S3method(Ops, data.table)
-
 S3method(anyDuplicated, data.table)
-
-export(split.data.table)
 S3method(split, data.table)
+
 export(melt)
-export(melt.data.table)
-if(getRversion() >= "3.6.0") S3method(reshape2::melt, data.table) else S3method(melt, data.table)
+S3method(melt, data.table)
 export(dcast)
-export(dcast.data.table)
 S3method(dcast, data.table)
 
 import(utils)
@@ -110,18 +103,23 @@ S3method(head, data.table)
 import(stats)
 S3method(na.omit, data.table)
 
+S3method(as.data.table, xts)
+if(getRversion() >= "3.6.0") {
+  S3method(xts::as.xts, data.table)  # delayed registration (new in R-devel)
+} else {
+  export(as.xts.data.table)
+}
+
 # IDateTime support:
 export(as.IDate,as.ITime,IDateTime)
 export(second,minute,hour,yday,wday,mday,week,isoweek,month,quarter,year)
-
-export(as.Date.IDate) # workaround for zoo bug, see #1500
 
 S3method("[", ITime)
 S3method("+", IDate)
 S3method("-", IDate)
 S3method(as.character, ITime)
 S3method(as.data.frame, ITime)
-if(getRversion() >= "3.6.0") S3method(zoo::as.Date, IDate) else S3method(as.Date, IDate)
+S3method(as.Date, IDate)   # note that zoo::as.Date masks base::as.Date. Both generic. Causes trouble like #1500.
 S3method(as.IDate, Date)
 S3method(as.IDate, POSIXct)
 S3method(as.IDate, default)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -105,7 +105,8 @@ S3method(na.omit, data.table)
 
 S3method(as.data.table, xts)
 if(getRversion() >= "3.6.0") {
-  S3method(xts::as.xts, data.table)  # delayed registration (new in R-devel)
+  export(as.xts.data.table)          # fails in R-devel if not exported too, but I don't understand why
+  S3method(xts::as.xts, data.table)  # delayed registration (new in R-devel)  -- shouldn't this also export as.xts.data.table for us?
 } else {
   export(as.xts.data.table)
 }

--- a/R/fcast.R
+++ b/R/fcast.R
@@ -12,9 +12,13 @@ dcast <- function(data, formula, fun.aggregate = NULL, ..., margins = NULL,
       subset = NULL, fill = NULL, value.var = guess(data)) {
   if (is.data.table(data))
     UseMethod("dcast", data)
-  else
-    reshape2::dcast(data, formula, fun.aggregate = fun.aggregate, ..., margins = margins,
-      subset = subset, fill = fill, value.var = value.var)
+  else {
+    # reshape2::dcast is not generic so we have to call it explicitly. See comments at the top of fmelt.R too.
+    ns = tryCatch(getNamespace("reshape2"), error=function(e)
+         stop("The dcast generic in data.table has been passed a ",class(data)[1L]," (not a data.table) but the reshape2 package is not installed to process this type. Please either install reshape2 and try again, or pass a data.table to dcast instead."))
+    ns$dcast(data, formula, fun.aggregate = fun.aggregate, ..., margins = margins,
+             subset = subset, fill = fill, value.var = value.var)
+  }
 }
 
 check_formula <- function(formula, varnames, valnames) {

--- a/R/fcast.R
+++ b/R/fcast.R
@@ -14,10 +14,12 @@ dcast <- function(data, formula, fun.aggregate = NULL, ..., margins = NULL,
     UseMethod("dcast", data)
   else {
     # reshape2::dcast is not generic so we have to call it explicitly. See comments at the top of fmelt.R too.
+    # nocov start
     ns = tryCatch(getNamespace("reshape2"), error=function(e)
          stop("The dcast generic in data.table has been passed a ",class(data)[1L]," (not a data.table) but the reshape2 package is not installed to process this type. Please either install reshape2 and try again, or pass a data.table to dcast instead."))
     ns$dcast(data, formula, fun.aggregate = fun.aggregate, ..., margins = margins,
              subset = subset, fill = fill, value.var = value.var)
+    # nocov end
   }
 }
 

--- a/R/fmelt.R
+++ b/R/fmelt.R
@@ -1,9 +1,11 @@
-# Add melt generic, don't import reshape2 as it requires R >= 3.0.0.
+
+# melt is generic in reshape2 which is good (unlike dcast) but we still don't import reshape2 because reshape2's
+# dependency on R 3.1 could change in a future release of reshape2. Say it started to depend on R 3.3. Users of data.table
+# couldn't then install data.table in R 3.1 even if they only needed melt.data.table. The other reason is that
+# reshape2::dcast is not generic (see that method in fcast.R).
 melt <- function(data, ..., na.rm = FALSE, value.name = "value") {
-  if (is.data.table(data))
-    UseMethod("melt", data)
-  else
-    reshape2::melt(data, ..., na.rm=na.rm, value.name=value.name)
+  UseMethod("melt", data)
+  # if data is not data.table and reshape2 is installed, this will still dispatch to reshape2's method
 }
 
 patterns <- function(..., cols=character(0L)) {


### PR DESCRIPTION
Closes #3080 
Completes final item in #2740

Added comments to the top of `fmelt.c` as to why we don't import `reshape2` (R dependency inheritance)

`melt` is generic in `reshape2` so I'm not sure why we were explicitly calling it

`dcast` dispatches non-data.table to non-generic `reshape2::dcast` the same as before, but with a more helpful message if `reshape2` is not installed.

Tidied NAMESPACE.   There were a few methods explicitly exported which didn't need to be since S3method already exports the method.  This leaves just one use of the new delayed S3method registration, for `xts`.

The `as.Date` method has another twist in that `zoo::as.Date` masks `base::as.Date` and they are both generic.