### PR TITLE
upgraded R on windows runner, #3147

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -173,7 +173,7 @@ test-rel-win: # windows test and build binaries
   <<: *test-win
   variables:
     R_BIN_VERSION: "3.5"
-    R_DIR: "R-3.5.0"
+    R_DIR: "R-3.5.1"
   script:
     - Rscript -e "source('ci.R'); install.packages(dcf.dependencies('DESCRIPTION', which='all'))"
     - *copy-src


### PR DESCRIPTION
#3147
r-devel has been upgraded also, but ci yaml does not need to be updated as path did not change