### PR TITLE
[WIP] froll more robust, no nested parallelism

### DIFF
--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -280,9 +280,20 @@ test <- function(num,x,y=TRUE,error=NULL,warning=NULL,output=NULL,message=NULL) 
   }
   if (!fail && !length(error) && length(output)) {
     if (out[length(out)] == "NULL") out = out[-length(out)]
-    out = paste(out, collapse="\n")
-    output = paste(output, collapse="\n")  # so that output= can be either a \n separated string, or a vector of strings.
-    if (!string_match(output, out)) {
+    output_mismatch = FALSE
+    if (length(output)>1L && length(output)==length(out)) { # allow matching which would fail due to newline symbol in string
+      if (!all(mapply(string_match, output, out, USE.NAMES=FALSE))) {
+        output_mismatch = TRUE
+      }
+      out = paste(out, collapse="\n")
+      output = paste(output, collapse="\n")
+    } else {
+      out = paste(out, collapse="\n")
+      output = paste(output, collapse="\n")  # so that output= can be either a \n separated string, or a vector of strings.
+      if (!string_match(output, out))
+        output_mismatch = TRUE
+    }
+    if (output_mismatch) {
       # nocov start
       cat("Test",num,"didn't produce correct output:\n")
       cat("Expected: <<",gsub("\n","\\\\n",output),">>\n",sep="")  # \n printed as '\\n' so the two lines of output can be compared vertically

--- a/inst/tests/froll.Rraw
+++ b/inst/tests/froll.Rraw
@@ -299,28 +299,44 @@ test(9999.067, ans2, expected)
 #### early stopping NAs in leading k obs
 test(9999.0671, frollmean(c(1:2,NA,4:10), 4, verbose=TRUE), c(rep(NA_real_, 6), 5.5, 6.5, 7.5, 8.5), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped",
+  "frollfunR: 1 column(s) and 1 window(s), if product > 1 then entering parallel execution",
+  "frollfunR: 1:",
   "frollmeanFast: running for input length 10, window 4, hasna 0, narm 0",
-  "frollmeanFast: NA (or other non-finite) value(s) are present in input, skip non-NA attempt and run with extra care for NAs"
+  "frollmeanFast: NA (or other non-finite) value(s) are present in input, skip non-NA attempt and run with extra care for NAs",
+  "frollmean: processing.*took.*s",
+  "frollfunR: processing.*took.*s",
+  ".*[[]1[]] .*"
 ))
 test(9999.0672, frollmean(c(1:2,NA,4:10), 4, hasNA=FALSE, verbose=TRUE), c(rep(NA_real_, 6), 5.5, 6.5, 7.5, 8.5), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped",
+  "frollfunR: 1 column(s) and 1 window(s), if product > 1 then entering parallel execution",
+  "frollfunR: 1:",
   "frollmeanFast: running for input length 10, window 4, hasna -1, narm 0",
-  "frollmeanFast: NA (or other non-finite) value(s) are present in input, skip non-NA attempt and run with extra care for NAs"
+  "frollmeanFast: NA (or other non-finite) value(s) are present in input, skip non-NA attempt and run with extra care for NAs",
+  "frollmean: processing.*took.*s",
+  "frollfunR: processing.*took.*s",
+  ".*[[]1[]] .*"
 ), warning="hasNA=FALSE used but NA (or other non-finite) value(s) are present in input, use default hasNA=NA to avoid this warning")
-test(9999.0673, ans<-frollmean(c(1:2,NA,4:10), 2, hasNA=FALSE, verbose=TRUE), c(NA, 1.5, NA, NA, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5), output=c(
+test(9999.0673, frollmean(c(1:2,NA,4:10), 2, hasNA=FALSE, verbose=TRUE), c(NA, 1.5, NA, NA, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped",
+  "frollfunR: 1 column(s) and 1 window(s), if product > 1 then entering parallel execution",
+  "frollfunR: 1:",
   "frollmeanFast: running for input length 10, window 2, hasna -1, narm 0",
-  "frollmeanFast: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs"
+  "frollmeanFast: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs",
+  "frollmean: processing.*took.*s",
+  "frollfunR: processing.*took.*s",
+  ".*[[]1[]] .*"
 ), warning="hasNA=FALSE used but NA (or other non-finite) value(s) are present in input, use default hasNA=NA to avoid this warning")
 test(9999.0674, frollmean(c(1:2,NA,4:10), 4, verbose=TRUE, align="center"), c(rep(NA_real_, 4), 5.5, 6.5, 7.5, 8.5, NA, NA), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped",
+  "frollfunR: 1 column(s) and 1 window(s), if product > 1 then entering parallel execution",
+  "frollfunR: 1:",
   "frollmeanFast: running for input length 10, window 4, hasna 0, narm 0",
   "frollmeanFast: NA (or other non-finite) value(s) are present in input, skip non-NA attempt and run with extra care for NAs",
-  "frollmean: align 0, shift answer by -2"
+  "frollmean: align 0, shift answer by -2",
+  "frollmean: processing.*took.*s",
+  "frollfunR: processing.*took.*s",
+  ".*[[]1[]] .*"
 ))
 
 #### fill constant
@@ -414,16 +430,24 @@ test(9999.1195, frollmean(1:5, 2, na.rm=TRUE, hasNA=FALSE), error="using hasNA F
 #### exact na.rm=TRUE adaptive=TRUE verbose=TRUE
 test(9999.1196, frollmean(c(1:5,NA), 1:6, algo="exact", na.rm=TRUE, adaptive=TRUE, verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped but 'exact' version of rolling function will compute results in parallel", 
-  "fadaptiverollmeanExact: running for input length 6, hasna 0, narm 1", 
-  "fadaptiverollmeanExact: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs"
+  "frollfunR: 1 column(s) and 1 window(s), not entering parallel execution here because algo='exact' will compute results in parallel", 
+  "frollfunR: 1:",
+  "fadaptiverollmeanExact: running in parallel for input length 6, hasna 0, narm 1", 
+  "fadaptiverollmeanExact: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs",
+  "fadaptiverollmean: processing.*took.*s",
+  "frollfunR: processing.*took.*s",
+  ".*[[]1[]] .*"
 ))
 #### exact na.rm=TRUE verbose=TRUE
 test(9999.1197, frollmean(c(1:5,NA), 2, algo="exact", na.rm=TRUE, verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped but 'exact' version of rolling function will compute results in parallel", 
-  "frollmeanExact: running for input length 6, window 2, hasna 0, narm 1", 
-  "frollmeanExact: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs"
+  "frollfunR: 1 column(s) and 1 window(s), not entering parallel execution here because algo='exact' will compute results in parallel", 
+  "frollfunR: 1:",
+  "frollmeanExact: running in parallel for input length 6, window 2, hasna 0, narm 1", 
+  "frollmeanExact: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs",
+  "frollmean: processing.*took.*s",
+  "frollfunR: processing.*took.*s",
+  ".*[[]1[]] .*"
 ))
 #### adaptive=TRUE n=character
 test(9999.1198, frollmean(1:5, n=letters[1:5], adaptive=TRUE), error="n must be integer vector or list of integer vectors")
@@ -633,82 +657,162 @@ x = 1:10
 n = 3
 test(9999.171, frollmean(x, n, verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped",
-  "frollmeanFast: running for input length 10, window 3, hasna 0, narm 0"))
+  "frollfunR: 1 column(s) and 1 window(s), if product > 1 then entering parallel execution",
+  "frollfunR: 1:",
+  "frollmeanFast: running for input length 10, window 3, hasna 0, narm 0",
+  "frollmean: processing.*took.*s",
+  "frollfunR: processing.*took.*s",
+  ".*[[]1[]] .*"))
 test(9999.172, frollmean(list(x, x+1), n, verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 2x1",
-  "frollfunR: 2 column(s) and 1 window(s), entering parallel execution, but actually single threaded due to enabled verbose which is not thread safe",
+  "frollfunR: 2 column(s) and 1 window(s), if product > 1 then entering parallel execution",
+  "frollfunR: 1:",
   "frollmeanFast: running for input length 10, window 3, hasna 0, narm 0",
-  "frollmeanFast: running for input length 10, window 3, hasna 0, narm 0"))
+  "frollmean: processing.*took.*s",
+  "frollfunR: 2:",
+  "frollmeanFast: running for input length 10, window 3, hasna 0, narm 0",
+  "frollmean: processing.*took.*s",
+  "frollfunR: processing.*took.*s",
+  "[[][[]1[]][]]",".*[[]1[]] .*", "", "[[][[]2[]][]]",".*[[]1[]] .*", ""))
 test(9999.173, frollmean(x, c(n, n+1), verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x2",
-  "frollfunR: 1 column(s) and 2 window(s), entering parallel execution, but actually single threaded due to enabled verbose which is not thread safe",
+  "frollfunR: 1 column(s) and 2 window(s), if product > 1 then entering parallel execution",
+  "frollfunR: 1:",
   "frollmeanFast: running for input length 10, window 3, hasna 0, narm 0",
-  "frollmeanFast: running for input length 10, window 4, hasna 0, narm 0"))
+  "frollmean: processing.*took.*s",
+  "frollfunR: 2:",
+  "frollmeanFast: running for input length 10, window 4, hasna 0, narm 0",
+  "frollmean: processing.*took.*s",
+  "frollfunR: processing.*took.*s",
+  "[[][[]1[]][]]",".*[[]1[]] .*", "", "[[][[]2[]][]]",".*[[]1[]] .*", ""))
 test(9999.174, frollmean(list(x, x+1), c(n, n+1), verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 2x2",
-  "frollfunR: 2 column(s) and 2 window(s), entering parallel execution, but actually single threaded due to enabled verbose which is not thread safe",
+  "frollfunR: 2 column(s) and 2 window(s), if product > 1 then entering parallel execution",
+  "frollfunR: 1:",
   "frollmeanFast: running for input length 10, window 3, hasna 0, narm 0",
-  "frollmeanFast: running for input length 10, window 4, hasna 0, narm 0"))
+  "frollmean: processing.*took.*s",
+  "frollfunR: 2:",
+  "frollmeanFast: running for input length 10, window 4, hasna 0, narm 0",
+  "frollmean: processing.*took.*s",
+  "frollfunR: 3:",
+  "frollmeanFast: running for input length 10, window 3, hasna 0, narm 0",
+  "frollmean: processing.*took.*s",
+  "frollfunR: 4:",
+  "frollmeanFast: running for input length 10, window 4, hasna 0, narm 0",
+  "frollmean: processing.*took.*s",
+  "frollfunR: processing.*took.*s",
+  "[[][[]1[]][]]",".*[[]1[]] .*", "", "[[][[]2[]][]]",".*[[]1[]] .*", "",
+  "[[][[]3[]][]]",".*[[]1[]] .*", "", "[[][[]4[]][]]",".*[[]1[]] .*", ""))
 test(9999.175, frollmean(x, n, algo="exact", verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped but 'exact' version of rolling function will compute results in parallel",
-  "frollmeanExact: running for input length 10, window 3, hasna 0, narm 0"))
+  "frollfunR: 1 column(s) and 1 window(s), not entering parallel execution here because algo='exact' will compute results in parallel",
+  "frollfunR: 1:",
+  "frollmeanExact: running in parallel for input length 10, window 3, hasna 0, narm 0",
+  "frollmean: processing.*took.*s",
+  "frollfunR: processing.*took.*s",
+  ".*[[]1[]] .*"))
 test(9999.176, frollmean(x, n, align="center", verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped",
+  "frollfunR: 1 column(s) and 1 window(s), if product > 1 then entering parallel execution",
+  "frollfunR: 1:",
   "frollmeanFast: running for input length 10, window 3, hasna 0, narm 0",
-  "frollmean: align 0, shift answer by -1"))
+  "frollmean: align 0, shift answer by -1",
+  "frollmean: processing.*took.*s",
+  "frollfunR: processing.*took.*s",
+  ".*[[]1[]] .*"))
 test(9999.177, frollmean(x, n, align="left", verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped",
+  "frollfunR: 1 column(s) and 1 window(s), if product > 1 then entering parallel execution",
+  "frollfunR: 1:",
   "frollmeanFast: running for input length 10, window 3, hasna 0, narm 0",
-  "frollmean: align -1, shift answer by -2"))
+  "frollmean: align -1, shift answer by -2",
+  "frollmean: processing.*took.*s",
+  "frollfunR: processing.*took.*s",
+  ".*[[]1[]] .*"))
 nn = c(1:4,2:3,1:4)
 test(9999.178, frollmean(x, nn, adaptive=TRUE, verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped",
-  "fadaptiverollmeanFast: running for input length 10, hasna 0, narm 0"))
+  "frollfunR: 1 column(s) and 1 window(s), if product > 1 then entering parallel execution",
+  "frollfunR: 1:",
+  "fadaptiverollmeanFast: running for input length 10, hasna 0, narm 0",
+  "fadaptiverollmean: processing.*took.*s",
+  "frollfunR: processing.*took.*s",
+  ".*[[]1[]] .*"))
 test(9999.179, frollmean(x, nn, algo="exact", adaptive=TRUE, verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped but 'exact' version of rolling function will compute results in parallel",
-  "fadaptiverollmeanExact: running for input length 10, hasna 0, narm 0"))
+  "frollfunR: 1 column(s) and 1 window(s), not entering parallel execution here because algo='exact' will compute results in parallel",
+  "frollfunR: 1:",
+  "fadaptiverollmeanExact: running in parallel for input length 10, hasna 0, narm 0",
+  "fadaptiverollmean: processing.*took.*s",
+  "frollfunR: processing.*took.*s",
+  ".*[[]1[]] .*"))
 
 x[8] = NA
 test(9999.180, frollmean(x, n, verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped",
+  "frollfunR: 1 column(s) and 1 window(s), if product > 1 then entering parallel execution",
+  "frollfunR: 1:",
   "frollmeanFast: running for input length 10, window 3, hasna 0, narm 0",
-  "frollmeanFast: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs"))
+  "frollmeanFast: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs",
+  "frollmean: processing.*took.*s",
+  "frollfunR: processing.*took.*s",
+  ".*[[]1[]] .*"))
 test(9999.181, frollmean(x, n, algo="exact", verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped but 'exact' version of rolling function will compute results in parallel",
-  "frollmeanExact: running for input length 10, window 3, hasna 0, narm 0",
-  "frollmeanExact: NA (or other non-finite) value(s) are present in input, na.rm was FALSE so in 'exact' implementation NAs were handled already, no need to re-run"))
+  "frollfunR: 1 column(s) and 1 window(s), not entering parallel execution here because algo='exact' will compute results in parallel",
+  "frollfunR: 1:",
+  "frollmeanExact: running in parallel for input length 10, window 3, hasna 0, narm 0",
+  "frollmeanExact: NA (or other non-finite) value(s) are present in input, na.rm was FALSE so in 'exact' implementation NAs were handled already, no need to re-run",
+  "frollmean: processing.*took.*s",
+  "frollfunR: processing.*took.*s",
+  ".*[[]1[]] .*"))
 test(9999.182, frollmean(x, nn, adaptive=TRUE, verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped",
+  "frollfunR: 1 column(s) and 1 window(s), if product > 1 then entering parallel execution",
+  "frollfunR: 1:",
   "fadaptiverollmeanFast: running for input length 10, hasna 0, narm 0",
-  "fadaptiverollmeanFast: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs"))
+  "fadaptiverollmeanFast: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs",
+  "fadaptiverollmean: processing.*took.*s",
+  "frollfunR: processing.*took.*s",
+  ".*[[]1[]] .*"))
 test(9999.183, frollmean(x, nn, algo="exact", adaptive=TRUE, verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped but 'exact' version of rolling function will compute results in parallel",
-  "fadaptiverollmeanExact: running for input length 10, hasna 0, narm 0",
-  "fadaptiverollmeanExact: NA (or other non-finite) value(s) are present in input, na.rm was FALSE so in 'exact' implementation NAs were handled already, no need to re-run"))
+  "frollfunR: 1 column(s) and 1 window(s), not entering parallel execution here because algo='exact' will compute results in parallel",
+  "frollfunR: 1:",
+  "fadaptiverollmeanExact: running in parallel for input length 10, hasna 0, narm 0",
+  "fadaptiverollmeanExact: NA (or other non-finite) value(s) are present in input, na.rm was FALSE so in 'exact' implementation NAs were handled already, no need to re-run",
+  "fadaptiverollmean: processing.*took.*s",
+  "frollfunR: processing.*took.*s",
+  ".*[[]1[]] .*"))
 
 d = as.data.table(list(1:10/2, 10:1/4))
 test(9999.184, frollmean(d[,1], 3, algo="exact", verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped but 'exact' version of rolling function will compute results in parallel",
-  "frollmeanExact: running for input length 10, window 3, hasna 0, narm 0"
+  "frollfunR: 1 column(s) and 1 window(s), not entering parallel execution here because algo='exact' will compute results in parallel",
+  "frollfunR: 1:",
+  "frollmeanExact: running in parallel for input length 10, window 3, hasna 0, narm 0",
+  "frollmean: processing.*took.*s",
+  "frollfunR: processing.*took.*s",
+  "[[][[]1[]][]]",".*[[]1[]] .*",""
 ))
 test(9999.185, frollmean(d, 3:4, algo="exact", verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 2x2",
-  "frollfunR: 2 column(s) and 2 window(s), entering parallel execution, but actually single threaded due to enabled verbose which is not thread safe, 'exact' version of rolling function will compute results in parallel anyway as it does not print with verbose",
-  "frollmeanExact: running for input length 10, window 3, hasna 0, narm 0",
-  "frollmeanExact: running for input length 10, window 4, hasna 0, narm 0",
-  "frollmeanExact: running for input length 10, window 3, hasna 0, narm 0",
-  "frollmeanExact: running for input length 10, window 4, hasna 0, narm 0"
+  "frollfunR: 2 column(s) and 2 window(s), not entering parallel execution here because algo='exact' will compute results in parallel",
+  "frollfunR: 1:",
+  "frollmeanExact: running in parallel for input length 10, window 3, hasna 0, narm 0",
+  "frollmean: processing.*took.*s",
+  "frollfunR: 2:",
+  "frollmeanExact: running in parallel for input length 10, window 4, hasna 0, narm 0",
+  "frollmean: processing.*took.*s",
+  "frollfunR: 3:",
+  "frollmeanExact: running in parallel for input length 10, window 3, hasna 0, narm 0",
+  "frollmean: processing.*took.*s",
+  "frollfunR: 4:",
+  "frollmeanExact: running in parallel for input length 10, window 4, hasna 0, narm 0",
+  "frollmean: processing.*took.*s",
+  "frollfunR: processing.*took.*s",
+  "[[][[]1[]][]]",".*[[]1[]] .*", "", "[[][[]2[]][]]",".*[[]1[]] .*", "",
+  "[[][[]3[]][]]",".*[[]1[]] .*", "", "[[][[]4[]][]]",".*[[]1[]] .*", ""
 ))
 
 ## test warnings

