### PR TITLE
keepLeadingZeros follow up

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,8 @@ Authors@R: c(
   person("James","Sams",           role="ctb"),
   person("Martin","Morgan",        role="ctb"),
   person("Michael","Quinn",        role="ctb"),
-  person("@javrucebo","",          role="ctb"))
+  person("@javrucebo","",          role="ctb"),
+  person("@marc-outins","",        role="ctb"))
 Depends: R (>= 3.1.0)
 Imports: methods
 Suggests: bit64, curl, R.utils, knitr, xts, nanotime, zoo

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 
 5. `rbindlist`'s `use.names=` default has changed from `FALSE` to `"check"`. This warns if the column names of each item are not identical and then proceeds as if `use.names=FALSE` for backwards compatibility; i.e., bind by column number not by column name. In future, it will warn and then proceed as if `use.names=TRUE`. Eventually the default will be changed from `NA` to `TRUE` unless user feedback is negative. The `rbind` method for `data.table` already sets `use.names=TRUE` as does `rbind` for `data.frame` in base, and is clearly safer. To stack differently named columns together silently (the previous default behavior), it is now necessary to write `use.names=FALSE` for clarity to readers of your code. Thanks to Clayton Stanley who first raised the issue [here](http://lists.r-forge.r-project.org/pipermail/datatable-help/2014-April/002480.html).
 
