### PR TITLE
add non exported .git function to get data.table git sha, closes #3272

### DIFF
--- a/R/onAttach.R
+++ b/R/onAttach.R
@@ -58,4 +58,12 @@ update.dev.pkg = function(object="data.table", repo="https://Rdatatable.gitlab.i
               utils::packageVersion(pkg)))
 }
 
+# non-exported utility when using devel version #3272: data.table:::.git()
+.git = function(quiet=FALSE) {
+  ans = unname(read.dcf(system.file("DESCRIPTION", package="data.table"), fields="Revision")[, "Revision"])
+  if (!quiet && is.na(ans))
+    cat("Git revision is not available. Most likely data.table was installed from CRAN or local archive.\nGit revision is available when installing from our repositories 'https://Rdatatable.gitlab.io/data.table' and 'https://Rdatatable.github.io/data.table'.\n")
+  ans
+}
+
 # nocov end


### PR DESCRIPTION
#3272