### PR TITLE
add -O0 and -O3 jobs to CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -91,7 +91,7 @@ build: # build data.table sources as tar.gz archive
   tags:
     - macosx
 
-test-rel: #  most comprehensive tests, force all suggests, also integration tests
+test-rel-lin: #  most comprehensive tests, force all suggests, also integration tests, using gcc -O3
   <<: *test-lin
   image: registry.gitlab.com/jangorecki/dockerfiles/r-builder
   variables: # unlike CRAN
@@ -100,6 +100,10 @@ test-rel: #  most comprehensive tests, force all suggests, also integration test
     _R_CHECK_FORCE_SUGGESTS_: "TRUE"
     OPENBLAS_MAIN_FREE: "1"
     TEST_DATA_TABLE_WITH_OTHER_PACKAGES: "TRUE"
+  before_script:
+    - mkdir -p ~/.R
+    - echo 'CFLAGS=-g -O3 -fopenmp -Wall -pedantic -fstack-protector-strong -D_FORTIFY_SOURCE=2' > ~/.R/Makevars
+    - echo 'CXXFLAGS=-g -O3 -fopenmp -Wall -pedantic -fstack-protector-strong -D_FORTIFY_SOURCE=2' >> ~/.R/Makevars
   script:
     - Rscript -e 'source("ci.R"); install.packages(dcf.dependencies(c("DESCRIPTION","inst/tests/tests-DESCRIPTION"), which="all"))'
     - *copy-src
@@ -109,11 +113,15 @@ test-rel: #  most comprehensive tests, force all suggests, also integration test
     - R CMD check $(ls -1t data.table_*.tar.gz | head -n 1)
     - *cleanup-src
 
-test-rel-vanilla: # minimal installation, no suggested deps, no vignettes or manuals, measure memory
+test-rel-vanilla-lin: # minimal installation, no suggested deps, no vignettes or manuals, measure memory, using gcc -O0 -fno-openmp
   <<: *test-lin
   image: registry.gitlab.com/jangorecki/dockerfiles/r-base-dev
   variables:
     TEST_DATA_TABLE_MEMTEST: "TRUE"
+  before_script:
+    - mkdir -p ~/.R
+    - echo 'CFLAGS=-g -O0 -fno-openmp -Wall -pedantic -fstack-protector-strong -D_FORTIFY_SOURCE=2' > ~/.R/Makevars
+    - echo 'CXXFLAGS=-g -O0 -fno-openmp -Wall -pedantic -fstack-protector-strong -D_FORTIFY_SOURCE=2' >> ~/.R/Makevars
   script:
     - *copy-src
     - rm -r bus
@@ -122,7 +130,7 @@ test-rel-vanilla: # minimal installation, no suggested deps, no vignettes or man
     - R CMD check --no-manual --ignore-vignettes $(ls -1t data.table_*.tar.gz | head -n 1)
     - *cleanup-src
 
-test-rel-lin: # currently released R on Linux
+test-rel-cran-lin: # currently released R on Linux
   <<: *test-lin
   image: registry.gitlab.com/jangorecki/dockerfiles/r-builder
   variables:
@@ -139,7 +147,7 @@ test-rel-lin: # currently released R on Linux
     - >-
         Rscript -e 'l<-readLines("data.table.Rcheck/00check.log"); if (!identical(l[length(l)], "Status: OK")) stop("Last line of ", shQuote("00check.log"), " is not ", shQuote("Status: OK"), " but ", shQuote(toString(l[length(l)]))) else q("no")'
 
-test-dev-lin: # R-devel on Linux
+test-dev-cran-lin: # R-devel on Linux
   <<: *test-lin
   image: registry.gitlab.com/jangorecki/dockerfiles/r-devel
   allow_failure: false
@@ -155,7 +163,7 @@ test-dev-lin: # R-devel on Linux
     - R CMD check --as-cran $(ls -1t data.table_*.tar.gz | head -n 1)
     - *cleanup-src
 
-test-310-lin: # test stated R dependency (3.1.0) using Linux
+test-310-cran-lin: # test stated R dependency (3.1.0) using Linux
   <<: *test-lin
   image: registry.gitlab.com/jangorecki/dockerfiles/r-3.1.0
   variables:
@@ -232,11 +240,11 @@ integration: # merging all artifacts to produce single R repository and summarie
   dependencies:
   - mirror-packages
   - build
-  - test-rel
   - test-rel-lin
-  - test-dev-lin
-  - test-rel-vanilla
-  - test-310-lin
+  - test-rel-cran-lin
+  - test-dev-cran-lin
+  - test-rel-vanilla-lin
+  - test-310-cran-lin
   - test-rel-win
   - test-dev-win
   #- test-rel-osx
@@ -288,7 +296,7 @@ integration: # merging all artifacts to produce single R repository and summarie
     # web/checks/$pkg/$job: 00install.out, 00check.log, *.Rout, memtest.csv, memtest.png
     - Rscript -e 'sapply(names(test.jobs), check.copy, simplify=FALSE)'
     # web/packages/$pkg/$pkg.pdf
-    - Rscript -e 'pdf.copy("data.table", "test-rel")'
+    - Rscript -e 'pdf.copy("data.table", "test-rel-lin")'
     # web/checks/check_results_$pkg.html
     - Rscript -e 'check.index("data.table", names(test.jobs))'
     # cleanup artifacts from other jobs


### PR DESCRIPTION
two jobs gets -O0 or -O3 and first one also -fno-openmp. closes #3361
minor rename of jobs to to align pattern.