### PR TITLE
Print zero-column data.frame properly

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@
 
 4. The Travis build matrix is expanded to OSX and to the R previous major and R-devel releases [#3326](https://github.com/Rdatatable/data.table/issues/3326). An OpenMP enabled compiler is required to correctly build on OSX, therefore the homebrew llvm package is installed on the Travis (OSX) machine before R CMD build is run. The OSX build on R-devel was explicitly excluded because it's currently unstable. Thanks @marcusklik for the PR.
 
+5. Improve `print.data.table()` to handle `data.frame` with 0 column properly.
+   Thanks @heavywatal for the PR.
 
 ### Changes in v1.12.0  (13 Jan 2019)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,8 +20,8 @@
 
 4. The Travis build matrix is expanded to OSX and to the R previous major and R-devel releases [#3326](https://github.com/Rdatatable/data.table/issues/3326). An OpenMP enabled compiler is required to correctly build on OSX, therefore the homebrew llvm package is installed on the Travis (OSX) machine before R CMD build is run. The OSX build on R-devel was explicitly excluded because it's currently unstable. Thanks @marcusklik for the PR.
 
-5. Improve `print.data.table()` to handle `data.frame` with 0 column properly.
-   Thanks @heavywatal for the PR.
+5. Calling `data.table:::print.data.table()` directly (i.e. bypassing method dispatch by using 3 colons) and passing it a 0-column `data.frame` (not `data.table`) now works, [#3363](https://github.com/Rdatatable/data.table/pull/3363). Thanks @heavywatal for the PR.
+
 
 ### Changes in v1.12.0  (13 Jan 2019)
 

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -42,9 +42,9 @@ print.data.table <- function(x, topn=getOption("datatable.print.topn"),
     cat("Ind", if (length(ixs) > 1L) "ices" else "ex", ": <",
       paste(ixs, collapse=">, <"), ">\n", sep="")
   }
-  if (nrow(x) == 0L) {
+  if (any(dim(x) == 0L)) {
     if (length(x)==0L)
-       cat("Null data.table (0 rows and 0 cols)\n")  # See FAQ 2.5 and NEWS item in v1.8.9
+       cat("Null data.table (", dim(x)[1L], " rows and 0 cols)\n", sep = "")  # See FAQ 2.5 and NEWS item in v1.8.9
     else
        cat("Empty data.table (0 rows) of ",length(x)," col",if(length(x)>1L)"s",": ",paste(head(names(x),6L),collapse=","),if(ncol(x)>6L)"...","\n",sep="")
     return(invisible(x))

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -42,11 +42,12 @@ print.data.table <- function(x, topn=getOption("datatable.print.topn"),
     cat("Ind", if (length(ixs) > 1L) "ices" else "ex", ": <",
       paste(ixs, collapse=">, <"), ">\n", sep="")
   }
-  if (any(dim(x) == 0L)) {
-    if (length(x)==0L)
-       cat("Null data.table (", dim(x)[1L], " rows and 0 cols)\n", sep = "")  # See FAQ 2.5 and NEWS item in v1.8.9
+  if (any(dim(x)==0L)) {
+    class = if (is.data.table(x)) "table" else "frame"  # a data.frame could be passed to print.data.table() directly, #3363
+    if (all(dim(x)==0L))
+      cat("Null data.",class," (0 rows and 0 cols)\n", sep="")  # See FAQ 2.5 and NEWS item in v1.8.9
     else
-       cat("Empty data.table (0 rows) of ",length(x)," col",if(length(x)>1L)"s",": ",paste(head(names(x),6L),collapse=","),if(ncol(x)>6L)"...","\n",sep="")
+      cat("Empty data.",class," (", dim(x)[1L], " rows and ",length(x)," cols): ",paste(head(names(x),6L),collapse=","),if(ncol(x)>6L)"...","\n",sep="")
     return(invisible(x))
   }
   if ((topn*2+1)<nrow(x) && (nrow(x)>nrows || !topnmiss)) {

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -44,10 +44,13 @@ print.data.table <- function(x, topn=getOption("datatable.print.topn"),
   }
   if (any(dim(x)==0L)) {
     class = if (is.data.table(x)) "table" else "frame"  # a data.frame could be passed to print.data.table() directly, #3363
-    if (all(dim(x)==0L))
+    if (all(dim(x)==0L)) {
       cat("Null data.",class," (0 rows and 0 cols)\n", sep="")  # See FAQ 2.5 and NEWS item in v1.8.9
-    else
-      cat("Empty data.",class," (", dim(x)[1L], " rows and ",length(x)," cols): ",paste(head(names(x),6L),collapse=","),if(ncol(x)>6L)"...","\n",sep="")
+    } else {
+      cat("Empty data.",class," (", dim(x)[1L], " rows and ",length(x)," cols)", sep="")
+      if (length(x)>0L) cat(": ",paste(head(names(x),6L),collapse=","),if(length(x)>6L)"...",sep="")
+      cat("\n")
+    }
     return(invisible(x))
   }
   if ((topn*2+1)<nrow(x) && (nrow(x)>nrows || !topnmiss)) {

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -52,6 +52,7 @@ if (exists("test.data.table", .GlobalEnv, inherits=FALSE)) {
   groupingsets.data.table = data.table:::groupingsets.data.table
   dcast.data.table = data.table:::dcast.data.table
   all.equal.data.table = data.table:::all.equal.data.table
+  print.data.table = data.table:::print.data.table
 
   # Also, for functions that are masked by other packages, we need to map the data.table one. Or else,
   # the other package's function would be picked up. As above, we only need to do this because we desire
@@ -476,7 +477,7 @@ g <- quote( list( d ) )
 test(170, DT[,list(d)], DT[,eval(g)])
 
 DT = data.table(A=c(25L,85L,25L,25L,85L), B=c("a","a","b","c","c"), C=c(2,65,9,82,823))
-test(171.1, DT[B=="b"][A==85], output="Empty data.table (0 rows) of 3 cols: A,B,C")
+test(171.1, DT[B=="b"][A==85], output="Empty data.table (0 rows and 3 cols): A,B,C")
 test(171.2, DT[B=="b"][A==85,C], numeric())
 test(171.3, DT[ , data.table( A, C )[ A==25, C ] + data.table( A, C )[ A==85, C ], by=B ], data.table(B=c("a","c"),V1=c(67,905)))
 test(172, DT[ , list(3,data.table( A, C )[ A==25, C ] + data.table( A, C )[ A==85, C ]), by=B ], data.table(B=c("a","b","c"),V1=3,V2=c(67,NA,905)))
@@ -1669,9 +1670,10 @@ DT = data.table(a=1:3,v=1:6)
 test(581, DT[a<1,sum(v),by=a], data.table(a=integer(),V1=integer()))
 test(582, DT[a<1,sum(v),by=list(a)], data.table(a=integer(),V1=integer()))
 test(583, DT[a<1], DT[0])
-test(584, DT[a<1], output="Empty data.table (0 rows) of 2 cols: a,v")
-test(585, DT[a<1,list(v)], output="Empty data.table (0 rows) of 1 col: v")
-test(586, data.table(a=integer(),V1=integer()), output="Empty data.table (0 rows) of 2 cols: a,V1")
+test(584, DT[a<1], output="Empty data.table (0 rows and 2 cols): a,v")
+test(585, DT[a<1,list(v)], output="Empty data.table (0 rows and 1 cols): v")
+test(586.1, data.table(a=integer(),V1=integer()), output="Empty data.table (0 rows and 2 cols): a,V1")
+test(586.2, print.data.table(iris[,FALSE]), output="Empty data.frame (150 rows and 0 cols)")   #3363
 
 # Test that .N is available in by on empty table, also in #1945
 test(587, DT[a<1,list(sum(v),.N),by=a], data.table(a=integer(),V1=integer(),N=integer()))
@@ -2388,7 +2390,7 @@ test(867, names(ans2<-DT[,list(name1=sum(v),name2=sum(w)),by="a,b"]), c("a","b",
 test(868, ans1, ans2)
 # and related to setnames, too
 DT = data.table(a=1:3,b=1:6,key="a")
-test(869, DT[J(2,42,84),print(.SD),by=.EACHI], output="   b\n.*1.*2\n2:.*5.*Empty data.table.*of 3 cols: a,V2,V3")  # .* for when verbose mode
+test(869, DT[J(2,42,84),print(.SD),by=.EACHI], output="   b\n.*1.*2\n2:.*5.*Empty data.table [(]0 rows and 3 cols[)]: a,V2,V3")  # .* for when verbose mode
 
 # Test setnames with duplicate colnames
 DT = data.table(a=1:3,b=4:6,b=7:9)
@@ -3056,9 +3058,9 @@ test(1061, x[c(0, 3), number:=5L], ans)
 
 # bug #2440 fix - seqfault when j refers to grouping variable when results are empty
 DT = data.table(x=rep(c("a","b"),each=3),v=c(42,42,42,4,5,6))
-test(1062, DT[x %in% c('z'),list(x2=x),by=x], output="Empty data.table (0 rows) of 2 cols: x,x2")
-test(1063, DT[x %in% c('z'),list(vpaste=paste(v,collapse=','),x2=paste(x,x)),by=x], output="Empty data.table (0 rows) of 3 cols: x,vpaste,x2")
-test(1064, DT[integer(0), list(x2=x), by=x], output="Empty data.table (0 rows) of 2 cols: x,x2")
+test(1062, DT[x %in% c('z'),list(x2=x),by=x], output="Empty data.table (0 rows and 2 cols): x,x2")
+test(1063, DT[x %in% c('z'),list(vpaste=paste(v,collapse=','),x2=paste(x,x)),by=x], output="Empty data.table (0 rows and 3 cols): x,vpaste,x2")
+test(1064, DT[integer(0), list(x2=x), by=x], output="Empty data.table (0 rows and 2 cols): x,x2")
 
 # bug #2445 fix - := fails when subsetting yields NAs and with=FALSE
 X = data.table(A=1:3, B=1:6, key="A")


### PR DESCRIPTION
The attribute `$row.names` is preserved in zero-column `base::data.frame`, while not in `data.table`. I won't go deeply into this feature difference here, but just want to fix printing function.

``` r
attributes(iris[,FALSE])
#> $names
#> character(0)
#> 
#> $class
#> [1] "data.frame"
#> 
#> $row.names
#>   [1]   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17
#>  [18]  18  19  20  21  22  23  24  25  26  27  28  29  30  31  32  33  34
#>  [35]  35  36  37  38  39  40  41  42  43  44  45  46  47  48  49  50  51
#>  [52]  52  53  54  55  56  57  58  59  60  61  62  63  64  65  66  67  68
#>  [69]  69  70  71  72  73  74  75  76  77  78  79  80  81  82  83  84  85
#>  [86]  86  87  88  89  90  91  92  93  94  95  96  97  98  99 100 101 102
#> [103] 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119
#> [120] 120 121 122 123 124 125 126 127 128 129 130 131 132 133 134 135 136
#> [137] 137 138 139 140 141 142 143 144 145 146 147 148 149 150

base::print.data.frame(iris[FALSE,])
#> [1] Sepal.Length Sepal.Width  Petal.Length Petal.Width  Species     
#> <0 rows> (or 0-length row.names)
base::print.data.frame(iris[,FALSE])
#> data frame with 0 columns and 150 rows
base::print.data.frame(iris[FALSE,FALSE])
#> data frame with 0 columns and 0 rows

dtiris = data.table::data.table(iris)
attributes(dtiris[,FALSE]) # row.names are removed
#> $class
#> [1] "data.table" "data.frame"
#> 
#> $row.names
#> integer(0)
#> 
#> $names
#> character(0)
#> 
#> $.internal.selfref
#> <pointer: 0x7fb84001d8e0>

data.table:::print.data.table(dtiris[FALSE,])
#> Empty data.table (0 rows) of 5 cols: Sepal.Length,Sepal.Width,Petal.Length,Petal.Width,Species
data.table:::print.data.table(dtiris[,FALSE]) # OK, 0 rows
#> Null data.table (0 rows and 0 cols)
data.table:::print.data.table(dtiris[FALSE,FALSE])
#> Null data.table (0 rows and 0 cols)

data.table:::print.data.table(iris[,FALSE]) # Error
#> Error in `rownames<-`(`*tmp*`, value = paste0(format(rn, right = TRUE, : attempt to set 'rownames' on an object with no dimensions
```

<sup>Created on 2019-02-06 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>