### PR TITLE
Update setDT.Rd

### DIFF
--- a/man/setDT.Rd
+++ b/man/setDT.Rd
@@ -12,7 +12,7 @@ setDT(x, keep.rownames=FALSE, key=NULL, check.names=FALSE)
 }
 \arguments{
   \item{x}{ A named or unnamed \code{list}, \code{data.frame} or \code{data.table}. }
-  \item{keep.rownames}{ For \code{data.frame}s, \code{TRUE} retains the \code{data.frame}'s row names under a new column \code{rn}. }
+  \item{keep.rownames}{ For \code{data.frame}s, \code{TRUE} retains the \code{data.frame}'s row names under a new column \code{rn}. \code{keep.rownames = "id"} names the column \code{"id"} instead. } 
   \item{key}{Character vector of one or more column names which is passed to \code{\link{setkeyv}}. It may be a single comma separated string such as \code{key="x,y,z"}, or a vector of names such as \code{key=c("x","y","z")}. }
   \item{check.names}{ Just as \code{check.names} in \code{\link{data.frame}}. }
 }


### PR DESCRIPTION
Keep `?setDT` docs consistent with `?as.data.table` regarding the fact that `keep.rownames` accepts not only a Boolean rather you can pass it a new column name.

Mentioned on SO under a high volume Q/A by @snoram [here](https://stackoverflow.com/questions/29511215/convert-row-names-into-first-column/29511387?noredirect=1#comment95868434_29511387)