### PR TITLE
RFC:  .SDcols=patterns()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,8 @@
 
 6. `groupingsets()` groups by empty column set and constant value in `j`, [#3173](https://github.com/Rdatatable/data.table/issues/3173).
 
+7. `.SDcols = integer(0L)` will not fail peculiarly, [#3185](https://github.com/Rdatatable/data.table/issues/3185); instead an empty `data.table` is returned.
+
 #### NOTES
 
 1. When data.table first loads it now checks the DLL's MD5. This is to detect installation issues on Windows when you upgrade and i) the DLL is in use by another R session and ii) the CRAN source version > CRAN binary binary which happens just after a new release (R prompts users to install from source until the CRAN binary is available). This situation can lead to a state where the package's new R code calls old C code in the old DLL; [R#17478](https://bugs.r-project.org/bugzilla/show_bug.cgi?id=17478), [#3056](https://github.com/Rdatatable/data.table/issues/3056). This broken state can persist until, hopefully, you experience a strange error caused by the mismatch. Otherwise, wrong results may occur silently. This situation applies to any R package with compiled code not just data.table, is Windows-only, and is long-standing. It has only recently been understood as it typically only occurs during the few days after each new release until binaries are available on CRAN. Thanks to Gabor Csardi for the suggestion to use `tools::checkMD5sums()`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 4. `NA` in `between`'s `lower` and `upper` are now taken as missing bounds and return `TRUE` rather than than `NA`. This is now documented.
 
+5. `.SDcols` in `[.data.table` now accepts `patterns`, similar to the existing usage in `melt.data.table`, for filtering columns according to a pattern, concisely and dynamically, [#1878](https://github.com/Rdatatable/data.table/issues/1878). Thanks to many people for pushing for this and @MichaelChirico for ultimately filing the PR. See `?data.table` for full details and examples. 
+
 #### BUG FIXES
 
 1. Providing an `i` subset expression when attempting to delete a column correctly failed with helpful error, but when the column was missing too created a new column full of `NULL` values, [#3089](https://github.com/Rdatatable/data.table/issues/3089). Thanks to Michael Chirico for reporting.

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1016,8 +1016,14 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
             # .SDcols is of the format a:b
             .SDcols = eval(colsub, setattr(as.list(seq_along(x)), 'names', names(x)), parent.frame())
           } else {
-            .SDcols = eval(colsub, parent.frame(), parent.frame())
+            if (is.call(colsub) && colsub[[1L]] == "patterns") {
+              # each pattern gives a new filter condition, intersect the end result
+              .SDcols = Reduce(intersect, do_patterns(colsub, names(x)))
+            } else {
+              .SDcols = eval(colsub, parent.frame(), parent.frame())
+            }
           }
+          if (!length(.SDcols)) return(null.data.table())
           if (anyNA(.SDcols))
             stop(".SDcols missing at the following indices: ", brackify(which(is.na(.SDcols))))
           if (is.logical(.SDcols)) {

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1023,7 +1023,7 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
               .SDcols = eval(colsub, parent.frame(), parent.frame())
             }
           }
-          if (!length(.SDcols)) return(null.data.table())
+          if (!length(.SDcols)) stop("Empty .SDcols is not yet supported.")
           if (anyNA(.SDcols))
             stop(".SDcols missing at the following indices: ", brackify(which(is.na(.SDcols))))
           if (is.logical(.SDcols)) {

--- a/R/fmelt.R
+++ b/R/fmelt.R
@@ -34,18 +34,7 @@ melt.data.table <- function(data, id.vars, measure.vars, variable.name = "variab
   if (missing(measure.vars)) measure.vars = NULL
   measure.sub = substitute(measure.vars)
   if (is.call(measure.sub) && measure.sub[[1L]] == "patterns") {
-    measure.sub = as.list(measure.sub)[-1L]
-    idx = which(names(measure.sub) == "cols")
-    if (length(idx)) {
-      cols = eval(measure.sub[["cols"]], parent.frame())
-      measure.sub = measure.sub[-idx]
-    } else cols = names(data)
-    pats = lapply(measure.sub, eval, parent.frame())
-    measure.vars = patterns(pats, cols=cols)
-    # replace with lengths when R 3.2.0 dependency arrives
-    if (length(idx <- which(sapply(measure.vars, length) == 0L)))
-      stop('Pattern', if (length(idx) > 1L) 's', ' not found: [',
-           paste(pats[idx], collapse = ', '), ']')
+    measure.vars = do_patterns(measure.sub, names(data))
   }
   if (is.list(measure.vars) && length(measure.vars) > 1L) {
     meas.nm = names(measure.vars)

--- a/R/utils.R
+++ b/R/utils.R
@@ -93,3 +93,23 @@ brackify = function(x) {
   if (length(x) > 10L) x = c(x[1:10], '...')
   sprintf('[%s]', paste(x, collapse = ', '))
 }
+
+# patterns done via NSE in melt.data.table and .SDcols in `[.data.table`
+do_patterns = function(pat_sub, all_cols) {
+  # received as substitute(patterns(...))
+  pat_sub = as.list(pat_sub)[-1L]
+  # identify cols = argument if present
+  idx = which(names(pat_sub) == "cols")
+  if (length(idx)) {
+    cols = eval(pat_sub[["cols"]], parent.frame(2L))
+    pat_sub = pat_sub[-idx]
+  } else cols = all_cols
+  pats = lapply(pat_sub, eval, parent.frame(2L))
+  matched = patterns(pats, cols=cols)
+  # replace with lengths when R 3.2.0 dependency arrives
+  if (length(idx <- which(sapply(matched, length) == 0L)))
+    stop('Pattern', if (length(idx) > 1L) 's', ' not found: [',
+         paste(pats[idx], collapse = ', '), ']')
+
+  return(matched)
+}

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -12468,10 +12468,13 @@ gs = groupingsets(d, j = sum(val), by = c("a", "b", "c"),
                            character()), id=TRUE)
 test(1961, cb, gs)
 
-# #3185 -- .SDcols = integer(0L) completes gracefully
+# #3185 -- .SDcols = integer(0L) errors until broader handling
+#   of empty .SDcols is addressed
 DT = data.table(a = 1:10)
-test(1962.1, DT[ , .SD, .SDcols = integer(0L)], data.table(NULL))
-test(1962.2, DT[ , .SD, .SDcols = character(0L)], data.table(NULL))
+test(1962.1, DT[ , .SD, .SDcols = integer(0L)],
+     error = 'Empty .SDcols is not yet supported')
+test(1962.2, DT[ , .SD, .SDcols = character(0L)],
+     error = 'Empty .SDcols is not yet supported')
 
 # #1878 -- patterns API in .SDcols
 library(data.table)
@@ -12494,13 +12497,11 @@ test(1963.1, DT[ , lapply(.SD, sum), .SDcols = patterns('^V')],
      data.table(V1 = -6.3, V2 = -6.5, V3 = 1.3, V4 = 3.4, V5 = -0.9,
                 V6 = -1.6, V7 = -2, V8 = -0.4, V9 = 6.1, V10 = -1.8))
 # multiple pattens --> intersection of patterns
-test(1963.2, DT[ , lapply(.SD, sum), .SDcols = patterns('^V[0-4]', '^V[5-9]')],
-     data.table(NULL))
-test(1963.3, DT[ , lapply(.SD, sum), .SDcols = patterns('^V[02468]', '^V[48]')],
+test(1963.2, DT[ , lapply(.SD, sum), .SDcols = patterns('^V[02468]', '^V[48]')],
      data.table(V4 = 3.4, V8 = -0.4))
 
 # also with !/- inversion
-test(1963.4, DT[ , lapply(.SD, sum), .SDcols = !patterns('^c|i')],
+test(1963.3, DT[ , lapply(.SD, sum), .SDcols = !patterns('^c|i')],
      data.table(V1 = -6.3, V2 = -6.5, V3 = 1.3, V4 = 3.4, V5 = -0.9,
                 V6 = -1.6, V7 = -2, V8 = -0.4, V9 = 6.1, V10 = -1.8))
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -12468,6 +12468,43 @@ gs = groupingsets(d, j = sum(val), by = c("a", "b", "c"),
                            character()), id=TRUE)
 test(1961, cb, gs)
 
+# #3185 -- .SDcols = integer(0L) completes gracefully
+DT = data.table(a = 1:10)
+test(1962.1, DT[ , .SD, .SDcols = integer(0L)], data.table(NULL))
+test(1962.2, DT[ , .SD, .SDcols = character(0L)], data.table(NULL))
+
+# #1878 -- patterns API in .SDcols
+library(data.table)
+DT = data.table(
+  i = 1:10,
+  c = c("a", "b", "c", "d", "e", "f", "g", "h", "i", "j"),
+  V1 = c(0.4, -0.1, -1.1, -2.6, -0.1, -1.3, 0.3, -2.1, -0.6, 0.9),
+  V2 = c(-0.1, -2.5, -1, -0.1, -0.5, -0.7, -1, -2.1, 2.7, -1.2),
+  V3 = c(1.1, -1.6, 0.7, 1.6, -1.4, 1, -0.6, 1.2, -0.8, 0.1),
+  V4 = c(1.3, -0.8, 2.3, -0.7, 0.5, 0.5, 0.2, 0.7, -1.4, 0.8),
+  V5 = c(-0.1, -0.5, 1.5, -0.5, 1.9, 0.2, -0.1, -0.7, -1.7, -0.9),
+  V6 = c(0.8, -1.3, -0.7, -0.3, 1.4, 0.7, 0.4, 0.3, -1.6, -1.3),
+  V7 = c(-0.1, 0.8, 0.7, -0.2, -2, 0.5, 0.4, -0.2, -1.2, -0.7),
+  V8 = c(0.7, -1, 1.3, 0.5, 0.2, 0.8, 0.6, -1.4, -2, -0.1),
+  V9 = c(0.2, -0.1, 1.2, -0.5, 1.4, 1, 0.2, 0.7, 0.4, 1.6),
+  V10 = c(0.8, 0.7, -1.2, -0.9, -0.6, 0.4, -2.3, 2.2, 0.5, -1.4)
+)
+
+test(1963.1, DT[ , lapply(.SD, sum), .SDcols = patterns('^V')],
+     data.table(V1 = -6.3, V2 = -6.5, V3 = 1.3, V4 = 3.4, V5 = -0.9,
+                V6 = -1.6, V7 = -2, V8 = -0.4, V9 = 6.1, V10 = -1.8))
+# multiple pattens --> intersection of patterns
+test(1963.2, DT[ , lapply(.SD, sum), .SDcols = patterns('^V[0-4]', '^V[5-9]')],
+     data.table(NULL))
+test(1963.3, DT[ , lapply(.SD, sum), .SDcols = patterns('^V[02468]', '^V[48]')],
+     data.table(V4 = 3.4, V8 = -0.4))
+
+# also with !/- inversion
+test(1963.4, DT[ , lapply(.SD, sum), .SDcols = !patterns('^c|i')],
+     data.table(V1 = -6.3, V2 = -6.5, V3 = 1.3, V4 = 3.4, V5 = -0.9,
+                V6 = -1.6, V7 = -2, V8 = -0.4, V9 = 6.1, V10 = -1.8))
+
+
 
 ###################################
 #  Add new tests above this line  #

--- a/man/data.table.Rd
+++ b/man/data.table.Rd
@@ -141,7 +141,13 @@ data.table(\dots, keep.rownames=FALSE, check.names=FALSE, key=NULL, stringsAsFac
 
     \item{.SDcols}{ Specifies the columns of \code{x} to be included in the special symbol \code{\link{.SD}} which stands for \code{Subset of data.table}. May be character column names or numeric positions. This is useful for speed when applying a function through a subset of (possible very many) columns; e.g., \code{DT[, lapply(.SD, sum), by="x,y", .SDcols=301:350]}.
 
-    For convenient interactive use, the form \code{startcol:endcol} is also allowed (as in \code{by}), e.g., \code{DT[, lapply(.SD, sum), by=x:y, .SDcols=a:f]}
+    For convenient interactive use, the form \code{startcol:endcol} is also allowed (as in \code{by}), e.g., \code{DT[, lapply(.SD, sum), by=x:y, .SDcols=a:f]}.
+
+    Inversion (column dropping instead of keeping) can be accomplished be prepending the argument with \code{!} or \code{-} (there's no difference between these), e.g. \code{.SDcols = !c('x', 'y')}.
+
+    Finally, you can filter columns to include in \code{.SD} according to regular expressions via \code{.SDcols=patterns(regex1, regex2, ...)}. The included columns will be the \emph{intersection} of the columns identified by each pattern; pattern unions can easily be specified with \code{|} in a regex. You can also invert a pattern as usual with \code{.SDcols = !patterns(...)}.
+
+    Empty \code{.SDcols} will return an empty \code{data.table}.
 }
   \item{verbose}{ \code{TRUE} turns on status and information messages to the console. Turn this on by default using \code{options(datatable.verbose=TRUE)}. The quantity and types of verbosity may be expanded in future.
 
@@ -357,16 +363,18 @@ kDT[!.("a")]                          # not join
 kDT[!"a"]                             # same
 
 # more on special symbols, see also ?"special-symbols"
-DT[.N]                                # last row
-DT[, .N]                              # total number of rows in DT
-DT[, .N, by=x]                        # number of rows in each group
-DT[, .SD, .SDcols=x:y]                # select columns 'x' and 'y'
-DT[, .SD[1]]                          # first row of all columns
-DT[, .SD[1], by=x]                    # first row of 'y' and 'v' for each group in 'x'
-DT[, c(.N, lapply(.SD, sum)), by=x]   # get rows *and* sum columns 'v' and 'y' by group
-DT[, .I[1], by=x]                     # row number in DT corresponding to each group
-DT[, grp := .GRP, by=x]               # add a group counter column
-X[, DT[.BY, y, on="x"], by=x]         # join within each group
+DT[.N]                                  # last row
+DT[, .N]                                # total number of rows in DT
+DT[, .N, by=x]                          # number of rows in each group
+DT[, .SD, .SDcols=x:y]                  # select columns 'x' through 'y'
+DT[ , .SD, .SDcols = !x:y]              # drop columns 'x' through 'y'
+DT[ , .SD, .SDcols = patterns('^[xv]')] # select columns matching '^x' or '^v'
+DT[, .SD[1]]                            # first row of all columns
+DT[, .SD[1], by=x]                      # first row of 'y' and 'v' for each group in 'x'
+DT[, c(.N, lapply(.SD, sum)), by=x]     # get rows *and* sum columns 'v' and 'y' by group
+DT[, .I[1], by=x]                       # row number in DT corresponding to each group
+DT[, grp := .GRP, by=x]                 # add a group counter column
+X[, DT[.BY, y, on="x"], by=x]           # join within each group
 
 # add/update/delete by reference (see ?assign)
 print(DT[, z:=42L])                   # add new column by reference

--- a/man/data.table.Rd
+++ b/man/data.table.Rd
@@ -146,8 +146,6 @@ data.table(\dots, keep.rownames=FALSE, check.names=FALSE, key=NULL, stringsAsFac
     Inversion (column dropping instead of keeping) can be accomplished be prepending the argument with \code{!} or \code{-} (there's no difference between these), e.g. \code{.SDcols = !c('x', 'y')}.
 
     Finally, you can filter columns to include in \code{.SD} according to regular expressions via \code{.SDcols=patterns(regex1, regex2, ...)}. The included columns will be the \emph{intersection} of the columns identified by each pattern; pattern unions can easily be specified with \code{|} in a regex. You can also invert a pattern as usual with \code{.SDcols = !patterns(...)}.
-
-    Empty \code{.SDcols} will return an empty \code{data.table}.
 }
   \item{verbose}{ \code{TRUE} turns on status and information messages to the console. Turn this on by default using \code{options(datatable.verbose=TRUE)}. The quantity and types of verbosity may be expanded in future.
 


### PR DESCRIPTION
Closes #1878 (.SDcols=patterns(...))
Closes #3185 (ancillary edge case)

RFC given the popularity of this issue despite how simple the PR is to be sure we can basically agree this is the right API for implementing this feature. 

Tagging everyone who participated in #1878: @eantonya, @ksavin, @mbacou, @hannes101, @franknarf1, @HughParsonage, @arunsrinivasan, @skanskan, @therimalaya, @bchen102, @sbsdc as well as @mattdowle and @jangorecki.

## As Implemented

Essentially we re-use `patterns` like we do in `melt`; multiple patterns --> intersection of matches:

```
library(data.table)
DT = data.table(i = 1:10, c = letters[1:10])
set.seed(3459)
DT[ , paste0('V', 1:10) := lapply(integer(10L), function(...) rnorm(10L))][]
#      i c         V1         V2          V3         V4          V5         V6         V7
#  1:  1 a  0.3714012 -0.1494429  1.13300407  1.2661908 -0.09249212  0.7954114 -0.1211000
#  2:  2 b -0.1177177 -2.4585715 -1.63960330 -0.7998233 -0.54588880 -1.3338185  0.8138912
#  3:  3 c -1.0918951 -1.0230666  0.68272545  2.2874009  1.54356767 -0.7094124  0.7326431
#  4:  4 d -2.5809883 -0.1065164  1.60203979 -0.6913598 -0.47854994 -0.2953956 -0.2386240
#  5:  5 e -0.1362863 -0.4616205 -1.41872650  0.5156108  1.90234433  1.3667683 -2.0415515
#  6:  6 f -1.2504643 -0.7284620  0.98501940  0.5406783  0.21214610  0.6952400  0.4622092
#  7:  7 g  0.2597725 -1.0290593 -0.55132090  0.1504328 -0.14798292  0.4138119  0.4046622
#  8:  8 h -2.1484501 -2.0823730  1.18265952  0.6882005 -0.70851129  0.3380656 -0.2353361
#  9:  9 i -0.5772339  2.6833881 -0.78724790 -1.4424652 -1.72913363 -1.6478304 -1.2496821
# 10: 10 j  0.9225026 -1.1975755  0.09083374  0.7527641 -0.94123194 -1.2617830 -0.6598987
#             V8          V9        V10
#  1:  0.6730572  0.17482020  0.8189296
#  2: -1.0052455 -0.05906419  0.6700489
#  3:  1.2782899  1.18298399 -1.2358743
#  4:  0.4508402 -0.53088184 -0.8933916
#  5:  0.1969130  1.41444639 -0.6043715
#  6:  0.8346712  1.00041944  0.3736168
#  7:  0.6027966  0.16537790 -2.3239332
#  8: -1.3998695  0.73790807  2.2070307
#  9: -1.9737772  0.36031874  0.5035344
# 10: -0.1259538  1.55622494 -1.3582985

DT[ , lapply(.SD, sum), .SDcols = patterns('^V')]
#           V1      V2       V3      V4         V5        V6        V7         V8       V9
# 1: -6.349359 -6.5533 1.279383 3.26763 -0.9857325 -1.638943 -2.132787 -0.4682779 6.002554
#          V10
# 1: -1.842709

# non-empty intersection
DT[ , lapply(.SD, sum), .SDcols = patterns('^V[02468]', '^V[48]')]
#         V4         V8
# 1: 3.26763 -0.4682779
```

## Questions to address before merging:

I think for me the main design decision was this line:

```
.SDcols = Reduce(intersect, do_patterns(colsub, names(x)))
```

 - Should we take `patterns(regex1, regex2, ...)` to mean the user wants only columns matching _both_ `regex1` _and_ `regex2`, or is it columns matching `regex1` _or_ `regex2`?
 - Does this answer depend on whether `patterns` is negated? I considered conditioning if `.SDcols` is like `!patterns(regex1, regex2, ...)`, we take the `union`, otherwise, the `intersection`.

Other points to clarify:

 - Should we bother implementing the `cols` argument to `patterns`? Right now it's undefined behavior, but it will fail/not work as expected. Would take a bit more digging around in the code to get this to work, is it worth it? Should we fail if `cols` is supplied?
 - Is `patterns` the right name? Is it confusing that the behavior of `patterns` is not exactly the same as it is for `melt.data.table`? Should we replace `patterns` with a flexible helper _a la_ `like_any`/`like_all` which could handle the `intersect`/`union` question directly?

🙇 in advance and happy `data.table`ing!