### PR TITLE
Gforce tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ Rplots.pdf
 *-Ex.R
 data.table_*.tar.gz
 data.table.Rcheck
+# useful to source cc.r in your .Rprofile; see comments there
+.Rprofile
 
 # Emacs IDE files
 .emacs.desktop

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -1865,10 +1865,18 @@ setnames(ans2,"x","V1")
 setnames(ans2,"y","V2")
 test(654, ans1, ans2)
 
-options(datatable.optimize = Inf)
-test(656, DT[,mean(x),by=grp1,verbose=TRUE], output="GForce optimized j to.*gmean")
-test(657, DT[,list(mean(x)),by=grp1,verbose=TRUE], output="GForce optimized j to.*gmean")
-test(658, DT[,list(mean(x),mean(y)),by=grp1,verbose=TRUE], output="GForce optimized j to.*gmean")
+options(datatable.optimize = 0L)
+test(656.1, DT[ , mean(x), by=grp1, verbose=TRUE], output='(GForce FALSE)')
+test(657.1, DT[ , list(mean(x)), by=grp1, verbose=TRUE], output="(GForce FALSE)")
+test(658.3, DT[ , list(mean(x), mean(y)), by=grp1, verbose=TRUE], output="(GForce FALSE)")
+options(datatable.optimize = 1L)
+test(656.2, DT[ , mean(x), by=grp1, verbose=TRUE], output='(GForce FALSE)')
+test(657.2, DT[ , list(mean(x)), by=grp1, verbose=TRUE], output="(GForce FALSE)")
+test(658.2, DT[ , list(mean(x), mean(y)), by=grp1, verbose=TRUE], output="(GForce FALSE)")
+options(datatable.optimize = 2L)
+test(656.3, DT[ , mean(x), by=grp1, verbose=TRUE], output="GForce optimized j to.*gmean")
+test(657.3, DT[ , list(mean(x)), by=grp1, verbose=TRUE], output="GForce optimized j to.*gmean")
+test(658.3, DT[ , list(mean(x), mean(y)), by=grp1, verbose=TRUE], output="GForce optimized j to.*gmean")
 tt = capture.output(DT[,list(mean(x),mean(y)),by=list(grp1,grp2),verbose=TRUE])
 test(659, !length(grep("Wrote less rows", tt)))  # first group is one row with this seed. Ensure we treat this as aggregate case rather than allocate too many rows.
 
