### PR TITLE
fread(skip=...) works with all types of newlines now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .RData
 .Rhistory
 .Rapp.history
+Rplots.pdf
 
 # Package build process
 *-Ex.R

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,9 @@
 
 2. Column names that look like expressions (e.g. `"a<=colB"`) caused an error when used in `on=` even when wrapped with backticks, [#3092](https://github.com/Rdatatable/data.table/issues/3092). Additionally, `on=` now supports white spaces around operators; e.g. `on = "colA == colB"`. Thanks to @mt1022 for reporting and to @MarkusBonsch for fixing.
 
-3. Unmatched `patterns` in `measure.vars` fail early and with feedback, [#3106](https://github.com/Rdatatable/data.table/issues/3092).
+3. Unmatched `patterns` in `measure.vars` fail early and with feedback, [#3106](https://github.com/Rdatatable/data.table/issues/3106).
+
+4. `skip` parameter in fread now works correctly with all newline types (#3006).
 
 #### NOTES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,7 +18,7 @@
 
 3. Unmatched `patterns` in `measure.vars` fail early and with feedback, [#3106](https://github.com/Rdatatable/data.table/issues/3106).
 
-4. `skip` parameter in fread now works correctly with all newline types (#3006).
+4. `fread(..., skip=)` now skips non-standard `\r` and `\n\r` line endings properly again, [#3006](https://github.com/Rdatatable/data.table/issues/3006). Standard line endings (`\n` Linux/Mac and `\r\n` Windows) were skipped ok. Thanks to @brattono and @tbrycekelly for providing reproducible examples, and @st-pasha for fixing.
 
 #### NOTES
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -12354,6 +12354,15 @@ test(1953.4, melt.data.table(DT, id.vars = 'id', measure.vars = 'a'),
 DT = data.table(A=INT(1,3,2,3,2), B=1:5)  # respect groups in 1st column (3's and 2's)
 test(1954, forderv(DT, sort=FALSE, retGrp=TRUE), structure(INT(1,2,4,3,5), starts=1:5, maxgrpn=1L))
 
+for (i in 1:4) {  # Skip should work with all types of newlines #3006
+  eol = eols[i]
+  src = paste(c("A", "B", "...", ",,,,,", "c1,c2,c3", "1,2,3"), collapse="\n")
+  test(1955 + (i*0.1), fread(text=src, skip=4), data.table(c1=1L, c2=2L, c3=3L))
+}
+test(1955.6, fread("A\n\nB\n\nC\n1\n", skip=2), data.table(B=c("", "C", "1")))
+test(1955.5, fread("A,B\r\r\nX,Y\r\r\nB,C\r\r\n1,2", skip=4), data.table(B=1L, C=2L))
+
+
 
 ###################################
 #  Add new tests above this line  #

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -12354,14 +12354,14 @@ test(1953.4, melt.data.table(DT, id.vars = 'id', measure.vars = 'a'),
 DT = data.table(A=INT(1,3,2,3,2), B=1:5)  # respect groups in 1st column (3's and 2's)
 test(1954, forderv(DT, sort=FALSE, retGrp=TRUE), structure(INT(1,2,4,3,5), starts=1:5, maxgrpn=1L))
 
+eols = c("\n", "\r\n", "\r", "\n\r")
 for (i in 1:4) {  # Skip should work with all types of newlines #3006
   eol = eols[i]
-  src = paste(c("A", "B", "...", ",,,,,", "c1,c2,c3", "1,2,3"), collapse="\n")
+  src = paste(c("A", "B", "...", ",,,,,", "c1,c2,c3", "1,2,3"), collapse=eol)
   test(1955 + (i*0.1), fread(text=src, skip=4), data.table(c1=1L, c2=2L, c3=3L))
 }
-test(1955.6, fread("A\n\nB\n\nC\n1\n", skip=2), data.table(B=c("", "C", "1")))
-test(1955.5, fread("A,B\r\r\nX,Y\r\r\nB,C\r\r\n1,2", skip=4), data.table(B=1L, C=2L))
-
+test(1955.5, fread("A\n\nB\n\nC\n1\n", skip=2), data.table(B=c("", "C", "1")))
+test(1955.6, fread("A,B\r\r\nX,Y\r\r\nB,C\r\r\n1,2", skip=4), data.table(B=1L, C=2L))
 
 
 ###################################

--- a/src/fread.c
+++ b/src/fread.c
@@ -1380,7 +1380,14 @@ int freadMain(freadMainArgs _args) {
   }
   else if (args.skipNrow >= 0) {
     // Skip the first `skipNrow` lines of input, including 0 to force the first line to be the start
-    while (ch<eof && row1line<=args.skipNrow) row1line+=(*ch++=='\n');
+    while (ch < eof && row1line <= args.skipNrow) {
+      char c = *ch++;
+      if (c == '\n' || c == '\r') {
+        ch += (ch < eof && c + ch[0] == '\n' + '\r');
+        row1line++;
+      }
+    }
+    if (ch > sof && verbose) DTPRINT("  Skipped to line %llu in the file", (llu)row1line);
     if (ch>=eof) STOP("skip=%llu but the input only has %llu line%s", (llu)args.skipNrow, (llu)row1line, row1line>1?"s":"");
     pos = ch;
   }


### PR DESCRIPTION
Previously, `skip=N` parameter in fread recognized only `\n` as newline characters. This led to spurious errors of the form "Skip=... but input has only 1 line" if the file was using `\r`-only newlines. With this PR, `skip` recognizes as newlines `\r`, `\n`, `\r\n` and `\n\r`.

Closes #3006