### PR TITLE
Add gzip support to fwrite

### DIFF
--- a/R/fwrite.R
+++ b/R/fwrite.R
@@ -7,7 +7,7 @@ fwrite <- function(x, file="", append=FALSE, quote="auto",
            dateTimeAs = c("ISO","squash","epoch","write.csv"),
            buffMB=8, nThread=getDTthreads(verbose),
            showProgress=getOption("datatable.showProgress", interactive()),
-           compress = c("none", "gzip"), 
+           compress = c("default", "none", "gzip"), 
            verbose=getOption("datatable.verbose", FALSE)
            ) {
   isLOGICAL = function(x) isTRUE(x) || identical(FALSE, x)  # it seems there is no isFALSE in R?
@@ -41,7 +41,7 @@ fwrite <- function(x, file="", append=FALSE, quote="auto",
     dec != sep,  # sep2!=dec and sep2!=sep checked at C level when we know if list columns are present
     is.character(eol) && length(eol)==1L,
     length(qmethod) == 1L && qmethod %chin% c("double", "escape"),
-    length(compress) == 1L && compress %chin% c("none", "gzip"),
+    length(compress) == 1L && compress %chin% c("default", "none", "gzip"),
     isLOGICAL(col.names), isLOGICAL(append), isLOGICAL(row.names),
     isLOGICAL(verbose), isLOGICAL(showProgress), isLOGICAL(logical01),
     length(na) == 1L, #1725, handles NULL or character(0) input
@@ -50,7 +50,7 @@ fwrite <- function(x, file="", append=FALSE, quote="auto",
     length(nThread)==1L && !is.na(nThread) && nThread>=1L
     )
   
-  is_gzip <- compress == "gzip" || grepl("\\.gz$", file)
+  is_gzip <- compress == "gzip" || (compress == "default" && grepl("\\.gz$", file))
   
   file <- path.expand(file)  # "~/foo/bar"
   if (append && missing(col.names) && (file=="" || file.exists(file)))
@@ -81,4 +81,3 @@ fwrite <- function(x, file="", append=FALSE, quote="auto",
           showProgress, is_gzip, verbose)
   invisible()
 }
-

--- a/R/fwrite.R
+++ b/R/fwrite.R
@@ -7,10 +7,13 @@ fwrite <- function(x, file="", append=FALSE, quote="auto",
            dateTimeAs = c("ISO","squash","epoch","write.csv"),
            buffMB=8, nThread=getDTthreads(verbose),
            showProgress=getOption("datatable.showProgress", interactive()),
-           verbose=getOption("datatable.verbose", FALSE)) {
+           compress = c("none", "gzip"), 
+           verbose=getOption("datatable.verbose", FALSE)
+           ) {
   isLOGICAL = function(x) isTRUE(x) || identical(FALSE, x)  # it seems there is no isFALSE in R?
   na = as.character(na[1L]) # fix for #1725
   if (missing(qmethod)) qmethod = qmethod[1L]
+  if (missing(compress)) compress = compress[1L]
   if (missing(dateTimeAs)) { dateTimeAs = dateTimeAs[1L] }
   else if (length(dateTimeAs)>1L) stop("dateTimeAs must be a single string")
   dateTimeAs = chmatch(dateTimeAs, c("ISO","squash","epoch","write.csv"))-1L
@@ -38,6 +41,7 @@ fwrite <- function(x, file="", append=FALSE, quote="auto",
     dec != sep,  # sep2!=dec and sep2!=sep checked at C level when we know if list columns are present
     is.character(eol) && length(eol)==1L,
     length(qmethod) == 1L && qmethod %chin% c("double", "escape"),
+    length(compress) == 1L && compress %chin% c("none", "gzip"),
     isLOGICAL(col.names), isLOGICAL(append), isLOGICAL(row.names),
     isLOGICAL(verbose), isLOGICAL(showProgress), isLOGICAL(logical01),
     length(na) == 1L, #1725, handles NULL or character(0) input
@@ -45,6 +49,9 @@ fwrite <- function(x, file="", append=FALSE, quote="auto",
     length(buffMB)==1L && !is.na(buffMB) && 1L<=buffMB && buffMB<=1024,
     length(nThread)==1L && !is.na(nThread) && nThread>=1L
     )
+  
+  is_gzip <- compress == "gzip" || grepl("\\.gz$", file)
+  
   file <- path.expand(file)  # "~/foo/bar"
   if (append && missing(col.names) && (file=="" || file.exists(file)))
     col.names = FALSE  # test 1658.16 checks this
@@ -71,7 +78,7 @@ fwrite <- function(x, file="", append=FALSE, quote="auto",
   file <- enc2native(file) # CfwriteR cannot handle UTF-8 if that is not the native encoding, see #3078.
   .Call(CfwriteR, x, file, sep, sep2, eol, na, dec, quote, qmethod=="escape", append,
           row.names, col.names, logical01, dateTimeAs, buffMB, nThread,
-          showProgress, verbose)
+          showProgress, is_gzip, verbose)
   invisible()
 }
 

--- a/R/fwrite.R
+++ b/R/fwrite.R
@@ -7,7 +7,7 @@ fwrite <- function(x, file="", append=FALSE, quote="auto",
            dateTimeAs = c("ISO","squash","epoch","write.csv"),
            buffMB=8, nThread=getDTthreads(verbose),
            showProgress=getOption("datatable.showProgress", interactive()),
-           compress = c("default", "none", "gzip"), 
+           compress = c("auto", "none", "gzip"), 
            verbose=getOption("datatable.verbose", FALSE)
            ) {
   isLOGICAL = function(x) isTRUE(x) || identical(FALSE, x)  # it seems there is no isFALSE in R?
@@ -41,7 +41,7 @@ fwrite <- function(x, file="", append=FALSE, quote="auto",
     dec != sep,  # sep2!=dec and sep2!=sep checked at C level when we know if list columns are present
     is.character(eol) && length(eol)==1L,
     length(qmethod) == 1L && qmethod %chin% c("double", "escape"),
-    length(compress) == 1L && compress %chin% c("default", "none", "gzip"),
+    length(compress) == 1L && compress %chin% c("auto", "none", "gzip"),
     isLOGICAL(col.names), isLOGICAL(append), isLOGICAL(row.names),
     isLOGICAL(verbose), isLOGICAL(showProgress), isLOGICAL(logical01),
     length(na) == 1L, #1725, handles NULL or character(0) input
@@ -50,7 +50,7 @@ fwrite <- function(x, file="", append=FALSE, quote="auto",
     length(nThread)==1L && !is.na(nThread) && nThread>=1L
     )
   
-  is_gzip <- compress == "gzip" || (compress == "default" && grepl("\\.gz$", file))
+  is_gzip <- compress == "gzip" || (compress == "auto" && grepl("\\.gz$", file))
   
   file <- path.expand(file)  # "~/foo/bar"
   if (append && missing(col.names) && (file=="" || file.exists(file)))

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -9271,9 +9271,12 @@ test(1658.11, fwrite(data.table(a=c(1:3), b=c(1:3)), compress="gzip"),
             output='a,b\n1,1\n2,2\n3,3')
 
 # fwrite gzipped output 
-f <- tempfile()
-test(1658.12, fwrite(data.table(a=c(1:3), b=c(1:3)), compress="gzip"),
-            output='a,b\n1,1\n2,2\n3,3')
+if (.Platform$OS.type=="unix") {
+  f <- tempfile()
+  fwrite(data.table(a=c(1:3), b=c(1:3)), file=f, compress="gzip")
+  test(1658.12, system(paste("zcat", f), intern=T), output='[1] "a,b" "1,1" "2,2" "3,3"')
+  unlink(f)
+}
 
 # writing a data.frame
 test(1658.13, fwrite(data.frame(a="foo", b="bar"), quote=TRUE),

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -9266,17 +9266,13 @@ test(1658.8, fwrite(data.table(a=c(1:5), b=c(1:5)), quote=TRUE),
 test(1658.9, fwrite(data.table(a=c(1:3), b=c(1:3)), quote=TRUE),
             output='"a","b"\n1,1\n2,2\n3,3')
 
-# fwrite output to console ignore compress
-test(1658.11, fwrite(data.table(a=c(1:3), b=c(1:3)), compress="gzip"),
-            output='a,b\n1,1\n2,2\n3,3')
+# block size one bigger than number of rows
+test(1658.11, fwrite(data.table(a=c(1:3), b=c(1:3)), quote=TRUE),
+            output='"a","b"\n1,1\n2,2\n3,3')
 
-# fwrite gzipped output 
-if (.Platform$OS.type=="unix") {
-  f <- tempfile()
-  fwrite(data.table(a=c(1:3), b=c(1:3)), file=f, compress="gzip")
-  test(1658.12, system(paste("zcat", f), intern=T), output='[1] "a,b" "1,1" "2,2" "3,3"')
-  unlink(f)
-}
+# block size one less than number of rows
+test(1658.12, fwrite(data.table(a=c(1:3), b=c(1:3)), quote=TRUE),
+            output='"a","b"\n1,1\n2,2\n3,3')
 
 # writing a data.frame
 test(1658.13, fwrite(data.frame(a="foo", b="bar"), quote=TRUE),
@@ -9352,6 +9348,27 @@ test(1658.33, fwrite(matrix("foo"), quote=TRUE), output='"V1"\n.*"foo"', message
 test(1658.34, fwrite(matrix(1:4, nrow=2, ncol=2), quote = TRUE), output = '"V1","V2"\n.*1,3\n2,4', message = "x being coerced from class: matrix to data.table")
 test(1658.35, fwrite(matrix(1:3, nrow=3, ncol=1), quote = TRUE), output = '"V1"\n.*1\n2\n3', message = "x being coerced from class: matrix to data.table")
 test(1658.36, fwrite(matrix(1:4, nrow=2, ncol=2, dimnames = list(c("ra","rb"),c("ca","cb"))), quote = TRUE), output = '"ca","cb"\n.*1,3\n2,4', message = "x being coerced from class: matrix to data.table")
+
+# fwrite output to console ignore compress
+test(1658.37, fwrite(data.table(a=c(1:3), b=c(1:3)), compress="gzip"),
+            output='a,b\n1,1\n2,2\n3,3')
+
+# fwrite force gzipped output
+if (.Platform$OS.type=="unix") {
+  f <- tempfile()
+  fwrite(data.table(a=c(1:3), b=c(1:3)), file=f, compress="gzip")
+  test(1658.38, system(paste("zcat", f), intern=T), output='[1] "a,b" "1,1" "2,2" "3,3"')
+  unlink(f)
+}
+
+
+# fwrite force csv output
+if (.Platform$OS.type=="unix") {
+  f <- tempfile()
+  fwrite(data.table(a=c(1:3), b=c(1:3)), file=f, compress="none")
+  test(1658.39, system(paste("cat", f), intern=T), output='[1] "a,b" "1,1" "2,2" "3,3"')
+  unlink(f)
+}
 
 ## End fwrite tests
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -9266,13 +9266,14 @@ test(1658.8, fwrite(data.table(a=c(1:5), b=c(1:5)), quote=TRUE),
 test(1658.9, fwrite(data.table(a=c(1:3), b=c(1:3)), quote=TRUE),
             output='"a","b"\n1,1\n2,2\n3,3')
 
-# block size one bigger than number of rows
-test(1658.11, fwrite(data.table(a=c(1:3), b=c(1:3)), quote=TRUE),
-            output='"a","b"\n1,1\n2,2\n3,3')
+# fwrite output to console ignore compress
+test(1658.11, fwrite(data.table(a=c(1:3), b=c(1:3)), compress="gzip"),
+            output='a,b\n1,1\n2,2\n3,3')
 
-# block size one less than number of rows
-test(1658.12, fwrite(data.table(a=c(1:3), b=c(1:3)), quote=TRUE),
-            output='"a","b"\n1,1\n2,2\n3,3')
+# fwrite gzipped output 
+f <- tempfile()
+test(1658.12, fwrite(data.table(a=c(1:3), b=c(1:3)), compress="gzip"),
+            output='a,b\n1,1\n2,2\n3,3')
 
 # writing a data.frame
 test(1658.13, fwrite(data.frame(a="foo", b="bar"), quote=TRUE),

--- a/man/fwrite.Rd
+++ b/man/fwrite.Rd
@@ -17,6 +17,7 @@ fwrite(x, file = "", append = FALSE, quote = "auto",
   dateTimeAs = c("ISO","squash","epoch","write.csv"),
   buffMB = 8L, nThread = getDTthreads(verbose),
   showProgress = getOption("datatable.showProgress", interactive()),
+  compress = c("none", "gzip"),
   verbose = getOption("datatable.verbose", FALSE))
 }
 \arguments{
@@ -52,6 +53,7 @@ fwrite(x, file = "", append = FALSE, quote = "auto",
   \item{buffMB}{The buffer size (MB) per thread in the range 1 to 1024, default 8MB. Experiment to see what works best for your data on your hardware.}
   \item{nThread}{The number of threads to use. Experiment to see what works best for your data on your hardware.}
   \item{showProgress}{ Display a progress meter on the console? Ignored when \code{file==""}. }
+  \item{compress}{If compress = \code{"gzip"} or if \code{file} ends in \code{.gz}, even if compress = \code{"none"}, then the output format is gzipped csv. Output to console is never gzipped even if compress = \code{"gzip"}. By default, compress = \code{"none"}.}
   \item{verbose}{Be chatty and report timings?}
 }
 \details{

--- a/man/fwrite.Rd
+++ b/man/fwrite.Rd
@@ -17,7 +17,7 @@ fwrite(x, file = "", append = FALSE, quote = "auto",
   dateTimeAs = c("ISO","squash","epoch","write.csv"),
   buffMB = 8L, nThread = getDTthreads(verbose),
   showProgress = getOption("datatable.showProgress", interactive()),
-  compress = c("none", "gzip"),
+  compress = c("default", "none", "gzip"),
   verbose = getOption("datatable.verbose", FALSE))
 }
 \arguments{
@@ -53,7 +53,7 @@ fwrite(x, file = "", append = FALSE, quote = "auto",
   \item{buffMB}{The buffer size (MB) per thread in the range 1 to 1024, default 8MB. Experiment to see what works best for your data on your hardware.}
   \item{nThread}{The number of threads to use. Experiment to see what works best for your data on your hardware.}
   \item{showProgress}{ Display a progress meter on the console? Ignored when \code{file==""}. }
-  \item{compress}{If compress = \code{"gzip"} or if \code{file} ends in \code{.gz}, even if compress = \code{"none"}, then the output format is gzipped csv. Output to console is never gzipped even if compress = \code{"gzip"}. By default, compress = \code{"none"}.}
+  \item{compress}{If \code{compress = "default"} and if \code{file} ends in \code{.gz} then output format is gzipped csv else csv. If \code{compress = "none"}, output format is always csv. If \code{compress = "gzip"} then format is gzipped csv. Output to the console is never gzipped even if \code{compress = "gzip"}. By default, \code{compress = "default"}.}
   \item{verbose}{Be chatty and report timings?}
 }
 \details{

--- a/man/fwrite.Rd
+++ b/man/fwrite.Rd
@@ -53,7 +53,7 @@ fwrite(x, file = "", append = FALSE, quote = "auto",
   \item{buffMB}{The buffer size (MB) per thread in the range 1 to 1024, default 8MB. Experiment to see what works best for your data on your hardware.}
   \item{nThread}{The number of threads to use. Experiment to see what works best for your data on your hardware.}
   \item{showProgress}{ Display a progress meter on the console? Ignored when \code{file==""}. }
-  \item{compress}{If \code{compress = "default"} and if \code{file} ends in \code{.gz} then output format is gzipped csv else csv. If \code{compress = "none"}, output format is always csv. If \code{compress = "gzip"} then format is gzipped csv. Output to the console is never gzipped even if \code{compress = "gzip"}. By default, \code{compress = "default"}.}
+  \item{compress}{If \code{compress = "auto"} and if \code{file} ends in \code{.gz} then output format is gzipped csv else csv. If \code{compress = "none"}, output format is always csv. If \code{compress = "gzip"} then format is gzipped csv. Output to the console is never gzipped even if \code{compress = "gzip"}. By default, \code{compress = "auto"}.}
   \item{verbose}{Be chatty and report timings?}
 }
 \details{

--- a/src/fwrite.c
+++ b/src/fwrite.c
@@ -661,6 +661,7 @@ void fwriteMain(fwriteMainArgs args)
 #else
     f = open(args.filename, O_WRONLY | O_CREAT | (args.append ? O_APPEND : O_TRUNC), 0666);
     // There is no binary/text mode distinction on Linux and Mac
+#endif
     if (f == -1) {
       int erropen = errno;
       STOP(access( args.filename, F_OK ) != -1 ?
@@ -669,7 +670,6 @@ void fwriteMain(fwriteMainArgs args)
            strerror(erropen), args.filename);
     }
   } else {
-#endif
     zf = gzopen(args.filename, "wb");
     if (zf == NULL) {
       int erropen = errno;

--- a/src/fwrite.h
+++ b/src/fwrite.h
@@ -32,14 +32,10 @@ typedef struct fwriteMainArgs
   // contains non-ASCII characters, it should be UTF-8 encoded (however fread
   // will not validate the encoding).
   const char *filename;
-
   int ncol;
-
   int64_t nrow;
-
   // a vector of pointers to all-same-length column vectors
   void **columns;
-
   writer_fun_t *funs;      // a vector of writer_fun_t function pointers
 
   // length ncol vector containing which fun[] to use for each column
@@ -48,19 +44,12 @@ typedef struct fwriteMainArgs
   uint8_t *whichFun;
 
   void *colNames;         // NULL means no header, otherwise ncol strings
-
   bool doRowNames;        // optional, likely false
-
   void *rowNames;         // if doRowNames is true and rowNames is not NULL then they're used, otherwise row numbers are output.
-
   char sep;
-
   char sep2;
-
   char dec;
-
   const char *eol;
-
   const char *na;
 
   // The quote character is always " (ascii 34) and cannot be changed since nobody on Earth uses a different quoting character, surely
@@ -69,19 +58,13 @@ typedef struct fwriteMainArgs
   int8_t doQuote;
 
   bool qmethodEscape;     // true means escape quotes using backslash, else double-up double quotes.
-
   bool squashDateTime;
-
   bool append;
-
   int buffMB;             // [1-1024] default 8MB
-
   int nth;
-
   bool showProgress;
-
   bool verbose;
-
+  bool is_gzip;
 } fwriteMainArgs;
 
 void fwriteMain(fwriteMainArgs args);

--- a/src/fwriteR.c
+++ b/src/fwriteR.c
@@ -1,4 +1,3 @@
-
 #include <stdbool.h>
 #include "data.table.h"
 #include "fwrite.h"
@@ -128,10 +127,13 @@ SEXP fwriteR(
   SEXP buffMB_Arg,         // [1-1024] default 8MB
   SEXP nThread_Arg,
   SEXP showProgress_Arg,
-  SEXP verbose_Arg)
+  SEXP is_gzip_Arg,
+  SEXP verbose_Arg
+  )
 {
   if (!isNewList(DF)) error("fwrite must be passed an object of type list; e.g. data.frame, data.table");
   fwriteMainArgs args;
+  args.is_gzip = LOGICAL(is_gzip_Arg)[0];
   args.verbose = LOGICAL(verbose_Arg)[0];
   args.filename = CHAR(STRING_ELT(filename_Arg, 0));
   args.ncol = length(DF);


### PR DESCRIPTION
This is a first attempt to implement gzipped csv output in fwrite (issue #2016).

It uses zlib library and replaces open/write/close used for csv file by gzopen/gzwrite/gzclose for gzipped csv. A second buffer, which size is around 10% bigger than main buffer, is allocated for each thread. zlib is thread-safe and the gzip compression use all the available threads.
  
Option `compress="gzip"` is added to fwrite and is automatically set when file ends with `.gz`. Default is `compress = "none"`.

On my system (Debian Linux), r-base-dev install zlib1g-dev, which is needed to compile. I don't need to add a -lz for gcc to compile but that may be not true for others systems and on Windows or Mac. I guess that file `cc.R` must be modified to indicate the zlib dependence but it's too hard for me.

I've added 2 tests but it seems to be difficult to test a binary output like a gzipped csv. Test uses command `zcat` and runs only on unix platforms.

Please feel free to test.