@@ -2390,8 +2398,12 @@ test(864.3, rbindlist(list(data.table(logical(0),logical(0)), DT<-data.table(baz
 
 # Steve's find that setnames failed for numeric 'old' when pointing to duplicated names
 DT = data.table(a=1:3,b=1:3,v=1:6,w=1:6)
+options(datatable.optimize = 0L)
+test(865.1, ans1<-DT[,{list(name1=sum(v),name2=sum(w))},by="a,b",verbose=TRUE], output="(GForce FALSE)")
+options(datatable.optimize = 1L)
+test(865.2, ans1<-DT[,{list(name1=sum(v),name2=sum(w))},by="a,b",verbose=TRUE], output="(GForce FALSE)")
 options(datatable.optimize = 2L)
-test(865, ans1<-DT[,{list(name1=sum(v),name2=sum(w))},by="a,b",verbose=TRUE],
+test(865.3, ans1<-DT[,{list(name1=sum(v),name2=sum(w))},by="a,b",verbose=TRUE],
           output="GForce optimized.*gsum[(]v[)], gsum[(]w[)]")  # v1.9.7 treats wrapped {} better, so this is now optimized
 options(datatable.optimize = Inf)
 test(866, names(ans1), c("a","b","name1","name2"))
@@ -4453,56 +4465,49 @@ unlink(f)
 #################################
 # FR #2722 optimise j=c(lapply(.SD,sum, ...)) - here any amount of such lapply(.SD, ...) can occur and in any order
 set.seed(45L)
-dt <- data.table(a=sample(2,10,TRUE), b=sample(3,10,TRUE), c=sample(4,10,TRUE), d=sample(5,10,TRUE))
+dt = data.table(a=sample(2,10,TRUE), b=sample(3,10,TRUE), c=sample(4,10,TRUE), d=sample(5,10,TRUE))
+dt2 = data.table(x=c(1,1,1,2,2,2), y=1:6)
+
+options(datatable.optimize=0L)
+# auto-naming behavior is different for no-optimization case; just check optimization is off
+test(1268.1, dt[, c(lapply(.SD, mean), lapply(.SD, sum)), by=a, verbose=TRUE], output = 'All optimizations are turned off')
+test(1268.2, dt[, c(lapply(.SD, mean), .N), by=a, verbose=TRUE], output = 'All optimizations are turned off')
+test(1268.3, dt[, c(list(c), lapply(.SD, mean)), by=a, verbose=TRUE], output="All optimizations are turned off")
+test(1268.4, dt[, c(sum(d), lapply(.SD, mean)), by=a, verbose=TRUE], output="All optimizations are turned off")
+test(1268.5, dt[, c(list(sum(d)), lapply(.SD, mean)), by=a, verbose=TRUE], output="All optimizations are turned off")
+# newly added tests for #861 -- optimise, but no GForce
+test(1268.6, dt[, c(list(sum(d), .I), lapply(.SD, mean)), by=a, verbose=TRUE], output="All optimizations are turned off")
+# don't optimise .I in c(...)
+test(1268.7, dt2[, c(.I, lapply(.SD, mean)), by=x, verbose=TRUE], output="All optimizations are turned off")
 
 options(datatable.optimize=1L)
-ans2 <- dt[, c(lapply(.SD, mean), lapply(.SD, sum)), by=a]
+test(1268.8, ans1 <- dt[ , c(lapply(.SD, mean), lapply(.SD, sum)), by=a, verbose=TRUE], output="Old mean optimization.*(GForce FALSE)")
+test(1268.9, ans2 <- dt[, c(lapply(.SD, mean), .N), by=a, verbose = TRUE], output="Old mean optimization.*GForce FALSE")
+test(1268.10, ans3 <- dt[, c(list(c), lapply(.SD, mean)), by=a, verbose=TRUE], output = 'Old mean optimization.*GForce FALSE')
+test(1268.11, ans4 <- dt[, c(sum(d), lapply(.SD, mean)), by=a, verbose = TRUE], output="Old mean optimization.*GForce FALSE")
+test(1268.12, ans5 <- dt[, c(list(sum(d)), lapply(.SD, mean)), by=a, verbose=TRUE], output="Old mean optimization.*GForce FALSE")
+test(1268.13, ans6 <- dt[, c(list(sum(d), .I), lapply(.SD, mean)), by=a, verbose=TRUE], output="Old mean optimization.*GForce FALSE")
+test(1268.14, ans7 <- dt2[, c(.I, lapply(.SD, mean)), by=x, verbose=TRUE], output="Old mean optimization.*GForce FALSE")
+
 options(datatable.optimize=Inf)
-test(1268.1, dt[, c(lapply(.SD, mean), lapply(.SD, sum)), by=a, verbose=TRUE], ans2,
+test(1268.15, dt[, c(lapply(.SD, mean), lapply(.SD, sum)), by=a, verbose=TRUE], ans1,
              output="GForce optimized j to 'list(gmean(b), gmean(c), gmean(d), gsum(b), gsum(c), gsum(d))'")
-
-options(datatable.optimize=1L)
-ans2 <- dt[, c(lapply(.SD, mean), .N), by=a]
-options(datatable.optimize=Inf)
-test(1268.2, dt[, c(lapply(.SD, mean), .N), by=a, verbose=TRUE], ans2,
+test(1268.16, dt[, c(lapply(.SD, mean), .N), by=a, verbose=TRUE], ans2,
                   output = "lapply optimization changed j from 'c(lapply(.SD, mean), .N)' to 'list(mean(b), mean(c), mean(d), .N)'")
-
-options(datatable.optimize=1L)
-ans2 <- dt[, c(list(c), lapply(.SD, mean)), by=a]
-options(datatable.optimize=Inf)
-test(1268.3, dt[, c(list(c), lapply(.SD, mean)), by=a, verbose=TRUE], ans2,
+test(1268.17, dt[, c(list(c), lapply(.SD, mean)), by=a, verbose=TRUE], ans3,
              output = "lapply optimization changed j from 'c(list(c), lapply(.SD, mean))' to 'list(c, mean(b), mean(c), mean(d))")
+test(1268.18, dt[, c(sum(d), lapply(.SD, mean)), by=a, verbose=TRUE], ans4,
+             output = "GForce optimized j to 'list(gsum(d), gmean(b), gmean(c), gmean(d))'")
+test(1268.19, dt[, c(list(sum(d)), lapply(.SD, mean)), by=a, verbose=TRUE], ans5,
+             output = "GForce optimized j to 'list(gsum(d), gmean(b), gmean(c), gmean(d))'")
+test(1268.20, dt[, c(list(sum(d), .I), lapply(.SD, mean)), by=a, verbose=TRUE], ans6,
+             output = "lapply optimization changed j from 'c(list(sum(d), .I), lapply(.SD, mean))' to 'list(sum(d), .I, mean(b), mean(c), mean(d))'")
+test(1268.21, dt2[, c(.I, lapply(.SD, mean)), by=x, verbose=TRUE], ans7,
+             output = "lapply optimization is on, j unchanged as 'c(.I, lapply(.SD, mean))'")
 
-test(1268.4, dt[, c(as.list(c), lapply(.SD, mean)), by=a],
+test(1268.22, dt[, c(as.list(c), lapply(.SD, mean)), by=a],
              error = "j doesn't evaluate to the same number of columns for each group")
 
-options(datatable.optimize=1L)
-ans2 <- dt[, c(sum(d), lapply(.SD, mean)), by=a]
-options(datatable.optimize=Inf)
-test(1268.5, dt[, c(sum(d), lapply(.SD, mean)), by=a, verbose=TRUE], ans2,
-             output = "GForce optimized j to 'list(gsum(d), gmean(b), gmean(c), gmean(d))'")
-
-options(datatable.optimize=1L)
-ans2 <- dt[, c(list(sum(d)), lapply(.SD, mean)), by=a]
-options(datatable.optimize=Inf)
-test(1268.6, dt[, c(list(sum(d)), lapply(.SD, mean)), by=a, verbose=TRUE], ans2,
-             output = "GForce optimized j to 'list(gsum(d), gmean(b), gmean(c), gmean(d))'")
-
-# newly added tests for #861
-# optimise, but no GForce
-options(datatable.optimize=1L)
-ans2 <- dt[, c(list(sum(d), .I), lapply(.SD, mean)), by=a]
-options(datatable.optimize=Inf)
-test(1268.7, dt[, c(list(sum(d), .I), lapply(.SD, mean)), by=a, verbose=TRUE], ans2,
-             output = "lapply optimization changed j from 'c(list(sum(d), .I), lapply(.SD, mean))' to 'list(sum(d), .I, mean(b), mean(c), mean(d))'")
-
-# don't optimise .I in c(...)
-options(datatable.optimize=1L)
-dt = data.table(x=c(1,1,1,2,2,2), y=1:6)
-ans2 <- dt[, c(.I, lapply(.SD, mean)), by=x]
-options(datatable.optimize=Inf)
-test(1268.8, dt[, c(.I, lapply(.SD, mean)), by=x, verbose=TRUE], ans2,
-             output = "lapply optimization is on, j unchanged as 'c(.I, lapply(.SD, mean))'")
 
 ### FR #2722 tests end here ###
 
@@ -5949,7 +5954,7 @@ test(1437.17, DT[!a %chin% c("A", "B") & x == 2], DT[c(4, 5, 6)])
 ## queries with j are optimized (Correct results are tested extensively below)
 test(1437.18, DT[x == 2, .(test = x+y), verbose = TRUE], output = "Optimized subsetting")
 test(1437.19, DT[x == 2, test := x+y, verbose = TRUE], output = "Optimized subsetting")
-## optimize option level 3 is required
+## optimize option level 3 is required to get optimized subsetting
 options(datatable.optimize = 2L)
 test(1437.21, DT[x == 2, verbose = TRUE], output = "^   x y")
 options(datatable.optimize = Inf)
@@ -7505,12 +7510,12 @@ test(1564.3, dt[a==5, .SD][, b := 1L], data.table(a=5L, b=1L))
 
 # Fix for #1251, DT[, .N, by=a] and DT[, .(.N), by=a] uses GForce now
 dt = data.table(a=sample(3,20,TRUE), b=1:10)
+options(datatable.optimize = 0L)
+test(1565.1, ans <- dt[, .N, by=a, verbose=TRUE], output="All optimizations are turned off")
+options(datatable.optimize = 1L)
+test(1565.2, dt[ , .N, by=a, verbose=TRUE], ans, output="lapply optimization is on, j unchanged")
 options(datatable.optimize = Inf)
-ans1 = dt[, .N, by=a]
-ans2 = capture.output(dt[, .N, by=a, verbose=TRUE])
-test(1565.1, length(grep("GForce optimized j to", ans2))>0L, TRUE) # make sure GForce optimisation works
-options(datatable.optimize = 1L) # make sure result is right
-test(1565.2, ans1, dt[, .N, by=a])
+test(1565.3, dt[ , .N, by=a, verbose=TRUE], ans, output = "GForce optimized j to")
 
 # Fix for #1212
 set.seed(123)
@@ -13129,11 +13134,15 @@ suppressWarnings(rm(`___data.table_internal_test_1967.68___`))
 test(1967.68, setDT(`___data.table_internal_test_1967.68___`), error = 'Cannot find symbol')
 
 ### [.data.table verbosity & non-equi-join tests
-options('datatable.optimize' = 2)
-test(1967.69, x[order(a), .N, verbose = TRUE], 5L,
+options(datatable.optimize = 0L)
+verbose_output = capture.output(x[order(a), .N, verbose = TRUE])
+test(1967.69, !any(grepl('order optimization', verbose_output, fixed = TRUE)))
+test(1967.70, any(grepl('[1] 5', verbose_output, fixed = TRUE)))
+options('datatable.optimize' = 1L)
+test(1967.71, x[order(a), .N, verbose = TRUE], 5L,
      output = "i changed from 'order(...)' to 'forder(")
 setkey(x)
-test(1967.70, x[x, .N, on = 'a', verbose = TRUE], 5L,
+test(1967.72, x[x, .N, on = 'a', verbose = TRUE], 5L,
      output = "on= matches existing key")
 options(datatable.optimize = Inf)
 
@@ -13146,19 +13155,19 @@ y = data.table(
   i4 = c(-26L, 6L, -30L, -26L, -23L, 38L, -40L, -26L, -23L, 24L)
 )
 x[ , '_nqgrp_' := 5]
-test(1967.71, x[y, on = .(i1 <= i1, i4 >= i4)], error = "'_nqgrp_' is reserved")
+test(1967.73, x[y, on = .(i1 <= i1, i4 >= i4)], error = "'_nqgrp_' is reserved")
 x[ , '_nqgrp_' := NULL]
-test(1967.72, x[y, max(i4), on = .(i1 <= i1, i4 >= i4), verbose = TRUE], 38L,
+test(1967.74, x[y, max(i4), on = .(i1 <= i1, i4 >= i4), verbose = TRUE], 38L,
      output = 'Recomputing forder with non-equi.*done')
-test(1967.73, x[!y, sum(i4), on = 'i1', by = .EACHI, verbose = TRUE],
+test(1967.75, x[!y, sum(i4), on = 'i1', by = .EACHI, verbose = TRUE],
      data.table(i1 = c(169L, 369L), V1 = c(270L, 179L)),
      output = "not-join called with 'by=.EACHI'.*done")
-test(1967.74, x[!y, sum(i4), on = 'i1', verbose = TRUE], 510L,
+test(1967.76, x[!y, sum(i4), on = 'i1', verbose = TRUE], 510L,
      output = 'Inverting irows for notjoin.*sec')
 x[ , v := 0]
 ### hitting by = A:B branch
-test(1967.75, x[ , .(v = sum(v)), by = i1:i4], x[-10L])
-test(1967.76, x[1:5, sum(v), by = list(i5 = 1:5 %% 2L), verbose = TRUE],
+test(1967.77, x[ , .(v = sum(v)), by = i1:i4], x[-10L])
+test(1967.78, x[1:5, sum(v), by = list(i5 = 1:5 %% 2L), verbose = TRUE],
      data.table(i5 = 1:0, V1 = c(0, 0)), output = 'i clause present but columns used in by not detected')
 
 # gforce integer overflow coerce to double

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -1860,9 +1860,11 @@ setnames(ans2,"x","V1")
 setnames(ans2,"y","V2")
 test(654, ans1, ans2)
 
+old_opt = options(datatable.optimize = 2L)
 test(656, DT[,mean(x),by=grp1,verbose=TRUE], output="GForce optimized j to.*gmean")
 test(657, DT[,list(mean(x)),by=grp1,verbose=TRUE], output="GForce optimized j to.*gmean")
 test(658, DT[,list(mean(x),mean(y)),by=grp1,verbose=TRUE], output="GForce optimized j to.*gmean")
+options(datatable.optimize = old_opt$datatable_optimize)
 tt = capture.output(DT[,list(mean(x),mean(y)),by=list(grp1,grp2),verbose=TRUE])
 test(659, !length(grep("Wrote less rows", tt)))  # first group is one row with this seed. Ensure we treat this as aggregate case rather than allocate too many rows.
 
@@ -2384,8 +2386,10 @@ test(864.3, rbindlist(list(data.table(logical(0),logical(0)), DT<-data.table(baz
 
 # Steve's find that setnames failed for numeric 'old' when pointing to duplicated names
 DT = data.table(a=1:3,b=1:3,v=1:6,w=1:6)
+old_opt = options(datatable.optimize = 2L)
 test(865, ans1<-DT[,{list(name1=sum(v),name2=sum(w))},by="a,b",verbose=TRUE],
           output="GForce optimized.*gsum[(]v[)], gsum[(]w[)]")  # v1.9.7 treats wrapped {} better, so this is now optimized
+options(datatable.optimize = old_opt$datatable.optimize)
 test(866, names(ans1), c("a","b","name1","name2"))
 test(867, names(ans2<-DT[,list(name1=sum(v),name2=sum(w)),by="a,b"]), c("a","b","name1","name2"))  # list names extracted here
 test(868, ans1, ans2)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -90,9 +90,13 @@ for (s in sugg) {
 
 # Control options in case user set them. The user's values are restored at the end of this file.
 oldOptions = options(
+  datatable.optimize = Inf,
+  datatable.verbose = FALSE,
   datatable.alloccol = 1024L,
   datatable.print.class = FALSE  #  This is TRUE in cc.R and we like TRUE. But output= tests need to be updated (they assume FALSE currently)
 )
+# some tests (e.g. 1066, 1293) rely on capturing output that will be garbled with small width
+if (getOption('width') < 80L) options(width = 80L)
 
 ##########################
 
@@ -1206,9 +1210,9 @@ test(416, DT[J(2)], error="the columns to join by must be specified either using
 # Test shallow copy verbose message from := adding a column, and (TO DO) only when X is NAMED.
 DT = data.table(a=1:3,b=4:6)
 test(417, alloc.col(DT,3,verbose=TRUE), DT, output="Attempt to reduce allocation from.*to 5 ignored. Can only increase allocation via shallow copy")
-old = options(datatable.alloccol=1L)
+options(datatable.alloccol=1L)
 DT = data.table(a=1:3,b=4:6)
-options(old)
+options(datatable.alloccol=1024L)
 DT2 = DT
 test(418, length(DT)==2 && truelength(DT)==3)
 DT[,c:=7L]   # uses final slot
@@ -1233,9 +1237,10 @@ test(429, DT, data.table(a=factor(c("Z","Z","A","Z")),b=1:4))
 test(430, DT[1,1]<- 3L, 3L, warning="RHS contains 3 which is outside the levels range.*1,2.*of column 1, NAs generated")
 test(431, DT[1,1:=4L], data.table(a=factor(c(NA,"Z","A","Z")),b=1:4), warning="RHS contains 4 which is outside the levels range.*1,2.*of column 1, NAs generated")
 
-old = getOption("datatable.alloccol")  # Test that unsettting datatable.alloccol is caught, #2014
-options(datatable.alloccol=NULL)   # In this =NULL case, options() in R 3.0.0 returned TRUE rather than the old value. This R bug was fixed in R 3.1.1.
-                                   # This is why getOption is called first rather than just using the result of option() like elsewhere in this test file.
+old = getOption("datatable.alloccol")  # Test that unsetting datatable.alloccol is caught, #2014
+options(datatable.alloccol=NULL) # In this =NULL case, options() in R 3.0.0 returned TRUE rather than the old value. This R bug was fixed in R 3.1.1.
+                                 # This is why getOption is called first rather than just using the result of option() like elsewhere in this test file.
+                                 # TODO: simplify this test if/when R dependency >= 3.1.1
 err1 = try(data.table(a=1:3), silent=TRUE)
 options(datatable.alloccol="1024")
 err2 = try(data.table(a=1:3), silent=TRUE)
@@ -1245,7 +1250,7 @@ options(datatable.alloccol=NA_integer_)
 err4 = try(data.table(a=1:3), silent=TRUE)
 options(datatable.alloccol=-1)
 err5 = try(data.table(a=1:3), silent=TRUE)
-options(datatable.alloccol=old)   # otherwise test() itself fails in its internals with the alloc.col error
+options(datatable.alloccol=1024L)   # otherwise test() itself fails in its internals with the alloc.col error
 test(432.1, inherits(err1,"try-error") && grep("Has getOption[(]'datatable.alloccol'[)] somehow become unset?", err1))
 test(432.2, inherits(err2,"try-error") && grep("getOption[(]'datatable.alloccol'[)] should be a number, by default 1024. But its type is 'character'.", err2))
 test(432.3, inherits(err3,"try-error") && grep("is a numeric vector ok but its length is 2. Its length should be 1.", err3))
@@ -1263,7 +1268,7 @@ options(datatable.alloccol=NA_integer_)
 err4 = try(DT[,"b"], silent=TRUE)
 options(datatable.alloccol=-1)
 err5 = try(DT[2,"b"], silent=TRUE)
-options(datatable.alloccol=old)   # otherwise test() itself fails in its internals with the alloc.col error
+options(datatable.alloccol=1024L)   # otherwise test() itself fails in its internals with the alloc.col error
 test(433.1, inherits(err1,"try-error") && grep("Has getOption[(]'datatable.alloccol'[)] somehow become unset?", err1))
 test(433.2, inherits(err2,"try-error") && grep("getOption[(]'datatable.alloccol'[)] should be a number, by default 1024. But its type is 'character'.", err2))
 test(433.3, inherits(err3,"try-error") && grep("is a numeric vector ok but its length is 2. Its length should be 1.", err3))
@@ -1860,11 +1865,10 @@ setnames(ans2,"x","V1")
 setnames(ans2,"y","V2")
 test(654, ans1, ans2)
 
-old_opt = options(datatable.optimize = 2L)
+options(datatable.optimize = Inf)
 test(656, DT[,mean(x),by=grp1,verbose=TRUE], output="GForce optimized j to.*gmean")
 test(657, DT[,list(mean(x)),by=grp1,verbose=TRUE], output="GForce optimized j to.*gmean")
 test(658, DT[,list(mean(x),mean(y)),by=grp1,verbose=TRUE], output="GForce optimized j to.*gmean")
-options(datatable.optimize = old_opt$datatable_optimize)
 tt = capture.output(DT[,list(mean(x),mean(y)),by=list(grp1,grp2),verbose=TRUE])
 test(659, !length(grep("Wrote less rows", tt)))  # first group is one row with this seed. Ensure we treat this as aggregate case rather than allocate too many rows.
 
@@ -2323,7 +2327,7 @@ l = list(data.table(a=1:3), data.table(b=4:6))
 setattr(l,"names",c("foo","bar"))
 test(846, l[["foo"]][2,d:=4], data.table(a=1:3,d=c(NA,4,NA)))
 test(847, l, list(foo=data.table(a=1:3,d=c(NA,4,NA)), bar=data.table(b=4:6)))
-old = options(datatable.alloccol=0L)
+options(datatable.alloccol=0L)
 l = list(foo=data.table(a=1:3,b=4:6),bar=data.table(c=7:9,d=10:12))   # list() doesn't copy the NAMED==0 objects here
 test(848, truelength(l[[1L]]), 2L)
 test(849, {l[[1L]][,e:=13:15]; l[[1L]]}, data.table(a=1:3,b=4:6)[,e:=13:15])
@@ -2332,7 +2336,7 @@ test(851, truelength(l[[2L]]), 2L)
 options(datatable.alloccol=1L)
 l[["bar"]][,f:=16:18]
 test(852, truelength(l[[2L]]), 4L)
-options(old)
+options(datatable.alloccol=1024L)
 # Now create the list from named objected
 DT1 = data.table(a=1:3, b=4:6)
 DT2 = data.table(c=7:9)
@@ -2386,10 +2390,10 @@ test(864.3, rbindlist(list(data.table(logical(0),logical(0)), DT<-data.table(baz
 
 # Steve's find that setnames failed for numeric 'old' when pointing to duplicated names
 DT = data.table(a=1:3,b=1:3,v=1:6,w=1:6)
-old_opt = options(datatable.optimize = 2L)
+options(datatable.optimize = 2L)
 test(865, ans1<-DT[,{list(name1=sum(v),name2=sum(w))},by="a,b",verbose=TRUE],
           output="GForce optimized.*gsum[(]v[)], gsum[(]w[)]")  # v1.9.7 treats wrapped {} better, so this is now optimized
-options(datatable.optimize = old_opt$datatable.optimize)
+options(datatable.optimize = Inf)
 test(866, names(ans1), c("a","b","name1","name2"))
 test(867, names(ans2<-DT[,list(name1=sum(v),name2=sum(w)),by="a,b"]), c("a","b","name1","name2"))  # list names extracted here
 test(868, ans1, ans2)
@@ -2777,11 +2781,10 @@ test(995, DT[CJ(c(5,3), c(5,1), sorted=FALSE)], OUT)
 # CJ with ordered factor
 xx <- factor(letters[1:2], ordered=TRUE)
 yy <- sample(2)
-old = options(datatable.CJ.names=FALSE)
+options(datatable.CJ.names=FALSE)
 test(996.1, CJ(xx, yy), setkey(data.table(rep(xx, each=2), rep(base::sort.int(yy), 2))))
 options(datatable.CJ.names=TRUE)
 test(996.2, CJ(xx, yy), setkey(data.table(xx = rep(xx, each=2), yy = rep(base::sort.int(yy), 2))))
-options(old)
 
 # That CJ orders NA consistently with setkey and historically, now it doesn't use setkey.
 # NA must always come first in data.table throughout, since binary search relies on that internally.
@@ -2808,7 +2811,6 @@ DT = data.table(a=1:3,b=4:6,b=7:9,c=10:12)
 test(1005, rbind(DT,DT), data.table(a=rep(1:3,2),b=rep(4:6,2),b=rep(7:9,2),c=rep(10:12,2)))
 M <- mtcars
 colnames(M)[11] <- NA
-# NOTE -- this test requires having options('width') sufficiently wide
 test(1006, print(as.data.table(M), nrows=10), output="gear NA.*1: 21.0")
 
 # rbinding factor with non-factor/character
@@ -4227,10 +4229,8 @@ if (base::getRversion() < "3.3.0") {
 # Test for optimisation of 'order' to 'forder'. Copied to benchmarks.Rraw too.
 set.seed(45L)
 DT = data.table(x=sample(1e2, 1e5, TRUE), y=sample(1e2, 1e5, TRUE))
-old = options(datatable.optimize=Inf)
 test(1241, DT[order(x,-y)],       # optimized to forder()
            DT[base_order(x,-y)])  # not optimized
-options(old)
 
 DT = data.table(a=1:3, b=4:6)
 myCol = "a"
@@ -4754,7 +4754,6 @@ c(2497.94263862333,
 "fr", "fg", "fsal", "mr", "mg", "msal"), class = c("data.table",
 "data.frame"), row.names = c(NA, -2L))
 
-if (options()$width<80) options(width=80)
 ans1 = capture.output(print(DT, digits=4, row.names=FALSE))
 ans2 = c(" fisyr  er      eg      esal  fr      fg      fsal    mr      mg      msal",
          "  1995 1,3 0.01973 2330,2424 4,4 0.03931 2521,2521  5,30 0.01978 2572,4216",
@@ -5570,12 +5569,12 @@ f = paste("file://",testDir("russellCRCRLF.csv"),sep="")
 test(1378.3, fread(f, showProgress=FALSE)[19,`Value With Dividends`], 357.97)
 #====================================
 
-oldv = options(datatable.fread.datatable = FALSE)
+options(datatable.fread.datatable = FALSE)
 test(1379.1, fread("A,B\n1,3\n2,4\n"), data.frame(A=1:2,B=3:4))
 test(1379.2, fread("A,B\n1,3\n2,4\n",data.table=TRUE), data.table(A=1:2,B=3:4))
 options(datatable.fread.datatable = TRUE)
 test(1379.3, fread("A,B\n1,3\n2,4\n",data.table=FALSE), data.frame(A=1:2,B=3:4))
-options(oldv)
+options(datatable.fread.datatable = TRUE)
 
 # That that RHS of == is coerced to x's type before bmerge in auto index. Package vardpoor does this in example(linqsr)
 DT = data.table(a=c(0,0,1,1,0,0), b=1:6)  # 'a' type double here, as it is in vardpoor
@@ -5951,9 +5950,9 @@ test(1437.17, DT[!a %chin% c("A", "B") & x == 2], DT[c(4, 5, 6)])
 test(1437.18, DT[x == 2, .(test = x+y), verbose = TRUE], output = "Optimized subsetting")
 test(1437.19, DT[x == 2, test := x+y, verbose = TRUE], output = "Optimized subsetting")
 ## optimize option level 3 is required
-old = options("datatable.optimize" = 2L)
+options(datatable.optimize = 2L)
 test(1437.21, DT[x == 2, verbose = TRUE], output = "^   x y")
-options(old)
+options(datatable.optimize = Inf)
 test(1437.22, DT[x == 2, verbose = TRUE], output = "Optimized subsetting")
 ## NaN on right hand side is treated correctly. NA on right hand side is not reaching .prepareFastSubset, so not tested here
 DT <- data.table(x = c(1L:10L, NA_integer_, NA_integer_), y = c(1:10, NA_real_, NaN))
@@ -5987,7 +5986,6 @@ test(1437.38, DT[x %in% 0:100 & y %in% 0:101], DT)
 ## very much inspired by the tests for non equi joins (1641ff)
 set.seed(13545)
 n <- 1e3 ## rows of the data.table. I checked that with these rows and the seed, all queries (except for == NA) have at least one match
-oldOpt <- getOption("datatable.optimize") ## remember for restoring after the test
 ## create test DT
 DT <- data.table(intCol    = sample(c(1:3, NA), n, replace = TRUE),
                  doubleCol = sample(c(1.86, 1000.345, 2.346, NA, NaN), n, replace = TRUE),
@@ -6068,8 +6066,7 @@ for(t in seq_len(nrow(all))){
 }
 
 }
-options("datatable.optimize" = oldOpt) ## restore to default
-
+options(datatable.optimize = Inf)
 
 # fread dec=',' e.g. France
 test(1439, fread("A;B\n1;2,34\n", dec="12"), error="nchar(dec) == 1L is not TRUE")
@@ -6521,7 +6518,7 @@ test(1480, DT[, x := strsplit(as.character(x), " ")], data.table(x=list("a", let
 
 # #970, over-allocation issue
 a=data.frame(matrix(1,ncol=101L))
-old = options(datatable.alloccol=100L)
+options(datatable.alloccol=100L)
 ans1 = data.table(a)
 options(datatable.alloccol=101L)
 ans2 = data.table(a)
@@ -6532,7 +6529,7 @@ test(1481.2, ans3, ans1)
 options(datatable.alloccol=1L)
 ans4 = data.table(a)
 test(1481.3, ans4, ans1)
-options(old)
+options(datatable.alloccol=1024L)
 
 # #479, check := assignment in environment (actual case is when loaded from disk, but we'll just simulate a scenario here).
 ee = new.env()
@@ -6841,11 +6838,9 @@ test(1514.7, isReallyReal(x), 0L)
 test(1514.8, isReallyReal(9L), 0L)
 
 # #1091
-old.option = getOption("datatable.prettyprint.char")
 options(datatable.prettyprint.char = 5L)
 DT = data.table(x=1:2, y=c("abcdefghijk", "lmnopqrstuvwxyz"))
 test(1515.1, grep("abcde...", capture.output(print(DT))), 2L)
-options(datatable.prettyprint.char = old.option)
 
 # test 1516: chain setnames() - used while mapping source to target columns
 SRC = data.table(x=1:2, y=c("abcdefghij", "klmnopqrstuv"), z=rnorm(2))
@@ -6906,11 +6901,10 @@ test(1524, ans1, ans2)
 # 'unique =' argument for CJ, #1148
 x = c(1, 2, 1)
 y = c(5, 8, 8, 4)
-old = options(datatable.CJ.names=FALSE)
+options(datatable.CJ.names=FALSE)
 test(1525.1, CJ(x, y, unique=TRUE), CJ(V1=c(1,2), V2=c(4,5,8)))
 options(datatable.CJ.names=TRUE)
 test(1525.2, CJ(x, y, unique=TRUE), CJ( x=c(1,2),  y=c(4,5,8)))
-options(old)
 
 # `key` argument fix for `setDT` when input is already a `data.table`,  #1169
 DT <- data.table(A = 1:4, B = 5:8)
@@ -7511,13 +7505,12 @@ test(1564.3, dt[a==5, .SD][, b := 1L], data.table(a=5L, b=1L))
 
 # Fix for #1251, DT[, .N, by=a] and DT[, .(.N), by=a] uses GForce now
 dt = data.table(a=sample(3,20,TRUE), b=1:10)
-old = options(datatable.optimize = Inf)
+options(datatable.optimize = Inf)
 ans1 = dt[, .N, by=a]
 ans2 = capture.output(dt[, .N, by=a, verbose=TRUE])
 test(1565.1, length(grep("GForce optimized j to", ans2))>0L, TRUE) # make sure GForce optimisation works
 options(datatable.optimize = 1L) # make sure result is right
 test(1565.2, ans1, dt[, .N, by=a])
-options(old)
 
 # Fix for #1212
 set.seed(123)
@@ -7631,7 +7624,6 @@ if (test_bit64) {
 }
 
 # make sure gforce is on
-optim = getOption("datatable.optimize")
 options(datatable.optimize=2L)
 
 # testing gforce::gmedian
@@ -7681,7 +7673,7 @@ test(1579.22, dt[, .SD[2L], keyby=x], dt[, mysub(.SD,2L), keyby=x])
 ans = capture.output(dt[, .SD[2], by=x, verbose=TRUE])
 test(1579.23, any(grepl("GForce optimized", ans)), TRUE)
 
-options(datatable.optimize=optim)
+options(datatable.optimize = Inf)
 
 # test for #1419, rleid doesn't remove names attribute
 x = c("a"=TRUE, "b"=FALSE)
@@ -7692,7 +7684,7 @@ test(1580, nx, names(x))
 # FR #971, partly addressed (only subsets in 'i')
 # make sure GForce kicks in and the results are identical
 dt = dt[, .(x, d1, d2)]
-old = options(datatable.optimize=1L)
+options(datatable.optimize=1L)
 
 test(1581.1, ans1 <- dt[x %in% letters[15:20],
                         c(.N, lapply(.SD, sum, na.rm=TRUE),
@@ -7737,15 +7729,13 @@ options(datatable.optimize=2L)
 test(1581.11, ans2 <- dt[x %in% letters[15:20], .SD[2], by=x, verbose=TRUE],
               output = "GForce optimized j")
 test(1581.12, ans1, ans2)
-
-options(old)
+options(datatable.optimize = Inf)
 
 # handle NULL value correctly #1429
 test(1582, uniqueN(NULL), 0L)
 
 # bug fix #1461
 dt = data.table(x=c(1,1,1,2,2,2,3,3,3,4,4,4,5), y=c(NaN,1,2, 2,NaN,1, NA,NaN,2, NaN,NA,NaN, NaN))
-optim = getOption("datatable.optimize")
 # make sure gforce is on
 options(datatable.optimize=Inf)
 ans1 = suppressWarnings(dt[, base::min(y, na.rm=TRUE), by=x])
@@ -7756,8 +7746,6 @@ ans3 = suppressWarnings(dt[, base::min(y), by=x])
 ans4 = suppressWarnings(dt[, base::max(y), by=x])
 test(1583.3, dt[, min(y), by=x], ans3)
 test(1583.4, dt[, max(y), by=x], ans4)
-# restore optimisation
-options(datatable.optimize=optim)
 
 # Fixed a minor bug in fread when blank.lines.skip=TRUE
 f1 <- function(x, f=TRUE, b=FALSE) fread(x, fill=f, blank.lines.skip=b, data.table=FALSE, logical01=FALSE)
@@ -8268,11 +8256,10 @@ test(1622.2, ans1, fread(testDir("issue_1573_fill.txt"), fill=TRUE, sep=" ", na.
 test(1623, fread("~"), error="")
 
 # testing print.rownames option, #1097 (part of #1523)
-old = getOption("datatable.print.rownames")
 options(datatable.print.rownames = FALSE)
 DT <- data.table(a = 1:3)
 test(1624, capture.output(print(DT)), c(" a", " 1", " 2", " 3"))
-options(datatable.print.rownames = old)
+options(datatable.print.rownames = TRUE)
 
 # fix for #1575
 text = "colA: dataA\ncolB: dataB\ncolC: dataC\n\nColA: dataA\nColB: dataB\nColC: dataC"
@@ -8464,7 +8451,6 @@ test(1629.7, dt[0][, .SD*v1, .SDcols=v2:v3], dt[0][, .SD, .SDcols=v2:v3])
 dt2 = copy(dt)
 test(1629.8, dt2[, c("v2", "v3") := .SD*v1, .SDcols=v2:v3], dt[, .(grp, v1, v2=v2*v1, v3=v3*v1)])
 # grouping operations
-oldopts = getOption("datatable.optimize") # backup
 options(datatable.optimize = 1L) # no gforce
 test(1629.9, dt[, .SD*sum(v1), by=grp, .SDcols=v2:v3], dt[, .SD*sum(v1), by=grp][, v1 := NULL])
 ans1 = dt[, sum(v1), by=grp]
@@ -8481,7 +8467,7 @@ dt[, v4 := v1/2]
 test(1629.14, dt[, c(.(v1=v1*min(v4)), lapply(.SD, function(x) x*max(v4))), by=grp, .SDcols=v2:v3],
     dt[, .(v1=v1*min(v4), v2=v2*max(v4), v3=v3*max(v4)), by=grp])
 test(1629.15, copy(dt)[, c("a", "b", "c") := c(min(v1), lapply(.SD, function(x) max(x)*min(v1))), by=grp, .SDcols=v3:v4], copy(dt)[, c("a", "b", "c") := .(min(v1), max(v3)*min(v1), max(v4)*min(v1)), by=grp])
-options(datatable.optimize = oldopts)
+options(datatable.optimize = Inf)
 # by=.EACHI and operations with 'i'
 test(1629.16, dt[.(2:3), c(.(sum(v1)), lapply(.SD, function(x) mean(x)*min(v1))), by=.EACHI, .SDcols=v2:v3, on="grp"], dt[grp %in% 2:3, c(.(sum(v1)), lapply(.SD, function(x) mean(x)*min(v1))), by=grp, .SDcols=v2:v3])
 test(1629.17, dt[.(2:3), c(sum(v1), lapply(.SD, function(x) mean(x)*v1)), .SDcols=v2:v3, on="grp"][order(V1,v2,v3)], dt[grp %in% 2:3, c(sum(v1), lapply(.SD, function(x) mean(x)*v1)), .SDcols=v2:v3][order(V1,v2,v3)])
@@ -8563,10 +8549,10 @@ test(1637.4, dt[, data.table(b, .SD), by = cumsum(a)], data.table(cumsum=1, b=1,
 test(1637.5, dt[, data.table(a, b), by = cumsum(a)], data.table(cumsum=1, a=1, b=1))
 
 # when datatable.optimize<1, no optimisation of j should take place:
-old = options(datatable.optimize=0L)
+options(datatable.optimize=0L)
 dt = data.table(x=1:5, y=6:10, z=c(1,1,1,2,2))
 test(1638, dt[, .SD, by=z, verbose=TRUE], output="All optimizations are turned off")
-options(old)
+options(datatable.optimize=Inf)
 
 #1389 - split.data.table - big chunk of unit tests
 set.seed(123)
@@ -9202,8 +9188,6 @@ set.seed(1L)
 dt = data.table(x=sample(3,10,TRUE), y=sample(2,10,TRUE), z=sample(5,10,TRUE))
 test(1657, dt[x %between% list(y,z)], dt[x>=y & x<=z])
 
-oldverbose = options(datatable.verbose=FALSE)
-
 # fwrite tests
 # without quoting
 test(1658.1, fwrite(data.table(a=c(NA, 2, 3.01), b=c('foo', NA, 'bar'))),
@@ -9334,7 +9318,6 @@ test(1658.31, fwrite(data.table(id=1:3,bool=c(TRUE,NA,FALSE)),na="NA",logical01=
 test(1658.32, fwrite(data.table(D = as.POSIXct(seq.Date(as.Date("2038-01-19"), as.Date("2038-01-20"), by = "day")))),
     output="D\n2038-01-19T00:00:00Z\n2038-01-20T00:00:00Z")
 
-options(oldverbose)
 
 # input is of class matrix
 test(1658.33, fwrite(matrix("foo"), quote=TRUE), output='"V1"\n.*"foo"', message = "x being coerced from class: matrix to data.table")
@@ -9600,9 +9583,7 @@ foo <- function(annot=c("a", "b")) {
   suppressWarnings(ro$dt[, flag := TRUE])
   ro
 }
-old = options(datatable.verbose=FALSE)
 test(1685, grep("dtu", capture.output(foo())), 7L)
-options(old)
 
 # fix for #1771
 test(1686.1, uniqueN(1L), 1L)
@@ -9721,12 +9702,11 @@ test(1695.27, between(0:1, -5:2, -2:5), error="Incompatible vector lengths: leng
 test(1695.28, between(0, -5:2, -2:4), error="Incompatible vector lengths: length(x)==1 length(lower)==8 length(upper)==7. Each should be either length 1 or the length of the longest")
 
 # test for #1819, verbose message for bmerge
-old_opt = getOption("datatable.verbose")
 options(datatable.verbose = TRUE)
 x = data.table(A = 10:17)
 test(1696.0, x[A %inrange% 13:14], output="bmerge")
 # restore verbosity
-options(datatable.verbose = old_opt)
+options(datatable.verbose = FALSE)
 
 # adding a test for #1825 (though it is not on timing, but correctness while
 # joining on keyed tables using 'on' argument)
@@ -9804,13 +9784,13 @@ test(1702.4, isoweek(isotest$input_date), isotest$expected_output)
 if (.Platform$OS.type=="unix") {
   cat("a,b\n4,2", file=f<-tempfile())
   cmd <- sprintf("cat %s", f)
-  old = options(datatable.fread.input.cmd.message = TRUE)
+  options(datatable.fread.input.cmd.message = TRUE)
   test(1703.0, fread(cmd), ans<-data.table(a=4L, b=2L), message="Please use fread.cmd=.*security concern.*Please read item 5 in the NEWS file for v1.11.6")
-  old = options(datatable.fread.input.cmd.message = NULL)  # when option is missing as it is by default, then TRUE
+  options(datatable.fread.input.cmd.message = NULL)  # when option is missing as it is by default, then TRUE
   test(1703.1, fread(cmd), ans, message="security concern")
-  old = options(datatable.fread.input.cmd.message = FALSE)
+  options(datatable.fread.input.cmd.message = FALSE)
   test(1703.2, tryCatch(fread(cmd), message=stop), ans)
-  options(old)
+  options(datatable.fread.input.cmd.message = NULL)
   test(1703.3, fread(cmd=cmd), ans)
   test(1703.4, fread(file=cmd), error=sprintf("File '%s' does not exist", cmd))
   unlink(f)
@@ -9951,7 +9931,6 @@ test(1728.12, DT[order(x,na.last=FALSE)], DT)
 test(1728.13, DT[order(x,na.last=NA)], DT[2])  # was randomly wrong
 
 # fwrite wrong and crash on 9.9999999999999982236431605, #1847
-oldverbose=options(datatable.verbose=FALSE)
 test(1729.1, fwrite(data.table(V1=c(1), V2=c(9.9999999999999982236431605997495353221893310546875))),
              output="V1,V2\n1,10")
 test(1729.2, fwrite(data.table(V2=c(9.9999999999999982236431605997495353221893310546875), V1=c(1))),
@@ -9962,7 +9941,6 @@ DT = data.table(V1=c(9999999999.99, 0.00000000000000099, 0.000000000000000000000
 ans = "V1\n9999999999.99\n9.9e-16\n9e-22\n0.9\n9\n9.1\n99.9\n1e-21\n1e+29"
 test(1729.3, fwrite(DT), output=ans)
 test(1729.4, write.csv(DT,row.names=FALSE,quote=FALSE), output=ans)
-options(oldverbose)
 
 # same decimal/scientific rule (shortest format) as write.csv
 DT = data.table(V1=c(-00000.00006, -123456789.123456789,
@@ -9982,9 +9960,7 @@ DT = data.table(V1=c(-00000.00006, -123456789.123456789,
                      5.123456789e+307, -5.123456789e+307))
 test(1729.5, nrow(DT), 507L)
 
-oldverbose=options(datatable.verbose=FALSE)
-# capture.output() exact tests must not be polluted with verbosity
-
+options(datatable.verbose = FALSE) # capture.output() exact tests must not be polluted with verbosity
 x = capture.output(fwrite(DT,na="NA"))[-1]   # -1 to remove the column name V1
 y = capture.output(write.csv(DT,row.names=FALSE,quote=FALSE))[-1]
 # One mismatch that seems to be accuracy in base R's write.csv
@@ -10266,7 +10242,7 @@ setattr(DT[[4]], "tzone", NULL)
 setattr(DT[[5]], "tzone", NULL)
 
 # format() now supports digits = 0, to display nsmall decimal places.
-old = options(digits.secs=0)
+options(digits.secs=0)
 test(1741.3, x1<-capture.output(fwrite(DT,dateTimeAs="write.csv")),
              capture.output(write.csv(DT,row.names=FALSE,quote=FALSE)))
 options(digits.secs=3)
@@ -10275,13 +10251,8 @@ test(1741.4, x2<-capture.output(fwrite(DT,dateTimeAs="write.csv")),
 options(digits.secs=6)
 test(1741.5, x3<-capture.output(fwrite(DT,dateTimeAs="write.csv")),
              capture.output(write.csv(DT,row.names=FALSE,quote=FALSE)))
-options(old)
 # check that extra digits made it into output
 test(1741.6, sum(nchar(x1)) < sum(nchar(x2)) && sum(nchar(x2)) < sum(nchar(x3)))
-
-###
-options(oldverbose)  # last capture.output(fwrite()) has happened now. TODO: tidy up and remove.
-###
 
 # fread should properly handle NA in colClasses argument #1910
 test(1743.1, sapply(fread("a,b\n3,a", colClasses=c(NA, "factor")), class), c(a="integer", b="factor"))
@@ -10675,11 +10646,11 @@ test(1765, print(IDateTime(x)), output=".*idate.*itime.*1: 2017-03-17")
 test(1766, capture.output(print(data.table(NULL))), "Null data.table (0 rows and 0 cols)")
 
 # Bug on subset of 1-row data.table when expr returns a named logical vector #2152
-op = options(datatable.auto.index=FALSE)
+options(datatable.auto.index=FALSE)
 dt = data.table(x=1, y="a")
 val = c(foo=1L)
 test(1767, dt[x == val], data.table(x=1, y="a"))
-options(op)
+options(datatable.auto.index=TRUE)
 
 # fread sampling overlap and reaching end early on small files with varying line lengths, #2157
 if (test_R.utils) {
@@ -12332,10 +12303,9 @@ DT[ , V1:=as.ordered(V1)]
 test(1918.3, DT[, min(V1)], structure(1L, .Label = lev, class = c("ordered", "factor")))
 test(1918.4, DT[, max(V1)], structure(5L, .Label = lev, class = c("ordered", "factor")))
 ## make sure GForce is activated
-old = options(datatable.optimize = Inf)
+options(datatable.optimize = Inf)
 test(1918.5, DT[, min(V1), by=V2], data.table(V2=c("f", "g", "h"), V1=structure(1:3, .Label=lev, class=c("ordered", "factor"))))
 test(1918.6, DT[, max(V1), by=V2], data.table(V2=c("f", "g", "h"), V1=structure(3:5, .Label=lev, class=c("ordered", "factor"))))
-options(old)
 
 # as.ITime.character bug for NA handling #2940
 test(1919, as.ITime(c('xxx', '10:43')), structure(c(NA, 38580L), class = "ITime"))
@@ -12437,7 +12407,7 @@ setkey(DT,id)
 test(1942.1, DT[,sum(v),by=id,verbose=TRUE], data.table(id=c("A","C","D"), V1=INT(6,8,1), key="id"), output="Finding groups using uniqlist on key")
 DT = data.table(id1=c("D","A","C","A","C"), id2=INT(3,9,2,9,3), id3=c(3.4, 9.1, 3.4, 3.3, 9.1), v=1:5)
 setindex(DT,id1)
-old = options(datatable.use.index=TRUE)
+options(datatable.use.index=TRUE)
 test(1942.2, DT[,sum(v),keyby=id1,verbose=TRUE], data.table(id1=c("D","A","C"), V1=INT(1,6,8), key="id1"), output="Finding groups using uniqlist on index 'id1'")
 setindex(DT,id2)
 test(1942.3, DT[,sum(v),keyby=id2,verbose=TRUE], data.table(id2=INT(3,9,2), V1=INT(6,6,3), key="id2"), output="Finding groups using uniqlist on index 'id2")
@@ -12456,7 +12426,7 @@ test(1942.8, DT[,sum(v),keyby=.(id1,id2),verbose=TRUE], data.table(id1=c("A","C"
 test(1942.9, DT[,sum(v),keyby=.(id2,id1),verbose=TRUE], data.table(id2=INT(2,3,3,9), id1=c("C","C","D","A"), V1=INT(3,5,1,6), key="id2,id1"), output="Finding groups using forderv")
 options(datatable.use.index=FALSE)
 test(1942.11, DT[,sum(v),keyby=id1,verbose=TRUE], data.table(id1=c("D","A","C"), V1=INT(1,6,8), key="id1"), output="Finding groups using forderv")
-options(old)
+options(datatable.use.index=TRUE)
 
 # merge warning: longer object length is not a multiple of shorter object length, #3061
 DT1 <- data.table(
@@ -12676,13 +12646,13 @@ test(1961, cb, gs)
 
 # coverage tests
 ## duplicated.R
-opt = options("datatable.old.unique.by.key" = TRUE)
+options("datatable.old.unique.by.key" = TRUE)
 DT = data.table(x = c(1, 1, 3, 2), key = 'x')
 test(1962.01, duplicated(DT), c(FALSE, TRUE, FALSE, FALSE),
      warning = 'deprecated option')
 test(1962.02, anyDuplicated(DT), 2L,
      warning = 'deprecated option')
-options("datatable.old.unique.by.key" = opt$datatable.old.unique.by.key)
+options("datatable.old.unique.by.key" = FALSE)
 
 test(1962.03, duplicated(DT, fromLast = NA),
      error = 'must be TRUE or FALSE')
@@ -13159,13 +13129,13 @@ suppressWarnings(rm(`___data.table_internal_test_1967.68___`))
 test(1967.68, setDT(`___data.table_internal_test_1967.68___`), error = 'Cannot find symbol')
 
 ### [.data.table verbosity & non-equi-join tests
-old = options('datatable.optimize' = 2)
+options('datatable.optimize' = 2)
 test(1967.69, x[order(a), .N, verbose = TRUE], 5L,
      output = "i changed from 'order(...)' to 'forder(")
 setkey(x)
 test(1967.70, x[x, .N, on = 'a', verbose = TRUE], 5L,
      output = "on= matches existing key")
-options(old)
+options(datatable.optimize = Inf)
 
 x = data.table(
   i1 = c(234L, 250L, 169L, 234L, 147L, 96L, 96L, 369L, 147L, 96L),
@@ -13360,11 +13330,10 @@ test(1984.06, DT[1:3, sum(a), by=b:c], data.table(b=10:8, c=1:3, V1=1:3))
 test(1984.07, DT[, sum(a), by=call('sin',pi)], error='must evaluate to a vector or a list of vectors')
 test(1984.08, DT[, sum(a), by=1+3i],           error='column or expression.*type complex')
 test(1984.09, DT[, sum(a), by=.(1,1:2)],       error='The items.*list are length [(]1,2[)].*Each must be length 10; .*rows in x.*after subsetting')
-old = options('datatable.optimize' = Inf)
+options('datatable.optimize' = Inf)
 test(1984.10, DT[ , 1, by = .(a %% 2), verbose = TRUE],
      data.table(a = c(1, 0), V1 = c(1, 1)),
      output = 'Optimization is on but left j unchanged')
-options(old)
 DT[ , f := rep(1:2, each = 5)]
 test(1984.11, DT[ , g:=sum(a), keyby=f, verbose=TRUE][,sum(g)], 275L, output='setkey() after the := with keyby=')
 test(1984.12, as.matrix(DT, rownames=character(0L)), error='length(rownames)==0 but should be')

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -6846,6 +6846,7 @@ test(1514.8, isReallyReal(9L), 0L)
 options(datatable.prettyprint.char = 5L)
 DT = data.table(x=1:2, y=c("abcdefghijk", "lmnopqrstuvwxyz"))
 test(1515.1, grep("abcde...", capture.output(print(DT))), 2L)
+options(datatable.prettyprint.char = NULL)
 
 # test 1516: chain setnames() - used while mapping source to target columns
 SRC = data.table(x=1:2, y=c("abcdefghij", "klmnopqrstuv"), z=rnorm(2))
@@ -9936,6 +9937,7 @@ test(1728.12, DT[order(x,na.last=FALSE)], DT)
 test(1728.13, DT[order(x,na.last=NA)], DT[2])  # was randomly wrong
 
 # fwrite wrong and crash on 9.9999999999999982236431605, #1847
+options(datatable.verbose = FALSE)
 test(1729.1, fwrite(data.table(V1=c(1), V2=c(9.9999999999999982236431605997495353221893310546875))),
              output="V1,V2\n1,10")
 test(1729.2, fwrite(data.table(V2=c(9.9999999999999982236431605997495353221893310546875), V1=c(1))),


### PR DESCRIPTION
Couple distinct but highly correlated things going on in this PR (separated by commit)

 - Minor edit to .gitignore to add local .Rprofile
 - Closing #3405 directly
 - Attempt at simplifying / being more intentional about the use of `options`/`getOption` overall, relying more heavily on the capturing of user's options and just being sure to set the options relevant to the current test
 - Finally, take care of point 1 in #2572 -- loop through the relevant levels of GForce optimization in all related/relevant tests