### PR TITLE
drop NA in factor levels

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -13887,6 +13887,9 @@ test_data_mult <- paste0(c(sample(1:100),"0010",sample(1:100)), collapse="\n")
 test(1978.4, class(fread(test_data_mult, keepLeadingZeros = TRUE)[[1]]), "character")
 test(1978.5, class(fread(test_data_mult, keepLeadingZeros = FALSE)[[1]]), "integer")
 
+# rbindlist should drop NA from levels of source factors, relied on by package emil
+test(1979, levels(rbindlist( list( data.frame(a=factor("a",levels=c("a",NA),exclude=NULL)) ))$a), "a")  # the NA level should not be retained
+
 
 ###################################
 #  Add new tests above this line  #


### PR DESCRIPTION
To pass package `emil` in #3473 which has a test that NA in factor levels are dropped by `rbindlist`.
