### PR TITLE
new make uninstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,5 +38,5 @@ test:
 
 .PHONY: check
 check:
-	$(R) CMD check data.table_1.12.1.tar.gz --as-cran --ignore-vignettes --no-stop-on-test-error
+	_R_CHECK_CRAN_INCOMING_REMOTE_=false $(R) CMD check data.table_1.12.1.tar.gz --as-cran --ignore-vignettes --no-stop-on-test-error
 

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,10 @@ build:
 install:
 	$(R) CMD INSTALL data.table_1.12.1.tar.gz
 
+.PHONY: uninstall
+uninstall:
+	$(R) CMD REMOVE data.table
+
 .PHONY: test
 test:
 	$(R) -e 'require(data.table); test.data.table()'

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ install:
 
 .PHONY: uninstall
 uninstall:
-	$(R) CMD REMOVE data.table
+	$(R) CMD REMOVE data.table || true
 
 .PHONY: test
 test:


### PR DESCRIPTION
We have `install` so we can also have `uninstall`. It will be faster to type. When working on multiple branches it is pretty handy when running checks in one console to prepare command in another one, like 
```sh
git checkout master && 
  git pull upstream master &&
  git checkout -b newbranch &&
  make uninstall && # this instead of (R CMD REMOVE data.table || true)
  R -q -e 'cc()' &&
  git add newfile &&
  git --no-pager diff --cached &&
  make build &&
  make install &&
  make check
```
then it is just commit and push left to do.
also relaxed `make check` for CRAN incoming remote FALSE.