### PR TITLE
datatable.CJ.names now TRUE by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 1. When upgrading to 1.12.0 some Windows users might have seen `CdllVersion not found` in some circumstances. We found a way to catch that so the [helpful message](https://twitter.com/MattDowle/status/1084528873549705217) now occurs for those upgrading from versions prior to 1.12.0 too, as well as those upgrading from 1.12.0 to a later version. See item 1 in notes section of 1.12.0 below for more background.
 
+2. As promised in new feature 6 of v1.11.6 Sep 2018 (see below in this file), the `datatable.CJ.names` option's default is now `TRUE`. In v1.13.0 it will be removed.
+
 
 ### Changes in v1.12.0  (13 Jan 2019)
 

--- a/R/setkey.R
+++ b/R/setkey.R
@@ -402,7 +402,7 @@ CJ <- function(..., sorted = TRUE, unique = FALSE)
   }
   setattr(l, "row.names", .set_row_names(length(l[[1L]])))
   setattr(l, "class", c("data.table", "data.frame"))
-  if (getOption("datatable.CJ.names", FALSE)) {  # added as FALSE in v1.11.6. TODO: default TRUE in v1.12.0, remove in v1.13.0
+  if (getOption("datatable.CJ.names", TRUE)) {  # added as FALSE in v1.11.6 with NEWS item saying TRUE in v1.12.0. TODO: remove in v1.13.0
     vnames = name_dots(...)$vnames
   } else {
     if (is.null(vnames <- names(l))) vnames = paste0("V", seq_len(length(l)))


### PR DESCRIPTION
Follow up to #1596
#3295 filed so as to not forget to remove option in 1.13.0