### PR TITLE
empty argument in j output caught early & stopped

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,8 @@
 
 2. `keyby=colName` could use the wrong index and return incorrect results if both `colName` and `colNameExtra` (where `colName` is a leading subset of characters of `colNameExtra`) are column names and an index exists on `colNameExtra`, [#3498](https://github.com/Rdatatable/data.table/issues/3498). Thanks to Xianying Tan for the detailed report and pinpointing the source line at fault.
 
+3. `j = list(x, )` would sometimes correctly error but with a confusing diagnosis, [#3507](https://github.com/Rdatatable/data.table/issues/3507). This is now caught and stopped much earlier with a helpful admonition; thanks @eddelbuettel for the report.
+
 #### NOTES
 
 1. `rbindlist`'s `use.names="check"` now emits its message for automatic column names (`"V[0-9]+"`) too, [#3484](https://github.com/Rdatatable/data.table/pull/3484). See news item 5 of v1.12.2 below.

--- a/NEWS.md
+++ b/NEWS.md
@@ -41,7 +41,7 @@
 
 2. `keyby=colName` could use the wrong index and return incorrect results if both `colName` and `colNameExtra` (where `colName` is a leading subset of characters of `colNameExtra`) are column names and an index exists on `colNameExtra`, [#3498](https://github.com/Rdatatable/data.table/issues/3498). Thanks to Xianying Tan for the detailed report and pinpointing the source line at fault.
 
-3. `j = list(x, )` would sometimes correctly error but with a confusing diagnosis, [#3507](https://github.com/Rdatatable/data.table/issues/3507). This is now caught and stopped much earlier with a helpful admonition; thanks @eddelbuettel for the report.
+3. A missing item in `j` such as `j=.(colA, )` now gives a helpful error (`Item 2 of the .() or list() passed to j is missing`) rather than the unhelpful error `argument "this_jsub" is missing, with no default` (v1.12.2) or `argument 2 is empty` (v1.12.0 and before), [#3507](https://github.com/Rdatatable/data.table/issues/3507). Thanks to @eddelbuettel for the report.
 
 #### NOTES
 

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -982,8 +982,12 @@ replace_dot_alias <- function(e) {
           jvnames = names(jsubl)[-1L]   # check list(a=sum(v),v)
           if (is.null(jvnames)) jvnames = rep.int("", length(jsubl)-1L)
           for (jj in seq.int(2L,length(jsubl))) {
-            if (jvnames[jj-1L] == "" && mode(jsubl[[jj]])=="name")
-              jvnames[jj-1L] = gsub("^[.](N|I|GRP|BY)$","\\1",deparse(jsubl[[jj]]))
+            if (jvnames[jj-1L] == "" && mode(jsubl[[jj]])=="name") {
+              # #3507 -- list(x, ) caught here as an error
+              if (!nzchar(as.character(jsubl[[jj]])))
+                stop("Empty list argument at input ", jj - 1L, "; please explicitly provide 'NULL' if you're intending to drop a column, and note that R doesn't currently support trailing commas.")
+              jvnames[jj-1L] = gsub("^[.](N|I|GRP|BY)$", "\\1", deparse(jsubl[[jj]]))
+            }
             # TO DO: if call to a[1] for example, then call it 'a' too
           }
           setattr(jsubl, "names", NULL)  # drops the names from the list so it's faster to eval the j for each group. We'll put them back aftwards on the result.

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -983,9 +983,7 @@ replace_dot_alias <- function(e) {
           if (is.null(jvnames)) jvnames = rep.int("", length(jsubl)-1L)
           for (jj in seq.int(2L,length(jsubl))) {
             if (jvnames[jj-1L] == "" && mode(jsubl[[jj]])=="name") {
-              # #3507 -- list(x, ) caught here as an error
-              if (!nzchar(as.character(jsubl[[jj]])))
-                stop("Empty list argument at input ", jj - 1L, "; please explicitly provide 'NULL' if you're intending to drop a column, and note that R doesn't currently support trailing commas.")
+              if (!nzchar(as.character(jsubl[[jj]]))) stop("Item ", jj-1L, " of the .() or list() passed to j is missing") #3507
               jvnames[jj-1L] = gsub("^[.](N|I|GRP|BY)$", "\\1", deparse(jsubl[[jj]]))
             }
             # TO DO: if call to a[1] for example, then call it 'a' too

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -14045,12 +14045,12 @@ DT[2,t:= as.POSIXct("2019-01-01 19:00:01",tz = "UTC")]
 test(2026.3, capture.output(print(DT)), c("   v1                   t","1:  1                <NA>", "2: NA 2019-01-01 19:00:01"))
 test(2026.4, capture.output(print(DT, timezone = TRUE)), c("   v1                       t","1:  1                    <NA>","2: NA 2019-01-01 19:00:01 UTC"))
 
-# 3507 -- catching list(x, ) errors gracefully
+# empty item in j=list(x, ) errors gracefully, #3507
 DT = data.table(a = 1:5)
-## original error triggered with grouping
-test(2027.1, DT[ , list(1, ), by = a], error = 'Empty list argument at input 2')
-## consistency in error in non-grouping query
-test(2027.2, DT[ , list(1, )], error = 'Empty list argument at input 2')
+test(2027.1, DT[, list(1, ), by=a], error = 'Item 2 of the .() or list() passed to j is missing')
+test(2027.2, DT[, list(1,2,)],      error = 'Item 3 of the .() or list() passed to j is missing')
+test(2027.3, DT[, .(1,,3,), by=a],  error = 'Item 2 of the .() or list() passed to j is missing')
+
 
 ###################################
 #  Add new tests above this line  #

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -14045,6 +14045,12 @@ DT[2,t:= as.POSIXct("2019-01-01 19:00:01",tz = "UTC")]
 test(2026.3, capture.output(print(DT)), c("   v1                   t","1:  1                <NA>", "2: NA 2019-01-01 19:00:01"))
 test(2026.4, capture.output(print(DT, timezone = TRUE)), c("   v1                       t","1:  1                    <NA>","2: NA 2019-01-01 19:00:01 UTC"))
 
+# 3507 -- catching list(x, ) errors gracefully
+DT = data.table(a = 1:5)
+## original error triggered with grouping
+test(2027.1, DT[ , list(1, ), by = a], error = 'Empty list argument at input 2')
+## consistency in error in non-grouping query
+test(2027.2, DT[ , list(1, )], error = 'Empty list argument at input 2')
 
 ###################################
 #  Add new tests above this line  #


### PR DESCRIPTION
Closes #3507 Given that some other languages support trailing commas, e.g. Python:

```
python3
$ x = [1, 2, ]
$ x
# [1, 2]
```

It might be worth considering whether to support that here by simply dropping that element of `jsub` (which would break from base R).

Probably coders should be held to picking their commas to match the language -- in R, it's better to use _leading_ commas rather than trailing (for the record, this practice greatly facilitates including/dropping fields in exploratory work, since lines can be commented/uncommented without breaking syntax)