### PR TITLE
fixed IDateTime.R use of base::.Date

### DIFF
--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -90,12 +90,12 @@ round.IDate <- function (x, digits=c("weeks", "months", "quarters", "years"), ..
   if (inherits(e2, "difftime"))
     stop("difftime objects may not be subtracted from IDate. Use plain integer instead of difftime.")
 
-  # IDate doesn't support fractional days so revert to base Date
   if ( isReallyReal(e2) ) {
-    # difference between two days
-    if (inherits(e2, 'Date')) return(difftime(e1, e2, units = 'days'))
-    # day - # of days
-    return(.Date(unclass(e1) - e2))
+    # IDate deliberately doesn't support fractional days so revert to base Date
+    return(base::`-.Date`(as.Date(e1), e2))
+    # can't call base::.Date directly (last line of base::`-.Date`) as tried in PR#3168 because
+    # i) ?.Date states "Internal objects in the base package most of which are only user-visible because of the special nature of the base namespace."
+    # ii) .Date was newly exposed in R some time after 3.4.4
   }
   ans = as.integer(unclass(e1) - unclass(e2))
   if (!inherits(e2, "Date")) class(ans) = c("IDate","Date")


### PR DESCRIPTION
Follow up to PR #3168
CI Pipeline revealed can't use `base::.Date`
Changed back to how it was before #3168 (calling `base::'-.Date'` when `e2` is `reallyReal`) but without `as.Date(e2)` so that the bug fix in #3168 and its new tests still work.
Since CI Pipeline is in error status now and I have all day before Michael and Jan wake up, and pipeline takes over an hour to run,  merging now to see if it passes and make progress.  @MichaelChirico please check post-merge and revert if necessary. If so a new test will need to be added since no tests changed in this follow up.