--- a/src/froll.c
+++ b/src/froll.c
@@ -12,21 +12,23 @@
  */
 
 void frollmean(unsigned int algo, double *x, uint_fast64_t nx, double_ans_t *ans, int k, int align, double fill, bool narm, int hasna, bool verbose) {
-  ans->status = 0;                                              // default status success
   if (nx < k) {                                                 // if window width bigger than input just return vector of fill values
-    if (verbose) Rprintf("%s: window width longer than input vector, returning all NA vector\n", __func__);
+    if (verbose) sprintf(ans->message[0], "%s%s: window width longer than input vector, returning all NA vector\n", ans->message[0], __func__);
     for (int i=0; i<nx; i++) ans->ans[i] = fill;
     return;
   }
+  double tic = 0;
+  if (verbose) tic = omp_get_wtime();
   if (algo==0) frollmeanFast(x, nx, ans, k, fill, narm, hasna, verbose);
   else if (algo==1) frollmeanExact(x, nx, ans, k, fill, narm, hasna, verbose);
   // align
   if (ans->status < 3 && align < 1) {                           // align center or left, only when no errors occurred
     int k_ = align==-1 ? k-1 : floor(k/2);                      // offset to shift
-    if (verbose) Rprintf("%s: align %d, shift answer by %d\n", __func__, align, -k_);
+    if (verbose) sprintf(ans->message[0], "%s%s: align %d, shift answer by %d\n", ans->message[0], __func__, align, -k_);
     memmove((char *)ans->ans, (char *)ans->ans + (k_*sizeof(double)), (nx-k_)*sizeof(double)); // apply shift to achieve expected align
     for (uint_fast64_t i=nx-k_; i<nx; i++) ans->ans[i] = fill;  // fill from right side
   }
+  if (verbose) sprintf(ans->message[0], "%s%s: processing algo %d took %.3fs\n", ans->message[0], __func__, algo, omp_get_wtime()-tic);
 }
 
 /* fast rolling mean - fast
@@ -36,7 +38,7 @@ void frollmean(unsigned int algo, double *x, uint_fast64_t nx, double_ans_t *ans
  */
 
 void frollmeanFast(double *x, uint_fast64_t nx, double_ans_t *ans, int k, double fill, bool narm, int hasna, bool verbose) {
-  if (verbose) Rprintf("%s: running for input length %llu, window %d, hasna %d, narm %d\n", __func__, nx, k, hasna, (int) narm);
+  if (verbose) sprintf(ans->message[0], "%s%s: running for input length %llu, window %d, hasna %d, narm %d\n", ans->message[0], __func__, (long long unsigned)nx, k, hasna, (int) narm);
   long double w = 0.0;                                          // sliding window aggregate
   bool truehasna = hasna>0;                                     // flag to re-run with NA support if NAs detected
   if (!truehasna) {
@@ -58,7 +60,7 @@ void frollmeanFast(double *x, uint_fast64_t nx, double_ans_t *ans, int k, double
           ans->status = 2;
           sprintf(ans->message[2], "%s: hasNA=FALSE used but NA (or other non-finite) value(s) are present in input, use default hasNA=NA to avoid this warning", __func__);
         }
-        if (verbose) Rprintf("%s: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs\n", __func__);
+        if (verbose) sprintf(ans->message[0], "%s%s: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs\n", ans->message[0], __func__);
         w = 0.0;
         truehasna = true;
       }
@@ -67,7 +69,7 @@ void frollmeanFast(double *x, uint_fast64_t nx, double_ans_t *ans, int k, double
         ans->status = 2;
         sprintf(ans->message[2], "%s: hasNA=FALSE used but NA (or other non-finite) value(s) are present in input, use default hasNA=NA to avoid this warning", __func__);
       }
-      if (verbose) Rprintf("%s: NA (or other non-finite) value(s) are present in input, skip non-NA attempt and run with extra care for NAs\n", __func__);
+      if (verbose) sprintf(ans->message[0], "%s%s: NA (or other non-finite) value(s) are present in input, skip non-NA attempt and run with extra care for NAs\n", ans->message[0], __func__);
       w = 0.0;
       truehasna = true;
     }
