### PR TITLE
test arbitrary Rraw script

### DIFF
--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -1,4 +1,4 @@
-test.data.table <- function(verbose=FALSE, pkg="pkg", silent=FALSE, with.other.packages=FALSE, benchmark=FALSE) {
+test.data.table <- function(verbose=FALSE, pkg="pkg", silent=FALSE, with.other.packages=FALSE, benchmark=FALSE, Rraw=NULL) {
   if (exists("test.data.table",.GlobalEnv,inherits=FALSE)) {
     # package developer
     # nocov start
@@ -12,10 +12,15 @@ test.data.table <- function(verbose=FALSE, pkg="pkg", silent=FALSE, with.other.p
   }
   # for (fn in dir(d,"*.[rR]$",full=TRUE)) {  # testthat runs those
 
-  stopifnot( !(with.other.packages && benchmark) )
-  fn = if (with.other.packages) "other.Rraw"
-       else if (benchmark) "benchmark.Rraw"
-       else "tests.Rraw"
+  if (!is.null(Rraw)) {
+    stopifnot(is.character(Rraw), length(Rraw)==1L, !is.na(Rraw), nzchar(Rraw))
+    fn = Rraw
+  } else {
+    stopifnot( !(with.other.packages && benchmark) )
+    fn = if (with.other.packages) "other.Rraw"
+         else if (benchmark) "benchmark.Rraw"
+         else "tests.Rraw"
+  }
   fn = file.path(d, fn)
   if (!file.exists(fn)) stop(fn," does not exist")
 

--- a/man/test.data.table.Rd
+++ b/man/test.data.table.Rd
@@ -6,7 +6,8 @@
 }
 \usage{
 test.data.table(verbose=FALSE, pkg="pkg", silent=FALSE,
-                with.other.packages=FALSE, benchmark=FALSE)
+                with.other.packages=FALSE, benchmark=FALSE,
+                Rraw=NULL)
 }
 \arguments{
 \item{verbose}{ If \code{TRUE} sets datatable.verbose to \code{TRUE} for the duration of the tests. }
@@ -14,6 +15,7 @@ test.data.table(verbose=FALSE, pkg="pkg", silent=FALSE,
 \item{silent}{Logical, default \code{FALSE}, when \code{TRUE} it will not raise error on in case of test fails.}
 \item{with.other.packages}{ Run compatibility tests with other packages. }
 \item{benchmark}{ Run the benchmark script. }
+\item{Rraw}{ Run arbitrary Rraw test script. }
 }
 \details{
    Runs a series of tests. These can be used to see features and examples of usage, too. Running test.data.table will tell you the full location of the test file(s) to open.


### PR DESCRIPTION
This was removed some time ago, now when summaries etc. has been moved to `test.data.table` it is easier to maintain multiple Rraw files.
So we can have better interface for running tests that are not yet merged to `inst/tests/tests.Rraw`, eventually others can write own tests scripts to run using our `test.data.table`.