### PR TITLE
Replace %in% with %chin% where appropriate

### DIFF
--- a/CRAN_Release.cmd
+++ b/CRAN_Release.cmd
@@ -191,7 +191,7 @@ cd ~/GitHub/data.table
 Rdevel-strict CMD INSTALL data.table_1.11.8.tar.gz
 # Check UBSAN and ASAN flags appear in compiler output above. Rdevel was compiled with them so should be passed through to here
 Rdevel-strict
-install.packages(c("bit64","xts","nanotime"), repos="http://cloud.r-project.org")  # minimum packages needed to not skip any tests in test.data.table()
+install.packages(c("bit64","xts","nanotime","R.utils"), repos="http://cloud.r-project.org")  # minimum packages needed to not skip any tests in test.data.table()
 require(data.table)
 test.data.table()      # 7 mins (vs 1min normally) under UBSAN, ASAN and --strict-barrier
 for (i in 1:100) if (!test.data.table()) break  # try several runs; e.g a few tests generate data with a non-fixed random seed

--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -26,7 +26,7 @@ as.IDate.Date <- function(x, ...) {
 
 as.IDate.POSIXct <- function(x, tz = attr(x, "tzone"), ...) {
   if (is.null(tz)) tz = "UTC"
-  if (tz %in% c("UTC", "GMT"))
+  if (tz %chin% c("UTC", "GMT"))
     structure(as.integer(x) %/% 86400L, class=c("IDate","Date"))
   else
     as.IDate(as.Date(x, tz = tz, ...))
@@ -113,7 +113,7 @@ as.ITime.default <- function(x, ...) {
 
 as.ITime.POSIXct <- function(x, tz = attr(x, "tzone"), ...) {
   if (is.null(tz)) tz = "UTC"
-  if (tz %in% c("UTC", "GMT")) as.ITime(unclass(x), ...) else as.ITime(as.POSIXlt(x, tz = tz, ...), ...)
+  if (tz %chin% c("UTC", "GMT")) as.ITime(unclass(x), ...) else as.ITime(as.POSIXlt(x, tz = tz, ...), ...)
 }
 
 as.ITime.numeric <- function(x, ms = 'truncate', ...) {

--- a/R/as.data.table.R
+++ b/R/as.data.table.R
@@ -92,7 +92,7 @@ as.data.table.array <- function(x, keep.rownames=FALSE, sorted=TRUE, value.name=
   val = rev(if (is.null(dnx)) lapply(dim(x), seq.int) else dnx)
   if (is.null(names(val)) || all(!nzchar(names(val))))
     setattr(val, 'names', paste0("V", rev(seq_along(val))))
-  if (value.name %in% names(val))
+  if (value.name %chin% names(val))
     stop(sprintf("Argument 'value.name' should not overlap with column names in result: %s.", paste(rev(names(val)), collapse=", ")))
   N = NULL
   ans = data.table(do.call(CJ, c(val, sorted=FALSE)), N=as.vector(x))

--- a/R/between.R
+++ b/R/between.R
@@ -1,6 +1,6 @@
 # is x[i] in between lower[i] and upper[i] ?
 between <- function(x,lower,upper,incbounds=TRUE) {
-  is_strictly_numeric <- function(x) is.numeric(x) && !"integer64" %in% class(x)
+  is_strictly_numeric <- function(x) is.numeric(x) && !"integer64" %chin% class(x)
   if (is_strictly_numeric(x) && is_strictly_numeric(lower) &&
     is_strictly_numeric(upper) && length(lower) == 1L && length(upper) == 1L) {
     # faster parallelised version for int/double for most common scenario

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -161,8 +161,8 @@ data.table <-function(..., keep.rownames=FALSE, check.names=FALSE, key=NULL, str
      if (length(ckey)
        && !recycledkey
        && !any(duplicated(ckey))
-       && all(ckey %in% names(value))
-       && !any(duplicated(names(value)[names(value) %in% ckey])))
+       && all(ckey %chin% names(value))
+       && !any(duplicated(names(value)[names(value) %chin% ckey])))
        setattr(value, "sorted", ckey)
   }
   # FR #643, setfactor is an internal function in fread.R
@@ -523,7 +523,7 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
           if (verbose) {cat("done in",timetaken(last.started.at),"\n"); flush.console()}
           if (length(nqgrp)) nqmaxgrp = max(nqgrp) # fix for #1986, when 'x' is 0-row table max(.) returns -Inf.
           if (nqmaxgrp > 1L) { # got some non-equi join work to do
-            if ("_nqgrp_" %in% names(x)) stop("Column name '_nqgrp_' is reserved for non-equi joins.")
+            if ("_nqgrp_" %chin% names(x)) stop("Column name '_nqgrp_' is reserved for non-equi joins.")
             if (verbose) {last.started.at=proc.time();cat("  Recomputing forder with non-equi ids ... ");flush.console()}
             set(nqx<-shallow(x), j="_nqgrp_", value=nqgrp)
             xo = forderv(nqx, c(ncol(nqx), rightcols))
@@ -757,7 +757,7 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
 
     if (!with) {
       # missing(by)==TRUE was already checked above before dealing with i
-      if (is.call(jsub) && deparse(jsub[[1L]], 500L, backtick=FALSE) %in% c("!", "-")) {  # TODO is deparse avoidable here?
+      if (is.call(jsub) && deparse(jsub[[1L]], 500L, backtick=FALSE) %chin% c("!", "-")) {  # TODO is deparse avoidable here?
         notj = TRUE
         jsub = jsub[[2L]]
       } else notj = FALSE
@@ -939,7 +939,7 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
                 if (!length(tt)) tt = all.vars(bysubl[[jj+1L]])[1L]
               }
               # fix for #497
-              if (length(byvars) > 1L && tt %in% all.vars(jsub, FALSE)) {
+              if (length(byvars) > 1L && tt %chin% all.vars(jsub, FALSE)) {
                 bynames[jj] = deparse(bysubl[[jj+1L]])
                 if (verbose)
                   cat("by-expression '", bynames[jj], "' is not named, and the auto-generated name '", tt, "' clashed with variable(s) in j. Therefore assigning the entire by-expression as name.\n", sep="")
@@ -997,7 +997,7 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
           # FR #4979 - negative numeric and character indices for SDcols
           colsub = substitute(.SDcols)
           # fix for #5190. colsub[[1L]] gave error when it's a symbol.
-          if (is.call(colsub) && deparse(colsub[[1L]], 500L, backtick=FALSE) %in% c("!", "-")) {
+          if (is.call(colsub) && deparse(colsub[[1L]], 500L, backtick=FALSE) %chin% c("!", "-")) {
             colm = TRUE
             colsub = colsub[[2L]]
           } else colm = FALSE
@@ -1186,7 +1186,7 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
       # patch for #1615. Allow 'x.' syntax. Only useful during join op when x's join col needs to be used.
       # Note that I specifically have not implemented x[y, aa, on=c(aa="bb")] to refer to x's join column
       # as well because x[i, col] == x[i][, col] will not be TRUE anymore..
-      if ( any(xdotprefixvals <- ansvars %in% xdotprefix)) {
+      if ( any(xdotprefixvals <- ansvars %chin% xdotprefix)) {
         w[xdotprefixvals] = chmatch(ansvars[xdotprefixvals], xdotprefix)
         xdotcols = TRUE
       }
@@ -1372,7 +1372,7 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
 
       # Fix for #813 and #758. Ex: DT[c(FALSE, FALSE), list(integer(0L), y)]
       # where DT = data.table(x=1:2, y=3:4) should return an empty data.table!!
-      if (!is.null(irows) && (identical(irows, integer(0L)) || all(irows %in% 0L))) ## TODO: any way to not check all 'irows' values?
+      if (!is.null(irows) && (identical(irows, integer(0L)) || all(irows == 0L))) ## TODO: any way to not check all 'irows' values?
         if (is.atomic(jval)) jval = jval[0L] else jval = lapply(jval, `[`, 0L)
       if (is.atomic(jval)) {
         setattr(jval,"names",NULL)
@@ -1637,7 +1637,7 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
                 jvnames = c(jvnames, jn__)
                 jsubl[[i_]] = jl__
               }
-            } else if (is.call(this) && length(this) > 1L && as.character(this[[1L]]) %in% optfuns) {
+            } else if (is.call(this) && length(this) > 1L && as.character(this[[1L]]) %chin% optfuns) {
               jvnames = c(jvnames, if (is.null(names(jsubl))) "" else names(jsubl)[i_])
             } else if ( length(this) == 3L && (this[[1L]] == "[" || this[[1L]] == "head") &&
                     this[[2L]] == ".SD" && (is.numeric(this[[3L]]) || this[[3L]] == ".N") ) {
@@ -2304,9 +2304,9 @@ split.data.table <- function(x, f, drop = FALSE, by, sorted = FALSE, keep.by = T
   }
   if (missing(by)) stop("you must provide 'by' or 'f' arguments")
   # check reserved column names during processing
-  if (".ll.tech.split" %in% names(x)) stop("column '.ll.tech.split' is reserved for split.data.table processing")
-  if (".nm.tech.split" %in% by) stop("column '.nm.tech.split' is reserved for split.data.table processing")
-  if (!all(by %in% names(x))) stop("argument 'by' must refer to data.table column names")
+  if (".ll.tech.split" %chin% names(x)) stop("column '.ll.tech.split' is reserved for split.data.table processing")
+  if (".nm.tech.split" %chin% by) stop("column '.nm.tech.split' is reserved for split.data.table processing")
+  if (!all(by %chin% names(x))) stop("argument 'by' must refer to data.table column names")
   if (!all(by.atomic <- vapply_1b(by, function(.by) is.atomic(x[[.by]])))) stop(sprintf("argument 'by' must refer only to atomic type columns, classes of '%s' columns are not atomic type", paste(by[!by.atomic], collapse=", ")))
   # list of data.tables (flatten) or list of lists of ... data.tables
   make.levels = function(x, cols, sorted) {
@@ -3039,7 +3039,7 @@ isReallyReal <- function(x) {
     onsub = eval(onsub[[2L]], parent.frame(2L), parent.frame(2L))
     if (is.call(onsub) && onsub[[1L]] == "eval") { onsub = onsub[[2L]] }
   }
-  if (is.call(onsub) && as.character(onsub[[1L]]) %in% c("list", ".")) {
+  if (is.call(onsub) && as.character(onsub[[1L]]) %chin% c("list", ".")) {
     spat = paste0("[ ]+(", pat, ")[ ]+")
     onsub = lapply(as.list(onsub)[-1L], function(x) gsub(spat, "\\1", deparse(x, width.cutoff=500L)))
     onsub = as.call(c(quote(c), onsub))

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1372,7 +1372,7 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
 
       # Fix for #813 and #758. Ex: DT[c(FALSE, FALSE), list(integer(0L), y)]
       # where DT = data.table(x=1:2, y=3:4) should return an empty data.table!!
-      if (!is.null(irows) && (identical(irows, integer(0L)) || all(irows == 0L))) ## TODO: any way to not check all 'irows' values?
+      if (!is.null(irows) && (identical(irows, integer(0L)) || (!anyNA(irows) && all(irows==0L)))) ## anyNA() because all() returns NA (not FALSE) when irows is all-NA. TODO: any way to not check all 'irows' values?
         if (is.atomic(jval)) jval = jval[0L] else jval = lapply(jval, `[`, 0L)
       if (is.atomic(jval)) {
         setattr(jval,"names",NULL)

--- a/R/fcast.R
+++ b/R/fcast.R
@@ -30,7 +30,7 @@ check_formula <- function(formula, varnames, valnames) {
   vars = all.vars(formula)
   vars = vars[!vars %chin% c(".", "...")]
   allvars = c(vars, valnames)
-  if (any(allvars %in% varnames[duplicated(varnames)]))
+  if (any(allvars %chin% varnames[duplicated(varnames)]))
     stop('data.table to cast must have unique column names')
   ans = deparse_formula(as.list(formula)[-1L], varnames, allvars)
 }
@@ -56,7 +56,7 @@ value_vars <- function(value.var, varnames) {
     value.var = list(value.var)
   value.var = lapply(value.var, unique)
   valnames = unique(unlist(value.var))
-  iswrong = which(!valnames %in% varnames)
+  iswrong = which(!valnames %chin% varnames)
   if (length(iswrong))
     stop("value.var values [", paste(value.var[iswrong], collapse=", "), "] are not found in 'data'.")
   value.var
@@ -65,9 +65,9 @@ value_vars <- function(value.var, varnames) {
 aggregate_funs <- function(funs, vals, sep="_", ...) {
   if (is.call(funs) && funs[[1L]] == "eval")
     funs = eval(funs[[2L]], parent.frame(2L), parent.frame(2L))
-  if (is.call(funs) && as.character(funs[[1L]]) %in% c("c", "list"))
+  if (is.call(funs) && as.character(funs[[1L]]) %chin% c("c", "list"))
     funs = lapply(as.list(funs)[-1L], function(x) {
-      if (is.call(x) && as.character(x[[1L]]) %in% c("c", "list")) as.list(x)[-1L] else x
+      if (is.call(x) && as.character(x[[1L]]) %chin% c("c", "list")) as.list(x)[-1L] else x
     })
   else funs = list(funs)
   if (length(funs) != length(vals)) {
@@ -121,11 +121,11 @@ dcast.data.table <- function(data, formula, fun.aggregate = NULL, sep = "_", ...
   setattr(lvars, 'names', c("lhs", "rhs"))
   # Have to take care of duplicate names, and provide names for expression columns properly.
   varnames = make.unique(vapply_1c(unlist(lvars), all.vars, max.names=1L), sep=sep)
-  dupidx = which(valnames %in% varnames)
+  dupidx = which(valnames %chin% varnames)
   if (length(dupidx)) {
     dups = valnames[dupidx]
     valnames = tail(make.unique(c(varnames, valnames)), -length(varnames))
-    lvals = lapply(lvals, function(x) { x[x %in% dups] = valnames[dupidx]; x })
+    lvals = lapply(lvals, function(x) { x[x %chin% dups] = valnames[dupidx]; x })
   }
   lhsnames = head(varnames, length(lvars$lhs))
   rhsnames = tail(varnames, -length(lvars$lhs))

--- a/R/fmelt.R
+++ b/R/fmelt.R
@@ -35,7 +35,7 @@ melt.data.table <- function(data, id.vars, measure.vars, variable.name = "variab
   measure.sub = substitute(measure.vars)
   if (is.call(measure.sub) && measure.sub[[1L]] == "patterns") {
     measure.sub = as.list(measure.sub)[-1L]
-    idx = which(names(measure.sub) %in% "cols")
+    idx = which(names(measure.sub) == "cols")
     if (length(idx)) {
       cols = eval(measure.sub[["cols"]], parent.frame())
       measure.sub = measure.sub[-idx]

--- a/R/fread.R
+++ b/R/fread.R
@@ -12,7 +12,7 @@ fread <- function(input="",file=NULL,text=NULL,cmd=NULL,sep="auto",sep2="auto",d
   }
   stopifnot( is.character(dec), length(dec)==1L, nchar(dec)==1L )
   # handle encoding, #563
-  if (length(encoding) != 1L || !encoding %in% c("unknown", "UTF-8", "Latin-1")) {
+  if (length(encoding) != 1L || !encoding %chin% c("unknown", "UTF-8", "Latin-1")) {
     stop("Argument 'encoding' must be 'unknown', 'UTF-8' or 'Latin-1'.")
   }
   isTrueFalse = function(x) isTRUE(x) || identical(FALSE, x)
@@ -160,7 +160,7 @@ fread <- function(input="",file=NULL,text=NULL,cmd=NULL,sep="auto",sep2="auto",d
   if (stringsAsFactors)
     cols = which(vapply(ans, is.character, TRUE))
   else if (length(colClasses)) {
-    if (is.list(colClasses) && "factor" %in% names(colClasses))
+    if (is.list(colClasses) && "factor" %chin% names(colClasses))
       cols = colClasses[["factor"]]
     else if (is.character(colClasses) && "factor" %chin% colClasses)
       cols = which(colClasses=="factor")

--- a/R/fwrite.R
+++ b/R/fwrite.R
@@ -33,7 +33,7 @@ fwrite <- function(x, file="", append=FALSE, quote="auto",
     is.character(dec) && length(dec)==1L && nchar(dec) == 1L,
     dec != sep,  # sep2!=dec and sep2!=sep checked at C level when we know if list columns are present
     is.character(eol) && length(eol)==1L,
-    length(qmethod) == 1L && qmethod %in% c("double", "escape"),
+    length(qmethod) == 1L && qmethod %chin% c("double", "escape"),
     isLOGICAL(col.names), isLOGICAL(append), isLOGICAL(row.names),
     isLOGICAL(verbose), isLOGICAL(showProgress), isLOGICAL(logical01),
     length(na) == 1L, #1725, handles NULL or character(0) input

--- a/R/last.R
+++ b/R/last.R
@@ -13,7 +13,7 @@ last <- function(x, ...) {
     tail(x, n = 1L, ...)
   } else {
     # fix with suggestion from Joshua, #1347
-    if (!"package:xts" %in% search()) {
+    if (!"package:xts" %chin% search()) {
       tail(x, n = 1L, ...)
     } else xts::last(x, ...) # UseMethod("last") doesn't find xts's methods, not sure what I did wrong.
   }
@@ -30,7 +30,7 @@ first <- function(x, ...) {
     head(x, n = 1L, ...)
   } else {
     # fix with suggestion from Joshua, #1347
-    if (!"package:xts" %in% search()) {
+    if (!"package:xts" %chin% search()) {
       head(x, n = 1L, ...)
     } else xts::first(x, ...)
   }

--- a/R/merge.R
+++ b/R/merge.R
@@ -22,9 +22,9 @@ merge.data.table <- function(x, y, by = NULL, by.x = NULL, by.y = NULL, all = FA
   if (!is.null(by.x)) {
     if ( !is.character(by.x) || !is.character(by.y))
       stop("A non-empty vector of column names are required for `by.x` and `by.y`.")
-    if (!all(by.x %in% names(x)))
+    if (!all(by.x %chin% names(x)))
       stop("Elements listed in `by.x` must be valid column names in x.")
-    if (!all(by.y %in% names(y)))
+    if (!all(by.y %chin% names(y)))
       stop("Elements listed in `by.y` must be valid column names in y.")
     by = by.x
     names(by) = by.y
@@ -37,7 +37,7 @@ merge.data.table <- function(x, y, by = NULL, by.x = NULL, by.y = NULL, all = FA
       by = intersect(names(x), names(y))
     if (length(by) == 0L || !is.character(by))
       stop("A non-empty vector of column names for `by` is required.")
-    if (!all(by %in% intersect(colnames(x), colnames(y))))
+    if (!all(by %chin% intersect(colnames(x), colnames(y))))
       stop("Elements listed in `by` must be valid column names in x and y")
     by = unname(by)
     by.x = by.y = by

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -9,7 +9,7 @@ print.data.table <- function(x, topn=getOption("datatable.print.topn"),
                quote=FALSE, ...) {    # topn  - print the top topn and bottom topn rows with '---' inbetween (5)
   # nrows - under this the whole (small) table is printed, unless topn is provided (100)
   # class - should column class be printed underneath column name? (FALSE)
-  if (!col.names %in% c("auto", "top", "none"))
+  if (!col.names %chin% c("auto", "top", "none"))
     stop("Valid options for col.names are 'auto', 'top', and 'none'")
   if (col.names == "none" && class)
     warning("Column classes will be suppressed when col.names is 'none'")

--- a/R/setkey.R
+++ b/R/setkey.R
@@ -50,7 +50,7 @@ setkeyv <- function(x, cols, verbose=getOption("datatable.verbose"), physical=TR
   } else {
     # remove backticks from cols
     cols <- gsub("`", "", cols)
-    miss = !(cols %in% colnames(x))
+    miss = !(cols %chin% colnames(x))
     if (any(miss)) stop("some columns are not in the data.table: ", paste(cols[miss], collapse=","))
   }
 
@@ -325,10 +325,10 @@ setorderv <- function(x, cols, order=1L, na.last=FALSE)
   } else {
     # remove backticks from cols
     cols <- gsub("`", "", cols)
-    miss = !(cols %in% colnames(x))
+    miss = !(cols %chin% colnames(x))
     if (any(miss)) stop("some columns are not in the data.table: ", paste(cols[miss], collapse=","))
   }
-  if (".xi" %in% colnames(x)) stop("x contains a column called '.xi'. Conflicts with internal use by data.table.")
+  if (".xi" %chin% colnames(x)) stop("x contains a column called '.xi'. Conflicts with internal use by data.table.")
   for (i in cols) {
     .xi = x[[i]]  # [[ is copy on write, otherwise checking type would be copying each column
     if (!typeof(.xi) %chin% c("integer","logical","character","double")) stop("Column '",i,"' is type '",typeof(.xi),"' which is not supported for ordering currently.")

--- a/R/setops.R
+++ b/R/setops.R
@@ -59,7 +59,7 @@ fintersect <- function(x, y, all=FALSE) {
   bad.type = setNames(c("raw","complex","list") %chin% c(vapply(x, typeof, FUN.VALUE = ""), vapply(y, typeof, FUN.VALUE = "")), c("raw","complex","list"))
   if (any(bad.type)) stop(sprintf("x and y must not have unsupported column types: %s", paste(names(bad.type)[bad.type], collapse=", ")))
   if (!identical(lapply(x, class), lapply(y, class))) stop("x and y must have same column classes")
-  if (".seqn" %in% names(x)) stop("None of the datasets to intersect should contain a column named '.seqn'")
+  if (".seqn" %chin% names(x)) stop("None of the datasets to intersect should contain a column named '.seqn'")
   if (!nrow(x) || !nrow(y)) return(x[0L])
   if (all) {
     x = shallow(x)[, ".seqn" := rowidv(x)]
@@ -80,7 +80,7 @@ fsetdiff <- function(x, y, all=FALSE) {
   bad.type = setNames(c("raw","complex","list") %chin% c(vapply(x, typeof, FUN.VALUE = ""), vapply(y, typeof, FUN.VALUE = "")), c("raw","complex","list"))
   if (any(bad.type)) stop(sprintf("x and y must not have unsupported column types: %s", paste(names(bad.type)[bad.type], collapse=", ")))
   if (!identical(lapply(x, class), lapply(y, class))) stop("x and y must have same column classes")
-  if (".seqn" %in% names(x)) stop("None of the datasets to setdiff should contain a column named '.seqn'")
+  if (".seqn" %chin% names(x)) stop("None of the datasets to setdiff should contain a column named '.seqn'")
   if (!nrow(x)) return(x)
   if (!nrow(y)) return(if (!all) funique(x) else x)
   if (all) {
@@ -185,7 +185,7 @@ all.equal.data.table <- function(target, current, trim.levels=TRUE, check.attrib
 
     # Trim any extra row.names attributes that came from some inheritence
     # Trim ".internal.selfref" as long as there is no `all.equal.externalptr` method
-    exclude.attrs = function(x, attrs = c("row.names",".internal.selfref")) x[!names(x) %in% attrs]
+    exclude.attrs = function(x, attrs = c("row.names",".internal.selfref")) x[!names(x) %chin% attrs]
     a1 = exclude.attrs(attributes(target))
     a2 = exclude.attrs(attributes(current))
     if (length(a1) != length(a2)) return(sprintf("Datasets has different number of (non-excluded) attributes: target %s, current %s", length(a1), length(a2)))
@@ -195,7 +195,7 @@ all.equal.data.table <- function(target, current, trim.levels=TRUE, check.attrib
   }
 
   if (ignore.row.order) {
-    if (".seqn" %in% names(target))
+    if (".seqn" %chin% names(target))
       stop("None of the datasets to compare should contain a column named '.seqn'")
     bad.type = setNames(c("raw","complex","list") %chin% c(vapply(current, typeof, FUN.VALUE = ""), vapply(target, typeof, FUN.VALUE = "")), c("raw","complex","list"))
     if (any(bad.type))

--- a/R/tables.R
+++ b/R/tables.R
@@ -25,7 +25,7 @@ tables <- function(mb=TRUE, order.col="NAME", width=80,
     if (index) set(info_i, , "INDICES", list(list(indices(DT))))
     info_i
   }))
-  if (!order.col %in% names(info)) stop("order.col='",order.col,"' not a column name of info")
+  if (!order.col %chin% names(info)) stop("order.col='",order.col,"' not a column name of info")
   info = info[base::order(info[[order.col]])]  # base::order to maintain locale ordering of table names
   if (!silent) {
     # prettier printing on console

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -2,8 +2,8 @@ test.data.table <- function(verbose=FALSE, pkg="pkg", silent=FALSE, with.other.p
   if (exists("test.data.table",.GlobalEnv,inherits=FALSE)) {
     # package developer
     # nocov start
-    if ("package:data.table" %in% search()) stop("data.table package is loaded. Unload or start a fresh R session.")
-    d = if (pkg %in% dir()) file.path(getwd(), pkg) else Sys.getenv("CC_DIR")
+    if ("package:data.table" %chin% search()) stop("data.table package is loaded. Unload or start a fresh R session.")
+    d = if (pkg %chin% dir()) file.path(getwd(), pkg) else Sys.getenv("CC_DIR")
     d = file.path(d, "inst/tests")
     # nocov end
   } else {

--- a/R/xts.R
+++ b/R/xts.R
@@ -2,7 +2,7 @@ as.data.table.xts <- function(x, keep.rownames = TRUE, ...) {
   stopifnot(requireNamespace("xts"), !missing(x), xts::is.xts(x))
   r = setDT(as.data.frame(x, row.names=NULL))
   if (!keep.rownames) return(r[])
-  if ("index" %in% names(x)) stop("Input xts object should not have 'index' column because it would result in duplicate column names. Rename 'index' column in xts or use `keep.rownames=FALSE` and add index manually as another column.")
+  if ("index" %chin% names(x)) stop("Input xts object should not have 'index' column because it would result in duplicate column names. Rename 'index' column in xts or use `keep.rownames=FALSE` and add index manually as another column.")
   r[, "index" := zoo::index(x)]
   setcolorder(r, c("index", setdiff(names(r), "index")))[]
 }
@@ -13,5 +13,5 @@ as.xts.data.table <- function(x, ...) {
   colsNumeric = vapply_1b(x, is.numeric)[-1L] # exclude first col, xts index
   if (any(!colsNumeric)) warning(paste("Following columns are not numeric and will be omitted:", paste(names(colsNumeric)[!colsNumeric], collapse = ", ")))
   r = setDF(x[, .SD, .SDcols = names(colsNumeric)[colsNumeric]])
-  return(xts::as.xts(r, order.by = if ("IDate" %in% class(x[[1L]])) as.Date(x[[1L]]) else x[[1L]]))
+  return(xts::as.xts(r, order.by = if ("IDate" %chin% class(x[[1L]])) as.Date(x[[1L]]) else x[[1L]]))
 }


### PR DESCRIPTION
This installs & builds but `test.data.table()` segfaults:

```
test.data.table()
Running /Users/michael.chirico/Library/R/3.5/library/data.table/tests/tests.Rraw 

 *** caught segfault ***
address 0x0, cause 'memory not mapped'

Traceback:
 1: data.table(ID = seq_len(3000L), time = 0, nTest = 0L)
 2: assign("timings", data.table(ID = seq_len(3000L), time = 0, nTest = 0L),     envir = env)
 3: test.data.table()
```

Within `data.table`, the bug comes almost immediately at:

```
.Call(CcopyNamedInList,x)
```