### PR TITLE
Add OSX to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,29 @@ warnings_are_errors: true
 r_check_args: ""
 # empty r_check_args to turn off --as-cran (on by default) as that can be slow
 
-branches:
-  only:
-    - "master"
+# branches:
+#   only:
+#     - "master"
+
+r:
+  - oldrel
+  - release
+  - devel
+
+os:
+  - linux
+  - osx
+
+matrix:
+  exclude:
+    - r: devel  # exclude osx r-devel build as it is currently unstable
+      os: osx
+
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install llvm &&
+    export PATH="/usr/local/opt/llvm/bin:$PATH" &&
+    export LDFLAGS="-L/usr/local/opt/llvm/lib" &&
+    export CFLAGS="-I/usr/local/opt/llvm/include"; fi
 
 r_packages:
   - covr
@@ -25,7 +45,10 @@ before_script:
 
 after_success:
   - travis_wait Rscript -e 'library(covr);codecov()'
-  - test $TRAVIS_REPO_SLUG == "Rdatatable/data.table" && test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && bash deploy.sh
+  - test $TRAVIS_REPO_SLUG == "Rdatatable/data.table" &&
+    test $TRAVIS_PULL_REQUEST == "false" &&
+    test $TRAVIS_BRANCH == "master" &&
+    bash deploy.sh
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ warnings_are_errors: true
 r_check_args: ""
 # empty r_check_args to turn off --as-cran (on by default) as that can be slow
 
-# branches:
-#   only:
-#     - "master"
+branches:
+  only:
+    - "master"
 
 r:
   - oldrel

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 
 2. As promised in new feature 6 of v1.11.6 Sep 2018 (see below in this file), the `datatable.CJ.names` option's default is now `TRUE`. In v1.13.0 it will be removed.
 
+3. The Travis build matrix is expanded to OSX and to the R previous major and R-devel releases [#3326](https://github.com/Rdatatable/data.table/issues/3326). An OpenMP enabled compiler is required to correctly build on OSX, therefore the homebrew llvm package is installed on the Travis (OSX) machine before R CMD build is run. The OSX build on R-devel was explicitly excluded because it's currently unstable. Thanks @marcusklik for the PR.
+
 
 ### Changes in v1.12.0  (13 Jan 2019)
 


### PR DESCRIPTION
Closes #3326.

In this PR the Travis configuration file has been updated to expand the Travis build matrix to OSX. In order to compile `data.table` on Travis OSX, an  OpenMP enabled compiler is required, so the `llvm` homebrew package is installed before running R CMD build. Also, global variables _LDFLAGS_ and _CFLAGS_ were added (for OSX) as described in the `data.table` [wiki documentation](https://github.com/Rdatatable/data.table/wiki/Installation#step-3).

In addition to adding OSX, also the _previous major release_ and _R-devel_ builds of R were selected in the Travis build matrix. The OSX _R-devel_ build was explicitly excluded from the matrix because Travis is currently not installing _R-devel_ correctly. The total number of Travis builds is now 5 for each commit on the master branch.

As can be seen from the Travis OSX build output [here](https://travis-ci.org/MarcusKlik/data.table/builds/486159786), the OSX build is executed successfully. The total build time on OSX is usually a little longer than for Linux (in this case 14-16 minutes as compared to 10 for Linux)

If the _previous major release_ and _R-devel_ builds are not required, the `r:` field can be removed from _travis.yml_.

Note that code coverage is now calculated on all 5 builds, we could adapt the _after success:_ field to run the coverage only on a linux/release build.

Thanks!