### PR TITLE
remove nested parallelism from froll

### DIFF
--- a/inst/tests/froll.Rraw
+++ b/inst/tests/froll.Rraw
@@ -299,25 +299,25 @@ test(9999.067, ans2, expected)
 #### early stopping NAs in leading k obs
 test(9999.0671, frollmean(c(1:2,NA,4:10), 4, verbose=TRUE), c(rep(NA_real_, 6), 5.5, 6.5, 7.5, 8.5), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped",
+  "frollfunR: 1 column(s) and 1 window(s), if product > 1 then entering parallel execution",
   "frollmeanFast: running for input length 10, window 4, hasna 0, narm 0",
   "frollmeanFast: NA (or other non-finite) value(s) are present in input, skip non-NA attempt and run with extra care for NAs"
 ))
 test(9999.0672, frollmean(c(1:2,NA,4:10), 4, hasNA=FALSE, verbose=TRUE), c(rep(NA_real_, 6), 5.5, 6.5, 7.5, 8.5), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped",
+  "frollfunR: 1 column(s) and 1 window(s), if product > 1 then entering parallel execution",
   "frollmeanFast: running for input length 10, window 4, hasna -1, narm 0",
   "frollmeanFast: NA (or other non-finite) value(s) are present in input, skip non-NA attempt and run with extra care for NAs"
 ), warning="hasNA=FALSE used but NA (or other non-finite) value(s) are present in input, use default hasNA=NA to avoid this warning")
