### PR TITLE
Fix one test to pass GL pipeline

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -4538,7 +4538,7 @@ ll <- list(data.table(x=1, y=-1, x=-2), data.table(y=10, y=20, y=30, x=-10, a="a
 test(1288.1, rbindlist(ll, use.names=TRUE, fill=FALSE), error = "Item 2 has 7 columns, inconsistent with item 1 which has 3 columns")
 # modified after fixing #725
 test(1288.2, rbindlist(ll, use.names=TRUE, fill=TRUE),
-    data.table(x=c(1,-10), y=c(-1,10), x=c(-2, NA), y=c(NA,20), y=c(NA,30), a=c(NA, "a"), b=c(NA, Inf), c=factor(c(NA, 1))))
+    data.table(x=c(1,-10), x=c(-2, NA), y=c(-1,10), y=c(NA,20), y=c(NA,30), a=c(NA, "a"), b=c(NA, Inf), c=factor(c(NA, 1))))
 
 # check the name of output are consistent when binding two empty dts with one empy and other non-empty dt
 dt1 <- data.table(x=1:5, y=6:10)
@@ -12349,6 +12349,11 @@ test(1953.3, melt(DT, id.vars = 'id', measure.vars = patterns(1L)),
 setDF(DT)
 test(1953.4, melt.data.table(DT, id.vars = 'id', measure.vars = 'a'),
      error = "must be a data.table")
+
+# appearance order of two low-cardinality columns that were squashed in pr#3124
+DT = data.table(A=INT(1,3,2,3,2), B=1:5)  # respect groups in 1st column (3's and 2's)
+test(1954, forderv(DT, sort=FALSE, retGrp=TRUE), structure(INT(1,2,4,3,5), starts=1:5, maxgrpn=1L))
+
 
 ###################################
 #  Add new tests above this line  #


### PR DESCRIPTION
follow up to pr #3124
fixed test 1246.55 that failed thanks to one random seed on gitlab pipelines
Added direct test of this case to consistently cover it.
```
Running test id 1246.54
Running test id 1246.55    
Test 1246.55 ran without errors but failed check that x equals y:
> x = duplicated(DT, by = jj, fromLast = TRUE)
First 6 of 100 (type 'logical'): [1] FALSE FALSE FALSE FALSE FALSE FALSE
> y = duplicated.data.frame(DT[, jj, with = FALSE], fromLast = TRUE)
First 6 of 100 (type 'logical'): [1] FALSE FALSE FALSE FALSE FALSE FALSE
1 element mismatch
Running test id 1246.56
Running test id 1246.57
Running test id 1246.58
Running test id 1246.59
Running test id 1246.6
forder decreasing argument test: seed = 1540402216  colorder = 4,2,3,1colorder = 2,4,3,1
Running test id 1247.1
```
also simplified `dtwiddle()`