### PR TITLE
Closes #3313 -- DT[,{}] returns DT, consistent with DT[,]

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 1. `rbindlist()` of a malformed factor missing levels attribute is now a helpful error rather than a cryptic error about `STRING_ELT`, [#3315](https://github.com/Rdatatable/data.table/issues/3315). Thanks to Michael Chirico for reporting.
 
+2. `DT[,{}]` returns `DT` instead of `NULL`, which is consistent with `DT[,]`, [#3313](https://github.com/Rdatatable/data.table/issues/3313). Thanks to @MichaelChirico for reporting and @smingerson for fixing.
+
 #### NOTES
 
 1. When upgrading to 1.12.0 some Windows users might have seen `CdllVersion not found` in some circumstances. We found a way to catch that so the [helpful message](https://twitter.com/MattDowle/status/1084528873549705217) now occurs for those upgrading from versions prior to 1.12.0 too, as well as those upgrading from 1.12.0 to a later version. See item 1 in notes section of 1.12.0 below for more background.

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -338,7 +338,9 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
         stop("Variable '",jsub,"' is not found in calling scope. Looking in calling scope because you set with=FALSE. Also, please use .. symbol prefix and remove with=FALSE.")
     }
     if (root=="{") {
-      if (length(jsub) == 2L) {
+      if (length(jsub) == 1L) {
+        return(x)
+      } else if (length(jsub) == 2L) {
         jsub = jsub[[2L]]  # to allow {} wrapping of := e.g. [,{`:=`(...)},] [#376]
         root = if (is.call(jsub)) as.character(jsub[[1L]])[1L] else ""
       } else if (length(jsub) > 2L && is.call(jsub[[2L]]) && jsub[[2L]][[1L]] == ":=") {

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -10652,9 +10652,9 @@ if (getDTthreads() != 2) {
 test(1761.1, fread("1\n2\n3", fill=TRUE), data.table(V1=1:3))
 test(1761.2, fread("1\n2\n3", fill=FALSE), data.table(V1=1:3))
 
-# non-error with non-empty empty j, #2142
+# non-error with non-empty empty j, #2142 #2876
 DT = data.table(a = 1:5)
-test(1762, DT[ , {}], NULL)
+test(1762, DT[,{}], DT[,])
 
 # rbindlist empty items segfault, #2019
 x = list(list(a = 1), list(), list(a = 2))
@@ -13307,6 +13307,8 @@ set.seed(32940)
 NN=7e5; KK=4e4; TT=25
 DT = data.table( id = sample(KK, NN, TRUE), tt = sample(TT, NN, TRUE), ff = factor(sample(3, NN, TRUE)) )
 test(1978, print(DT[ , diff(ff), by = id]), error="Column 2 of item 1 has type 'factor' but has no levels; i.e. malformed.") # the print invokes rbindlist which bites
+
+
 
 
 ###################################

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -10652,7 +10652,7 @@ if (getDTthreads() != 2) {
 test(1761.1, fread("1\n2\n3", fill=TRUE), data.table(V1=1:3))
 test(1761.2, fread("1\n2\n3", fill=FALSE), data.table(V1=1:3))
 
-# non-error with non-empty empty j, #2142 #2876
+# non-error with non-empty empty j, #2142 #3313
 DT = data.table(a = 1:5)
 test(1762, DT[,{}], DT[,])
 


### PR DESCRIPTION
Closes #3313. I have reviewed [Contributing](https://github.com/Rdatatable/data.table/wiki/Contributing) several times, but this is my first PR. 

I've modified an existing test (1762) that checked `DT[,{}]` was `NULL`, rather than adding a new one. I left the original issue number next to the test and added the new one, I couldn't tell whether that was the convention.

There are some similar questions about `j={}` in #2876, but it is not clear to me what the proper behavior is for all the variations.