-test(9999.0673, ans<-frollmean(c(1:2,NA,4:10), 2, hasNA=FALSE, verbose=TRUE), c(NA, 1.5, NA, NA, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5), output=c(
+test(9999.0673, frollmean(c(1:2,NA,4:10), 2, hasNA=FALSE, verbose=TRUE), c(NA, 1.5, NA, NA, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped",
+  "frollfunR: 1 column(s) and 1 window(s), if product > 1 then entering parallel execution",
   "frollmeanFast: running for input length 10, window 2, hasna -1, narm 0",
   "frollmeanFast: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs"
 ), warning="hasNA=FALSE used but NA (or other non-finite) value(s) are present in input, use default hasNA=NA to avoid this warning")
 test(9999.0674, frollmean(c(1:2,NA,4:10), 4, verbose=TRUE, align="center"), c(rep(NA_real_, 4), 5.5, 6.5, 7.5, 8.5, NA, NA), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped",
+  "frollfunR: 1 column(s) and 1 window(s), if product > 1 then entering parallel execution",
   "frollmeanFast: running for input length 10, window 4, hasna 0, narm 0",
   "frollmeanFast: NA (or other non-finite) value(s) are present in input, skip non-NA attempt and run with extra care for NAs",
   "frollmean: align 0, shift answer by -2"
@@ -414,15 +414,15 @@ test(9999.1195, frollmean(1:5, 2, na.rm=TRUE, hasNA=FALSE), error="using hasNA F
 #### exact na.rm=TRUE adaptive=TRUE verbose=TRUE
 test(9999.1196, frollmean(c(1:5,NA), 1:6, algo="exact", na.rm=TRUE, adaptive=TRUE, verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped but 'exact' version of rolling function will compute results in parallel", 
-  "fadaptiverollmeanExact: running for input length 6, hasna 0, narm 1", 
+  "frollfunR: 1 column(s) and 1 window(s), not entering parallel execution here because algo='exact' will compute results in parallel",
+  "fadaptiverollmeanExact: running in parallel for input length 6, hasna 0, narm 1",
   "fadaptiverollmeanExact: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs"
 ))
 #### exact na.rm=TRUE verbose=TRUE
 test(9999.1197, frollmean(c(1:5,NA), 2, algo="exact", na.rm=TRUE, verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped but 'exact' version of rolling function will compute results in parallel", 
-  "frollmeanExact: running for input length 6, window 2, hasna 0, narm 1", 
+  "frollfunR: 1 column(s) and 1 window(s), not entering parallel execution here because algo='exact' will compute results in parallel",
+  "frollmeanExact: running in parallel for input length 6, window 2, hasna 0, narm 1",
   "frollmeanExact: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs"
 ))
 #### adaptive=TRUE n=character
@@ -633,82 +633,84 @@ x = 1:10
 n = 3
 test(9999.171, frollmean(x, n, verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped",
+  "frollfunR: 1 column(s) and 1 window(s), if product > 1 then entering parallel execution",
   "frollmeanFast: running for input length 10, window 3, hasna 0, narm 0"))
 test(9999.172, frollmean(list(x, x+1), n, verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 2x1",
-  "frollfunR: 2 column(s) and 1 window(s), entering parallel execution, but actually single threaded due to enabled verbose which is not thread safe",
+  "frollfunR: 2 column(s) and 1 window(s), if product > 1 then entering parallel execution",
   "frollmeanFast: running for input length 10, window 3, hasna 0, narm 0",
   "frollmeanFast: running for input length 10, window 3, hasna 0, narm 0"))
 test(9999.173, frollmean(x, c(n, n+1), verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x2",
-  "frollfunR: 1 column(s) and 2 window(s), entering parallel execution, but actually single threaded due to enabled verbose which is not thread safe",
+  "frollfunR: 1 column(s) and 2 window(s), if product > 1 then entering parallel execution",
   "frollmeanFast: running for input length 10, window 3, hasna 0, narm 0",
   "frollmeanFast: running for input length 10, window 4, hasna 0, narm 0"))
 test(9999.174, frollmean(list(x, x+1), c(n, n+1), verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 2x2",
-  "frollfunR: 2 column(s) and 2 window(s), entering parallel execution, but actually single threaded due to enabled verbose which is not thread safe",
+  "frollfunR: 2 column(s) and 2 window(s), if product > 1 then entering parallel execution",
+  "frollmeanFast: running for input length 10, window 3, hasna 0, narm 0",
+  "frollmeanFast: running for input length 10, window 4, hasna 0, narm 0",
   "frollmeanFast: running for input length 10, window 3, hasna 0, narm 0",
   "frollmeanFast: running for input length 10, window 4, hasna 0, narm 0"))
 test(9999.175, frollmean(x, n, algo="exact", verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped but 'exact' version of rolling function will compute results in parallel",
-  "frollmeanExact: running for input length 10, window 3, hasna 0, narm 0"))
+  "frollfunR: 1 column(s) and 1 window(s), not entering parallel execution here because algo='exact' will compute results in parallel",
+  "frollmeanExact: running in parallel for input length 10, window 3, hasna 0, narm 0"))
 test(9999.176, frollmean(x, n, align="center", verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped",
+  "frollfunR: 1 column(s) and 1 window(s), if product > 1 then entering parallel execution",
   "frollmeanFast: running for input length 10, window 3, hasna 0, narm 0",
   "frollmean: align 0, shift answer by -1"))
 test(9999.177, frollmean(x, n, align="left", verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped",
+  "frollfunR: 1 column(s) and 1 window(s), if product > 1 then entering parallel execution",
   "frollmeanFast: running for input length 10, window 3, hasna 0, narm 0",
   "frollmean: align -1, shift answer by -2"))
 nn = c(1:4,2:3,1:4)
 test(9999.178, frollmean(x, nn, adaptive=TRUE, verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped",
+  "frollfunR: 1 column(s) and 1 window(s), if product > 1 then entering parallel execution",
   "fadaptiverollmeanFast: running for input length 10, hasna 0, narm 0"))
 test(9999.179, frollmean(x, nn, algo="exact", adaptive=TRUE, verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped but 'exact' version of rolling function will compute results in parallel",
-  "fadaptiverollmeanExact: running for input length 10, hasna 0, narm 0"))
+  "frollfunR: 1 column(s) and 1 window(s), not entering parallel execution here because algo='exact' will compute results in parallel",
+  "fadaptiverollmeanExact: running in parallel for input length 10, hasna 0, narm 0"))
 
 x[8] = NA
 test(9999.180, frollmean(x, n, verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped",
+  "frollfunR: 1 column(s) and 1 window(s), if product > 1 then entering parallel execution",
   "frollmeanFast: running for input length 10, window 3, hasna 0, narm 0",
   "frollmeanFast: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs"))
 test(9999.181, frollmean(x, n, algo="exact", verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped but 'exact' version of rolling function will compute results in parallel",
-  "frollmeanExact: running for input length 10, window 3, hasna 0, narm 0",
+  "frollfunR: 1 column(s) and 1 window(s), not entering parallel execution here because algo='exact' will compute results in parallel",
+  "frollmeanExact: running in parallel for input length 10, window 3, hasna 0, narm 0",
   "frollmeanExact: NA (or other non-finite) value(s) are present in input, na.rm was FALSE so in 'exact' implementation NAs were handled already, no need to re-run"))
 test(9999.182, frollmean(x, nn, adaptive=TRUE, verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped",
+  "frollfunR: 1 column(s) and 1 window(s), if product > 1 then entering parallel execution",
   "fadaptiverollmeanFast: running for input length 10, hasna 0, narm 0",
   "fadaptiverollmeanFast: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs"))
 test(9999.183, frollmean(x, nn, algo="exact", adaptive=TRUE, verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped but 'exact' version of rolling function will compute results in parallel",
-  "fadaptiverollmeanExact: running for input length 10, hasna 0, narm 0",
+  "frollfunR: 1 column(s) and 1 window(s), not entering parallel execution here because algo='exact' will compute results in parallel",
+  "fadaptiverollmeanExact: running in parallel for input length 10, hasna 0, narm 0",
   "fadaptiverollmeanExact: NA (or other non-finite) value(s) are present in input, na.rm was FALSE so in 'exact' implementation NAs were handled already, no need to re-run"))
 
 d = as.data.table(list(1:10/2, 10:1/4))
 test(9999.184, frollmean(d[,1], 3, algo="exact", verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: single column and single window, parallel processing by multiple answer vectors skipped but 'exact' version of rolling function will compute results in parallel",
-  "frollmeanExact: running for input length 10, window 3, hasna 0, narm 0"
+  "frollfunR: 1 column(s) and 1 window(s), not entering parallel execution here because algo='exact' will compute results in parallel",
+  "frollmeanExact: running in parallel for input length 10, window 3, hasna 0, narm 0"
 ))
 test(9999.185, frollmean(d, 3:4, algo="exact", verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 2x2",
-  "frollfunR: 2 column(s) and 2 window(s), entering parallel execution, but actually single threaded due to enabled verbose which is not thread safe, 'exact' version of rolling function will compute results in parallel anyway as it does not print with verbose",
-  "frollmeanExact: running for input length 10, window 3, hasna 0, narm 0",
-  "frollmeanExact: running for input length 10, window 4, hasna 0, narm 0",
-  "frollmeanExact: running for input length 10, window 3, hasna 0, narm 0",
-  "frollmeanExact: running for input length 10, window 4, hasna 0, narm 0"
+  "frollfunR: 2 column(s) and 2 window(s), not entering parallel execution here because algo='exact' will compute results in parallel",
+  "frollmeanExact: running in parallel for input length 10, window 3, hasna 0, narm 0",
+  "frollmeanExact: running in parallel for input length 10, window 4, hasna 0, narm 0",
+  "frollmeanExact: running in parallel for input length 10, window 3, hasna 0, narm 0",
+  "frollmeanExact: running in parallel for input length 10, window 4, hasna 0, narm 0"
 ))
 
 ## test warnings

