### PR TITLE
null column

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1411,8 +1411,9 @@ replace_dot_alias <- function(e) {
       setattr(jval, 'class', class(x)) # fix for #5296
       if (haskey(x) && all(key(x) %chin% names(jval)) && suppressWarnings(is.sorted(jval, by=key(x))))  # TO DO: perhaps this usage of is.sorted should be allowed internally then (tidy up and make efficient)
         setattr(jval, 'sorted', key(x))
-      w = sapply(jval, is.null)
-      if (any(w)) jval = jval[,!w,with=FALSE]  # no !..w due to 'Undefined global functions or variables' note from R CMD check
+      # postponed to v1.12.4 because package eplusr creates a NULL column and then runs setcolorder on the result which fails if there are fewer columns
+      # w = sapply(jval, is.null)
+      # if (any(w)) jval = jval[,!w,with=FALSE]  # no !..w due to 'Undefined global functions or variables' note from R CMD check
     }
     return(jval)
   }

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -13195,7 +13195,7 @@ test(1967.33, foverlaps(x, y, by.x = c('start', 'end'), by.y = c('end', 'start')
      error = 'All entries in column end should be <= corresponding entries')
 
 ## data.table.R
-test(1967.34, data.table(1:5, NULL), error = 'column or argument 2 is NULL')
+test(1967.34, data.table(1:5, NULL), data.table(V1=1:5))
 ### testing branches:
 ###   if (length(namesi)==0L) namesi = rep.int("",ncol(xi))
 ###   if (any(tt)) namesi[tt] = paste0("V", which(tt))
@@ -13826,9 +13826,13 @@ DT = structure(list(NULL), names="a", class=c("data.table","data.frame"))
 test(2009.1, DT[a>1], error="Column 1 is NULL; malformed data.table")
 DT = null.data.table()
 x = NULL
-test(2009.2, DT[, .(x)], error="Column 1 of j evaluates to NULL. A NULL column is invalid.")
-test(2009.3, data.table(character(0), NULL), error="column or argument 2 is NULL")
-test(2009.4, as.data.table(list(y = character(0), x = NULL)), data.table(y=character()))
+test(2009.2, DT[, .(x)], null.data.table())  # because .(x) evaluated to NULL; NULL columns in results removed
+DT = data.table(A=1:3)
+test(2009.3, DT[, .(x)], null.data.table())
+test(2009.4, DT[, .(x, sum(A))], data.table(V1=6L))
+test(2009.5, DT[, .(sum(A), x)], data.table(V1=6L))
+test(2009.6, data.table(character(0), NULL), data.table(V1=character()))
+test(2009.7, as.data.table(list(y = character(0), x = NULL)), data.table(y=character()))
 
 # use.names=NA warning for out-of-order; https://github.com/Rdatatable/data.table/pull/3455#issuecomment-472744347
 DT1 = data.table(a=1:2, b=5:6)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -13826,9 +13826,10 @@ DT = structure(list(NULL), names="a", class=c("data.table","data.frame"))
 test(2009.1, DT[a>1], error="Column 1 is NULL; malformed data.table")
 DT = null.data.table()
 x = NULL
-test(2009.2, DT[, .(x)], null.data.table())  # because .(x) evaluated to NULL; NULL columns in results removed
+test(2009.2, DT[, .(x)], ans<-alloc.col(structure(list(x=NULL), names="x", class=c("data.table","data.frame"))))
+# postponed to 1.12.4 ... V1=null.data.table())  # because .(x) evaluated to NULL; NULL columns in results removed
 DT = data.table(A=1:3)
-test(2009.3, DT[, .(x)], null.data.table())
+test(2009.3, DT[, .(x)], ans)   # null.data.table()
 test(2009.4, DT[, .(x, sum(A))], data.table(V1=6L))
 test(2009.5, DT[, .(sum(A), x)], data.table(V1=6L))
 test(2009.6, data.table(character(0), NULL), data.table(V1=character()))


### PR DESCRIPTION
data.table() skips NULL rather than error; surprise was than NCOL(NULL)==1 not 0
NULL columns can be created again; postponed to 1.12.4 so notice can be given to eplusr.
Passes eplusr for #3473