### PR TITLE
subsetDT malformed checks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -52,6 +52,8 @@
 
 18. `cbind` with a null (0-column) `data.table` now works as expected, [#3445](https://github.com/Rdatatable/data.table/issues/3445). Thanks to @mb706 for reporting.
 
+19. Subsetting does a better job of catching a malformed `data.table` with error rather than segfault. A column may not be NULL, nor may a column have columns. Thanks to a comment and reproducible example in [#3369](https://github.com/Rdatatable/data.table/issues/3369) from Drew Abbot which demonstrated subsetting a `data.table` formed by `as.data.table` when passed a `data.frame` containing columns that are `data.frame`.
+
 #### NOTES
 
 1. When upgrading to 1.12.0 some Windows users might have seen `CdllVersion not found` in some circumstances. We found a way to catch that so the [helpful message](https://twitter.com/MattDowle/status/1084528873549705217) now occurs for those upgrading from versions prior to 1.12.0 too, as well as those upgrading from 1.12.0 to a later version. See item 1 in notes section of 1.12.0 below for more background.

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -13818,7 +13818,7 @@ test(2008.8, rbindlist(list(DT1, list(c("e","foo")), DT1)), data.table(x=ordered
 
 # segfault comparing NULL column, #2303 #2305
 DT = structure(list(NULL), names="a", class=c("data.table","data.frame"))
-test(2009.1, DT[a>1], error="Internal error: column 1 of data.table is NULL; malformed")
+test(2009.1, DT[a>1], error="Column 1 is NULL; malformed data.table")
 DT = null.data.table()
 x = NULL
 test(2009.2, DT[, .(x)], error="Column 1 of j evaluates to NULL. A NULL column is invalid.")

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -13863,6 +13863,14 @@ test(2012.3, data.table(data.frame(), data.frame(a=integer())), data.table(a=int
 dt = as.data.table(iris)
 test(2012.4, cbind(data.table(), dt[0]), dt[0])
 
+# extra validity checks in subsetDT on data.table; #3369
+DT = structure(list(a=1:3, b=NULL, c=4:6), class=c("data.table","data.frame"))
+test(2013.1, DT[2], error="Column 2 is NULL; malformed data.table")
+DT = structure(list(a=1:3, b=data.frame(foo=10:12,bar=13:15), c=4:6), class=c("data.table","data.frame"))
+test(2013.2, DT[2], error="Column 2 ['b'] is a data.frame or data.table; malformed data.table.")
+DT = structure(list(a=1:3, b=1:4, c=4:6), class=c("data.table","data.frame"))
+test(2013.3, DT[2], error="Column 2 ['b'] is length 4 but column 1 is length 3; malformed data.table.")
+
 
 ###################################
 #  Add new tests above this line  #

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -69,6 +69,7 @@ SEXP char_allLen1;
 SEXP char_allGrp1;
 SEXP char_factor;
 SEXP char_ordered;
+SEXP char_dataframe;
 SEXP sym_sorted;
 SEXP sym_index;
 SEXP sym_BY;

--- a/src/freadR.c
+++ b/src/freadR.c
@@ -456,6 +456,7 @@ void pushBuffer(ThreadLocalFreadParsingContext *ctx)
       if (thisSize == 4) {
         char *dest = (char *)DATAPTR(VECTOR_ELT(DT, resj)) + DTi*4;
         char *src4 = (char*)buff4 + off4;
+        // debug line for #3369 ... if (DTi>2638000) printf("freadR.c:460: thisSize==4, resj=%d, %zd, %d, %d, j=%d, done=%d\n", resj, DTi, off4, rowSize4, j, done);
         for (int i=0; i<nRows; i++) {
           memcpy(dest, src4, 4);
           src4 += rowSize4;

--- a/src/init.c
+++ b/src/init.c
@@ -265,6 +265,7 @@ void attribute_visible R_init_datatable(DllInfo *info)
   char_allGrp1 =   PRINTNAME(install("allGrp1"));
   char_factor =    PRINTNAME(install("factor"));
   char_ordered =   PRINTNAME(install("ordered"));
+  char_dataframe = PRINTNAME(install("data.frame"));
 
   if (TYPEOF(char_integer64) != CHARSXP) {
     // checking one is enough in case of any R-devel changes

--- a/src/subset.c
+++ b/src/subset.c
@@ -282,7 +282,7 @@ SEXP subsetDT(SEXP x, SEXP rows, SEXP cols) {
     for (int i=0; i<LENGTH(cols); i++) {
       SEXP thisCol = VECTOR_ELT(x, colD[i]-1);
       checkCol(thisCol, colD[i], nrow, x);
-      SET_VECTOR_ELT(ans, i+1, duplicate(thisCol));
+      SET_VECTOR_ELT(ans, i, duplicate(thisCol));
       // materialize the column subset as we have always done for now, until REFCNT is on by default in R (TODO)
     }
   } else {


### PR DESCRIPTION
This PR addresses the `subsetDT` segfault parts of #3369.
It does not address the fread reread problem on the last line of file. I had a look but didn't see a quick fix so will postpone that.