### PR TITLE
closes #2996 -- add a helpful error suggesting setDT() to load()ed da…

### DIFF
--- a/src/assign.c
+++ b/src/assign.c
@@ -435,7 +435,10 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values, SEXP v
   if (length(newcolnames)) {
     oldtncol = TRUELENGTH(dt);   // TO DO: oldtncol can be just called tl now, as we won't realloc here any more.
 
-    if (oldtncol<oldncol) error("Internal error, please report (including result of sessionInfo()) to data.table issue tracker: oldtncol (%d) < oldncol (%d) but tl of class is marked.", oldtncol, oldncol); // # nocov
+    if (oldtncol<oldncol) {
+      // Likely user has loaded this object and not run setDT on it, e.g. #2996
+      if (oldtncol == 0) error("It appears this object has not yet had any columns; if you've loaded this data.table from disk, e.g. with load(), please remember to always call setDT() after loading to allocate columns. If the issue persists, please report (including result of sessionInfo()) to data.table issue tracker: oldtncol (%d) < oldncol (%d) but tl of class is marked.", oldtncol, oldncol); // # nocov
+      error("Internal error, please report (including result of sessionInfo()) to data.table issue tracker: oldtncol (%d) < oldncol (%d) but tl of class is marked.", oldtncol, oldncol); // # nocov
     if (oldtncol>oldncol+10000L) warning("truelength (%d) is greater than 10,000 items over-allocated (length = %d). See ?truelength. If you didn't set the datatable.alloccol option very large, please report to data.table issue tracker including the result of sessionInfo().",oldtncol, oldncol);
 
     if (oldtncol < oldncol+LENGTH(newcolnames))


### PR DESCRIPTION
…ta.tables

#2996 

I guess we could test this by running save() & load() in tests? Didn't add for now.

Also would be nice to have a wiki/FAQ to refer to on this since this issue comes up a lot.