### PR TITLE
overAlloc in CsubsetDT

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2475,7 +2475,7 @@ alloc.col <- function(DT, n=getOption("datatable.alloccol"), verbose=getOption("
 {
   name = substitute(DT)
   if (identical(name,quote(`*tmp*`))) stop("alloc.col attempting to modify `*tmp*`")
-  ans = .Call(Calloccolwrapper, DT, length(DT)+as.integer(eval(n)), verbose)
+  ans = .Call(Calloccolwrapper, DT, eval(n), verbose)
   if (is.name(name)) {
     name = as.character(name)
     assign(name,ans,parent.frame(),inherits=TRUE)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -1237,24 +1237,53 @@ test(429, DT, data.table(a=factor(c("Z","Z","A","Z")),b=1:4))
 test(430, DT[1,1]<- 3L, 3L, warning="RHS contains 3 which is outside the levels range.*1,2.*of column 1, NAs generated")
 test(431, DT[1,1:=4L], data.table(a=factor(c(NA,"Z","A","Z")),b=1:4), warning="RHS contains 4 which is outside the levels range.*1,2.*of column 1, NAs generated")
 
-
-old = getOption("datatable.alloccol")
-options(datatable.alloccol=NULL)   # In this =NULL case, R 3.0.0 returns TRUE rather than the old value.
-                                   # Hence split out into separate getOption() first.
-                                   # This was an R bug fixed in R 3.1.1.
-test(432.1, data.table(a=1:3,b=4:6), error="Has getOption('datatable.alloccol') somehow become unset?")
-options(datatable.alloccol=old)
+old = getOption("datatable.alloccol")  # Test that unsettting datatable.alloccol is caught, #2014
+options(datatable.alloccol=NULL)   # In this =NULL case, options() in R 3.0.0 returned TRUE rather than the old value. This R bug was fixed in R 3.1.1.
+                                   # This is why getOption is called first rather than just using the result of option() like elsewhere in this test file.
+err1 = try(data.table(a=1:3), silent=TRUE)
+options(datatable.alloccol="1024")
+err2 = try(data.table(a=1:3), silent=TRUE)
+options(datatable.alloccol=c(10L,20L))
+err3 = try(data.table(a=1:3), silent=TRUE)
+options(datatable.alloccol=NA_integer_)
+err4 = try(data.table(a=1:3), silent=TRUE)
+options(datatable.alloccol=-1)
+err5 = try(data.table(a=1:3), silent=TRUE)
+options(datatable.alloccol=old)   # otherwise test() itself fails in its internals with the alloc.col error
+test(432.1, inherits(err1,"try-error") && grep("Has getOption[(]'datatable.alloccol'[)] somehow become unset?", err1))
+test(432.2, inherits(err2,"try-error") && grep("getOption[(]'datatable.alloccol'[)] should be a number, by default 1024. But its type is 'character'.", err2))
+test(432.3, inherits(err3,"try-error") && grep("is a numeric vector ok but its length is 2. Its length should be 1.", err3))
+test(432.4, inherits(err4,"try-error") && grep("It must be >=0 and not NA.", err4))
+test(432.5, inherits(err5,"try-error") && grep("It must be >=0 and not NA.", err5))
+# Repeat the tests but this time with subsetting, to ensure the validity check on option happens for those too
+DT = data.table(a=1:3, b=4:6)
+options(datatable.alloccol=NULL)
+err1 = try(DT[2,], silent=TRUE)
+options(datatable.alloccol="1024")
+err2 = try(DT[,2], silent=TRUE)
+options(datatable.alloccol=c(10L,20L))
+err3 = try(DT[a>1], silent=TRUE)
+options(datatable.alloccol=NA_integer_)
+err4 = try(DT[,"b"], silent=TRUE)
+options(datatable.alloccol=-1)
+err5 = try(DT[2,"b"], silent=TRUE)
+options(datatable.alloccol=old)   # otherwise test() itself fails in its internals with the alloc.col error
+test(433.1, inherits(err1,"try-error") && grep("Has getOption[(]'datatable.alloccol'[)] somehow become unset?", err1))
+test(433.2, inherits(err2,"try-error") && grep("getOption[(]'datatable.alloccol'[)] should be a number, by default 1024. But its type is 'character'.", err2))
+test(433.3, inherits(err3,"try-error") && grep("is a numeric vector ok but its length is 2. Its length should be 1.", err3))
+test(433.4, inherits(err4,"try-error") && grep("It must be >=0 and not NA.", err4))
+test(433.5, inherits(err5,"try-error") && grep("It must be >=0 and not NA.", err5))
 
 # simple realloc test
 DT = data.table(a=1:3,b=4:6)
-test(432.2, truelength(DT), 1026L)
+test(434.1, truelength(DT), 1026L)
 alloc.col(DT,200)   # should have no affect since 200<1024
-test(433, truelength(DT), 1026L)
+test(434.2, truelength(DT), 1026L)
 DT = alloc.col(DT,2000)  # test the superfluous DT =
-test(434, truelength(DT), 2002L)
+test(434.3, truelength(DT), 2002L)
 DT2 = alloc.col(DT,3000)  #  DT changed then DT2 pointed to it
-test(435, truelength(DT), 3002L)
-test(436, truelength(DT2), 3002L)
+test(434.4, truelength(DT), 3002L)
+test(434.5, truelength(DT2), 3002L)
 
 # test that alloc.col assigns from within functions too (i.e. to wherever that object is)
 DT = data.table(a=1:3,b=4:6)   # tl 1024 now by default
@@ -1769,12 +1798,6 @@ test(631.1, merge(DT1,DT2,all.y=TRUE), setkey(adt(merge(adf(DT1),adf(DT2),by="a"
 
 test(632, merge(DT1,DT2,all=TRUE), data.table(a=c(1,2,3,4,5),total.x=c(2,NA,1,3,1),total.y=c(NA,5,1,NA,2),key="a"))
 test(632.1, merge(DT1,DT2,all=TRUE), setkey(adt(merge(adf(DT1),adf(DT2),by="a",all=TRUE)),a))
-
-# Test that unsettting datatable.alloccol is caught, #2014
-old = getOption("datatable.alloccol")
-options(datatable.alloccol=NULL)   # search above for R bug fix in 3.1.1 - why split into getOption first here.
-test(633, data.table(a=1:3), error="n must be integer length 1")
-options(datatable.alloccol=old)
 
 # Test that with=FALSE by number isn't messed up by dup column names, #2025
 DT = data.table(a=1:3,a=4:6)
@@ -7490,7 +7513,7 @@ test(1562, melt(DT, measure=patterns("^g[12]"), variable.factor=FALSE), data.tab
 # fix for #1341
 dt <- data.table(a = 1:10)
 test(1564.1, truelength(dt[, .SD]), 1025L)
-test(1564.2, truelength(dt[a==5, .SD]), 65L)
+test(1564.2, truelength(dt[a==5, .SD]), 1025L)
 test(1564.3, dt[a==5, .SD][, b := 1L], data.table(a=5L, b=1L))
 
 # Fix for #1251, DT[, .N, by=a] and DT[, .(.N), by=a] uses GForce now

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -88,6 +88,7 @@ SEXP SelfRefSymbol;
 SEXP allocNAVector(SEXPTYPE type, R_len_t n);
 void savetl_init(), savetl(SEXP s), savetl_end();
 Rboolean isDatatable(SEXP x);
+int checkOverAlloc(SEXP x);
 
 // forder.c
 int StrCmp(SEXP x, SEXP y);

--- a/src/subset.c
+++ b/src/subset.c
@@ -243,17 +243,7 @@ SEXP subsetDT(SEXP x, SEXP rows, SEXP cols) {
     if (this<1 || this>LENGTH(x)) error("Item %d of 'cols' is %d which is outside 1-based range [1,ncol(x)=%d]", i+1, this, LENGTH(x));
   }
 
-  SEXP opt = GetOption(install("datatable.alloccol"), R_NilValue);
-  if (isNull(opt))
-    error("Has getOption('datatable.alloccol') somehow become unset? It should be a number, by default 1024.");
-  if (!isInteger(opt) && !isReal(opt))
-    error("getOption('datatable.alloccol') should be a number, by default 1024. But its type is '%s'.", type2char(TYPEOF(opt)));
-  if (LENGTH(opt) != 1)
-    error("getOption('datatable.alloc') is a numeric vector ok but its length is %d. Its length should be 1.", LENGTH(opt));
-  int overAlloc = isInteger(opt) ? INTEGER(opt)[0] : (int)REAL(opt)[0];
-  if (overAlloc<0)
-    error("getOption('datatable.alloc')==%d.  It must be >=0 and not NA.", overAlloc);
-
+  int overAlloc = checkOverAlloc(GetOption(install("datatable.alloccol"), R_NilValue));
   SEXP ans = PROTECT(allocVector(VECSXP, LENGTH(cols)+overAlloc)); nprotect++;  // just do alloc.col directly, eventually alloc.col can be deprecated.
   copyMostAttrib(x, ans);  // other than R_NamesSymbol, R_DimSymbol and R_DimNamesSymbol
                // so includes row.names (oddly, given other dims aren't) and "sorted", dealt with below


### PR DESCRIPTION
Closes #3228
`CsubsetDT` used a hard coded 64. Now it gets the value from options("datatable.alloccol") (1024 by default) which restores the past value and avoids the reduction in dev.
Thanks to @renkun-ken's testing.