### PR TITLE
Fix file size display bug in fread

### DIFF
--- a/src/fread.c
+++ b/src/fread.c
@@ -419,7 +419,7 @@ static const char* filesize_to_str(size_t fsize)
       }
     } else {
       snprintf(output, BUFFSIZE, "%.*f%cB (%llu bytes)",
-               ndigits, (double)fsize / (1 << shift), suffixes[i], lsize);
+               ndigits, (double)fsize / (1LL << shift), suffixes[i], lsize);
       return output;
     }
   }


### PR DESCRIPTION
The bug only manifests for files of size > 1TB. Which is why it was not spotted earlier, and why it's impossible to write tests for it.

The problem was that the expression `(1 << shift)` (when `shift = 40`) was interpreted as `int(1) << 40`, causing an overflow, and as a result incorrect file size was displayed in the output. On the other hand `(1LL << shift)` is `long long int(1) << 40`, which no longer overflows.