### PR TITLE
catch backticked column names in wrap-up of keyby

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 4. Grouping `by = 'string_with_\\'` would fail, [#3319](https://github.com/Rdatatable/data.table/issues/3319). Thanks to @HughParsonage for reporting and @MichaelChirico for the fix.
 
+5. Using a column name that would internally be surrounded with backticks for processing (e.g. `"x y"`) in `keyby` would fail as the column wouldn't be recognized, [#3378](https://github.com/Rdatatable/data.table/issues/3378). Thanks to @HughParsonage for reporting and @MichaelChirico for the fix.
+
 #### NOTES
 
 1. When upgrading to 1.12.0 some Windows users might have seen `CdllVersion not found` in some circumstances. We found a way to catch that so the [helpful message](https://twitter.com/MattDowle/status/1084528873549705217) now occurs for those upgrading from versions prior to 1.12.0 too, as well as those upgrading from 1.12.0 to a later version. See item 1 in notes section of 1.12.0 below for more background.

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,9 +14,7 @@
 
 3. Default print output (top 5 and bottom 5 rows) when ncol>255 could display the columns in the wrong order, [#3306](https://github.com/Rdatatable/data.table/issues/3306). Thanks to Kun Ren for reporting.
 
-4. Grouping `by = 'string_with_\\'` would fail, [#3319](https://github.com/Rdatatable/data.table/issues/3319). Thanks to @HughParsonage for reporting and @MichaelChirico for the fix.
-
-5. Using a column name that would internally be surrounded with backticks for processing (e.g. `"x y"`) in `keyby` would fail as the column wouldn't be recognized, [#3378](https://github.com/Rdatatable/data.table/issues/3378). Thanks to @HughParsonage for reporting and @MichaelChirico for the fix.
+4. Grouping by unusual column names such as `by='string_with_\\'` and `keyby="x y"` could fail, [#3319](https://github.com/Rdatatable/data.table/issues/3319) and [#3378](https://github.com/Rdatatable/data.table/issues/3378). Thanks to @HughParsonage for reporting and @MichaelChirico for the fixes.
 
 #### NOTES
 

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -966,8 +966,8 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
               if (length(byvars) > 1L && tt %chin% all.vars(jsub, FALSE)) {
                 bynames[jj] = deparse(bysubl[[jj+1L]])
                 if (verbose)
-                  cat("by-expression '", bynames[jj], "' is not named, and the auto-generated name '", tt, "' clashed with variable(s) in j. Therefore assigning the entire by-expression as name.\n", sep="")
-
+                  cat("by-expression '", bynames[jj], "' is not named, and the auto-generated name '", tt,
+                      "' clashed with variable(s) in j. Therefore assigning the entire by-expression as name.\n", sep="")
               }
               else bynames[jj] = tt
               # if user doesn't like this inferred name, user has to use by=list() to name the column

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1850,6 +1850,9 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
     }
     if (!missing(keyby)) {
       cnames = as.character(bysubl)[-1L]
+      # ` added for quoting above, can be removed now. Some
+      #   extra care taken to only remove initial or final `.
+      cnames = gsub('^`|`$', '', cnames)
       if (all(cnames %chin% names(x))) {
         if (verbose) {last.started.at=proc.time();cat("setkey() after the := with keyby= ... ");flush.console()}
         setkeyv(x,cnames)  # TO DO: setkey before grouping to get memcpy benefit.

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1850,9 +1850,7 @@ chmatch2 <- function(x, table, nomatch=NA_integer_) {
     }
     if (!missing(keyby)) {
       cnames = as.character(bysubl)[-1L]
-      # ` added for quoting above, can be removed now. Some
-      #   extra care taken to only remove initial or final `.
-      cnames = gsub('^`|`$', '', cnames)
+      cnames = gsub('^`|`$', '', cnames)  # the wrapping backticks that were added above can be removed now, #3378
       if (all(cnames %chin% names(x))) {
         if (verbose) {last.started.at=proc.time();cat("setkey() after the := with keyby= ... ");flush.console()}
         setkeyv(x,cnames)  # TO DO: setkey before grouping to get memcpy benefit.

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -13343,7 +13343,6 @@ DT <- data.table(x=1:5, y=letters[1:5])
 setnames(DT, "x", "x y")
 test(1983.2, DT[, y:="j", keyby="x y"], data.table(`x y`=1:5, y='j', key='x y'))
 
-
 # more coverage tests
 DT = data.table(a = 1:10)
 test(1984.01, DT[NULL], data.table(NULL))

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -13332,6 +13332,12 @@ DT <- data.table(x = 1, y = 1:5)
 setnames(DT, "x", "\\phantom{.}")
 test(1983.1, DT[, .(y = mean(y)), keyby = "\\phantom{.}"],
      data.table(`\\phantom{.}` = 1, y = 3, key = '\\phantom{.}'))
+     
+# keyby = 'x y' failes, #3378
+DT <- data.table(x = 1:5, y = letters[1:5])
+setnames(DT, "x", "x y")
+test(1983.2, DT[, y := "j", keyby = "x y"],
+     data.table(`x y` = 1:5, y = 'j', key = 'x y'))
 
 ###################################
 #  Add new tests above this line  #

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -13328,16 +13328,14 @@ test(1982.2, tt, seq_along(tt))
 
 # parse(text = 'list(`\\phantom{.}`)') fails, #3319
 library(data.table)
-DT <- data.table(x = 1, y = 1:5)
+DT <- data.table(x=1, y=1:5)
 setnames(DT, "x", "\\phantom{.}")
-test(1983.1, DT[, .(y = mean(y)), keyby = "\\phantom{.}"],
-     data.table(`\\phantom{.}` = 1, y = 3, key = '\\phantom{.}'))
-     
-# keyby = 'x y' failes, #3378
-DT <- data.table(x = 1:5, y = letters[1:5])
+test(1983.1, DT[, .(y=mean(y)), keyby="\\phantom{.}"], data.table(`\\phantom{.}`=1, y=3, key='\\phantom{.}'))
+# keyby = 'x y' fails, #3378
+DT <- data.table(x=1:5, y=letters[1:5])
 setnames(DT, "x", "x y")
-test(1983.2, DT[, y := "j", keyby = "x y"],
-     data.table(`x y` = 1:5, y = 'j', key = 'x y'))
+test(1983.2, DT[, y:="j", keyby="x y"], data.table(`x y`=1:5, y='j', key='x y'))
+
 
 ###################################
 #  Add new tests above this line  #


### PR DESCRIPTION
Closes #3378 

Another kludgy duct-tape

If you ever try and name a column like ``"`this_is_my_column`"``, @HughParsonage....