### PR TITLE
setkey reorder indices rather than drop

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 #### NEW FEATURES
 
-1. `setkey` and `setkeyv` gains new argument `update.index`. When `TRUE` provided it will retain existing indices when sorting data.table by reordering them so they are valid for newly keyed data.table. By default argument is set to `FALSE` because of overhead (relatively small but still) related to reordering indices. Closes [#1158](https://github.com/Rdatatable/data.table/issues/1158).
+1. `setkey()` and `setkeyv()` gain `keep.indices=`, [#1158](https://github.com/Rdatatable/data.table/issues/1158). This option retains any existing indices (i.e. secondary keys) by reordering them appropriately given the new row order. This is more efficient and more convenient than creating indices anew after the `setkey()`. This option is experimental, subject to change and currently `FALSE` by default. The default may be changed to `TRUE` in future via a global option such as `datatable.keep.indices`.
 
 #### BUG FIXES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 #### NEW FEATURES
 
+1. `setkey` and `setkeyv` gains new argument `update.index`. When `TRUE` provided it will retain existing indices when sorting data.table by reordering them so they are valid for newly keyed data.table. By default argument is set to `FALSE` because of overhead (relatively small but still) related to reordering indices. Closes [#1158](https://github.com/Rdatatable/data.table/issues/1158).
+
 #### BUG FIXES
 
 #### NOTES

--- a/R/setkey.R
+++ b/R/setkey.R
@@ -98,9 +98,10 @@ setkeyv <- function(x, cols, verbose=getOption("datatable.verbose"), physical=TR
       if (!update.index) setattr(x,"index",NULL)
       else if (!is.null(IDX<-attr(x,"index",exact=TRUE))) { # setkeyv capable to reorder index #1158
         tt = system.time({
+          oo = order(o)
           for (idx in names(attributes(IDX))) {
             io = attr(IDX, idx, exact=TRUE)
-            setattr(IDX, idx, if (length(io)) order(o)[io] else o)
+            setattr(IDX, idx, if (length(io)) oo[io] else o)
           }
         })
         cat("reorder indices took", tt["user.self"]+tt["sys.self"], "sec\n")
@@ -110,9 +111,10 @@ setkeyv <- function(x, cols, verbose=getOption("datatable.verbose"), physical=TR
     } else {
       if (!update.index) setattr(x,"index",NULL)
       else if(!is.null(IDX<-attr(x,"index",exact=TRUE))) { # setkeyv capable to reorder index #1158
+        oo = order(o)
         for (idx in names(attributes(IDX))) {
           io = attr(IDX, idx, exact=TRUE)
-          setattr(IDX, idx, if (length(io)) order(o)[io] else o)
+          setattr(IDX, idx, if (length(io)) oo[io] else o)
         }
       }
       .Call(Creorder,x,o)

--- a/R/setkey.R
+++ b/R/setkey.R
@@ -1,10 +1,10 @@
-setkey <- function(x, ..., verbose=getOption("datatable.verbose"), physical=TRUE, update.index=FALSE)
+setkey <- function(x, ..., verbose=getOption("datatable.verbose"), physical=TRUE, keep.indices=FALSE)
 {
   if (is.character(x)) stop("x may no longer be the character name of the data.table. The possibility was undocumented and has been removed.")
   cols = as.character(substitute(list(...))[-1L])
   if (!length(cols)) { cols=colnames(x) }
   else if (identical(cols,"NULL")) cols=NULL
-  setkeyv(x, cols, verbose=verbose, physical=physical, update.index=update.index)
+  setkeyv(x, cols, verbose=verbose, physical=physical, keep.indices=keep.indices)
 }
 
 # FR #1442
@@ -28,7 +28,7 @@ key2 <- function(x) {
   stop("key2() is now deprecated. Please use indices() instead.")
 }
 
-setkeyv <- function(x, cols, verbose=getOption("datatable.verbose"), physical=TRUE, update.index=FALSE)
+setkeyv <- function(x, cols, verbose=getOption("datatable.verbose"), physical=TRUE, keep.indices=FALSE)
 {
   if (is.null(cols)) {   # this is done on a data.frame when !cedta at top of [.data.table
     if (physical) setattr(x,"sorted",NULL)
@@ -45,7 +45,7 @@ setkeyv <- function(x, cols, verbose=getOption("datatable.verbose"), physical=TR
   }
   if (identical(cols,"")) stop("cols is the empty string. Use NULL to remove the key.")
   if (!all(nzchar(cols))) stop("cols contains some blanks.")
-  if (!(identical(update.index,TRUE) || identical(update.index,FALSE))) stop("update.index must be TRUE or FALSE")
+  if (!(identical(keep.indices,TRUE) || identical(keep.indices,FALSE))) stop("keep.indices must be TRUE or FALSE")
   if (!length(cols)) {
     cols = colnames(x)   # All columns in the data.table, usually a few when used in this form
   } else {
@@ -95,7 +95,7 @@ setkeyv <- function(x, cols, verbose=getOption("datatable.verbose"), physical=TR
   }
   if (length(o)) {
     if (verbose) {
-      if (!update.index) setattr(x,"index",NULL)
+      if (!keep.indices) setattr(x,"index",NULL)
       else if (!is.null(IDX<-attr(x,"index",exact=TRUE))) { # setkeyv capable to reorder index #1158
         tt = system.time({
           oo = order(o)
@@ -109,7 +109,7 @@ setkeyv <- function(x, cols, verbose=getOption("datatable.verbose"), physical=TR
       tt = suppressMessages(system.time(.Call(Creorder,x,o)))
       cat("reorder took", tt["user.self"]+tt["sys.self"], "sec\n")
     } else {
-      if (!update.index) setattr(x,"index",NULL)
+      if (!keep.indices) setattr(x,"index",NULL)
       else if(!is.null(IDX<-attr(x,"index",exact=TRUE))) { # setkeyv capable to reorder index #1158
         oo = order(o)
         for (idx in names(attributes(IDX))) {

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -13352,13 +13352,13 @@ setindexv(d1, "b")
 setindexv(d2, "b")
 setkeyv(d1, "a")
 setindexv(d1, "b")
-test(1981.11, getindex(setkeyv(d2, "a", keep.indices=TRUE, verbose=TRUE), "b"), getindex(d1, "b"), output="forder took.*reorder indices took.*reorder took.*")
+test(1981.11, getindex(setkeyv(d2, "a", keep.indices=TRUE, verbose=TRUE), "b"), getindex(d1, "b"), output="forder took.*reorder indices took.*reorder rows took.*")
 d1 = data.table(a=c(2L,1L,3L), b=1:3) # some verbose branch coverage and check !length(io) branch
 d2 = copy(d1)
 setkeyv(d1, "a")
 setindexv(d1, "b")
 setindexv(d2, "b")
-test(1981.12, getindex(setkeyv(d2, "a", keep.indices=TRUE, verbose=TRUE), "b"), getindex(d1, "b"), output="forder took.*reorder indices took.*reorder took.*")
+test(1981.12, getindex(setkeyv(d2, "a", keep.indices=TRUE, verbose=TRUE), "b"), getindex(d1, "b"), output="forder took.*reorder indices took.*reorder rows took.*")
 
 
 ###################################

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -10904,7 +10904,7 @@ test(1775.3, capture.output(print(DT2, print.keys = TRUE)),
 setkey(DT2, a)
 setindexv(DT2, c("b","a"))
 test(1775.4, capture.output(print(DT2, print.keys = TRUE)),
-     c("Key: <a>", "Index: <b__a>", "   a b", "1: 1 4", "2: 2 5", "3: 3 6"))
+     c("Key: <a>", "Indices: <b__a>, <b>", "   a b", "1: 1 4", "2: 2 5", "3: 3 6")) # test updated during #1158 because DT2 was already sorted by 'a', index retained even when update.index=FALSE
 
 # dev regression #2285
 cat("A  B  C\n1  2  3\n4  5  6", file=f<-tempfile())
@@ -13301,6 +13301,56 @@ test(1977.3, DT["D"], data.table(ID="D", GRP=NA_integer_, X=NA_real_, key="ID"))
 test(1977.4, DT["D", -"GRP"], data.table(ID="D", X=NA_real_, key="ID"))
 test(1977.5, DT["D", c("ID","GRP")], data.table(ID="D", GRP=NA_integer_, key="ID"))
 test(1977.6, DT[c("A","D"), c("ID","GRP")], data.table(ID=c("A","A","D"), GRP=INT(1,1,NA)))
+
+# setkey update.index=TRUE #1158
+d1 = data.table(a=5:1,b=c(1L,3L,2L,5L,4L),c=c(2:3,1L,5L,4L))
+d2 = copy(d1)
+setindexv(d1, "b")
+setindexv(d1, c("c","b"))
+setindexv(d2, "b")
+setindexv(d2, c("c","b"))
+setkeyv(d1, "a")
+test(1978.1, indices(d1), NULL) # index removed when update.index=FALSE
+setkeyv(d2, "a", update.index=TRUE)
+test(1978.2, indices(d2, vectors=TRUE), list("b", c("c","b")))
+setindexv(d1, "b")
+setindexv(d1, c("c","b"))
+test(1978.3, getindex(d1, "b"), getindex(d2, "b"))
+test(1978.4, getindex(d1, c("c","b")), getindex(d2, c("c","b")))
+d = data.table(a=1:3, b=3:1) # index retained even when update.index=FALSE because there was no re-order, so no update required, data already sorted, old test 1775.4 affected
+setindexv(d, "b")
+setkeyv(d, "a")
+test(1978.5, indices(d), "b")
+d1 = data.table(a=c(2L,1L,3L), b=1:3) # check !length(io) branch
+d2 = copy(d1)
+setkeyv(d1, "a")
+setindexv(d1, "b")
+setindexv(d2, "b")
+setkeyv(d2, "a", update.index=TRUE)
+test(1978.6, getindex(d1, "b"), getindex(d2, "b"))
+d1 = data.table(a=5:1, b=c(1:2,1:2,1L)) # indexes might not be identical due to within groups order mismatch
+d2 = copy(d1)
+setindexv(d1, "b")
+setindexv(d2, "b")
+setkeyv(d1, "a")
+test(1978.7, indices(d1), NULL) # index removed when update.index=FALSE
+setkeyv(d2, "a", update.index=TRUE)
+test(1978.8, indices(d2, vectors=TRUE), list("b"))
+setindexv(d1, "b")
+test(1978.9, d1[getindex(d1, "b")]$b, d2[getindex(d2, "b")]$b) # indexes are not identical but they sort column "b" identically
+d1 = data.table(a=5:1,b=c(1L,3L,2L,5L,4L),c=c(2:3,1L,5L,4L)) # some verbose branch coverage
+d2 = copy(d1)
+setindexv(d1, "b")
+setindexv(d2, "b")
+setkeyv(d1, "a")
+setindexv(d1, "b")
+test(1978.10, identical(getindex(d1, "b"), getindex(setkeyv(d2, "a", update.index=TRUE), "b")), output="forder took.*reorder indices took.*reorder took.*")
+d1 = data.table(a=c(2L,1L,3L), b=1:3) # some verbose branch coverage and check !length(io) branch
+d2 = copy(d1)
+setkeyv(d1, "a")
+setindexv(d1, "b")
+setindexv(d2, "b")
+test(1978.11, identical(getindex(d1, "b"), getindex(setkeyv(d2, "a", update.index=TRUE, verbose=TRUE), "b")), output="forder took.*reorder indices took.*reorder took.*")
 
 
 ###################################

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -13344,13 +13344,13 @@ setindexv(d1, "b")
 setindexv(d2, "b")
 setkeyv(d1, "a")
 setindexv(d1, "b")
-test(1978.10, identical(getindex(d1, "b"), getindex(setkeyv(d2, "a", update.index=TRUE), "b")), output="forder took.*reorder indices took.*reorder took.*")
+test(1978.10, getindex(setkeyv(d2, "a", update.index=TRUE, verbose=TRUE), "b"), getindex(d1, "b"), output="forder took.*reorder indices took.*reorder took.*")
 d1 = data.table(a=c(2L,1L,3L), b=1:3) # some verbose branch coverage and check !length(io) branch
 d2 = copy(d1)
 setkeyv(d1, "a")
 setindexv(d1, "b")
 setindexv(d2, "b")
-test(1978.11, identical(getindex(d1, "b"), getindex(setkeyv(d2, "a", update.index=TRUE, verbose=TRUE), "b")), output="forder took.*reorder indices took.*reorder took.*")
+test(1978.11, getindex(setkeyv(d2, "a", update.index=TRUE, verbose=TRUE), "b"), getindex(d1, "b"), output="forder took.*reorder indices took.*reorder took.*")
 
 
 ###################################

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -13336,7 +13336,7 @@ setindexv(d1, "b")
 setindexv(d2, "b")
 setkeyv(d2, "a", keep.indices=TRUE)
 test(1981.6, getindex(d1, "b"), getindex(d2, "b"))
-d1 = data.table(a=5:1, b=c(1:2,1:2,1L)) # indexes might not be identical due to within groups order mismatch
+d1 = data.table(a=5:1, b=c(1:2,1:2,1L)) # indexes must be just as if setindexv() were run after the setkey (within-group order)
 d2 = copy(d1)
 setindexv(d1, "b")
 setindexv(d2, "b")
@@ -13345,7 +13345,7 @@ test(1981.7, indices(d1), NULL) # index removed when keep.indices=FALSE
 setkeyv(d2, "a", keep.indices=TRUE)
 test(1981.8, indices(d2, vectors=TRUE), list("b"))
 setindexv(d1, "b")
-test(1981.9, d1[getindex(d1, "b")]$b, d2[getindex(d2, "b")]$b) # indexes are not identical but they sort column "b" identically
+test(1981.9, getindex(d1, "b"), getindex(d2, "b"))  # reordered index must be identical to rebuilt index
 d1 = data.table(a=5:1,b=c(1L,3L,2L,5L,4L),c=c(2:3,1L,5L,4L)) # some verbose branch coverage
 d2 = copy(d1)
 setindexv(d1, "b")

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -10899,7 +10899,7 @@ test(1775.3, capture.output(print(DT2, print.keys = TRUE)),
 setkey(DT2, a)
 setindexv(DT2, c("b","a"))
 test(1775.4, capture.output(print(DT2, print.keys = TRUE)),
-     c("Key: <a>", "Indices: <b__a>, <b>", "   a b", "1: 1 4", "2: 2 5", "3: 3 6")) # test updated during #1158 because DT2 was already sorted by 'a', index retained even when update.index=FALSE
+     c("Key: <a>", "Indices: <b__a>, <b>", "   a b", "1: 1 4", "2: 2 5", "3: 3 6")) # test updated during #1158 because DT2 was already sorted by 'a', index retained even when keep.indices=FALSE
 
 # dev regression #2285
 cat("A  B  C\n1  2  3\n4  5  6", file=f<-tempfile())
@@ -13310,7 +13310,7 @@ test(1979, DT[,.(a,b,if(FALSE)c)], DT[,c("a","b")])
 x <- as.array(1:5)
 test(1980, names(data.table(x)), "x")
 
-# setkey update.index=TRUE #1158
+# setkey keep.indices=TRUE #1158
 d1 = data.table(a=5:1,b=c(1L,3L,2L,5L,4L),c=c(2:3,1L,5L,4L))
 d2 = copy(d1)
 setindexv(d1, "b")
@@ -13318,14 +13318,14 @@ setindexv(d1, c("c","b"))
 setindexv(d2, "b")
 setindexv(d2, c("c","b"))
 setkeyv(d1, "a")
-test(1981.1, indices(d1), NULL) # index removed when update.index=FALSE
-setkeyv(d2, "a", update.index=TRUE)
+test(1981.1, indices(d1), NULL) # index removed when keep.indices=FALSE
+setkeyv(d2, "a", keep.indices=TRUE)
 test(1981.2, indices(d2, vectors=TRUE), list("b", c("c","b")))
 setindexv(d1, "b")
 setindexv(d1, c("c","b"))
 test(1981.3, getindex(d1, "b"), getindex(d2, "b"))
 test(1981.4, getindex(d1, c("c","b")), getindex(d2, c("c","b")))
-d = data.table(a=1:3, b=3:1) # index retained even when update.index=FALSE because there was no re-order, so no update required, data already sorted, old test 1775.4 affected
+d = data.table(a=1:3, b=3:1) # index retained even when keep.indices=FALSE because there was no re-order, so no update required, data already sorted, old test 1775.4 affected
 setindexv(d, "b")
 setkeyv(d, "a")
 test(1981.5, indices(d), "b")
@@ -13334,15 +13334,15 @@ d2 = copy(d1)
 setkeyv(d1, "a")
 setindexv(d1, "b")
 setindexv(d2, "b")
-setkeyv(d2, "a", update.index=TRUE)
+setkeyv(d2, "a", keep.indices=TRUE)
 test(1981.6, getindex(d1, "b"), getindex(d2, "b"))
 d1 = data.table(a=5:1, b=c(1:2,1:2,1L)) # indexes might not be identical due to within groups order mismatch
 d2 = copy(d1)
 setindexv(d1, "b")
 setindexv(d2, "b")
 setkeyv(d1, "a")
-test(1981.7, indices(d1), NULL) # index removed when update.index=FALSE
-setkeyv(d2, "a", update.index=TRUE)
+test(1981.7, indices(d1), NULL) # index removed when keep.indices=FALSE
+setkeyv(d2, "a", keep.indices=TRUE)
 test(1981.8, indices(d2, vectors=TRUE), list("b"))
 setindexv(d1, "b")
 test(1981.9, d1[getindex(d1, "b")]$b, d2[getindex(d2, "b")]$b) # indexes are not identical but they sort column "b" identically
@@ -13352,13 +13352,13 @@ setindexv(d1, "b")
 setindexv(d2, "b")
 setkeyv(d1, "a")
 setindexv(d1, "b")
-test(1981.11, getindex(setkeyv(d2, "a", update.index=TRUE, verbose=TRUE), "b"), getindex(d1, "b"), output="forder took.*reorder indices took.*reorder took.*")
+test(1981.11, getindex(setkeyv(d2, "a", keep.indices=TRUE, verbose=TRUE), "b"), getindex(d1, "b"), output="forder took.*reorder indices took.*reorder took.*")
 d1 = data.table(a=c(2L,1L,3L), b=1:3) # some verbose branch coverage and check !length(io) branch
 d2 = copy(d1)
 setkeyv(d1, "a")
 setindexv(d1, "b")
 setindexv(d2, "b")
-test(1981.12, getindex(setkeyv(d2, "a", update.index=TRUE, verbose=TRUE), "b"), getindex(d1, "b"), output="forder took.*reorder indices took.*reorder took.*")
+test(1981.12, getindex(setkeyv(d2, "a", keep.indices=TRUE, verbose=TRUE), "b"), getindex(d1, "b"), output="forder took.*reorder indices took.*reorder took.*")
 
 
 ###################################

--- a/man/setkey.Rd
+++ b/man/setkey.Rd
@@ -36,8 +36,8 @@ if none exist.
 the \code{data.table} has a key (or not).
 }
 \usage{
-setkey(x, \dots, verbose=getOption("datatable.verbose"), physical = TRUE, update.index = FALSE)
-setkeyv(x, cols, verbose=getOption("datatable.verbose"), physical = TRUE, update.index = FALSE)
+setkey(x, \dots, verbose=getOption("datatable.verbose"), physical = TRUE, keep.indices = FALSE)
+setkeyv(x, cols, verbose=getOption("datatable.verbose"), physical = TRUE, keep.indices = FALSE)
 setindex(\dots)
 setindexv(x, cols, verbose=getOption("datatable.verbose"))
 key(x)
@@ -56,9 +56,8 @@ names.}
 \item{verbose}{ Output status and information. }
 \item{physical}{ TRUE changes the order of the data in RAM. FALSE adds a
 secondary key a.k.a. index. }
-\item{update.index}{ logical, defaults to FALSE, when TRUE it will retain indices after sorting. }
-\item{vectors}{ logical scalar default \code{FALSE}, when set to \code{TRUE}
-then list of character vectors is returned, each vector refers to one index. }
+\item{keep.indices}{ The default \code{FALSE} drops existing indices because they are not valid for the new row order. \code{TRUE} will retain existing indices by reordering them appropriately. This is more efficient than recreating the indices anew after \code{setkey}, especially for indexes of many columns and/or high cardinality. }
+\item{vectors}{ Logical scalar default \code{FALSE}, when set to \code{TRUE} then list of character vectors is returned, each vector refers to one index. }
 }
 \details{
 \code{setkey} reorders (or sorts) the rows of a data.table by the columns

--- a/man/setkey.Rd
+++ b/man/setkey.Rd
@@ -36,8 +36,8 @@ if none exist.
 the \code{data.table} has a key (or not).
 }
 \usage{
-setkey(x, \dots, verbose=getOption("datatable.verbose"), physical = TRUE)
-setkeyv(x, cols, verbose=getOption("datatable.verbose"), physical = TRUE)
+setkey(x, \dots, verbose=getOption("datatable.verbose"), physical = TRUE, update.index = FALSE)
+setkeyv(x, cols, verbose=getOption("datatable.verbose"), physical = TRUE, update.index = FALSE)
 setindex(\dots)
 setindexv(x, cols, verbose=getOption("datatable.verbose"))
 key(x)
@@ -56,6 +56,7 @@ names.}
 \item{verbose}{ Output status and information. }
 \item{physical}{ TRUE changes the order of the data in RAM. FALSE adds a
 secondary key a.k.a. index. }
+\item{update.index}{ logical, defaults to FALSE, when TRUE it will retain indices after sorting. }
 \item{vectors}{ logical scalar default \code{FALSE}, when set to \code{TRUE}
 then list of character vectors is returned, each vector refers to one index. }
 }


### PR DESCRIPTION
closes #1158 
has to be well reviewed, especially the part that we are unable(?) to retain identical index to the one that would be freshly build because of within groups order - test 1981.9
It would be interesting to change default to `update.index=TRUE` and see if any revdeps are failing, if there is no bug in the logic in this PR they shouldn't.