### PR TITLE
Empty .SDcols back to 1.11.8 behaviour, plus fix for integer()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -72,7 +72,7 @@
 
 11. `as.data.table.default` method will now always copy its input, closes [#3230](https://github.com/Rdatatable/data.table/issues/3230). Thanks to @NikdAK for reporting.
 
-12. `DT[..., .SDcols=integer()]` failed with `.SDcols is numeric but has both +ve and -ve indices`, [#3185](https://github.com/Rdatatable/data.table/issues/3185). It now functions as `.SDcols=character()` has done and creates an empty `.SD`. Thanks to Hugh Parsonage for highlighting. A related issue with empty `.SDcols` was fixed in developement before release thanks to Kun Ren's testing, [#3211](https://github.com/Rdatatable/data.table/issues/3211).
+12. `DT[..., .SDcols=integer()]` failed with `.SDcols is numeric but has both +ve and -ve indices`, [#1789](https://github.com/Rdatatable/data.table/issues/1789) and [#3185](https://github.com/Rdatatable/data.table/issues/3185). It now functions as `.SDcols=character()` has done and creates an empty `.SD`. Thanks to Gabor Grothendieck and Hugh Parsonage for reporting. A related issue with empty `.SDcols` was fixed in development before release thanks to Kun Ren's testing, [#3211](https://github.com/Rdatatable/data.table/issues/3211).
 
 #### NOTES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -72,6 +72,8 @@
 
 11. `as.data.table.default` method will now always copy its input, closes [#3230](https://github.com/Rdatatable/data.table/issues/3230). Thanks to @NikdAK for reporting.
 
+12. `DT[..., .SDcols=integer()]` failed with `.SDcols is numeric but has both +ve and -ve indices`, [#3185](https://github.com/Rdatatable/data.table/issues/3185). It now functions as `.SDcols=character()` has done and creates an empty `.SD`. Thanks to Hugh Parsonage for highlighting. A related issue with empty `.SDcols` was fixed in developement before release thanks to Kun Ren's testing, [#3211](https://github.com/Rdatatable/data.table/issues/3211).
+
 #### NOTES
 
 1. When data.table loads it now checks its DLL version against the version of its R level code. This is to detect installation issues on Windows when i) the DLL is in use by another R session and ii) the CRAN source version > CRAN binary binary which happens just after a new release (R prompts users to install from source until the CRAN binary is available). This situation can lead to a state where the package's new R code calls old C code in the old DLL; [R#17478](https://bugs.r-project.org/bugzilla/show_bug.cgi?id=17478), [#3056](https://github.com/Rdatatable/data.table/issues/3056). This broken state can persist until, hopefully, you experience a strange error caused by the mismatch. Otherwise, wrong results may occur silently. This situation applies to any R package with compiled code not just data.table, is Windows-only, and is long-standing. It has only recently been understood as it typically only occurs during the few days after each new release until binaries are available on CRAN.

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1024,7 +1024,6 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
               .SDcols = eval(colsub, parent.frame(), parent.frame())
             }
           }
-          if (!length(.SDcols)) stop("Empty .SDcols is not yet supported.")
           if (anyNA(.SDcols))
             stop(".SDcols missing at the following indices: ", brackify(which(is.na(.SDcols))))
           if (is.logical(.SDcols)) {
@@ -1032,7 +1031,7 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
             ansvars = names(x)[ansvals]
           } else if (is.numeric(.SDcols)) {
             # if .SDcols is numeric, use 'dupdiff' instead of 'setdiff'
-            if (length(unique(sign(.SDcols))) != 1L) stop(".SDcols is numeric but has both +ve and -ve indices")
+            if (length(unique(sign(.SDcols))) > 1L) stop(".SDcols is numeric but has both +ve and -ve indices")
             if (any(idx <- abs(.SDcols)>ncol(x) | abs(.SDcols)<1L))
               stop(".SDcols is numeric but out of bounds [1, ", ncol(x), "] at: ", brackify(which(idx)))
             if (colm) ansvars = dupdiff(names(x)[-.SDcols], bynames) else ansvars = names(x)[.SDcols]

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -13164,10 +13164,17 @@ x = rbind(x, y)
 y = rbind(y, x)
 test(1969.5, fsetequal(x, y), FALSE)
 
-# #3185 -- .SDcols = integer(0L) errors until broader handling of empty .SDcols is addressed
-DT = data.table(a = 1:10)
-test(1970.1, DT[ , .SD, .SDcols = integer(0L)], error = 'Empty .SDcols is not yet supported')
-test(1970.2, DT[ , .SD, .SDcols = character(0L)], error = 'Empty .SDcols is not yet supported')
+# empty .SDcols, #3185 and comments in #3211
+DT = data.table(x=1:3, y=4:6)
+test(1970.1, DT[, .SD, .SDcols=integer(0L)], data.table(NULL))
+test(1970.2, DT[, .SD, .SDcols=character(0L)], data.table(NULL))
+test(1970.3, DT[, rowSums(.SD), .SDcols=integer()], numeric())
+test(1970.4, DT[, rowSums(.SD), .SDcols=character()], numeric())
+test(1970.5, DT[, z:=rowSums(.SD), .SDcols=integer()], data.table(x=1:3, y=4:6, z=NA_real_))
+test(1970.6, DT[, z:=rowSums(.SD), .SDcols=integer()], error="RHS of assignment to existing column 'z' is zero length but not NULL")
+test(1970.7, DT[, z:=NULL], data.table(x=1:3, y=4:6))
+test(1970.8, DT[, z:=rowSums(.SD), .SDcols=character()], data.table(x=1:3, y=4:6, z=NA_real_))
+test(1970.9, DT[, z:=rowSums(.SD), .SDcols=character()], error="RHS of assignment to existing column 'z' is zero length but not NULL")
 
 # .SDcols=patterns(), #1878
 DT = data.table(


### PR DESCRIPTION
Closes #1789
Follow up to #3185 
Fixes regression in dev before release reported by Kun Ren in comments in #3211