### PR TITLE
Allow to customize format of objects in 'print.data.table'

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -172,3 +172,6 @@ S3method(unique, ITime)
 # which.first
 # which.last
 
+# fmt generic to support custom printers
+export(fmt)
+S3method(fmt, default)

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -115,7 +115,7 @@ format.data.table <- function (x, ..., justify="none") {
     else if (is.atomic(x) || inherits(x,"formula")) # FR #2591 - format.data.table issue with columns of class "formula"
       paste(c(format(head(x, 6L), justify=justify, ...), if (length(x) > 6L) "..."), collapse=",")  # fix for #5435 - format has to be added here...
     else
-      paste0("<", class(x)[1L], ">")
+      fmt(x)
   }
   # FR #1091 for pretty printing of character
   # TODO: maybe instead of doing "this is...", we could do "this ... test"?
@@ -148,3 +148,10 @@ shouldPrint = function(x) {
 #   as opposed to printing a blank line, for excluding col.names per PR #1483
 cut_top = function(x) cat(capture.output(x)[-1L], sep = '\n')
 
+fmt = function(x, ...) {
+  UseMethod("fmt")
+}
+
+fmt.default = function(x) {
+  paste0("<", class(x)[1L], ">")
+}

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -152,6 +152,6 @@ fmt = function(x, ...) {
   UseMethod("fmt")
 }
 
-fmt.default = function(x) {
+fmt.default = function(x, ...) {
   paste0("<", class(x)[1L], ">")
 }

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -13313,8 +13313,8 @@ test(1980, names(data.table(x)), "x")
 fmt.myclass <- function(x, ...) paste0("<", class(x)[1L], ":", x$id, ">")
 registerS3method("fmt", "myclass", fmt.myclass)
 DT = data.table(row = 1:2, objs = list(structure(list(id = "foo"), class = "myclass"),  structure(list(id = "bar"), class = "myclass")))
-test(1981.1, print.data.table(DT), output = "myclass:foo")
-test(1981.2, print.data.table(DT), output = "myclass:bar")
+test(1981.1, print(DT), output = "myclass:foo")
+test(1981.2, print(DT), output = "myclass:bar")
 
 ###################################
 #  Add new tests above this line  #

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -13309,6 +13309,12 @@ test(1979, DT[,.(a,b,if(FALSE)c)], DT[,c("a","b")])
 x <- as.array(1:5)
 test(1980, names(data.table(x)), "x")
 
+# fmt() generic is used
+fmt.myclass <- function(x, ...) paste0("<", class(x)[1L], ":", x$id, ">")
+registerS3method("fmt", "myclass", fmt.myclass)
+DT = data.table(row = 1:2, objs = list(structure(list(id = "foo"), class = "myclass"),  structure(list(id = "bar"), class = "myclass")))
+test(1981.1, print.data.table(DT), output = "myclass:foo")
+test(1981.2, print.data.table(DT), output = "myclass:bar")
 
 ###################################
 #  Add new tests above this line  #

--- a/man/fmt.Rd
+++ b/man/fmt.Rd
@@ -1,0 +1,21 @@
+\name{fmt}
+\alias{fmt}
+\title{ Format arbitrary objects for printing in data.table }
+\description{
+    S3 method to customize the printing of non-atomic items
+    in \code{\link{print.data.table}}.
+    
+    The default method returns the first class of the object
+    (as returned by \code{\link{class()}}) in angle brackets
+    (\dQuote{<Class>}).
+}
+\usage{
+    fmt(x, ...)
+}
+\arguments{
+  \item{x}{ Anything. }
+}
+\value{
+    A single string.
+}
+

--- a/man/fmt.Rd
+++ b/man/fmt.Rd
@@ -6,7 +6,7 @@
     in \code{\link{print.data.table}}.
     
     The default method returns the first class of the object
-    (as returned by \code{\link{class()}}) in angle brackets
+    (as returned by \code{\link{class}}) in angle brackets
     (\dQuote{<Class>}).
 }
 \usage{
@@ -14,6 +14,7 @@
 }
 \arguments{
   \item{x}{ Anything. }
+  \item{...}{ Currently ignored. }
 }
 \value{
     A single string.


### PR DESCRIPTION
This PR introduces a S3 generic (`fmt()`, name is up for discussion) which is called on non-atomic items in `print.data.table()`. This allows to customize how more complex objects are formatted.

Here is a simple example illustrating a use case:

```r
obj1 = structure(list(id = "foo"), class = "myclass")
obj2 = structure(list(id = "bar"), class = "myclass")
DT = data.table(row = 1:2, objs = list(obj1,  obj2))

print(DT)

     row      objs
   <int>    <list>
1:     1 <myclass>
2:     2 <myclass>

fmt.myclass <- function(x, ...) paste0("<", class(x)[1L], ":", x$id, ">")
registerS3method("fmt", "myclass", fmt.myclass)

print(DT)

     row          objs
   <int>        <list>
1:     1 <myclass:foo>
2:     2 <myclass:bar>
```