### PR TITLE
add tests on frankv behavior with NA/NaN

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -5314,8 +5314,6 @@ x = c(2147483647L, NA_integer_, -2L)
 test(1368.2, forderv(x), c(2L, 3L, 1L))
 
 # tests for frankv. testing on vectors alone so that we can compare with base::rank
-# One difference is that NAs belong to the same group, unlike base::rank. So are NaNs.
-# So, they can't be compared to base::rank, won't be identical except for ties="first", and (ties="random", na.last=NA) - should document this.
 
 # no seed set on purpose
 dt = data.table(AA=sample(c(-2:2), 50, TRUE),
@@ -13427,6 +13425,15 @@ DT = as.data.table(mtcars)[1]
 test(1986.3, DT[, colMeans(.SD), by=gear], data.table(gear=4, V1=c(21,6,160,110,3.9,2.62,16.46,0,1,4)))
 test(1986.4, DT[, as.list(colMeans(.SD)), by=gear], cbind(DT[,"gear"],DT[,-"gear"]))
 
+# testing frankv behavior with NA/NaN;
+#   earlier tests compare consistency with base::rank,
+#   but we intentionally break from base w.r.t. ranking NAs
+#   (we consider NAs to be tied, ditto NaN)
+x = data.table(r = c(6, 4, 2, NA, 1, NaN, 5, NaN, 9, 10, NA))
+test(1987.1, frankv(x, cols = 'r', order = 1L, ties.method = 'average'), c(5, 3, 2, 10.5, 1, 8.5, 4, 8.5, 6, 7, 10.5))
+test(1987.2, frankv(x, cols = 'r', order = 1L, ties.method = 'max'), c(5L, 3L, 2L, 11L, 1L, 9L, 4L, 9L, 6L, 7L, 11L))
+test(1987.3, frankv(x, cols = 'r', order = 1L, ties.method = 'min'), c(5L, 3L, 2L, 10L, 1L, 8L, 4L, 8L, 6L, 7L, 10L))
+test(1987.4, frankv(x, cols = 'r', order = 1L, ties.method = 'dense'), c(5L, 3L, 2L, 9L, 1L, 8L, 4L, 8L, 6L, 7L, 9L))
 
 ###################################
 #  Add new tests above this line  #


### PR DESCRIPTION
Part of #2572 

I already see this in the manual, so assume the "we should document" part is covered:

> To be consistent with other data.table operations, NAs are considered identical to other NAs (and NaNs to other NaNs), unlike base::rank. Therefore, for na.last=TRUE and na.last=FALSE, NAs (and NaNs) are given identical ranks, unlike rank.