@@ -104,7 +106,7 @@ void frollmeanFast(double *x, uint_fast64_t nx, double_ans_t *ans, int k, double
  */
 
 void frollmeanExact(double *x, uint_fast64_t nx, double_ans_t *ans, int k, double fill, bool narm, int hasna, bool verbose) {
-  if (verbose) Rprintf("%s: running for input length %llu, window %d, hasna %d, narm %d\n", __func__, nx, k, hasna, (int) narm);
+  if (verbose) sprintf(ans->message[0], "%s%s: running in parallel for input length %llu, window %d, hasna %d, narm %d\n", ans->message[0], __func__, (long long unsigned)nx, k, hasna, (int) narm);
   for (int i=0; i<k-1; i++) {                                   // fill partial window only
     ans->ans[i] = fill;
   }
@@ -135,8 +137,8 @@ void frollmeanExact(double *x, uint_fast64_t nx, double_ans_t *ans, int k, doubl
         sprintf(ans->message[2], "%s: hasNA=FALSE used but NA (or other non-finite) value(s) are present in input, use default hasNA=NA to avoid this warning", __func__);
       }
       if (verbose) {
-        if (narm) Rprintf("%s: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs\n", __func__);
-        else Rprintf("%s: NA (or other non-finite) value(s) are present in input, na.rm was FALSE so in 'exact' implementation NAs were handled already, no need to re-run\n", __func__);
+        if (narm) sprintf(ans->message[0], "%s%s: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs\n", ans->message[0], __func__);
+        else sprintf(ans->message[0], "%s%s: NA (or other non-finite) value(s) are present in input, na.rm was FALSE so in 'exact' implementation NAs were handled already, no need to re-run\n", ans->message[0], __func__);
       }
     }
   }

