### PR TITLE
Rename variables that are reserved keywords in C++

### DIFF
--- a/src/assign.c
+++ b/src/assign.c
@@ -188,12 +188,12 @@ static SEXP shallow(SEXP dt, SEXP cols, R_len_t n)
 
 SEXP alloccol(SEXP dt, R_len_t n, Rboolean verbose)
 {
-  SEXP names, class;
+  SEXP names, klass;
   R_len_t l, tl;
   if (isNull(dt)) error("alloccol has been passed a NULL dt");
   if (TYPEOF(dt) != VECSXP) error("dt passed to alloccol isn't type VECSXP");
-  class = getAttrib(dt, R_ClassSymbol);
-  if (isNull(class)) error("dt passed to alloccol has no class attribute. Please report result of traceback() to data.table issue tracker.");
+  klass = getAttrib(dt, R_ClassSymbol);
+  if (isNull(klass)) error("dt passed to alloccol has no class attribute. Please report result of traceback() to data.table issue tracker.");
   l = LENGTH(dt);
   names = getAttrib(dt,R_NamesSymbol);
   // names may be NULL when null.data.table() passes list() to alloccol for example.
@@ -246,9 +246,9 @@ SEXP shallowwrapper(SEXP dt, SEXP cols) {
 // is.data.table() C-function, extracted from assign.c
 // Check if "data.table" class exists somewhere in class (#5115)
 Rboolean isDatatable(SEXP x) {
-  SEXP class = getAttrib(x, R_ClassSymbol);
-  for (int i=0; i<length(class); i++) {
-    if (strcmp(CHAR(STRING_ELT(class, i)), "data.table") == 0) return(TRUE);
+  SEXP klass = getAttrib(x, R_ClassSymbol);
+  for (int i=0; i<length(klass); i++) {
+    if (strcmp(CHAR(STRING_ELT(klass, i)), "data.table") == 0) return(TRUE);
   }
   return (FALSE);
 }
@@ -279,7 +279,7 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values, SEXP v
   // cols : column names or numbers corresponding to the values to set
   // rows : row numbers to assign
   R_len_t i, j, nrow, numToDo, targetlen, vlen, r, oldncol, oldtncol, coln, protecti=0, newcolnum, indexLength;
-  SEXP targetcol, RHS, names, nullint, thisvalue, thisv, targetlevels, newcol, s, colnam, class, tmp, colorder, key, index, a, assignedNames, indexNames;
+  SEXP targetcol, RHS, names, nullint, thisvalue, thisv, targetlevels, newcol, s, colnam, klass, tmp, colorder, key, index, a, assignedNames, indexNames;
   SEXP bindingIsLocked = getAttrib(dt, install(".data.table.locked"));
   Rboolean verbose = LOGICAL(verb)[0], anytodelete=FALSE, isDataTable=FALSE;
   const char *c1, *tc1, *tc2;
@@ -290,22 +290,22 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values, SEXP v
   if (length(bindingIsLocked) && LOGICAL(bindingIsLocked)[0])
     error(".SD is locked. Updating .SD by reference using := or set are reserved for future use. Use := in j directly. Or use copy(.SD) as a (slow) last resort, until shallow() is exported.");
 
-  class = getAttrib(dt, R_ClassSymbol);
-  if (isNull(class)) error("Input passed to assign has no class attribute. Must be a data.table or data.frame.");
+  klass = getAttrib(dt, R_ClassSymbol);
+  if (isNull(klass)) error("Input passed to assign has no class attribute. Must be a data.table or data.frame.");
   // Check if there is a class "data.table" somewhere (#5115).
   // We allow set() on data.frame too; e.g. package Causata uses set() on a data.frame in tests/testTransformationReplay.R
   // := is only allowed on a data.table. However, the ":=" = stop(...) message in data.table.R will have already
   // detected use on a data.frame before getting to this point.
-  for (i=0; i<length(class); i++) {   // There doesn't seem to be an R API interface to inherits(), but manually here isn't too bad.
-    if (strcmp(CHAR(STRING_ELT(class, i)), "data.table") == 0) break;
+  for (i=0; i<length(klass); i++) {   // There doesn't seem to be an R API interface to inherits(), but manually here isn't too bad.
+    if (strcmp(CHAR(STRING_ELT(klass, i)), "data.table") == 0) break;
   }
-  if (i<length(class))
+  if (i<length(klass))
     isDataTable = TRUE;
   else {
-    for (i=0; i<length(class); i++) {
-      if (strcmp(CHAR(STRING_ELT(class, i)), "data.frame") == 0) break;
+    for (i=0; i<length(klass); i++) {
+      if (strcmp(CHAR(STRING_ELT(klass, i)), "data.frame") == 0) break;
     }
-    if (i == length(class)) error("Input is not a data.table, data.frame or an object that inherits from either.");
+    if (i == length(klass)) error("Input is not a data.table, data.frame or an object that inherits from either.");
     isDataTable = FALSE;   // meaning data.frame from now on. Can use set() on existing columns but not add new ones because DF aren't over-allocated.
   }
   oldncol = LENGTH(dt);
@@ -988,17 +988,17 @@ void savetl_end() {
   savedtl = NULL;
 }
 
-SEXP setcharvec(SEXP x, SEXP which, SEXP new)
+SEXP setcharvec(SEXP x, SEXP which, SEXP newx)
 {
   int w;
   if (!isString(x)) error("x must be a character vector");
   if (!isInteger(which)) error("'which' must be an integer vector");
-  if (!isString(new)) error("'new' must be a character vector");
-  if (LENGTH(new)!=LENGTH(which)) error("'new' is length %d. Should be the same as length of 'which' (%d)",LENGTH(new),LENGTH(which));
+  if (!isString(newx)) error("'new' must be a character vector");
+  if (LENGTH(newx)!=LENGTH(which)) error("'new' is length %d. Should be the same as length of 'which' (%d)",LENGTH(newx),LENGTH(which));
   for (int i=0; i<LENGTH(which); i++) {
     w = INTEGER(which)[i];
     if (w==NA_INTEGER || w<1 || w>LENGTH(x)) error("Item %d of 'which' is %d which is outside range of the length %d character vector", i+1,w,LENGTH(x));
-    SET_STRING_ELT(x, w-1, STRING_ELT(new, i));
+    SET_STRING_ELT(x, w-1, STRING_ELT(newx, i));
   }
   return R_NilValue;
 }

--- a/src/frank.c
+++ b/src/frank.c
@@ -6,17 +6,17 @@
 extern SEXP char_integer64;
 
 SEXP dt_na(SEXP x, SEXP cols) {
-  int i, j, n=0, this;
+  int i, j, n=0, elem;
   double *dv;
   SEXP v, ans, class;
 
   if (!isNewList(x)) error("Internal error. Argument 'x' to Cdt_na is type '%s' not 'list'", type2char(TYPEOF(x))); // # nocov
   if (!isInteger(cols)) error("Internal error. Argument 'cols' to Cdt_na is type '%s' not 'integer'", type2char(TYPEOF(cols))); // # nocov
   for (i=0; i<LENGTH(cols); i++) {
-    this = INTEGER(cols)[i];
-    if (this<1 || this>LENGTH(x))
-      error("Item %d of 'cols' is %d which is outside 1-based range [1,ncol(x)=%d]", i+1, this, LENGTH(x));
-    if (!n) n = length(VECTOR_ELT(x, this-1));
+    elem = INTEGER(cols)[i];
+    if (elem<1 || elem>LENGTH(x))
+      error("Item %d of 'cols' is %d which is outside 1-based range [1,ncol(x)=%d]", i+1, elem, LENGTH(x));
+    if (!n) n = length(VECTOR_ELT(x, elem-1));
   }
   ans = PROTECT(allocVector(LGLSXP, n));
   for (i=0; i<n; i++) LOGICAL(ans)[i]=0;
@@ -127,17 +127,17 @@ SEXP frank(SEXP xorderArg, SEXP xstartArg, SEXP xlenArg, SEXP ties_method) {
 
 // internal version of anyNA for data.tables
 SEXP anyNA(SEXP x, SEXP cols) {
-  int i, j, n=0, this;
+  int i, j, n=0, elem;
   double *dv;
   SEXP v, ans, class;
 
   if (!isNewList(x)) error("Internal error. Argument 'x' to CanyNA is type '%s' not 'list'", type2char(TYPEOF(x))); // #nocov
   if (!isInteger(cols)) error("Internal error. Argument 'cols' to CanyNA is type '%s' not 'integer'", type2char(TYPEOF(cols))); // # nocov
   for (i=0; i<LENGTH(cols); i++) {
-    this = INTEGER(cols)[i];
-    if (this<1 || this>LENGTH(x))
-      error("Item %d of 'cols' is %d which is outside 1-based range [1,ncol(x)=%d]", i+1, this, LENGTH(x));
-    if (!n) n = length(VECTOR_ELT(x, this-1));
+    elem = INTEGER(cols)[i];
+    if (elem<1 || elem>LENGTH(x))
+      error("Item %d of 'cols' is %d which is outside 1-based range [1,ncol(x)=%d]", i+1, elem, LENGTH(x));
+    if (!n) n = length(VECTOR_ELT(x, elem-1));
   }
   ans = PROTECT(allocVector(LGLSXP, 1));
   LOGICAL(ans)[0]=0;

--- a/src/frank.c
+++ b/src/frank.c
@@ -8,7 +8,7 @@ extern SEXP char_integer64;
 SEXP dt_na(SEXP x, SEXP cols) {
   int i, j, n=0, elem;
   double *dv;
-  SEXP v, ans, class;
+  SEXP v, ans, klass;
 
   if (!isNewList(x)) error("Internal error. Argument 'x' to Cdt_na is type '%s' not 'list'", type2char(TYPEOF(x))); // # nocov
   if (!isInteger(cols)) error("Internal error. Argument 'cols' to Cdt_na is type '%s' not 'integer'", type2char(TYPEOF(cols))); // # nocov
@@ -36,8 +36,8 @@ SEXP dt_na(SEXP x, SEXP cols) {
       for (j=0; j<n; j++) LOGICAL(ans)[j] |= (STRING_ELT(v, j) == NA_STRING);
       break;
     case REALSXP:
-      class = getAttrib(v, R_ClassSymbol);
-      if (isString(class) && STRING_ELT(class, 0) == char_integer64) {
+      klass = getAttrib(v, R_ClassSymbol);
+      if (isString(klass) && STRING_ELT(klass, 0) == char_integer64) {
         dv = (double *)REAL(v);
         for (j=0; j<n; j++) {
           LOGICAL(ans)[j] |= (DtoLL(dv[j]) == NA_INT64_LL);   // TODO: can be == NA_INT64_D directly

--- a/src/freadR.c
+++ b/src/freadR.c
@@ -191,15 +191,15 @@ _Bool userOverride(int8_t *type, lenOff *colNames, const char *anchor, int ncol)
   if (colNames!=NULL) {
     SET_VECTOR_ELT(RCHK, 1, colNamesSxp=allocVector(STRSXP, ncol));
     for (int i=0; i<ncol; i++) {
-      SEXP this;
+      SEXP elem;
       if (colNames[i].len<=0) {
         char buff[12];
         sprintf(buff,"V%d",i+1);
-        this = mkChar(buff);  // no PROTECT as passed immediately to SET_STRING_ELT
+        elem = mkChar(buff);  // no PROTECT as passed immediately to SET_STRING_ELT
       } else {
-        this = mkCharLenCE(anchor+colNames[i].off, colNames[i].len, ienc);  // no PROTECT as passed immediately to SET_STRING_ELT
+        elem = mkCharLenCE(anchor+colNames[i].off, colNames[i].len, ienc);  // no PROTECT as passed immediately to SET_STRING_ELT
       }
-      SET_STRING_ELT(colNamesSxp, i, this);
+      SET_STRING_ELT(colNamesSxp, i, elem);
     }
   }
   if (length(colClassesSxp)) {

--- a/src/gsumm.c
+++ b/src/gsumm.c
@@ -512,14 +512,14 @@ SEXP gmedian(SEXP x, SEXP narm) {
   R_len_t i=0, j=0, k=0, imed=0, thisgrpsize=0, medianindex=0, nacount=0;
   double val = 0.0;
   Rboolean isna = FALSE, isint64 = FALSE;
-  SEXP ans, sub, class;
+  SEXP ans, sub, klass;
   void *ptr;
   int n = (irowslen == -1) ? length(x) : irowslen;
   if (grpn != n) error("grpn [%d] != length(x) [%d] in gmedian", grpn, n);
   switch(TYPEOF(x)) {
   case REALSXP:
-    class = getAttrib(x, R_ClassSymbol);
-    isint64 = (isString(class) && STRING_ELT(class, 0) == char_integer64);
+    klass = getAttrib(x, R_ClassSymbol);
+    isint64 = (isString(klass) && STRING_ELT(klass, 0) == char_integer64);
     ans = PROTECT(allocVector(REALSXP, ngrp));
     sub = PROTECT(allocVector(REALSXP, maxgrpn)); // allocate once upfront
     ptr = DATAPTR(sub);

--- a/src/gsumm.c
+++ b/src/gsumm.c
@@ -55,14 +55,14 @@ SEXP gforce(SEXP env, SEXP jsub, SEXP o, SEXP f, SEXP l, SEXP irowsArg) {
   if (LENGTH(o)) {
     isunsorted = 1; // for gmedian
     for (int g=0, *od=INTEGER(o), *fd=INTEGER(f); g<ngrp; g++) {   // R API outside should help when very many small groups, pr#3045
-      int *this = od + fd[g]-1;
-      for (int j=0; j<grpsize[g]; j++)  grp[ this[j]-1 ] = g;
+      int *elem = od + fd[g]-1;
+      for (int j=0; j<grpsize[g]; j++)  grp[ elem[j]-1 ] = g;
       if (grpsize[g]>maxgrpn) maxgrpn = grpsize[g];  // recalculate (may as well since looping anyway) and check below
     }
   } else {
     for (int g=0, *fd=INTEGER(f); g<ngrp; g++) {
-      int *this = grp + fd[g]-1;
-      for (int j=0; j<grpsize[g]; j++)  this[j] = g;
+      int *elem = grp + fd[g]-1;
+      for (int j=0; j<grpsize[g]; j++)  elem[j] = g;
       if (grpsize[g]>maxgrpn) maxgrpn = grpsize[g];  // needed for #2046 and #2111 when maxgrpn attribute is not attached to empty o
     }
   }
@@ -114,13 +114,13 @@ SEXP gsum(SEXP x, SEXP narmArg)
       }
     } else {
       for (int i=0, *g=grp; i<n; i++) {
-        int this = xd[irows[i]-1];
-        if (this==NA_INTEGER) {
+        int elem = xd[irows[i]-1];
+        if (elem==NA_INTEGER) {
           if (!narm) s[*g] = NA_REAL;
           g++;
           continue;
         }
-        s[*g++] += this;
+        s[*g++] += elem;
       }
     }
     ans = PROTECT(allocVector(INTSXP, ngrp));
@@ -149,9 +149,9 @@ SEXP gsum(SEXP x, SEXP narmArg)
       }
     } else {
       for (int i=0, *g=grp; i<n; i++) {
-        double this = xd[irows[i]-1];
-        if (narm && ISNAN(this)) {g++; continue;}
-        s[*g++] += this;
+        double elem = xd[irows[i]-1];
+        if (narm && ISNAN(elem)) {g++; continue;}
+        s[*g++] += elem;
       }
     }
     ans = PROTECT(allocVector(REALSXP, ngrp));

--- a/src/init.c
+++ b/src/init.c
@@ -276,10 +276,10 @@ inline bool INHERITS(SEXP x, SEXP char_) {
   // Thread safe in the limited sense of correct and intended usage :
   // i) no API call such as install() or mkChar() must be passed in.
   // ii) no attrib writes must be possible in other threads.
-  SEXP class;
-  if (isString(class = getAttrib(x, R_ClassSymbol))) {
-    for (int i=0; i<LENGTH(class); i++) {
-      if (STRING_ELT(class, i) == char_) return true;
+  SEXP klass;
+  if (isString(klass = getAttrib(x, R_ClassSymbol))) {
+    for (int i=0; i<LENGTH(klass); i++) {
+      if (STRING_ELT(klass, i) == char_) return true;
     }
   }
   return false;

--- a/src/shift.c
+++ b/src/shift.c
@@ -6,7 +6,7 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
 
   size_t size;
   R_len_t i=0, j, m, nx, nk, xrows, thisk, protecti=0;
-  SEXP x, tmp=R_NilValue, this, ans, thisfill, class;
+  SEXP x, tmp=R_NilValue, elem, ans, thisfill, class;
   unsigned long long *dthisfill;
   enum {LAG, LEAD} stype = LAG;
   if (!length(obj)) return(obj); // NULL, list()
@@ -35,10 +35,10 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
   ans = PROTECT(allocVector(VECSXP, nk * nx)); protecti++;
   if (stype == LAG) {
     for (i=0; i<nx; i++) {
-      this  = VECTOR_ELT(x, i);
-      size  = SIZEOF(this);
-      xrows = length(this);
-      switch (TYPEOF(this)) {
+      elem  = VECTOR_ELT(x, i);
+      size  = SIZEOF(elem);
+      xrows = length(elem);
+      switch (TYPEOF(elem)) {
       case INTSXP :
         thisfill = PROTECT(coerceVector(fill, INTSXP)); protecti++;
         for (j=0; j<nk; j++) {
@@ -46,18 +46,18 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
           SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(INTSXP, xrows) );
           if (xrows - INTEGER(k)[j] > 0)
             memcpy((char *)DATAPTR(tmp)+(INTEGER(k)[j]*size),
-                 (char *)DATAPTR(this),
+                 (char *)DATAPTR(elem),
                  (xrows-INTEGER(k)[j])*size);
           for (m=0; m<thisk; m++)
             INTEGER(tmp)[m] = INTEGER(thisfill)[0];
-          copyMostAttrib(this, tmp);
-          if (isFactor(this))
-            setAttrib(tmp, R_LevelsSymbol, getAttrib(this, R_LevelsSymbol));
+          copyMostAttrib(elem, tmp);
+          if (isFactor(elem))
+            setAttrib(tmp, R_LevelsSymbol, getAttrib(elem, R_LevelsSymbol));
         }
         break;
 
       case REALSXP :
-        class = getAttrib(this, R_ClassSymbol);
+        class = getAttrib(elem, R_ClassSymbol);
         if (isString(class) && STRING_ELT(class, 0) == char_integer64) {
           thisfill = PROTECT(allocVector(REALSXP, 1)); protecti++;
           dthisfill = (unsigned long long *)REAL(thisfill);
@@ -72,13 +72,13 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
           SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(REALSXP, xrows) );
           if (xrows - INTEGER(k)[j] > 0) {
             memcpy((char *)DATAPTR(tmp)+(INTEGER(k)[j]*size),
-                 (char *)DATAPTR(this),
+                 (char *)DATAPTR(elem),
                  (xrows-INTEGER(k)[j])*size);
           }
           for (m=0; m<thisk; m++) {
             REAL(tmp)[m] = REAL(thisfill)[0];
           }
-          copyMostAttrib(this, tmp);
+          copyMostAttrib(elem, tmp);
         }
         break;
 
@@ -89,11 +89,11 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
           SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(LGLSXP, xrows) );
           if (xrows - INTEGER(k)[j] > 0)
             memcpy((char *)DATAPTR(tmp)+(INTEGER(k)[j]*size),
-                 (char *)DATAPTR(this),
+                 (char *)DATAPTR(elem),
                  (xrows-INTEGER(k)[j])*size);
           for (m=0; m<thisk; m++)
             LOGICAL(tmp)[m] = LOGICAL(thisfill)[0];
-          copyMostAttrib(this, tmp);
+          copyMostAttrib(elem, tmp);
         }
         break;
 
@@ -102,8 +102,8 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
         for (j=0; j<nk; j++) {
           SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(STRSXP, xrows) );
           for (m=0; m<xrows; m++)
-            SET_STRING_ELT(tmp, m, (m < INTEGER(k)[j]) ? STRING_ELT(thisfill, 0) : STRING_ELT(this, m - INTEGER(k)[j]));
-          copyMostAttrib(this, tmp);
+            SET_STRING_ELT(tmp, m, (m < INTEGER(k)[j]) ? STRING_ELT(thisfill, 0) : STRING_ELT(elem, m - INTEGER(k)[j]));
+          copyMostAttrib(elem, tmp);
         }
         break;
 
@@ -112,24 +112,24 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
         for (j=0; j<nk; j++) {
           SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(VECSXP, xrows) );
           for (m=0; m<xrows; m++)
-            SET_VECTOR_ELT(tmp, m, (m < INTEGER(k)[j]) ? VECTOR_ELT(thisfill, 0) : VECTOR_ELT(this, m - INTEGER(k)[j]));
-          copyMostAttrib(this, tmp);
+            SET_VECTOR_ELT(tmp, m, (m < INTEGER(k)[j]) ? VECTOR_ELT(thisfill, 0) : VECTOR_ELT(elem, m - INTEGER(k)[j]));
+          copyMostAttrib(elem, tmp);
         }
         break;
 
       default :
-        error("Unsupported type '%s'", type2char(TYPEOF(this)));
+        error("Unsupported type '%s'", type2char(TYPEOF(elem)));
       }
-      copyMostAttrib(this, tmp);
-      if (isFactor(this))
-        setAttrib(tmp, R_LevelsSymbol, getAttrib(this, R_LevelsSymbol));
+      copyMostAttrib(elem, tmp);
+      if (isFactor(elem))
+        setAttrib(tmp, R_LevelsSymbol, getAttrib(elem, R_LevelsSymbol));
     }
   } else if (stype == LEAD) {
     for (i=0; i<nx; i++) {
-      this  = VECTOR_ELT(x, i);
-      size  = SIZEOF(this);
-      xrows = length(this);
-      switch (TYPEOF(this)) {
+      elem  = VECTOR_ELT(x, i);
+      size  = SIZEOF(elem);
+      xrows = length(elem);
+      switch (TYPEOF(elem)) {
       case INTSXP :
         thisfill = PROTECT(coerceVector(fill, INTSXP)); protecti++;
         for (j=0; j<nk; j++) {
@@ -137,18 +137,18 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
           SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(INTSXP, xrows) );
           if (xrows - INTEGER(k)[j] > 0)
             memcpy((char *)DATAPTR(tmp),
-                 (char *)DATAPTR(this)+(INTEGER(k)[j]*size),
+                 (char *)DATAPTR(elem)+(INTEGER(k)[j]*size),
                  (xrows-INTEGER(k)[j])*size);
           for (m=xrows-thisk; m<xrows; m++)
             INTEGER(tmp)[m] = INTEGER(thisfill)[0];
-          copyMostAttrib(this, tmp);
-          if (isFactor(this))
-            setAttrib(tmp, R_LevelsSymbol, getAttrib(this, R_LevelsSymbol));
+          copyMostAttrib(elem, tmp);
+          if (isFactor(elem))
+            setAttrib(tmp, R_LevelsSymbol, getAttrib(elem, R_LevelsSymbol));
         }
         break;
 
       case REALSXP :
-        class = getAttrib(this, R_ClassSymbol);
+        class = getAttrib(elem, R_ClassSymbol);
         if (isString(class) && STRING_ELT(class, 0) == char_integer64) {
           thisfill = PROTECT(allocVector(REALSXP, 1)); protecti++;
           dthisfill = (unsigned long long *)REAL(thisfill);
@@ -163,11 +163,11 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
           SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(REALSXP, xrows));
           if (xrows - INTEGER(k)[j] > 0)
             memcpy((char *)DATAPTR(tmp),
-                 (char *)DATAPTR(this)+(INTEGER(k)[j]*size),
+                 (char *)DATAPTR(elem)+(INTEGER(k)[j]*size),
                  (xrows-INTEGER(k)[j])*size);
           for (m=xrows-thisk; m<xrows; m++)
             REAL(tmp)[m] = REAL(thisfill)[0];
-          copyMostAttrib(this, tmp);
+          copyMostAttrib(elem, tmp);
         }
         break;
 
@@ -178,11 +178,11 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
           SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(LGLSXP, xrows) );
           if (xrows - INTEGER(k)[j] > 0)
             memcpy((char *)DATAPTR(tmp),
-                 (char *)DATAPTR(this)+(INTEGER(k)[j]*size),
+                 (char *)DATAPTR(elem)+(INTEGER(k)[j]*size),
                  (xrows-INTEGER(k)[j])*size);
           for (m=xrows-thisk; m<xrows; m++)
             LOGICAL(tmp)[m] = LOGICAL(thisfill)[0];
-          copyMostAttrib(this, tmp);
+          copyMostAttrib(elem, tmp);
         }
         break;
 
@@ -191,8 +191,8 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
         for (j=0; j<nk; j++) {
           SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(STRSXP, xrows) );
           for (m=0; m<xrows; m++)
-            SET_STRING_ELT(tmp, m, (xrows-m <= INTEGER(k)[j]) ? STRING_ELT(thisfill, 0) : STRING_ELT(this, m + INTEGER(k)[j]));
-          copyMostAttrib(this, tmp);
+            SET_STRING_ELT(tmp, m, (xrows-m <= INTEGER(k)[j]) ? STRING_ELT(thisfill, 0) : STRING_ELT(elem, m + INTEGER(k)[j]));
+          copyMostAttrib(elem, tmp);
         }
         break;
 
@@ -201,13 +201,13 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
         for (j=0; j<nk; j++) {
           SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(VECSXP, xrows) );
           for (m=0; m<xrows; m++)
-            SET_VECTOR_ELT(tmp, m, (xrows-m <= INTEGER(k)[j]) ? VECTOR_ELT(thisfill, 0) : VECTOR_ELT(this, m + INTEGER(k)[j]));
-            copyMostAttrib(this, tmp);
+            SET_VECTOR_ELT(tmp, m, (xrows-m <= INTEGER(k)[j]) ? VECTOR_ELT(thisfill, 0) : VECTOR_ELT(elem, m + INTEGER(k)[j]));
+            copyMostAttrib(elem, tmp);
         }
         break;
 
       default :
-        error("Unsupported type '%s'", type2char(TYPEOF(this)));
+        error("Unsupported type '%s'", type2char(TYPEOF(elem)));
       }
     }
   }

--- a/src/shift.c
+++ b/src/shift.c
@@ -6,7 +6,7 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
 
   size_t size;
   R_len_t i=0, j, m, nx, nk, xrows, thisk, protecti=0;
-  SEXP x, tmp=R_NilValue, elem, ans, thisfill, class;
+  SEXP x, tmp=R_NilValue, elem, ans, thisfill, klass;
   unsigned long long *dthisfill;
   enum {LAG, LEAD} stype = LAG;
   if (!length(obj)) return(obj); // NULL, list()
@@ -57,8 +57,8 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
         break;
 
       case REALSXP :
-        class = getAttrib(elem, R_ClassSymbol);
-        if (isString(class) && STRING_ELT(class, 0) == char_integer64) {
+        klass = getAttrib(elem, R_ClassSymbol);
+        if (isString(klass) && STRING_ELT(klass, 0) == char_integer64) {
           thisfill = PROTECT(allocVector(REALSXP, 1)); protecti++;
           dthisfill = (unsigned long long *)REAL(thisfill);
           if (INTEGER(fill)[0] == NA_INTEGER)
@@ -148,8 +148,8 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
         break;
 
       case REALSXP :
-        class = getAttrib(elem, R_ClassSymbol);
-        if (isString(class) && STRING_ELT(class, 0) == char_integer64) {
+        klass = getAttrib(elem, R_ClassSymbol);
+        if (isString(klass) && STRING_ELT(klass, 0) == char_integer64) {
           thisfill = PROTECT(allocVector(REALSXP, 1)); protecti++;
           dthisfill = (unsigned long long *)REAL(thisfill);
           if (INTEGER(fill)[0] == NA_INTEGER)

--- a/src/subset.c
+++ b/src/subset.c
@@ -11,9 +11,9 @@ static SEXP subsetVectorRaw(SEXP target, SEXP source, SEXP idx, Rboolean any0orN
     if (any0orNA) {
       // any 0 or NA *in idx*; if there's 0 or NA in the data that's just regular data to be copied
       for (int i=0, ansi=0; i<LENGTH(idx); i++) {
-        int this = INTEGER(idx)[i];
-        if (this==0) continue;
-        INTEGER(target)[ansi++] = (this==NA_INTEGER || this>max) ? NA_INTEGER : INTEGER(source)[this-1];
+        int elem = INTEGER(idx)[i];
+        if (elem==0) continue;
+        INTEGER(target)[ansi++] = (elem==NA_INTEGER || elem>max) ? NA_INTEGER : INTEGER(source)[elem-1];
         // negatives are checked before (in check_idx()) not to have reached here
         // NA_INTEGER == NA_LOGICAL is checked in init.c
       }
@@ -36,9 +36,9 @@ static SEXP subsetVectorRaw(SEXP target, SEXP source, SEXP idx, Rboolean any0orN
       if (INHERITS(source, char_integer64)) naval.ll = NA_INT64_LL;
       else naval.d = NA_REAL;
       for (int i=0, ansi=0; i<LENGTH(idx); i++) {
-        int this = INTEGER(idx)[i];
-        if (this==0) continue;
-        REAL(target)[ansi++] = (this==NA_INTEGER || this>max) ? naval.d : REAL(source)[this-1];
+        int elem = INTEGER(idx)[i];
+        if (elem==0) continue;
+        REAL(target)[ansi++] = (elem==NA_INTEGER || elem>max) ? naval.d : REAL(source)[elem-1];
       }
     } else {
       double *vd = REAL(source);
@@ -62,9 +62,9 @@ static SEXP subsetVectorRaw(SEXP target, SEXP source, SEXP idx, Rboolean any0orN
     {
       if (any0orNA) {
       for (int i=0, ansi=0; i<LENGTH(idx); i++) {
-        int this = INTEGER(idx)[i];
-        if (this==0) continue;
-        SET_STRING_ELT(target, ansi++, (this==NA_INTEGER || this>max) ? NA_STRING : STRING_ELT(source, this-1));
+        int elem = INTEGER(idx)[i];
+        if (elem==0) continue;
+        SET_STRING_ELT(target, ansi++, (elem==NA_INTEGER || elem>max) ? NA_STRING : STRING_ELT(source, elem-1));
       }
       } else {
       SEXP *vd = (SEXP *)DATAPTR(source);
@@ -81,9 +81,9 @@ static SEXP subsetVectorRaw(SEXP target, SEXP source, SEXP idx, Rboolean any0orN
     {
       if (any0orNA) {
       for (int i=0, ansi=0; i<LENGTH(idx); i++) {
-        int this = INTEGER(idx)[i];
-        if (this==0) continue;
-        SET_VECTOR_ELT(target, ansi++, (this==NA_INTEGER || this>max) ? R_NilValue : VECTOR_ELT(source, this-1));
+        int elem = INTEGER(idx)[i];
+        if (elem==0) continue;
+        SET_VECTOR_ELT(target, ansi++, (elem==NA_INTEGER || elem>max) ? R_NilValue : VECTOR_ELT(source, elem-1));
       }
       } else {
       for (int i=0; i<LENGTH(idx); i++) {
@@ -95,12 +95,12 @@ static SEXP subsetVectorRaw(SEXP target, SEXP source, SEXP idx, Rboolean any0orN
   case CPLXSXP :
     if (any0orNA) {
       for (int i=0, ansi=0; i<LENGTH(idx); i++) {
-        int this = INTEGER(idx)[i];
-        if (this==0) continue;
-        if (this==NA_INTEGER || this>max) {
+        int elem = INTEGER(idx)[i];
+        if (elem==0) continue;
+        if (elem==NA_INTEGER || elem>max) {
           COMPLEX(target)[ansi].r = NA_REAL;
           COMPLEX(target)[ansi++].i = NA_REAL;
-        } else COMPLEX(target)[ansi++] = COMPLEX(source)[this-1];
+        } else COMPLEX(target)[ansi++] = COMPLEX(source)[elem-1];
       }
     } else {
       for (int i=0; i<LENGTH(idx); i++)
@@ -110,9 +110,9 @@ static SEXP subsetVectorRaw(SEXP target, SEXP source, SEXP idx, Rboolean any0orN
   case RAWSXP :
     if (any0orNA) {
       for (int i=0, ansi=0; i<LENGTH(idx); i++) {
-        int this = INTEGER(idx)[i];
-        if (this==0) continue;
-        RAW(target)[ansi++] = (this==NA_INTEGER || this>max) ? (Rbyte) 0 : RAW(source)[this-1];
+        int elem = INTEGER(idx)[i];
+        if (elem==0) continue;
+        RAW(target)[ansi++] = (elem==NA_INTEGER || elem>max) ? (Rbyte) 0 : RAW(source)[elem-1];
       }
     } else {
       for (int i=0; i<LENGTH(idx); i++)
@@ -139,17 +139,17 @@ static void check_idx(SEXP idx, int max, /*outputs...*/int *ansLen, Rboolean *an
   int ans=0;
   int last = INT32_MIN;
   for (int i=0; i<LENGTH(idx); i++) {
-    int this = INTEGER(idx)[i];
-    ans += (this!=0);
-    anyNeg |= this<0 && this!=NA_INTEGER;
-    anyNA |= this==NA_INTEGER || this>max;
-    anyLess |= this<last;
-    last = this;
+    int elem = INTEGER(idx)[i];
+    ans += (elem!=0);
+    anyNeg |= elem<0 && elem!=NA_INTEGER;
+    anyNA |= elem==NA_INTEGER || elem>max;
+    anyLess |= elem<last;
+    last = elem;
   }
   if (anyNeg) error("Internal error: idx contains negatives. Should have been dealt with earlier."); // # nocov
   *ansLen = ans;
   *any0orNA = ans<LENGTH(idx) || anyNA;
-  *monotonic = !anyLess; // for the purpose of ordered keys, this==last is allowed
+  *monotonic = !anyLess; // for the purpose of ordered keys, elem==last is allowed
 }
 
 // TODO - currently called from R level first. Can it be called from check_idx instead?
@@ -165,10 +165,10 @@ SEXP convertNegativeIdx(SEXP idx, SEXP maxArg)
   if (max<0) error("Internal error. max is %d, must be >= 0.", max); // # nocov
   int firstNegative = 0, firstPositive = 0, firstNA = 0, num0 = 0;
   for (int i=0; i<LENGTH(idx); i++) {
-    int this = INTEGER(idx)[i];
-    if (this==NA_INTEGER) { if (firstNA==0) firstNA = i+1;  continue; }
-    if (this==0)          { num0++;  continue; }
-    if (this>0)           { if (firstPositive==0) firstPositive=i+1; continue; }
+    int elem = INTEGER(idx)[i];
+    if (elem==NA_INTEGER) { if (firstNA==0) firstNA = i+1;  continue; }
+    if (elem==0)          { num0++;  continue; }
+    if (elem>0)           { if (firstPositive==0) firstPositive=i+1; continue; }
     if (firstNegative==0) firstNegative=i+1;
   }
   if (firstNegative==0) return(idx);  // 0's and NA can be mixed with positives, there are no negatives present, so we're done
@@ -185,17 +185,17 @@ SEXP convertNegativeIdx(SEXP idx, SEXP maxArg)
   // Maybe R needs to be rebuilt with valgrind before Calloc's Free can be matched up by valgrind?
   int firstDup = 0, numDup = 0, firstBeyond = 0, numBeyond = 0;
   for (int i=0; i<LENGTH(idx); i++) {
-    int this = -INTEGER(idx)[i];
-    if (this==0) continue;
-    if (this>max) {
+    int elem = -INTEGER(idx)[i];
+    if (elem==0) continue;
+    if (elem>max) {
       numBeyond++;
       if (firstBeyond==0) firstBeyond=i+1;
       continue;
     }
-    if (tmp[this-1]==1) {
+    if (tmp[elem-1]==1) {
       numDup++;
       if (firstDup==0) firstDup=i+1;
-    } else tmp[this-1] = 1;
+    } else tmp[elem-1] = 1;
   }
   if (numBeyond)
     warning("Item %d of i is %d but there are only %d rows. Ignoring this and %d more like it out of %d.", firstBeyond, INTEGER(idx)[firstBeyond-1], max, numBeyond-1, LENGTH(idx));

--- a/src/uniqlist.c
+++ b/src/uniqlist.c
@@ -31,14 +31,14 @@ SEXP uniqlist(SEXP l, SEXP order)
 #define COMPARE1                                                                 \
       prev = *vd;                                                                \
       for (int i=1; i<nrow; i++) {                                               \
-        this = *++vd;                                                            \
-        if (this!=prev
+        elem = *++vd;                                                            \
+        if (elem!=prev
 
 #define COMPARE1_VIA_ORDER                                                       \
       prev = vd[*o -1];                                                          \
       for (int i=1; i<nrow; i++) {                                               \
-        this = vd[*++o -1];                                                      \
-        if (this!=prev
+        elem = vd[*++o -1];                                                      \
+        if (elem!=prev
 
 #define COMPARE2                                                                 \
                         ) {                                                      \
@@ -48,14 +48,14 @@ SEXP uniqlist(SEXP l, SEXP order)
             iidx = Realloc(iidx, isize, int);                                    \
           }                                                                      \
         }                                                                        \
-        prev = this;                                                             \
+        prev = elem;                                                             \
       }
 
     SEXP v = VECTOR_ELT(l,0);
     int *o = INTEGER(order);  // only used when via_order is true
     switch(TYPEOF(v)) {
     case INTSXP : case LGLSXP : {
-      int *vd=INTEGER(v), prev, this;
+      int *vd=INTEGER(v), prev, elem;
       if (via_order) {
         // ad hoc by (order passed in)
         COMPARE1_VIA_ORDER COMPARE2
@@ -65,15 +65,15 @@ SEXP uniqlist(SEXP l, SEXP order)
       }
     } break;
     case STRSXP : {
-      SEXP *vd=(SEXP *)DATAPTR(v), prev, this;   // TODO: tried to replace DATAPTR here but (SEXP *)&STRING_ELT(v,0) results in lvalue required as unary ‘&’ operand
+      SEXP *vd=(SEXP *)DATAPTR(v), prev, elem;   // TODO: tried to replace DATAPTR here but (SEXP *)&STRING_ELT(v,0) results in lvalue required as unary ‘&’ operand
       if (via_order) {
-        COMPARE1_VIA_ORDER && ENC2UTF8(this)!=ENC2UTF8(prev) COMPARE2   // but most of the time they are equal, so ENC2UTF8 doesn't need to be called
+        COMPARE1_VIA_ORDER && ENC2UTF8(elem)!=ENC2UTF8(prev) COMPARE2   // but most of the time they are equal, so ENC2UTF8 doesn't need to be called
       } else {
-        COMPARE1           && ENC2UTF8(this)!=ENC2UTF8(prev) COMPARE2
+        COMPARE1           && ENC2UTF8(elem)!=ENC2UTF8(prev) COMPARE2
       }
     } break;
     case REALSXP : {
-      uint64_t *vd=(uint64_t *)REAL(v), prev, this;
+      uint64_t *vd=(uint64_t *)REAL(v), prev, elem;
       // grouping by integer64 makes sense (ids). grouping by float supported but a good use-case for that is harder to imagine
       if (getNumericRounding_C()==0 /*default*/ || inherits(v, "integer64")) {
         if (via_order) {
@@ -83,9 +83,9 @@ SEXP uniqlist(SEXP l, SEXP order)
         }
       } else {
         if (via_order) {
-          COMPARE1_VIA_ORDER && dtwiddle(&this, 0)!=dtwiddle(&prev, 0) COMPARE2
+          COMPARE1_VIA_ORDER && dtwiddle(&elem, 0)!=dtwiddle(&prev, 0) COMPARE2
         } else {
-          COMPARE1           && dtwiddle(&this, 0)!=dtwiddle(&prev, 0) COMPARE2
+          COMPARE1           && dtwiddle(&elem, 0)!=dtwiddle(&prev, 0) COMPARE2
         }
       }
     } break;
@@ -163,8 +163,8 @@ SEXP rleid(SEXP l, SEXP cols)
   if (!nrow || !ncol) return (allocVector(INTSXP, 0));
   if (!isInteger(cols) || LENGTH(cols)==0) error("cols must be an integer vector with length >= 1");
   for (int i=0; i<LENGTH(cols); i++) {
-    int this = INTEGER(cols)[i];
-    if (this<1 || this>LENGTH(l)) error("Item %d of cols is %d which is outside range of l [1,length(l)=%d]", i+1, this, LENGTH(l));
+    int elem = INTEGER(cols)[i];
+    if (elem<1 || elem>LENGTH(l)) error("Item %d of cols is %d which is outside range of l [1,length(l)=%d]", i+1, elem, LENGTH(l));
   }
   for (int i=1; i<ncol; i++) {
     if (length(VECTOR_ELT(l,i)) != nrow) error("All elements to input list must be of same length. Element [%d] has length %d != length of first element = %d.", i+1, length(VECTOR_ELT(l,i)), nrow);


### PR DESCRIPTION
C++ introduced about 2 dozens of new reserved keywords compared to C. Out of those, `data.table` is using only 3: `this`, `class` and `new`. This PR renames these variables to prevent such clashes.
This is in preparation of allowing data.table to be compiled by a C++ compiler.