### PR TITLE
forder3

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1463,9 +1463,7 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
     if (length(byval) && length(byval[[1L]])) {
       if (!bysameorder && identical(byindex,FALSE)) {
         if (verbose) {last.started.at=proc.time();cat("Finding groups using forderv ... ");flush.console()}
-        # tt = .Internal(Sys.time())
         o__ = forderv(byval, sort=!missing(keyby), retGrp=TRUE)
-        # cat("forderv call 1 took ", round(.Internal(Sys.time())-tt,3), "s\n", sep="")
         # The sort= argument is called sortStr at C level. It's just about saving the sort of unique strings at
         # C level for efficiency (cgroup vs csort) when by= not keyby=. All other types are always sorted. Getting
         # orginal order below is the part that retains original order. Passing sort=TRUE here always won't change any
@@ -1474,7 +1472,7 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
         # forderv() returns empty integer() if already ordered to save allocating 1:xnrow
         bysameorder = orderedirows && !length(o__)
         if (verbose) {
-          cat(timetaken(last.started.at),"\n")   #TODO timetaken should report wallclock time too, given openmp
+          cat(timetaken(last.started.at),"\n")
           last.started.at=proc.time()
           cat("Finding group sizes from the positions (can be avoided to save RAM) ... ")
           flush.console()  # for windows

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1464,11 +1464,13 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
       if (!bysameorder && identical(byindex,FALSE)) {
         if (verbose) {last.started.at=proc.time();cat("Finding groups using forderv ... ");flush.console()}
         o__ = forderv(byval, sort=!missing(keyby), retGrp=TRUE)
-        # The sort= argument is called sortStr at C level. It's just about saving the sort of unique strings at
-        # C level for efficiency (cgroup vs csort) when by= not keyby=. All other types are always sorted. Getting
-        # orginal order below is the part that retains original order. Passing sort=TRUE here always won't change any
-        # result at all (tested and confirmed to double check), it'll just make by= slower when there's a large
-        # number of unique strings. It must be TRUE when keyby= though, since the key is just marked afterwards.
+        # The sort= argument is called sortGroups at C level. It's primarily for saving the sort of unique strings at
+        # C level for efficiency when by= not keyby=. Other types also retain appearance order, but at byte level to
+        # minimize data movement and benefit from skipping subgroups which happen to be grouped but not sorted. This byte
+        # appearance order is not the same as the order of group values within by= columns, so the 2nd forder below is
+        # still needed to get the group appearance order. Always passing sort=TRUE above won't change any result at all
+        # (tested and confirmed), it'll just make by= slower. It must be TRUE when keyby= though since the key is just
+        # marked afterwards.
         # forderv() returns empty integer() if already ordered to save allocating 1:xnrow
         bysameorder = orderedirows && !length(o__)
         if (verbose) {

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1463,9 +1463,9 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
     if (length(byval) && length(byval[[1L]])) {
       if (!bysameorder && identical(byindex,FALSE)) {
         if (verbose) {last.started.at=proc.time();cat("Finding groups using forderv ... ");flush.console()}
-        tt = .Internal(Sys.time())
+        # tt = .Internal(Sys.time())
         o__ = forderv(byval, sort=!missing(keyby), retGrp=TRUE)
-        cat("forderv call 1 took ", round(.Internal(Sys.time())-tt,3), "s\n", sep="")
+        # cat("forderv call 1 took ", round(.Internal(Sys.time())-tt,3), "s\n", sep="")
         # The sort= argument is called sortStr at C level. It's just about saving the sort of unique strings at
         # C level for efficiency (cgroup vs csort) when by= not keyby=. All other types are always sorted. Getting
         # orginal order below is the part that retains original order. Passing sort=TRUE here always won't change any
@@ -1474,7 +1474,7 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
         # forderv() returns empty integer() if already ordered to save allocating 1:xnrow
         bysameorder = orderedirows && !length(o__)
         if (verbose) {
-          cat(timetaken(last.started.at),"\n")
+          cat(timetaken(last.started.at),"\n")   #TODO timetaken should report wallclock time too, given openmp
           last.started.at=proc.time()
           cat("Finding group sizes from the positions (can be avoided to save RAM) ... ")
           flush.console()  # for windows

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1463,7 +1463,9 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
     if (length(byval) && length(byval[[1L]])) {
       if (!bysameorder && identical(byindex,FALSE)) {
         if (verbose) {last.started.at=proc.time();cat("Finding groups using forderv ... ");flush.console()}
+        tt = .Internal(Sys.time())
         o__ = forderv(byval, sort=!missing(keyby), retGrp=TRUE)
+        cat("forderv call 1 took ", round(.Internal(Sys.time())-tt,3), "s\n", sep="")
         # The sort= argument is called sortStr at C level. It's just about saving the sort of unique strings at
         # C level for efficiency (cgroup vs csort) when by= not keyby=. All other types are always sorted. Getting
         # orginal order below is the part that retains original order. Passing sort=TRUE here always won't change any

--- a/R/timetaken.R
+++ b/R/timetaken.R
@@ -1,6 +1,6 @@
 timetaken <- function(started.at)
 {
-  if (!inherits(started.at,"proc_time")) stop("Use started.at=proc.time() not Sys.time() (POSIXt and slow)")
+  if (!inherits(started.at,"proc_time")) stop("Use started.at=proc.time() not Sys.time() (POSIXt and slow)")  # nocov
   format = function(secs) {
     if (secs > 60.0) {
       secs = as.integer(secs)

--- a/R/timetaken.R
+++ b/R/timetaken.R
@@ -1,17 +1,15 @@
 timetaken <- function(started.at)
 {
-   if (!inherits(started.at,"proc_time")) stop("Use started.at=proc.time() (faster) not Sys.time() (POSIXt and slow)")
-   secs = proc.time()[3L] - started.at[3L]
-   mins = as.integer(secs) %/% 60L
-   hrs = mins %/% 60L
-   days = hrs %/% 24L
-   mins = mins - hrs * 60L
-   hrs = hrs - days * 24L
-   if (secs > 60.0) {
-     res = if (days>=1L) paste0(days," day", if (days>1L) "s " else " ") else ""
-     paste0(res,sprintf("%02d:%02d:%02d", hrs, mins, as.integer(secs) %% 60L))
-   } else {
-     sprintf(if (secs >= 10.0) "%.1fsec" else "%.3fsec", secs)
-   }
+  if (!inherits(started.at,"proc_time")) stop("Use started.at=proc.time() not Sys.time() (POSIXt and slow)")
+  format = function(secs) {
+    if (secs > 60.0) {
+      secs = as.integer(secs)
+      sprintf("%02d:%02d:%02d", secs%/%3600L, (secs%/%60L)%%60L, secs%%60L)
+    } else {
+      sprintf(if (secs >= 10.0) "%.1fs" else "%.3fs", secs)
+    }
+  }
+  tt = proc.time()-started.at  # diff all 3 times
+  paste0(format(tt[3L])," elapsed (", format(tt[1L]), " cpu)")
 }
 

--- a/cc.R
+++ b/cc.R
@@ -37,7 +37,7 @@ sourceDir <- function(path=getwd(), trace = TRUE, ...) {
   if(trace) cat("\n")
 }
 
-cc = function(test=TRUE, clean=FALSE, debug=FALSE, cc_dir=Sys.getenv("CC_DIR"), CC="gcc") {
+cc = function(test=TRUE, clean=FALSE, debug=FALSE, omp=!debug, cc_dir=Sys.getenv("CC_DIR"), CC="gcc") {
   stopifnot(is.character(CC), length(CC)==1L, !is.na(CC), nzchar(CC))
   gc()
 
@@ -59,10 +59,11 @@ cc = function(test=TRUE, clean=FALSE, debug=FALSE, cc_dir=Sys.getenv("CC_DIR"), 
   setwd(file.path(cc_dir,"src"))
   cat(getwd(),"\n")
   if (clean) system("rm *.o *.so")
+  OMP = if (omp) "" else "no-"
   if (debug) {
-    ret = system(sprintf("MAKEFLAGS='-j CC=%s PKG_CFLAGS=-fno-openmp CFLAGS=-std=c99\\ -O0\\ -ggdb\\ -pedantic' R CMD SHLIB -d -o data.table.so *.c", CC))
+    ret = system(sprintf("MAKEFLAGS='-j CC=%s PKG_CFLAGS=-f%sopenmp CFLAGS=-std=c99\\ -O0\\ -ggdb\\ -pedantic' R CMD SHLIB -d -o data.table.so *.c", CC, OMP))
   } else {
-    ret = system(sprintf("MAKEFLAGS='-j CC=%s CFLAGS=-fopenmp\\ -std=c99\\ -O3\\ -pipe\\ -Wall\\ -pedantic' R CMD SHLIB -o data.table.so *.c", CC))
+    ret = system(sprintf("MAKEFLAGS='-j CC=%s CFLAGS=-f%sopenmp\\ -std=c99\\ -O3\\ -pipe\\ -Wall\\ -pedantic' R CMD SHLIB -o data.table.so *.c", CC, OMP))
     # TODO add -Wextra too?
   }
   if (ret) return()
@@ -86,5 +87,5 @@ cc = function(test=TRUE, clean=FALSE, debug=FALSE, cc_dir=Sys.getenv("CC_DIR"), 
   invisible()
 }
 
-dd = function()cc(FALSE,debug=TRUE,clean=TRUE)
+dd = function(omp=FALSE)cc(FALSE,debug=TRUE,omp=omp,clean=TRUE)
 

--- a/src/forder.c
+++ b/src/forder.c
@@ -1,5 +1,4 @@
 #include "data.table.h"
-#define TIMING_ON
 /*
   Inspired by :
   icount in do_radixsort in src/main/sort.c @ rev 51389.
@@ -29,6 +28,7 @@
   overhead. They reach outside themselves to place results in the end result directly rather than returning many small pieces of memory.
 */
 
+// #define TIMING_ON
 static int *gs[2] = {NULL};          // gs = groupsizes e.g. 23,12,87,2,1,34,...
 static int flip = 0;                 // two vectors flip flopped: flip and 1-flip
 static int gsalloc[2] = {0};         // allocated stack size
@@ -683,7 +683,7 @@ SEXP forder(SEXP DT, SEXP by, SEXP retGrp, SEXP sortStrArg, SEXP orderArg, SEXP 
     // Rprintf("Written key for column %d\n", col);
   }
   if (key[nradix]!=NULL) nradix++;  // nradix now number of bytes in key
-  Rprintf("nradix=%d\n", nradix);
+  // Rprintf("nradix=%d\n", nradix);
 
   stackgrps = true;
   push(n);
@@ -894,8 +894,8 @@ SEXP forder(SEXP DT, SEXP by, SEXP retGrp, SEXP sortStrArg, SEXP orderArg, SEXP 
         }
       }
     }
-    Rprintf("After radix %d, ngrp=%d ...\n", radix, gsngrp[flip]);
-    if (radix==0) for (int i=0; i<gsngrp[flip]; i++) Rprintf("%d\n", gs[flip][i]);
+    //Rprintf("After radix %d, ngrp=%d ...\n", radix, gsngrp[flip]);
+    //if (radix==0) for (int i=0; i<gsngrp[flip]; i++) Rprintf("%d\n", gs[flip][i]);
     /*for (int i=0; i<n; i++) {
       Rprintf("%03d: ",i);
       for (int r=0; r<nradix; r++) Rprintf("%03d ",key[r][i]);

--- a/src/forder.c
+++ b/src/forder.c
@@ -404,7 +404,7 @@ uint64_t dtwiddle(void *p, int i)
   }
   if (ISNAN(u.d)) return ISNA(u.d)    ? 0 /*NA*/   : 1 /*NaN*/;  // also normalises a difference between NA on 32bit R (bit 13 set) and 64bit R (bit 13 not set)
   if (isinf(u.d)) return signbit(u.d) ? 2 /*-Inf*/ : (0xffffffffffffffff>>(dround*8)) /*+Inf*/;
-  Error("Unknown non-finite value; not NA, NaN, -Inf or +Inf");
+  Error("Unknown non-finite value; not NA, NaN, -Inf or +Inf");  // # nocov
 }
 
 void radix_r(const int from, const int to, const int radix);

--- a/src/forder.c
+++ b/src/forder.c
@@ -29,7 +29,7 @@
   overhead. They reach outside themselves to place results in the end result directly rather than returning many small pieces of memory.
 */
 
-//#define TIMING_ON
+#define TIMING_ON
 static int *gs = NULL;          // gs = groupsizes e.g. 23,12,87,2,1,34,...
 //static int flip = 0;                 // two vectors flip flopped: flip and 1-flip
 static int gsalloc = 0;         // allocated stack size
@@ -919,7 +919,7 @@ void radix_r(const int from, const int to, const int radix) {
           my_from+=gs;
         }
       }
-      TEND(21)
+      //TEND(21)
       //for (int i=0; i<256; i++) my_counts[i] = 0;  // ready for next time to save initializing should the stack 256-initialization above ever be identified as too slow
       //TEND(5)
     }

--- a/src/myomp.h
+++ b/src/myomp.h
@@ -7,5 +7,6 @@
   #define omp_get_max_threads() 1
   #define omp_get_thread_limit() 1
   #define omp_set_nested(a)   // empty statement to remove the call
+  #define omp_get_nested() 0
 #endif
 

--- a/src/myomp.h
+++ b/src/myomp.h
@@ -6,7 +6,5 @@
   #define omp_get_thread_num() 0
   #define omp_get_max_threads() 1
   #define omp_get_thread_limit() 1
-  #define omp_set_nested(a)   // empty statement to remove the call
-  #define omp_get_nested() 0
 #endif
 


### PR DESCRIPTION
Slow down in dev ordering all-unique input fixed; thanks to @arunsrinivasan's testing.
```
N = 1e8
set.seed(1)
x = sample(N)                       # v1.11.8  master     this PR
system.time(o <- forderv(x))        # 4.5s     5.9s-7.0s  1.2s
!base::is.unsorted(x[o])  # TRUE

x = sample(N/10, N, replace=TRUE)   
system.time(o <- forderv(x))        # 2.6s     1.3s       0.8s
```

Long-standing flip-flop group sizes removed; now recursive and writes directly to final group size stack via thread buffers.
Nested parallelism recently added, removed. skew still handled.
timetaken() in verbose mode now displays both elapsed and cpu time

Looks like AppVeyor timings on this PR are back to normal at about 5 mins (were over 10 min on master) so that's a good sign. 