--- a/src/frollR.c
+++ b/src/frollR.c
@@ -1,12 +1,14 @@
 #include "frollR.h"
 
 SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEXP narm, SEXP hasna, SEXP adaptive, SEXP verbose) {
-  int protecti=0;
+  int protecti = 0;
   if (!isLogical(verbose) || length(verbose)!=1 || LOGICAL(verbose)[0]==NA_LOGICAL)
     error("verbose must be TRUE or FALSE");
   bool bverbose = LOGICAL(verbose)[0];
 
   if (!xlength(obj)) return(obj);                               // empty input: NULL, list()
+  double tic = 0;
+  if (bverbose) tic = omp_get_wtime();
   SEXP x;                                                       // holds input data as list
   if (isVectorAtomic(obj)) {                                    // wrap atomic vector into list
     x = PROTECT(allocVector(VECSXP, 1)); protecti++;
@@ -110,7 +112,7 @@ SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEX
   double_ans_t dans[nx*nk];                                     // answer columns as array of double_ans_t struct
   double* dx[nx];                                               // pointers to source columns
   uint_fast64_t inx[nx];                                        // to not recalculate `length(x[[i]])` we store it in extra array
-  if (bverbose) Rprintf("frollfunR: allocating memory for results %dx%d\n", nx, nk);
+  if (bverbose) Rprintf("%s: allocating memory for results %dx%d\n", __func__, nx, nk);
   for (R_len_t i=0; i<nx; i++) {
     inx[i] = xlength(VECTOR_ELT(x, i));                         // for list input each vector can have different length
     for (R_len_t j=0; j<nk; j++) {
@@ -169,54 +171,34 @@ SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEX
     // ik is still R_NilValue from initialization. But that's ok as it's only needed below when !badaptive.
   }
 
-  if (nx==1 && nk==1) {                                         // no need to init openmp for single thread call
-    if (bverbose) {
-      if (ialgo==0) Rprintf("frollfunR: single column and single window, parallel processing by multiple answer vectors skipped\n");
-      else if (ialgo==1) Rprintf("frollfunR: single column and single window, parallel processing by multiple answer vectors skipped but 'exact' version of rolling function will compute results in parallel\n");
-    }
-    switch (sfun) {
+  if (bverbose) {
+    if (ialgo==0) Rprintf("%s: %d column(s) and %d window(s), if product > 1 then entering parallel execution\n", __func__, nx, nk);
+    else if (ialgo==1) Rprintf("%s: %d column(s) and %d window(s), not entering parallel execution here because algo='exact' will compute results in parallel\n", __func__, nx, nk);
+  }
+  #pragma omp parallel for if (ialgo==0 && nx*nk>1) schedule(auto) collapse(2) num_threads(getDTthreads())
+  for (R_len_t i=0; i<nx; i++) {                            // loop over multiple columns
+    for (R_len_t j=0; j<nk; j++) {                          // loop over multiple windows
+      switch (sfun) {
       case MEAN :
-        if (!badaptive) frollmean(ialgo, dx[0], inx[0], &dans[0], iik[0], ialign, dfill, bnarm, ihasna, bverbose);
-        else fadaptiverollmean(ialgo, dx[0], inx[0], &dans[0], ikl[0], dfill, bnarm, ihasna, bverbose);
+        if (!badaptive) frollmean(ialgo, dx[i], inx[i], &dans[i*nk+j], iik[j], ialign, dfill, bnarm, ihasna, bverbose);
+        else fadaptiverollmean(ialgo, dx[i], inx[i], &dans[i*nk+j], ikl[j], dfill, bnarm, ihasna, bverbose);
         break;
-      //case SUM :
-      //  break;
-    }
-  } else {
-    if (bverbose>0) {
-      if (ialgo==0) Rprintf("frollfunR: %d column(s) and %d window(s), entering parallel execution, but actually single threaded due to enabled verbose which is not thread safe\n", nx, nk);
-      else if (ialgo==1) Rprintf("frollfunR: %d column(s) and %d window(s), entering parallel execution, but actually single threaded due to enabled verbose which is not thread safe, 'exact' version of rolling function will compute results in parallel anyway as it does not print with verbose\n", nx, nk);
-    }
-    omp_set_nested(1);
-    #pragma omp parallel for num_threads(bverbose ? 1 : getDTthreads()) schedule(auto) collapse(2)
-    for (R_len_t i=0; i<nx; i++) {                            // loop over multiple columns
-      for (R_len_t j=0; j<nk; j++) {                          // loop over multiple windows
-        switch (sfun) {
-          case MEAN :
-            if (!badaptive) frollmean(ialgo, dx[i], inx[i], &dans[i*nk+j], iik[j], ialign, dfill, bnarm, ihasna, bverbose);
-            else fadaptiverollmean(ialgo, dx[i], inx[i], &dans[i*nk+j], ikl[j], dfill, bnarm, ihasna, bverbose);
-            break;
-          //case SUM :
-          //  break;
-        }
+        //case SUM :
+        //  break;
       }
     }
-    omp_set_nested(0);
   }
-
+  
   for (R_len_t i=0; i<nx; i++) {                                // raise errors and warnings, as of now messages are not being produced and stdout is printed in live not carried in ans_t
     for (R_len_t j=0; j<nk; j++) {
-      if (dans[i*nk+j].status == 3) {
-        error(dans[i*nk+j].message[3]);                         // # nocov becase only errors we can currently have from low level C function is failed malloc
-      } else if (dans[i*nk+j].status == 2) {
-        warning(dans[i*nk+j].message[2]);
-      } else if (dans[i*nk+j].status == 1) {
-        //message(dans[i*nk+j].message[1]);                     // no messages yet in C functions, need to check R API for that
-      } else if (dans[i*nk+j].status == 1) {
-        //Rprintf(dans[i*nk+j].message[0]);                     // console output can be printed here instead of 'live' so parallel stuff can run even when verbose=T
-      }
+      if (bverbose && (dans[i*nk+j].message[0][0] != '\0')) Rprintf("%s: %d:\n%s", __func__, i*nk+j+1, dans[i*nk+j].message[0]);
+      if (dans[i*nk+j].message[1][0] != '\0') REprintf("%s: %d:\n%s", __func__, i*nk+j+1, dans[i*nk+j].message[1]); // # nocov because no messages yet
+      if (dans[i*nk+j].message[2][0] != '\0') warning("%s: %d:\n%s", __func__, i*nk+j+1, dans[i*nk+j].message[2]);
+      if (dans[i*nk+j].status == 3) error("%s: %d: %s", __func__, i*nk+j+1, dans[i*nk+j].message[3]); // # nocov because only caused by malloc
     }
   }
+  
+  if (bverbose) Rprintf("%s: processing of %d column(s) and %d window(s) took %.3fs\n", __func__, nx, nk, omp_get_wtime()-tic);
 
   UNPROTECT(protecti);
   return isVectorAtomic(obj) && length(ans) == 1 ? VECTOR_ELT(ans, 0) : ans;

--- a/src/frolladaptive.c
+++ b/src/frolladaptive.c
@@ -12,9 +12,11 @@
  */
 
 void fadaptiverollmean(unsigned int algo, double *x, uint_fast64_t nx, double_ans_t *ans, int *k, double fill, bool narm, int hasna, bool verbose) {
-  ans->status = 0;                                              // default status success
+  double tic = 0;
+  if (verbose) tic = omp_get_wtime();
   if (algo==0) fadaptiverollmeanFast(x, nx, ans, k, fill, narm, hasna, verbose);
   else if (algo==1) fadaptiverollmeanExact(x, nx, ans, k, fill, narm, hasna, verbose);
+  if (verbose) sprintf(ans->message[0], "%s%s: processing algo %d took %.3fs\n", ans->message[0], __func__, algo, omp_get_wtime()-tic);
 }
 
 /* fast adaptive rolling mean - fast
@@ -24,10 +26,9 @@ void fadaptiverollmean(unsigned int algo, double *x, uint_fast64_t nx, double_an
  */
 
 void fadaptiverollmeanFast(double *x, uint_fast64_t nx, double_ans_t *ans, int *k, double fill, bool narm, int hasna, bool verbose) {
-  if (verbose) Rprintf("%s: running for input length %llu, hasna %d, narm %d\n", __func__, nx, hasna, (int) narm);
+  if (verbose) sprintf(ans->message[0], "%s%s: running for input length %llu, hasna %d, narm %d\n", ans->message[0], __func__, (long long unsigned)nx, hasna, (int) narm);
   bool truehasna = hasna>0;                                     // flag to re-run if NAs detected
   long double w = 0.0;
-  // TODO measure speed of cs as long double
   double *cs = malloc(nx*sizeof(double));                       // cumsum vector, same as double cs[nx] but no segfault
   if (!cs) {
     ans->status = 3;                                            // raise error
@@ -52,7 +53,7 @@ void fadaptiverollmeanFast(double *x, uint_fast64_t nx, double_ans_t *ans, int *
         ans->status = 2;
         sprintf(ans->message[2], "%s: hasNA=FALSE used but NA (or other non-finite) value(s) are present in input, use default hasNA=NA to avoid this warning", __func__);
       }
-      if (verbose) Rprintf("%s: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs\n", __func__);
+      if (verbose) sprintf(ans->message[0], "%s%s: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs\n", ans->message[0], __func__);
       w = 0.0;
       truehasna = true;
     }
@@ -103,7 +104,7 @@ void fadaptiverollmeanFast(double *x, uint_fast64_t nx, double_ans_t *ans, int *
  */
 
 void fadaptiverollmeanExact(double *x, uint_fast64_t nx, double_ans_t *ans, int *k, double fill, bool narm, int hasna, bool verbose) {
-  if (verbose) Rprintf("%s: running for input length %llu, hasna %d, narm %d\n", __func__, nx, hasna, (int) narm);
+  if (verbose) sprintf(ans->message[0], "%s%s: running in parallel for input length %llu, hasna %d, narm %d\n", ans->message[0], __func__, (long long unsigned)nx, hasna, (int) narm);
   bool truehasna = hasna>0;                                   // flag to re-run if NAs detected
 
   if (!truehasna || !narm) {                                  // narm=FALSE handled here as NAs properly propagated in exact algo
@@ -135,8 +136,8 @@ void fadaptiverollmeanExact(double *x, uint_fast64_t nx, double_ans_t *ans, int 
         sprintf(ans->message[2], "%s: hasNA=FALSE used but NA (or other non-finite) value(s) are present in input, use default hasNA=NA to avoid this warning", __func__);
       }
       if (verbose) {
-        if (narm) Rprintf("%s: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs\n", __func__);
-        else Rprintf("%s: NA (or other non-finite) value(s) are present in input, na.rm was FALSE so in 'exact' implementation NAs were handled already, no need to re-run\n", __func__);
+        if (narm) sprintf(ans->message[0], "%s%s: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs\n", ans->message[0], __func__);
+        else sprintf(ans->message[0], "%s%s: NA (or other non-finite) value(s) are present in input, na.rm was FALSE so in 'exact' implementation NAs were handled already, no need to re-run\n", ans->message[0], __func__);
       }
     }
   }

--- a/src/types.h
+++ b/src/types.h
@@ -3,5 +3,5 @@
 typedef struct double_ans_t {
   double *ans;
   uint8_t status;   // 0:ok, 1:message, 2:warning, 3:error; unix return signal: {0,1,2}=0, {3}=1
-  char message[4][256]; // STDOUT: output, STDERR: message, warning, error
+  char message[4][1024]; // STDOUT: output, STDERR: message, warning, error
 } double_ans_t;


### PR DESCRIPTION
- no longer has nested parallelism - for algos that uses parallelism to compute rollmean the outer parallelism over columns/window sizes is turned off
- verbose does not turn off parallel processing anymore, all verbose messages are deferred to print outside of parallel region
- some code refactor to use #pragma omp if
- timing
- test.data.table is more flexible when passing `output` as vector of mixed constant strings and regexps