### PR TITLE
Reworked subset.c 

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -2963,11 +2963,14 @@ test(1041, rbindlist(l), data.table(i1=factor(letters[1:5]),val=1:5))
 
 # negative indexing in *i* leads to crash/wrong aggregates when dogroups is called. bug #2697
 DT = data.table(x = c(1,2,3,4,5), group = c(1,1,2,2,3))
-test(1042, DT[-5, mean(x), by = group], data.table(group=c(1,2), V1=c(1.5, 3.5)))
+test(1042.1, DT[-5, mean(x), by = group], data.table(group=c(1,2), V1=c(1.5, 3.5)))
 # Test when abs(negative index) > nrow(dt) - should warn
-test(1042.1, DT[-10], DT, warning="Item 1 of i is -10 but there are only 5 rows. Ignoring this and 0 more like it out of 1.")
-test(1042.2, DT[c(-5, -10), mean(x), by = group], data.table(group=c(1,2),V1=c(1.5,3.5)), warning="Item 2 of i is -10 but there are only 5 rows. Ignoring this and 0 more like it out of 2.")
-test(1043, DT[c(1, -5)], error="Cannot mix positives and negatives.")
+test(1042.2, DT[-10], DT, warning="Item 1 of i is -10 but there are only 5 rows. Ignoring this and 0 more like it out of 1.")
+test(1042.3, DT[c(-5, -10), mean(x), by = group], data.table(group=c(1,2),V1=c(1.5,3.5)), warning="Item 2 of i is -10 but there are only 5 rows. Ignoring this and 0 more like it out of 2.")
+test(1042.4, DT[c(-5, -4, -5)], DT[1:3], warning="Item 3 of i is -5 which removes that item but that has occurred before. Ignoring this dup and 0 other dup")
+test(1042.5, DT[c(-5, -4, -5, -5, -4)], DT[1:3], warning="Item 3 of i is -5 which removes that item but that has occurred before. Ignoring this dup and 2 other dup")
+test(1043.1, DT[c(1, -5)], error="Item 2 of i is -5 and item 1 is 1. Cannot mix positives and negatives.")
+test(1043.2, DT[c(-1, NA)], error="Item 1 of i is -1 and item 2 is NA. Cannot mix negatives and NA.")
 
 # crash (floating point exception), when assigning null data.table() to multiple cols, #4731
 DT = data.table(x=1:5,y=6:10)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -2998,10 +2998,10 @@ test(1057, print(DT, digits=2, big.mark=","), output="   x         y logy\n1: a 
 
 # bug #2758 fix - segfault with zeros in i and factors in by
 x <- data.table(letters=letters[1:5], factor=factor(letters[1:5]), number=1:5)
-test(1058, x[c(0, 3), list(letters, number), by=factor], error="While grouping, i=0 is allowed")
-test(1059, x[c(3, 0), list(letters, number), by=factor], error="While grouping, i=0 is allowed")
-test(1060, x[c(0, 3), number:=5L, by=factor], error="While grouping, i=0 is allowed")
-test(1061, x[c(0, 3), number:=5L], data.table(letters=letters[1:5], factor=factor(letters[1:5]), number=c(1:2,5L,4:5)))
+test(1058, x[c(0, 3), list(letters, number), by=factor], ans<-x[3,c(2,1,3)])
+test(1059, x[c(3, 0), list(letters, number), by=factor], ans)
+test(1060, x[c(0, 3), number:=5L, by=factor], ans<-data.table(letters=letters[1:5], factor=factor(letters[1:5]), number=c(1:2,5L,4:5)))
+test(1061, x[c(0, 3), number:=5L], ans)
 
 # bug #2440 fix - seqfault when j refers to grouping variable when results are empty
 DT = data.table(x=rep(c("a","b"),each=3),v=c(42,42,42,4,5,6))

--- a/src/init.c
+++ b/src/init.c
@@ -47,7 +47,7 @@ SEXP binary();
 SEXP chmatch2();
 SEXP subsetDT();
 SEXP subsetVector();
-SEXP convertNegativeIdx();
+SEXP convertNegAndZeroIdx();
 SEXP frank();
 SEXP dt_na();
 SEXP lookup();
@@ -127,7 +127,7 @@ R_CallMethodDef callMethods[] = {
 {"Cchmatch2", (DL_FUNC) &chmatch2, -1},
 {"CsubsetDT", (DL_FUNC) &subsetDT, -1},
 {"CsubsetVector", (DL_FUNC) &subsetVector, -1},
-{"CconvertNegativeIdx", (DL_FUNC) &convertNegativeIdx, -1},
+{"CconvertNegAndZeroIdx", (DL_FUNC) &convertNegAndZeroIdx, -1},
 {"Cfrank", (DL_FUNC) &frank, -1},
 {"Cdt_na", (DL_FUNC) &dt_na, -1},
 {"Clookup", (DL_FUNC) &lookup, -1},

--- a/src/subset.c
+++ b/src/subset.c
@@ -81,7 +81,7 @@ static void subsetVectorRaw(SEXP ans, SEXP source, SEXP idx, const bool anyNA)
     PARLOOP(0)
   } break;
   default :
-    error("Internal error: column type '%s' not supported by data.table subset. All known types are supported so please report as bug.", type2char(TYPEOF(source)));
+    error("Internal error: column type '%s' not supported by data.table subset. All known types are supported so please report as bug.", type2char(TYPEOF(source)));  // # nocov
   }
 }
 
