### PR TITLE
Minor fix for the `.checkTypos` error message

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -202,7 +202,7 @@ replace_dot_alias <- function(e) {
     used = gsub(".*object '([^']+)'.*", "\\1", err$message)
     found = agrep(used, ref, value=TRUE, ignore.case=TRUE, fixed=TRUE)
     if (length(found)) {
-      stop("Object '", used, "' not found. Perhaps you intended ", used,
+      stop("Object '", used, "' not found. Perhaps you intended ",
            paste(head(found, 5L), collapse=", "),
            if (length(found)<=5L) "" else paste(" or",length(found)-5L, "more"))
     } else {


### PR DESCRIPTION
The (non-found) object name appears twice in the `.checkTypos` error message:
```
Error in .checkTypos(e, names(x)) : 
  Object 'exclude2' not found. Perhaps you intended exclude2exclude
```
According to git blame, this was introduced in https://github.com/Rdatatable/data.table/commit/bb28b25916c16986802ab2780e4da4bdc21c9856 after removing `sprintf`