--- a/src/froll.c
+++ b/src/froll.c
@@ -12,7 +12,6 @@
  */
 
 void frollmean(unsigned int algo, double *x, uint_fast64_t nx, double_ans_t *ans, int k, int align, double fill, bool narm, int hasna, bool verbose) {
-  ans->status = 0;                                              // default status success
   if (nx < k) {                                                 // if window width bigger than input just return vector of fill values
     if (verbose) Rprintf("%s: window width longer than input vector, returning all NA vector\n", __func__);
     for (int i=0; i<nx; i++) ans->ans[i] = fill;
@@ -104,7 +103,7 @@ void frollmeanFast(double *x, uint_fast64_t nx, double_ans_t *ans, int k, double
  */
 
 void frollmeanExact(double *x, uint_fast64_t nx, double_ans_t *ans, int k, double fill, bool narm, int hasna, bool verbose) {
-  if (verbose) Rprintf("%s: running for input length %llu, window %d, hasna %d, narm %d\n", __func__, nx, k, hasna, (int) narm);
+  if (verbose) Rprintf("%s: running in parallel for input length %llu, window %d, hasna %d, narm %d\n", __func__, nx, k, hasna, (int) narm);
   for (int i=0; i<k-1; i++) {                                   // fill partial window only
     ans->ans[i] = fill;
   }

--- a/src/frolladaptive.c
+++ b/src/frolladaptive.c
@@ -12,7 +12,6 @@
  */
 
 void fadaptiverollmean(unsigned int algo, double *x, uint_fast64_t nx, double_ans_t *ans, int *k, double fill, bool narm, int hasna, bool verbose) {
-  ans->status = 0;                                              // default status success
   if (algo==0) fadaptiverollmeanFast(x, nx, ans, k, fill, narm, hasna, verbose);
   else if (algo==1) fadaptiverollmeanExact(x, nx, ans, k, fill, narm, hasna, verbose);
 }
@@ -103,7 +102,7 @@ void fadaptiverollmeanFast(double *x, uint_fast64_t nx, double_ans_t *ans, int *
  */
 
 void fadaptiverollmeanExact(double *x, uint_fast64_t nx, double_ans_t *ans, int *k, double fill, bool narm, int hasna, bool verbose) {
-  if (verbose) Rprintf("%s: running for input length %llu, hasna %d, narm %d\n", __func__, nx, hasna, (int) narm);
+  if (verbose) Rprintf("%s: running in parallel for input length %llu, hasna %d, narm %d\n", __func__, nx, hasna, (int) narm);
   bool truehasna = hasna>0;                                   // flag to re-run if NAs detected
 
   if (!truehasna || !narm) {                                  // narm=FALSE handled here as NAs properly propagated in exact algo


### PR DESCRIPTION
simplified #3394

* no longer has nested parallelism - for algos that uses parallelism to compute rollmean the outer parallelism over columns/window sizes is turned off
* some code refactor to use #pragma omp if

----

* verbose still does turn off parallel processing (outer one), algo="exact" is/was always parallel as there is no verbose from there
* no timing yet