@@ -202,7 +202,7 @@ SEXP convertNegAndZeroIdx(SEXP idx, SEXP maxArg, SEXP allowOverMax)
     if (countBeyond)
       warning("Item %d of i is %d but there are only %d rows. Ignoring this and %d more like it out of %d.", firstBeyond, idxp[firstBeyond-1], max, countBeyond-1, n);
     if (countDup)
-      warning("Item %d of i is %d which removes that item but that has occurred before. Ignoring this dup and %d other dups out of %d.", firstDup, idxp[firstDup-1], countDup-1, n);
+      warning("Item %d of i is %d which removes that item but that has occurred before. Ignoring this dup and %d other dups.", firstDup, idxp[firstDup-1], countDup-1);
     int ansn = max-countRemoved;
     ans = PROTECT(allocVector(INTSXP, ansn));
     int *ansp = INTEGER(ans);
@@ -294,10 +294,7 @@ SEXP subsetVector(SEXP x, SEXP idx) { // idx is 1-based passed from R level
   bool anyNA=false, orderedSubset=false;
   int nprotect=0;
   if (check_idx(idx, length(x), &anyNA, &orderedSubset) != NULL) {
-    SEXP max = PROTECT(ScalarInteger(length(x))); nprotect++;
-    idx = PROTECT(convertNegAndZeroIdx(idx, max, ScalarLogical(TRUE))); nprotect++;
-    const char *err = check_idx(idx, length(x), &anyNA, &orderedSubset);
-    if (err!=NULL) error(err);
+    error("Internal error: CsubsetVector is internal-use-only but has received negatives, zeros or out-of-range");  // # nocov
   }
   SEXP ans = PROTECT(allocVector(TYPEOF(x), length(idx))); nprotect++;
   copyMostAttrib(x, ans);

--- a/src/subset.c
+++ b/src/subset.c
@@ -1,225 +1,226 @@
 #include "data.table.h"
 
-static SEXP subsetVectorRaw(SEXP target, SEXP source, SEXP idx, Rboolean any0orNA)
+static void subsetVectorRaw(SEXP ans, SEXP source, SEXP idx, const bool anyNA)
 // Only for use by subsetDT() or subsetVector() below, hence static
 {
-  if (!length(target)) return target;
+  const int n = length(idx);
+  if (length(ans)!=n) error("Internal error: subsetVectorRaw length(ans)==%d n=%d", length(ans), n);
 
-  const int max=length(source);
+  const int *restrict idxp = INTEGER(idx);
+  // anyNA refers to NA _in idx_; if there's NA in the data (source) that's just regular data to be copied
+  // negatives, zeros and out-of-bounds have already been dealt with in convertNegAndZero so we can rely
+  // here on idx in range [1,length(ans)].
+
+  #define PARLOOP(_NAVAL_)                                        \
+  if (anyNA) {                                                    \
+    _Pragma("omp parallel for num_threads(getDTthreads())")       \
+    for (int i=0; i<n; i++) {                                     \
+      int elem = idxp[i];                                         \
+      ap[i] = elem==NA_INTEGER ? _NAVAL_ : sp[elem-1];            \
+    }                                                             \
+  } else {                                                        \
+    _Pragma("omp parallel for num_threads(getDTthreads())")       \
+    for (int i=0; i<n; i++) {                                     \
+      ap[i] = sp[idxp[i]-1];                                      \
+    }                                                             \
+  }
+  // For small n such as 2,3,4 etc we hope OpenMP will be sensible inside it and not create a team with each thread doing just one item. Otherwise,
+  // call overhead would be too high for highly iterated calls on very small subests. TODO: test and confirm
+  // Futher, we desire (currently at least) to stress-test the threaded code (especially in latest R-devel) on small data to reduce chance that bugs
+  // arise only over a threshold of n.
+
   switch(TYPEOF(source)) {
-  case INTSXP : case LGLSXP :
-    if (any0orNA) {
-      // any 0 or NA *in idx*; if there's 0 or NA in the data that's just regular data to be copied
-      for (int i=0, ansi=0; i<LENGTH(idx); i++) {
-        int elem = INTEGER(idx)[i];
-        if (elem==0) continue;
-        INTEGER(target)[ansi++] = (elem==NA_INTEGER || elem>max) ? NA_INTEGER : INTEGER(source)[elem-1];
-        // negatives are checked before (in check_idx()) not to have reached here
-        // NA_INTEGER == NA_LOGICAL is checked in init.c
-      }
+  case INTSXP: case LGLSXP: {
+    int *sp = INTEGER(source);
+    int *ap = INTEGER(ans);
+    PARLOOP(NA_INTEGER)
+  } break;
+  case REALSXP : {
+    if (INHERITS(source, char_integer64)) {
+      int64_t *sp = (int64_t *)REAL(source);
+      int64_t *ap = (int64_t *)REAL(ans);
+      PARLOOP(INT64_MIN)
     } else {
-      // totally branch free to give optimizer/hardware best chance on all platforms
-      // We keep the branchless version together here inside the same switch to keep
-      // the code together by type
-      // INTEGER and LENGTH are up front to isolate in preparation to stop using USE_RINTERNALS
-      int *vd = INTEGER(source);
-      int *vi = INTEGER(idx);
-      int *p =  INTEGER(target);
-      const int upp = LENGTH(idx);
-      for (int i=0; i<upp; i++) *p++ = vd[vi[i]-1];
+      double *sp = REAL(source);
+      double *ap = REAL(ans);
+      PARLOOP(NA_REAL)
     }
-    break;
-  case REALSXP :
-    if (any0orNA) {
-      // define needed vars just when we need them. To registerize and to limit scope related bugs
-      union { double d; long long ll; } naval;
-      if (INHERITS(source, char_integer64)) naval.ll = NA_INT64_LL;
-      else naval.d = NA_REAL;
-      for (int i=0, ansi=0; i<LENGTH(idx); i++) {
-        int elem = INTEGER(idx)[i];
-        if (elem==0) continue;
-        REAL(target)[ansi++] = (elem==NA_INTEGER || elem>max) ? naval.d : REAL(source)[elem-1];
-      }
-    } else {
-      double *vd = REAL(source);
-      int *vi =    INTEGER(idx);
-      double *p =  REAL(target);
-      const int upp = LENGTH(idx);
-      for (int i=0; i<upp; i++) *p++ = vd[vi[i]-1];
-    }
-    break;
+  } break;
   case STRSXP : {
-    #pragma omp critical
-    // write barrier is not thread safe. We can and do do non-STRSXP at the same time, though.
-    // we don't strictly need the critical since subsetDT has been written to dispatch one-thread only to
-    // do all the STRSXP columns, but keep the critical here anyway for safety. So long as it's once at high
-    // level as it is here and not deep.
-    // We could go parallel here but would need access to NODE_IS_OLDER, at least. Given gcgen, mark and named
+    // write barrier (assigning strings/lists) is not thread safe. Hence single threaded.
+    // To go parallel here would need access to NODE_IS_OLDER, at least. Given gcgen, mark and named
     // are upper bounded and max 3, REFCNT==REFCNTMAX could be checked first and then critical SET_ if not.
     // Inside that critical just before SET_ it could check REFCNT<REFCNTMAX still held. Similarly for gcgen.
     // TODO - discuss with Luke Tierney. Produce benchmarks on integer/double to see if it's worth making a safe
-    // API interface for package use for STRSXP.
-    {
-      if (any0orNA) {
-      for (int i=0, ansi=0; i<LENGTH(idx); i++) {
-        int elem = INTEGER(idx)[i];
-        if (elem==0) continue;
-        SET_STRING_ELT(target, ansi++, (elem==NA_INTEGER || elem>max) ? NA_STRING : STRING_ELT(source, elem-1));
-      }
-      } else {
-      SEXP *vd = (SEXP *)DATAPTR(source);
-      int *vi =    INTEGER(idx);
-      const int upp = LENGTH(idx);
-      for (int i=0; i<upp; i++) SET_STRING_ELT(target, i, vd[vi[i]-1]);
-      // Aside: setkey() knows it always receives a permutation (it does a shuffle in-place) and so doesn't
-      // need to use SET_*. setkey() can do its own parallelism therefore, including STRSXP and VECSXP.
-      }
-    }}
-    break;
+    //        API interface for package use for STRSXP.
+    // Aside: setkey() is a separate special case (a permutation) and does do this in parallel without using SET_*.
+    SEXP *sp = STRING_PTR(source);
+    if (anyNA) {
+      for (int i=0; i<n; i++) { int elem = idxp[i]; SET_STRING_ELT(ans, i, elem==NA_INTEGER ? NA_STRING : sp[elem-1]); }
+    } else {
+      for (int i=0; i<n; i++) {                     SET_STRING_ELT(ans, i, sp[idxp[i]-1]); }
+    }
+  } break;
   case VECSXP : {
-    #pragma omp critical
-    {
-      if (any0orNA) {
-      for (int i=0, ansi=0; i<LENGTH(idx); i++) {
-        int elem = INTEGER(idx)[i];
-        if (elem==0) continue;
-        SET_VECTOR_ELT(target, ansi++, (elem==NA_INTEGER || elem>max) ? R_NilValue : VECTOR_ELT(source, elem-1));
-      }
-      } else {
-      for (int i=0; i<LENGTH(idx); i++) {
-        SET_VECTOR_ELT(target, i, VECTOR_ELT(source, INTEGER(idx)[i]-1));
-      }
-      }
-    }}
-    break;
-  case CPLXSXP :
-    if (any0orNA) {
-      for (int i=0, ansi=0; i<LENGTH(idx); i++) {
-        int elem = INTEGER(idx)[i];
-        if (elem==0) continue;
-        if (elem==NA_INTEGER || elem>max) {
-          COMPLEX(target)[ansi].r = NA_REAL;
-          COMPLEX(target)[ansi++].i = NA_REAL;
-        } else COMPLEX(target)[ansi++] = COMPLEX(source)[elem-1];
-      }
+    SEXP *sp = VECTOR_PTR(source);
+    if (anyNA) {
+      for (int i=0; i<n; i++) { int elem = idxp[i]; SET_VECTOR_ELT(ans, i, elem==NA_INTEGER ? R_NilValue : sp[elem-1]); }
     } else {
-      for (int i=0; i<LENGTH(idx); i++)
-        COMPLEX(target)[i] = COMPLEX(source)[INTEGER(idx)[i]-1];
+      for (int i=0; i<n; i++) {                     SET_VECTOR_ELT(ans, i, sp[idxp[i]-1]); }
     }
-    break;
-  case RAWSXP :
-    if (any0orNA) {
-      for (int i=0, ansi=0; i<LENGTH(idx); i++) {
-        int elem = INTEGER(idx)[i];
-        if (elem==0) continue;
-        RAW(target)[ansi++] = (elem==NA_INTEGER || elem>max) ? (Rbyte) 0 : RAW(source)[elem-1];
-      }
-    } else {
-      for (int i=0; i<LENGTH(idx); i++)
-        RAW(target)[i] = RAW(source)[INTEGER(idx)[i]-1];
-    }
-    break;
-  // default :
-  // no error() needed here as caught earlier when single threaded; error() here not thread-safe.
+  } break;
+  case CPLXSXP : {
+    Rcomplex *sp = COMPLEX(source);
+    Rcomplex *ap = COMPLEX(ans);
+    Rcomplex NA_CPLX = { NA_REAL, NA_REAL };
+    PARLOOP(NA_CPLX)
+  } break;
+  case RAWSXP : {
+    Rbyte *sp = RAW(source);
+    Rbyte *ap = RAW(ans);
+    PARLOOP(0)
+  } break;
+  default :
+    error("Internal error: column type '%s' not supported by data.table subset. All known types are supported so please report as bug.", type2char(TYPEOF(source)));
   }
-  return target;
 }
 
-static void check_idx(SEXP idx, int max, /*outputs...*/int *ansLen, Rboolean *any0orNA, Rboolean *monotonic)
-// count non-0 in idx => the length of the subset result stored in *ansLen
-// return whether any 0, NA (or >max) exist and set any0orNA if so, for branchless subsetVectorRaw
-// >max is treated as NA for consistency with [.data.frame and operations like cbind(DT[w],DT[w+1])
-// if any negatives then error since they should have been dealt with by convertNegativeIdx() called
-// from R level first.
-// do this once up-front and reuse the result for each column
-// single cache efficient sweep so no need to go parallel (well, very low priority to go parallel)
+static const char *check_idx(SEXP idx, int max, bool *anyNA_out, bool *orderedSubset_out)
+// set anyNA for branchless subsetVectorRaw
+// error if any negatives, zeros or >max since they should have been dealt with by convertNegAndZeroIdx() called ealier at R level.
+// single cache efficient sweep with prefetch, so very low priority to go parallel
 {
   if (!isInteger(idx)) error("Internal error. 'idx' is type '%s' not 'integer'", type2char(TYPEOF(idx))); // # nocov
-  Rboolean anyNeg=FALSE, anyNA=FALSE, anyLess=FALSE;
-  int ans=0;
+  bool anyLess=false, anyNA=false;
   int last = INT32_MIN;
-  for (int i=0; i<LENGTH(idx); i++) {
-    int elem = INTEGER(idx)[i];
-    ans += (elem!=0);
-    anyNeg |= elem<0 && elem!=NA_INTEGER;
-    anyNA |= elem==NA_INTEGER || elem>max;
+  int *idxp = INTEGER(idx), n=LENGTH(idx);
+  for (int i=0; i<n; i++) {
+    int elem = idxp[i];
+    if (elem<=0 && elem!=NA_INTEGER) return "Internal inefficiency: idx contains negatives or zeros. Should have been dealt with earlier.";  // e.g. test 762  (TODO-fix)
+    if (elem>max) return "Internal inefficiency: idx contains an item out-of-range. Should have been dealt with earlier.";                   // e.g. test 1639.64
+    anyNA |= elem==NA_INTEGER;
     anyLess |= elem<last;
     last = elem;
   }
-  if (anyNeg) error("Internal error: idx contains negatives. Should have been dealt with earlier."); // # nocov
-  *ansLen = ans;
-  *any0orNA = ans<LENGTH(idx) || anyNA;
-  *monotonic = !anyLess; // for the purpose of ordered keys, elem==last is allowed
+  *anyNA_out = anyNA;
+  *orderedSubset_out = !anyLess; // for the purpose of ordered keys elem==last is allowed
+  return NULL;
 }
 
-// TODO - currently called from R level first. Can it be called from check_idx instead?
-SEXP convertNegativeIdx(SEXP idx, SEXP maxArg)
+SEXP convertNegAndZeroIdx(SEXP idx, SEXP maxArg, SEXP allowOverMax)
 {
+  // called from [.data.table to massage user input, creating a new strictly positive idx if there are any negatives or zeros
   // + more precise and helpful error messages telling user exactly where the problem is (saving user debugging time)
   // + a little more efficient than negativeSubscript in src/main/subscript.c (it's private to R so we can't call it anyway)
+  // allowOverMaxArg is false when := (test 1024), otherwise true for selecting
 
   if (!isInteger(idx)) error("Internal error. 'idx' is type '%s' not 'integer'", type2char(TYPEOF(idx))); // # nocov
   if (!isInteger(maxArg) || length(maxArg)!=1) error("Internal error. 'maxArg' is type '%s' and length %d, should be an integer singleton", type2char(TYPEOF(maxArg)), length(maxArg)); // # nocov
-  int max = INTEGER(maxArg)[0];
-  // NA also an error which'll print as INT_MIN
-  if (max<0) error("Internal error. max is %d, must be >= 0.", max); // # nocov
-  int firstNegative = 0, firstPositive = 0, firstNA = 0, num0 = 0;
-  for (int i=0; i<LENGTH(idx); i++) {
-    int elem = INTEGER(idx)[i];
-    if (elem==NA_INTEGER) { if (firstNA==0) firstNA = i+1;  continue; }
-    if (elem==0)          { num0++;  continue; }
-    if (elem>0)           { if (firstPositive==0) firstPositive=i+1; continue; }
-    if (firstNegative==0) firstNegative=i+1;
+  if (!isLogical(allowOverMax) || LENGTH(allowOverMax)!=1 || LOGICAL(allowOverMax)[0]==NA_LOGICAL) error("Internal error: allowOverMax must be TRUE/FALSE");  // # nocov
+  int max = INTEGER(maxArg)[0], n=LENGTH(idx);
+  if (max<0) error("Internal error. max is %d, must be >= 0.", max); // # nocov    includes NA which will print as INT_MIN
+  int *idxp = INTEGER(idx);
+
+  bool stop = false;
+  #pragma omp parallel for num_threads(getDTthreads())
+  for (int i=0; i<n; i++) {
+    if (stop) continue;
+    int elem = idxp[i];
+    if ((elem<1 && elem!=NA_INTEGER) || elem>max) stop=true;
   }
-  if (firstNegative==0) return(idx);  // 0's and NA can be mixed with positives, there are no negatives present, so we're done
-  if (firstPositive) error("Item %d of i is %d and item %d is %d. Cannot mix positives and negatives.",
-         firstNegative, INTEGER(idx)[firstNegative-1], firstPositive, INTEGER(idx)[firstPositive-1]);
-  if (firstNA)       error("Item %d of i is %d and item %d is NA. Cannot mix negatives and NA.",
-         firstNegative, INTEGER(idx)[firstNegative-1], firstNA);
+  if (!stop) return(idx); // most common case to return early: no 0, no negative; all idx either NA or in range [1-max]
 
-  // idx is all negative without any NA but perhaps 0 present (num0) ...
+  // ---------
+  // else massage the input to a standard idx where all items are either NA or in range [1,max] ...
 
-  char *tmp = (char *)R_alloc(max, sizeof(char));    // 4 times less memory that INTSXP in src/main/subscript.c
-  for (int i=0; i<max; i++) tmp[i] = 0;
-  // Not using Calloc as valgrind shows it leaking (I don't see why) - just changed to R_alloc to be done with it.
-  // Maybe R needs to be rebuilt with valgrind before Calloc's Free can be matched up by valgrind?
-  int firstDup = 0, numDup = 0, firstBeyond = 0, numBeyond = 0;
-  for (int i=0; i<LENGTH(idx); i++) {
-    int elem = -INTEGER(idx)[i];
-    if (elem==0) continue;
-    if (elem>max) {
-      numBeyond++;
-      if (firstBeyond==0) firstBeyond=i+1;
-      continue;
+  int countNeg=0, countZero=0, countNA=0, firstOverMax=0;
+  for (int i=0; i<n; i++) {
+    int elem = idxp[i];
+    if (elem==NA_INTEGER) countNA++;
+    else if (elem<0) countNeg++;
+    else if (elem==0) countZero++;
+    else if (elem>max && firstOverMax==0) firstOverMax=i+1;
+  }
+  if (firstOverMax && LOGICAL(allowOverMax)[0]==FALSE) {
+    error("i[%d] is %d which is out of range [1,nrow=%d]", firstOverMax, idxp[firstOverMax-1], max);
+  }
+
+  int countPos = n-countNeg-countZero-countNA;
+  if (countPos && countNeg) {
+    int i=0, firstNeg=0, firstPos=0;
+    while (i<n && (firstNeg==0 || firstPos==0)) {
+      int elem = idxp[i];
+      if (firstPos==0 && elem>0) firstPos=i+1;
+      if (firstNeg==0 && elem<0 && elem!=NA_INTEGER) firstNeg=i+1;
+      i++;
     }
-    if (tmp[elem-1]==1) {
-      numDup++;
-      if (firstDup==0) firstDup=i+1;
-    } else tmp[elem-1] = 1;
+    error("Item %d of i is %d and item %d is %d. Cannot mix positives and negatives.", firstNeg, idxp[firstNeg-1], firstPos, idxp[firstPos-1]);
   }
-  if (numBeyond)
-    warning("Item %d of i is %d but there are only %d rows. Ignoring this and %d more like it out of %d.", firstBeyond, INTEGER(idx)[firstBeyond-1], max, numBeyond-1, LENGTH(idx));
-  if (numDup)
-    warning("Item %d of i is %d which has occurred before. Ignoring this and %d other duplicates out of %d.", firstDup, INTEGER(idx)[firstDup-1], numDup-1, LENGTH(idx));
+  if (countNeg && countNA) {
+    int i=0, firstNeg=0, firstNA=0;
+    while (i<n && (firstNeg==0 || firstNA==0)) {
+      int elem = idxp[i];
+      if (firstNeg==0 && elem<0 && elem!=NA_INTEGER) firstNeg=i+1;
+      if (firstNA==0 && elem==NA_INTEGER) firstNA=i+1;
+      i++;
+    }
+    error("Item %d of i is %d and item %d is NA. Cannot mix negatives and NA.", firstNeg, idxp[firstNeg-1], firstNA);
+  }
 
-  SEXP ans = PROTECT(allocVector(INTSXP, max-LENGTH(idx)+num0+numDup+numBeyond));
-  int ansi = 0;
-  for (int i=0; i<max; i++) if (tmp[i]==0) INTEGER(ans)[ansi++] = i+1;
+  SEXP ans;
+  if (countNeg==0) {
+    // just zeros to remove, or >max to convert to NA
+    ans = PROTECT(allocVector(INTSXP, n - countZero));
+    int *ansp = INTEGER(ans);
+    for (int i=0, ansi=0; i<n; i++) {
+      int elem = idxp[i];
+      if (elem==0) continue;
+      ansp[ansi++] = elem>max ? NA_INTEGER : elem;
+    }
+  } else {
+    // idx is all negative without any NA but perhaps some zeros
+    bool *keep = (bool *)R_alloc(max, sizeof(bool));    // 4 times less memory that INTSXP in src/main/subscript.c
+    for (int i=0; i<max; i++) keep[i] = true;
+    int countRemoved=0, countDup=0, countBeyond=0;   // idx=c(-10,-5,-10) removing row 10 twice
+    int firstBeyond=0, firstDup=0;
+    for (int i=0; i<n; i++) {
+      int elem = -idxp[i];
+      if (elem==0) continue;
+      if (elem>max) {
+        countBeyond++;
+        if (firstBeyond==0) firstBeyond=i+1;
+        continue;
+      }
+      if (!keep[elem-1]) {
+        countDup++;
+        if (firstDup==0) firstDup=i+1;
+      } else {
+        keep[elem-1] = false;
+        countRemoved++;
+      }
+    }
+    if (countBeyond)
+      warning("Item %d of i is %d but there are only %d rows. Ignoring this and %d more like it out of %d.", firstBeyond, idxp[firstBeyond-1], max, countBeyond-1, n);
+    if (countDup)
+      warning("Item %d of i is %d which removes that item but that has occurred before. Ignoring this dup and %d other dups out of %d.", firstDup, idxp[firstDup-1], countDup-1, n);
+    int ansn = max-countRemoved;
+    ans = PROTECT(allocVector(INTSXP, ansn));
+    int *ansp = INTEGER(ans);
+    for (int i=0, ansi=0; i<max; i++) {
+      if (keep[i]) ansp[ansi++] = i+1;
+    }
+  }
   UNPROTECT(1);
-  if (ansi != max-LENGTH(idx)+num0+numDup+numBeyond) error("Internal error: ansi[%d] != max[%d]-LENGTH(idx)[%d]+num0[%d]+numDup[%d]+numBeyond[%d] in convertNegativeIdx",ansi,max,LENGTH(idx),num0,numDup,numBeyond); // # nocov
-  return(ans);
+  return ans;
 }
 
 /*
 * subsetDT - Subsets a data.table
 * NOTE:
 *   1) 'rows' and 'cols' are 1-based, passed from R level
-*   2) Originally for subsetting vectors in fcast and now the beginnings of
-*       [.data.table ported to C
-*   3) Immediate need is for R 3.1 as lglVec[1] now returns R's global TRUE
-*       and we don't want := to change that global [think 1 row data.tables]
-*   4) Could do it other ways but may as well go to C now as we were going to
-*       do that anyway
+*   2) Originally for subsetting vectors in fcast and now the beginnings of [.data.table ported to C
+*   3) Immediate need is for R 3.1 as lglVec[1] now returns R's global TRUE and we don't want := to change that global [think 1 row data.tables]
+*   4) Could do it other ways but may as well go to C now as we were going to do that anyway
 */
 
 SEXP subsetDT(SEXP x, SEXP rows, SEXP cols) {
@@ -227,57 +228,38 @@ SEXP subsetDT(SEXP x, SEXP rows, SEXP cols) {
   if (!isNewList(x)) error("Internal error. Argument 'x' to CsubsetDT is type '%s' not 'list'", type2char(TYPEOF(rows))); // # nocov
   if (!length(x)) return(x);  // return empty list
 
-  // check index once up front for 0 or NA, for branchless subsetVectorRaw
-  R_len_t ansn=0;
-  Rboolean any0orNA=FALSE, orderedSubset=FALSE;
-  check_idx(rows, length(VECTOR_ELT(x,0)), &ansn, &any0orNA, &orderedSubset);
+  // check index once up front for 0 or NA, for branchless subsetVectorRaw which is repeated for each column
+  bool anyNA=false, orderedSubset=false;
+  if (check_idx(rows, length(VECTOR_ELT(x,0)), &anyNA, &orderedSubset) != NULL) {
+    SEXP max = PROTECT(ScalarInteger(length(VECTOR_ELT(x,0)))); nprotect++;
+    rows = PROTECT(convertNegAndZeroIdx(rows, max, ScalarLogical(TRUE))); nprotect++;
+    const char *err = check_idx(rows, length(VECTOR_ELT(x,0)), &anyNA, &orderedSubset);
+    if (err!=NULL) error(err);
+  }
 
   if (!isInteger(cols)) error("Internal error. Argument 'cols' to Csubset is type '%s' not 'integer'", type2char(TYPEOF(cols))); // # nocov
-  if (ALTREP(cols)) { cols = PROTECT(duplicate(cols)); nprotect++; }
-  if (ALTREP(rows)) { rows = PROTECT(duplicate(rows)); nprotect++; }
   for (int i=0; i<LENGTH(cols); i++) {
     int this = INTEGER(cols)[i];
     if (this<1 || this>LENGTH(x)) error("Item %d of 'cols' is %d which is outside 1-based range [1,ncol(x)=%d]", i+1, this, LENGTH(x));
   }
   SEXP ans = PROTECT(allocVector(VECSXP, LENGTH(cols)+64)); nprotect++;  // just do alloc.col directly, eventually alloc.col can be deprecated.
+  const int ansn = LENGTH(rows);  // has been checked not to contain zeros or negatives, so this length is the length of result
   copyMostAttrib(x, ans);  // other than R_NamesSymbol, R_DimSymbol and R_DimNamesSymbol
                // so includes row.names (oddly, given other dims aren't) and "sorted", dealt with below
   SET_TRUELENGTH(ans, LENGTH(ans));
   SETLENGTH(ans, LENGTH(cols));
   for (int i=0; i<LENGTH(cols); i++) {
     SEXP source = VECTOR_ELT(x, INTEGER(cols)[i]-1);
-    if (ALTREP(source)) SET_VECTOR_ELT(x, INTEGER(cols)[i]-1, source=duplicate(source));
-    SEXP target = PROTECT(allocVector(TYPEOF(source), ansn));
-    SETLENGTH(target, ansn);
-    SET_TRUELENGTH(target, ansn);
+    SEXP target;
+    SET_VECTOR_ELT(ans, i, target=allocVector(TYPEOF(source), ansn));
     copyMostAttrib(source, target);
-    SET_VECTOR_ELT(ans, i, target);
-    UNPROTECT(1);
-  }
-  #pragma omp parallel num_threads(MIN(getDTthreads(),LENGTH(cols)))
-  {
-    #pragma omp master
-    // this thread and this thread only handles all the STRSXP and VECSXP columns, one by one
-    // it doesn't have to be master; the directive is just convenient.
-    for (int i=0; i<LENGTH(cols); i++) {
-    SEXP target = VECTOR_ELT(ans, i);
-    if (isString(target) || isNewList(target))
-      subsetVectorRaw(target, VECTOR_ELT(x, INTEGER(cols)[i]-1), rows, any0orNA);
-    }
-    #pragma omp for schedule(dynamic)
-    // slaves get on with the other non-STRSXP non-VECSXP columns at the same time.
-    // master may join in when it's finished, straight away if there are no STRSXP or VECSXP columns
-    for (int i=0; i<LENGTH(cols); i++) {
-      SEXP target = VECTOR_ELT(ans, i);
-      if (!isString(target) && !isNewList(target))
-        subsetVectorRaw(target, VECTOR_ELT(x, INTEGER(cols)[i]-1), rows, any0orNA);
-    }
+    subsetVectorRaw(target, source, rows, anyNA);  // parallel within column
   }
   SEXP tmp = PROTECT(allocVector(STRSXP, LENGTH(cols)+64)); nprotect++;
   SET_TRUELENGTH(tmp, LENGTH(tmp));
   SETLENGTH(tmp, LENGTH(cols));
   setAttrib(ans, R_NamesSymbol, tmp);
-  subsetVectorRaw(tmp, getAttrib(x, R_NamesSymbol), cols, /*any0orNA=*/FALSE);
+  subsetVectorRaw(tmp, getAttrib(x, R_NamesSymbol), cols, /*anyNA=*/false);
 
   tmp = PROTECT(allocVector(INTSXP, 2)); nprotect++;
   INTEGER(tmp)[0] = NA_INTEGER;
@@ -309,15 +291,18 @@ SEXP subsetDT(SEXP x, SEXP rows, SEXP cols) {
 }
 
 SEXP subsetVector(SEXP x, SEXP idx) { // idx is 1-based passed from R level
-  int ansn;
-  Rboolean any0orNA, orderedSubset;
-  check_idx(idx, length(x), &ansn, &any0orNA, &orderedSubset);
-  SEXP ans = PROTECT(allocVector(TYPEOF(x), ansn));
-  SETLENGTH(ans, ansn);
-  SET_TRUELENGTH(ans, ansn);
+  bool anyNA=false, orderedSubset=false;
+  int nprotect=0;
+  if (check_idx(idx, length(x), &anyNA, &orderedSubset) != NULL) {
+    SEXP max = PROTECT(ScalarInteger(length(x))); nprotect++;
+    idx = PROTECT(convertNegAndZeroIdx(idx, max, ScalarLogical(TRUE))); nprotect++;
+    const char *err = check_idx(idx, length(x), &anyNA, &orderedSubset);
+    if (err!=NULL) error(err);
+  }
+  SEXP ans = PROTECT(allocVector(TYPEOF(x), length(idx))); nprotect++;
   copyMostAttrib(x, ans);
-  subsetVectorRaw(ans, x, idx, any0orNA);
-  UNPROTECT(1);
+  subsetVectorRaw(ans, x, idx, anyNA);
+  UNPROTECT(nprotect);
   return ans;
 }
 


### PR DESCRIPTION
`subset.c` complete for #3165.  Other files still to review.
Removed all R API use in parallel regions.
Removing the catch-and-expand ALTREP. That's left to R which will do that inside INTEGER(), REAL() etc when they see ALTREP vecs (which is now ok as those R API calls are now outside parallel regions).
Parallel within column rather than across columns:  A very big subset of 1 column should benefit from 8 cores now, whereas before that was single threaded.
No `critical` or anything complicated. Simpler.
Tighter branch-free loops by dealing with zeros and negatives up-front.
Also makes progress in being able to stop defining `USE_RINTERNALS` : should not be needed for this file now either to work or for performance.