### PR TITLE
rownames .SD 

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1965,7 +1965,7 @@ as.matrix.data.table <- function(x, rownames=NULL, rownames.value=NULL, ...) {
     rownames.value <- x[[rownames]]
     dm <- dim(x) - c(0, 1)
     cn <- names(x)[-rownames]
-    X <- x[, ..cn]
+    X <- x[, .SD, .SDcols = cn]
   } else {
     dm <- dim(x)
     cn <- names(x)

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1965,7 +1965,7 @@ as.matrix.data.table <- function(x, rownames=NULL, rownames.value=NULL, ...) {
     rownames.value <- x[[rownames]]
     dm <- dim(x) - c(0, 1)
     cn <- names(x)[-rownames]
-    X <- x[, .SD, .SDcols = cn]
+    X <- x[, ..cn]
   } else {
     dm <- dim(x)
     cn <- names(x)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -13230,6 +13230,12 @@ test(1975.2, DT[,sum(v,na.rm=TRUE),by=id], data.table(id=INT(1,2), V1=c(3.3,6.7)
 test(1975.3, DT[,mean(v),by=id], data.table(id=INT(1,2), V1=c(1.65,NaN)))
 test(1975.4, DT[,mean(v,na.rm=TRUE),by=id], data.table(id=INT(1,2), V1=c(1.65,3.35)))
 
+# rownames SD when a symbol in {} masks another column name
+DT = data.table(ID=INT(1,1,2,2,2), FOO=1:5, BAR=1:5)
+test(1976.1, DT[, length(rownames(.SD)), by=ID, .SDcols="FOO"], data.table(ID=1:2, V1=2:3))           # ok
+test(1976.2, DT[, {BA=1; length(rownames(.SD))}, by=ID, .SDcols="FOO"], data.table(ID=1:2, V1=2:3))   # ok
+test(1976.3, DT[, {BAR=1; length(rownames(.SD))}, by=ID, .SDcols="FOO"], data.table(ID=1:2, V1=2:3))  # BAR masks column name and affected rownames(.SD) in dev 1.11.9
+
 
 ###################################
 #  Add new tests above this line  #

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -13230,7 +13230,7 @@ test(1975.2, DT[,sum(v,na.rm=TRUE),by=id], data.table(id=INT(1,2), V1=c(3.3,6.7)
 test(1975.3, DT[,mean(v),by=id], data.table(id=INT(1,2), V1=c(1.65,NaN)))
 test(1975.4, DT[,mean(v,na.rm=TRUE),by=id], data.table(id=INT(1,2), V1=c(1.65,3.35)))
 
-# rownames SD when a symbol in {} masks another column name
+# rownames of .SD when a symbol in {} masks another column name
 DT = data.table(ID=INT(1,1,2,2,2), FOO=1:5, BAR=1:5)
 test(1976.1, DT[, length(rownames(.SD)), by=ID, .SDcols="FOO"], data.table(ID=1:2, V1=2:3))           # ok
 test(1976.2, DT[, {BA=1; length(rownames(.SD))}, by=ID, .SDcols="FOO"], data.table(ID=1:2, V1=2:3))   # ok


### PR DESCRIPTION
Thanks to revdep checking of package `rENA`. Very rare case where `rownames(.SD)` are used; e.g. `as.matrix(.SD)` by group together with using `.SDcols` too and also using a column inside `j={  }` which is not in `.SDcols`.  Problem arose in dev and not with CRAN version.

Separately, a one-line change is needed to rENA in one test, for reference from #3233.
I emailed rENA maintainer as follows : 

---

Dear Cody,

Firstly, happy new year!

data.table v1.12.0 is about to go to CRAN and revdep checking shows it will break rENA.

This change affects rENA :
![image](https://user-images.githubusercontent.com/2779998/50672107-dbdb5a00-0f8a-11e9-91dd-c869012a8805.png)
Please change line 105 of tests/testthat/test.ena.accumulate.data.file.R from :
    `testthat::expect_identical(x$adjacency.vectors, xtest[,grep("^adjacency", colnames(xtest)), with=F])`
to
    `testthat::expect_equal(x$adjacency.vectors, xtest[,grep("^adjacency", colnames(xtest)), with=F], check.attributes=FALSE)`

I've checked rENA passes v1.12.0 with this one line change.

Further, line 195 of ENAdata.R contains  [,,.SDcols=metaAvail].  This now throws a warning that i and j are both missing so the other arguments (.SDcols= in this case) are being ignored.  It's likely that line is not doing what you intended.

When data.table v1.12.0 goes to CRAN, rENA will start to fail. Could you update rENA on CRAN please.   Either in advance or after data.table v1.12.0 is there is ok too.

(If you are on GitHub I would submit a pull request.)

Best, Matt

---