+6. `fread` gains `keepLeadingZeros`, [#2999](https://github.com/Rdatatable/data.table/issues/2999). `FALSE` by default so that, as before, a field containing `001` is interpretted as the integer 1, otherwise the character string `"001"`. The default may be changed using `options(datatable.keepLeadingZeros=TRUE)`. Many thanks to @marc-outins for the PR.
+
 #### BUG FIXES
 
 1. `rbindlist()` of a malformed factor missing levels attribute is now a helpful error rather than a cryptic error about `STRING_ELT`, [#3315](https://github.com/Rdatatable/data.table/issues/3315). Thanks to Michael Chirico for reporting.
@@ -52,7 +54,7 @@
 
 18. `cbind` with a null (0-column) `data.table` now works as expected, [#3445](https://github.com/Rdatatable/data.table/issues/3445). Thanks to @mb706 for reporting.
 
-19. Subsetting does a better job of catching a malformed `data.table` with error rather than segfault. A column may not be NULL, nor may a column have columns. Thanks to a comment and reproducible example in [#3369](https://github.com/Rdatatable/data.table/issues/3369) from Drew Abbot which demonstrated subsetting a `data.table` formed by `as.data.table` when passed a `data.frame` containing columns that are `data.frame`.
+19. Subsetting does a better job of catching a malformed `data.table` with error rather than segfault. A column may not be NULL, nor may a column be an object such as a data.frame or matrix which have columns. Thanks to a comment and reproducible example in [#3369](https://github.com/Rdatatable/data.table/issues/3369) from Drew Abbot which demonstrated subsetting a `data.table` formed by `as.data.table` when passed a `data.frame` containing columns that are `data.frame`.
 
 #### NOTES
 

--- a/R/fread.R
+++ b/R/fread.R
@@ -1,5 +1,12 @@
 
-fread <- function(input="",file=NULL,text=NULL,cmd=NULL,sep="auto",sep2="auto",dec=".",quote="\"",nrows=Inf,header="auto",na.strings=getOption("datatable.na.strings","NA"),stringsAsFactors=FALSE,verbose=getOption("datatable.verbose",FALSE),skip="__auto__",select=NULL,drop=NULL,colClasses=NULL,integer64=getOption("datatable.integer64","integer64"), col.names, check.names=FALSE, encoding="unknown", strip.white=TRUE, fill=FALSE, blank.lines.skip=FALSE, key=NULL, index=NULL, showProgress=getOption("datatable.showProgress",interactive()), data.table=getOption("datatable.fread.datatable",TRUE), nThread=getDTthreads(verbose), logical01=getOption("datatable.logical01", FALSE), keepLeadingZeros = getOption("data.table.keepLeadingZeros", FALSE), autostart=NA)
+fread <- function(
+input="", file=NULL, text=NULL, cmd=NULL, sep="auto", sep2="auto", dec=".", quote="\"", nrows=Inf, header="auto",
+na.strings=getOption("datatable.na.strings","NA"), stringsAsFactors=FALSE, verbose=getOption("datatable.verbose",FALSE),
+skip="__auto__", select=NULL, drop=NULL, colClasses=NULL, integer64=getOption("datatable.integer64","integer64"),
+col.names, check.names=FALSE, encoding="unknown", strip.white=TRUE, fill=FALSE, blank.lines.skip=FALSE, key=NULL, index=NULL,
+showProgress=getOption("datatable.showProgress",interactive()), data.table=getOption("datatable.fread.datatable",TRUE),
+nThread=getDTthreads(verbose), logical01=getOption("datatable.logical01",FALSE), keepLeadingZeros=getOption("datatable.keepLeadingZeros",FALSE),
+autostart=NA)
 {
   if (missing(input)+is.null(file)+is.null(text)+is.null(cmd) < 3L) stop("Used more than one of the arguments input=, file=, text= and cmd=.")
   input_has_vars = length(all.vars(substitute(input)))>0L  # see news for v1.11.6

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -13875,13 +13875,13 @@ test(2013.3, DT[2], error="Column 2 ['b'] is length 4 but column 1 is length 3; 
 ## new fread keepLeadingZeros parameter in v1.12.2
 # leading zeros in both integer and float numbers are converted to character when keepLeadingZeros=TRUE
 test_data_single <- "0, 00, 01, 00010, 002.01\n"
-test(1978.0, fread(test_data_single), data.table(0L, 0L, 1L, 10L, 2.01))
-test(1978.1, fread(test_data_single, keepLeadingZeros = FALSE), data.table(0L, 0L, 1L, 10L, 2.01))
-test(1978.2, fread(test_data_single, keepLeadingZeros = TRUE),  data.table(0L, "00","01","00010","002.01"))
+test(1978.1, fread(test_data_single), data.table(0L, 0L, 1L, 10L, 2.01))
+test(1978.2, fread(test_data_single, keepLeadingZeros = FALSE), data.table(0L, 0L, 1L, 10L, 2.01))
+test(1978.3, fread(test_data_single, keepLeadingZeros = TRUE),  data.table(0L, "00","01","00010","002.01"))
 # converts whole column to character when keepLeadingZeros = TRUE and at least 1 value contains a leading zero
 test_data_mult <- paste0(c(sample(1:100),"0010",sample(1:100)), collapse="\n")
-test(1978.3, class(fread(test_data_mult, keepLeadingZeros = TRUE)[[1]]), "character")
-test(1978.4, class(fread(test_data_mult, keepLeadingZeros = FALSE)[[1]]), "integer")
+test(1978.4, class(fread(test_data_mult, keepLeadingZeros = TRUE)[[1]]), "character")
+test(1978.5, class(fread(test_data_mult, keepLeadingZeros = FALSE)[[1]]), "integer")
 
 
 ###################################

--- a/man/fread.Rd
+++ b/man/fread.Rd
@@ -23,7 +23,7 @@ showProgress=getOption("datatable.showProgress", interactive()),
 data.table=getOption("datatable.fread.datatable", TRUE),
 nThread=getDTthreads(verbose),
 logical01=getOption("datatable.logical01", FALSE),  # due to change to TRUE; see NEWS
-keepLeadingZeros = getOption("data.table.keepLeadingZeros", FALSE),
+keepLeadingZeros = getOption("datatable.keepLeadingZeros", FALSE),
 autostart=NA
 )
 }


### PR DESCRIPTION
Minor follow up to #3293.
Added news items and thanks to @marc-outins.
Added Marc to contributors list in DESCRIPTION.
Reformatted fread.R argument list; no changes there, other than `data.table.keepLeadingZeros` renamed `datatable.keepLeadingZeros` for consistency with other datatable options.
Simpler (less code) and more efficient (one `if`) at C level.