### PR TITLE
fixed rownames in CsubsetDT when irows==NULL

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -2217,14 +2217,12 @@ test(814.6, DT[,!c("b","foo")], DT[,list(a,c)], warning="column(s) not removed b
 test(814.7, DT[,-c("b","foo")], DT[,list(a,c)], warning="column(s) not removed because not found: foo")
 test(814.8, DT[,!2:3], DT[,"a"])  # for consistency, and ! avoids needing to wrap with () as in next test
 test(814.9, DT[,-(2:3)], DT[,"a"])
-
-# These currently need with=FALSE to work as in 812.6-9 above
-# mycols = "b"
-# test(815.1, DT[,!mycols], DT[,list(a,c)])
-# test(815.2, DT[,-mycols], DT[,list(a,c)])
-# mycols = 2
-# test(815.3, DT[,!mycols], DT[,list(a,c)])
-# test(815.4, DT[,-mycols], DT[,list(a,c)])
+mycols = "b"
+test(814.11, DT[,!..mycols], ans<-data.table(a=1:3, c=7:9))
+test(814.12, DT[,-..mycols], ans)
+mycols = 2
+test(814.13, DT[,!..mycols], ans)
+test(814.14, DT[,-..mycols], ans)
 
 
 # Test X[Y] slowdown, #2216

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -2188,15 +2188,44 @@ test(811, DT[c("b","foo","c"),which=NA,nomatch=0], error="which=NA with nomatch=
 
 # New notj for column names and positions when with=FALSE, #1384
 DT = data.table(a=1:3,b=4:6,c=7:9)
-test(812, DT[,!"b",with=FALSE], DT[,-match("b",names(DT)),with=FALSE])
-test(813, DT[,"foo",with=FALSE], error="column(s) not found: foo")
-test(814, DT[,!"foo",with=FALSE], DT, warning="column(s) not removed because not found: foo")
-test(815, DT[,!c("b","foo"),with=FALSE], DT[,list(a,c)], warning="column(s) not removed because not found: foo")
-test(816, DT[,!2:3,with=FALSE], DT[,-(2:3),with=FALSE])  # for consistency, but ! is really for character column names
+# old tests using with=FALSE retained.  Eventually will deprecate with=FALSE.
+test(812.1, DT[,!"b",with=FALSE], DT[,-match("b",names(DT)),with=FALSE])
+test(812.2, DT[,"foo",with=FALSE], error="column(s) not found: foo")
+test(812.3, DT[,!"foo",with=FALSE], DT, warning="column(s) not removed because not found: foo")
+test(812.4, DT[,!c("b","foo"),with=FALSE], DT[,list(a,c)], warning="column(s) not removed because not found: foo")
+test(812.5, DT[,!2:3,with=FALSE], DT[,-(2:3),with=FALSE])  # for consistency, but ! is really for character column names
 mycols = "b"
-test(817, DT[,!mycols,with=FALSE], DT[,list(a,c)])
+test(812.6, DT[,!mycols,with=FALSE], DT[,list(a,c)])
+test(812.7, DT[,-mycols,with=FALSE], DT[,list(a,c)])
 mycols = 2
-test(818, DT[,!mycols,with=FALSE], DT[,list(a,c)])
+test(812.8, DT[,!mycols,with=FALSE], DT[,list(a,c)])
+test(812.9, DT[,-mycols,with=FALSE], DT[,list(a,c)])
+
+# new tests for v1.12.0 to cover #3216 and #3217 (rownames of CsubsetDT when i=NULL was new and used more by [.data.table)
+test(813.1, rownames(DT[,!"b"]), rn<-c("1","2","3"))
+test(813.2, rownames(DT[,-"b"]), rn)
+test(813.3, rownames(DT[,"a"]), rn)
+test(813.4, rownames(DT[2,"a"]), "1")
+
+# also repeat 812.* but without with=FALSE since that will be deprecated in future, and cover - as well as !
+test(814.1, DT[,!"b"], DT[,c("a","c")])
+test(814.2, DT[,-"b"], DT[,c("a","c")])
+test(814.3, DT[,"foo"], error="column(s) not found: foo")
+test(814.4, DT[,!"foo"], DT, warning="column(s) not removed because not found: foo")
+test(814.5, DT[,-"foo"], DT, warning="column(s) not removed because not found: foo")
+test(814.6, DT[,!c("b","foo")], DT[,list(a,c)], warning="column(s) not removed because not found: foo")
+test(814.7, DT[,-c("b","foo")], DT[,list(a,c)], warning="column(s) not removed because not found: foo")
+test(814.8, DT[,!2:3], DT[,"a"])  # for consistency, and ! avoids needing to wrap with () as in next test
+test(814.9, DT[,-(2:3)], DT[,"a"])
+
+# These currently need with=FALSE to work as in 812.6-9 above
+# mycols = "b"
+# test(815.1, DT[,!mycols], DT[,list(a,c)])
+# test(815.2, DT[,-mycols], DT[,list(a,c)])
+# mycols = 2
+# test(815.3, DT[,!mycols], DT[,list(a,c)])
+# test(815.4, DT[,-mycols], DT[,list(a,c)])
+
 
 # Test X[Y] slowdown, #2216
 # Many minutes in 1.8.2!  Now well under 1s, but 10s for very wide tolerance for CRAN. We'd like CRAN to tell us if any changes

--- a/src/subset.c
+++ b/src/subset.c
@@ -243,17 +243,19 @@ SEXP subsetDT(SEXP x, SEXP rows, SEXP cols) {
     if (this<1 || this>LENGTH(x)) error("Item %d of 'cols' is %d which is outside 1-based range [1,ncol(x)=%d]", i+1, this, LENGTH(x));
   }
   SEXP ans = PROTECT(allocVector(VECSXP, LENGTH(cols)+64)); nprotect++;  // just do alloc.col directly, eventually alloc.col can be deprecated.
-  const int ansn = LENGTH(rows);  // has been checked not to contain zeros or negatives, so this length is the length of result
   copyMostAttrib(x, ans);  // other than R_NamesSymbol, R_DimSymbol and R_DimNamesSymbol
                // so includes row.names (oddly, given other dims aren't) and "sorted", dealt with below
   SET_TRUELENGTH(ans, LENGTH(ans));
   SETLENGTH(ans, LENGTH(cols));
+  int ansn;
   if (isNull(rows)) {
+    ansn = LENGTH(VECTOR_ELT(x, 0));
     for (int i=0; i<LENGTH(cols); i++) {
       SET_VECTOR_ELT(ans, i, duplicate(VECTOR_ELT(x, INTEGER(cols)[i]-1)));
       // materialize the column subset as we have always done for now, until REFCNT is on by default in R (TODO)
     }
   } else {
+    ansn = LENGTH(rows);  // has been checked not to contain zeros or negatives, so this length is the length of result
     for (int i=0; i<LENGTH(cols); i++) {
       SEXP source = VECTOR_ELT(x, INTEGER(cols)[i]-1);
       SEXP target;


### PR DESCRIPTION
Closes #3216
Closes #3217

I had added irows=NULL ability (all rows) to CsubsetDT but that made the rownames attribute c(NA, 0) since length(irows) was 0.  Should have been c(NA, -n).
There were tests for `DT[,-"col"]` but they compared to a `DT[, otherCols]` result.  rownames became missing on both sides, so the tests still passed.  