### PR TITLE
froll uses deferred verbose messages, closes #3423

### DIFF
--- a/inst/tests/froll.Rraw
+++ b/inst/tests/froll.Rraw
@@ -299,28 +299,39 @@ test(9999.067, ans2, expected)
 #### early stopping NAs in leading k obs
 test(9999.0671, frollmean(c(1:2,NA,4:10), 4, verbose=TRUE), c(rep(NA_real_, 6), 5.5, 6.5, 7.5, 8.5), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: 1 column(s) and 1 window(s), if product > 1 then entering parallel execution",
+  "frollfunR: 1 column.*1 window.*",
+  "frollfunR: 1:",
   "frollmeanFast: running for input length 10, window 4, hasna 0, narm 0",
-  "frollmeanFast: NA (or other non-finite) value(s) are present in input, skip non-NA attempt and run with extra care for NAs"
+  "frollmeanFast: NA.*are present in input, skip non-NA attempt and run with extra care for NAs",
+  "frollmean: processing algo 0 took.*",
+  "frollfunR: processing.*took.*"
 ))
 test(9999.0672, frollmean(c(1:2,NA,4:10), 4, hasNA=FALSE, verbose=TRUE), c(rep(NA_real_, 6), 5.5, 6.5, 7.5, 8.5), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: 1 column(s) and 1 window(s), if product > 1 then entering parallel execution",
+  "frollfunR: 1 column.*1 window.*",
+  "frollfunR: 1:",
   "frollmeanFast: running for input length 10, window 4, hasna -1, narm 0",
-  "frollmeanFast: NA (or other non-finite) value(s) are present in input, skip non-NA attempt and run with extra care for NAs"
-), warning="hasNA=FALSE used but NA (or other non-finite) value(s) are present in input, use default hasNA=NA to avoid this warning")
+  "frollmeanFast: NA.*are present in input, skip non-NA attempt and run with extra care for NAs",
+  "frollmean: processing algo 0 took.*",
+  "frollfunR: processing.*took.*"
+), warning="hasNA=FALSE used but NA.*are present in input, use default hasNA=NA to avoid this warning")
 test(9999.0673, frollmean(c(1:2,NA,4:10), 2, hasNA=FALSE, verbose=TRUE), c(NA, 1.5, NA, NA, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: 1 column(s) and 1 window(s), if product > 1 then entering parallel execution",
+  "frollfunR: 1 column.*1 window.*",
+  "frollfunR: 1:",
   "frollmeanFast: running for input length 10, window 2, hasna -1, narm 0",
-  "frollmeanFast: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs"
-), warning="hasNA=FALSE used but NA (or other non-finite) value(s) are present in input, use default hasNA=NA to avoid this warning")
+  "frollmeanFast: NA.*are present in input, re-running with extra care for NAs",
+  "frollmean: processing algo 0 took.*",
+  "frollfunR: processing.*took.*"
+), warning="hasNA=FALSE used but NA.*are present in input, use default hasNA=NA to avoid this warning")
 test(9999.0674, frollmean(c(1:2,NA,4:10), 4, verbose=TRUE, align="center"), c(rep(NA_real_, 4), 5.5, 6.5, 7.5, 8.5, NA, NA), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: 1 column(s) and 1 window(s), if product > 1 then entering parallel execution",
+  "frollfunR: 1 column.*1 window.*",
   "frollmeanFast: running for input length 10, window 4, hasna 0, narm 0",
-  "frollmeanFast: NA (or other non-finite) value(s) are present in input, skip non-NA attempt and run with extra care for NAs",
-  "frollmean: align 0, shift answer by -2"
+  "frollmeanFast: NA.*are present in input, skip non-NA attempt and run with extra care for NAs",
+  "frollmean: align 0, shift answer by -2",
+  "frollmean: processing algo 0 took.*",
+  "frollfunR: processing.*took.*"
 ))
 
 #### fill constant
@@ -414,16 +425,22 @@ test(9999.1195, frollmean(1:5, 2, na.rm=TRUE, hasNA=FALSE), error="using hasNA F
 #### exact na.rm=TRUE adaptive=TRUE verbose=TRUE
 test(9999.1196, frollmean(c(1:5,NA), 1:6, algo="exact", na.rm=TRUE, adaptive=TRUE, verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: 1 column(s) and 1 window(s), not entering parallel execution here because algo='exact' will compute results in parallel",
+  "frollfunR: 1 column.*1 window.*, not entering parallel execution here because algo='exact' will compute results in parallel",
+  "frollfunR: 1:",
   "fadaptiverollmeanExact: running in parallel for input length 6, hasna 0, narm 1",
-  "fadaptiverollmeanExact: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs"
+  "fadaptiverollmeanExact: NA.*are present in input, re-running with extra care for NAs",
+  "fadaptiverollmean: processing algo 1 took.*",
+  "frollfunR: processing.*took.*"
 ))
 #### exact na.rm=TRUE verbose=TRUE
 test(9999.1197, frollmean(c(1:5,NA), 2, algo="exact", na.rm=TRUE, verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: 1 column(s) and 1 window(s), not entering parallel execution here because algo='exact' will compute results in parallel",
+  "frollfunR: 1 column.*1 window.*, not entering parallel execution here because algo='exact' will compute results in parallel",
+  "frollfunR: 1:",
   "frollmeanExact: running in parallel for input length 6, window 2, hasna 0, narm 1",
-  "frollmeanExact: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs"
+  "frollmeanExact: NA.*are present in input, re-running with extra care for NAs",
+  "frollmean: processing algo 1 took.*",
+  "frollfunR: processing.*took.*"
 ))
 #### adaptive=TRUE n=character
 test(9999.1198, frollmean(1:5, n=letters[1:5], adaptive=TRUE), error="n must be integer vector or list of integer vectors")
@@ -633,89 +650,150 @@ x = 1:10
 n = 3
 test(9999.171, frollmean(x, n, verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: 1 column(s) and 1 window(s), if product > 1 then entering parallel execution",
-  "frollmeanFast: running for input length 10, window 3, hasna 0, narm 0"))
+  "frollfunR: 1 column.*1 window.*",
+  "frollfunR: 1:",
+  "frollmeanFast: running for input length 10, window 3, hasna 0, narm 0",
+  "frollmean: processing algo 0 took.*",
+  "frollfunR: processing.*took.*"))
 test(9999.172, frollmean(list(x, x+1), n, verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 2x1",
-  "frollfunR: 2 column(s) and 1 window(s), if product > 1 then entering parallel execution",
+  "frollfunR: 2 column.*1 window.*",
+  "frollfunR: 1:",
   "frollmeanFast: running for input length 10, window 3, hasna 0, narm 0",
-  "frollmeanFast: running for input length 10, window 3, hasna 0, narm 0"))
+  "frollmean: processing algo 0 took.*",
+  "frollfunR: 2:",
+  "frollmeanFast: running for input length 10, window 3, hasna 0, narm 0",
+  "frollmean: processing algo 0 took.*",
+  "frollfunR: processing.*took.*"))
 test(9999.173, frollmean(x, c(n, n+1), verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x2",
-  "frollfunR: 1 column(s) and 2 window(s), if product > 1 then entering parallel execution",
+  "frollfunR: 1 column.*2 window.*",
+  "frollfunR: 1:",
   "frollmeanFast: running for input length 10, window 3, hasna 0, narm 0",
-  "frollmeanFast: running for input length 10, window 4, hasna 0, narm 0"))
+  "frollmean: processing algo 0 took.*",
+  "frollfunR: 2:",
+  "frollmeanFast: running for input length 10, window 4, hasna 0, narm 0",
+  "frollmean: processing algo 0 took.*",
+  "frollfunR: processing.*took.*"))
 test(9999.174, frollmean(list(x, x+1), c(n, n+1), verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 2x2",
-  "frollfunR: 2 column(s) and 2 window(s), if product > 1 then entering parallel execution",
+  "frollfunR: 2 column.*2 window.*",
+  "frollfunR: 1:",
   "frollmeanFast: running for input length 10, window 3, hasna 0, narm 0",
+  "frollmean: processing algo 0 took.*",
+  "frollfunR: 2:",
   "frollmeanFast: running for input length 10, window 4, hasna 0, narm 0",
+  "frollmean: processing algo 0 took.*",
+  "frollfunR: 3:",
   "frollmeanFast: running for input length 10, window 3, hasna 0, narm 0",
-  "frollmeanFast: running for input length 10, window 4, hasna 0, narm 0"))
+  "frollmean: processing algo 0 took.*",
+  "frollfunR: 4:",
+  "frollmeanFast: running for input length 10, window 4, hasna 0, narm 0",
+  "frollmean: processing algo 0 took.*",
+  "frollfunR: processing.*took.*"))
 test(9999.175, frollmean(x, n, algo="exact", verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: 1 column(s) and 1 window(s), not entering parallel execution here because algo='exact' will compute results in parallel",
-  "frollmeanExact: running in parallel for input length 10, window 3, hasna 0, narm 0"))
+  "frollfunR: 1 column.*1 window.*",
+  "frollfunR: 1:",
+  "frollmeanExact: running in parallel for input length 10, window 3, hasna 0, narm 0",
+  "frollmean: processing algo 1 took.*",
+  "frollfunR: processing.*took.*"))
 test(9999.176, frollmean(x, n, align="center", verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: 1 column(s) and 1 window(s), if product > 1 then entering parallel execution",
+  "frollfunR: 1 column.*1 window.*",
+  "frollfunR: 1:",
   "frollmeanFast: running for input length 10, window 3, hasna 0, narm 0",
-  "frollmean: align 0, shift answer by -1"))
+  "frollmean: align 0, shift answer by -1",
+  "frollmean: processing algo 0 took.*",
+  "frollfunR: processing.*took.*"))
 test(9999.177, frollmean(x, n, align="left", verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: 1 column(s) and 1 window(s), if product > 1 then entering parallel execution",
+  "frollfunR: 1 column.*1 window.*",
+  "frollfunR: 1:",
   "frollmeanFast: running for input length 10, window 3, hasna 0, narm 0",
-  "frollmean: align -1, shift answer by -2"))
+  "frollmean: align -1, shift answer by -2",
+  "frollmean: processing algo 0 took.*",
+  "frollfunR: processing.*took.*"))
 nn = c(1:4,2:3,1:4)
 test(9999.178, frollmean(x, nn, adaptive=TRUE, verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: 1 column(s) and 1 window(s), if product > 1 then entering parallel execution",
-  "fadaptiverollmeanFast: running for input length 10, hasna 0, narm 0"))
+  "frollfunR: 1 column.*1 window.*",
+  "frollfunR: 1:",
+  "fadaptiverollmeanFast: running for input length 10, hasna 0, narm 0",
+  "fadaptiverollmean: processing algo 0 took.*",
+  "frollfunR: processing.*took.*"))
 test(9999.179, frollmean(x, nn, algo="exact", adaptive=TRUE, verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: 1 column(s) and 1 window(s), not entering parallel execution here because algo='exact' will compute results in parallel",
-  "fadaptiverollmeanExact: running in parallel for input length 10, hasna 0, narm 0"))
+  "frollfunR: 1 column.*1 window.*",
+  "frollfunR: 1:",
+  "fadaptiverollmeanExact: running in parallel for input length 10, hasna 0, narm 0",
+  "fadaptiverollmean: processing algo 1 took.*",
+  "frollfunR: processing.*took.*"))
 
 x[8] = NA
 test(9999.180, frollmean(x, n, verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: 1 column(s) and 1 window(s), if product > 1 then entering parallel execution",
+  "frollfunR: 1 column.*1 window.*",
+  "frollfunR: 1:",
   "frollmeanFast: running for input length 10, window 3, hasna 0, narm 0",
-  "frollmeanFast: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs"))
+  "frollmeanFast: NA.*are present in input, re-running with extra care for NAs",
+  "frollmean: processing algo 0 took.*",
+  "frollfunR: processing.*took.*"))
 test(9999.181, frollmean(x, n, algo="exact", verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: 1 column(s) and 1 window(s), not entering parallel execution here because algo='exact' will compute results in parallel",
+  "frollfunR: 1 column.*1 window.*",
+  "frollfunR: 1:",
   "frollmeanExact: running in parallel for input length 10, window 3, hasna 0, narm 0",
-  "frollmeanExact: NA (or other non-finite) value(s) are present in input, na.rm was FALSE so in 'exact' implementation NAs were handled already, no need to re-run"))
+  "frollmeanExact: NA.*are present in input, na.rm was FALSE so in 'exact' implementation NAs were handled already, no need to re-run",
+  "frollmean: processing algo 1 took.*",
+  "frollfunR: processing.*took.*"))
 test(9999.182, frollmean(x, nn, adaptive=TRUE, verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: 1 column(s) and 1 window(s), if product > 1 then entering parallel execution",
+  "frollfunR: 1 column.*1 window.*",
+  "frollfunR: 1:",
   "fadaptiverollmeanFast: running for input length 10, hasna 0, narm 0",
-  "fadaptiverollmeanFast: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs"))
+  "fadaptiverollmeanFast: NA.*are present in input, re-running with extra care for NAs",
+  "fadaptiverollmean: processing algo 0 took.*",
+  "frollfunR: processing.*took.*"))
 test(9999.183, frollmean(x, nn, algo="exact", adaptive=TRUE, verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: 1 column(s) and 1 window(s), not entering parallel execution here because algo='exact' will compute results in parallel",
+  "frollfunR: 1 column.*1 window.*",
+  "frollfunR: 1:",
   "fadaptiverollmeanExact: running in parallel for input length 10, hasna 0, narm 0",
-  "fadaptiverollmeanExact: NA (or other non-finite) value(s) are present in input, na.rm was FALSE so in 'exact' implementation NAs were handled already, no need to re-run"))
+  "fadaptiverollmeanExact: NA.*are present in input, na.rm was FALSE so in 'exact' implementation NAs were handled already, no need to re-run",
+  "fadaptiverollmean: processing algo 1 took.*",
+  "frollfunR: processing.*took.*"))
 
 d = as.data.table(list(1:10/2, 10:1/4))
 test(9999.184, frollmean(d[,1], 3, algo="exact", verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
-  "frollfunR: 1 column(s) and 1 window(s), not entering parallel execution here because algo='exact' will compute results in parallel",
-  "frollmeanExact: running in parallel for input length 10, window 3, hasna 0, narm 0"
+  "frollfunR: 1 column.*1 window.*",
+  "frollfunR: 1:",
+  "frollmeanExact: running in parallel for input length 10, window 3, hasna 0, narm 0",
+  "frollmean: processing algo 1 took.*",
+  "frollfunR: processing.*took.*"
 ))
 test(9999.185, frollmean(d, 3:4, algo="exact", verbose=TRUE), output=c(
   "frollfunR: allocating memory for results 2x2",
-  "frollfunR: 2 column(s) and 2 window(s), not entering parallel execution here because algo='exact' will compute results in parallel",
+  "frollfunR: 2 column.*2 window.*",
+  "frollfunR: 1:",
   "frollmeanExact: running in parallel for input length 10, window 3, hasna 0, narm 0",
+  "frollmean: processing algo 1 took.*",
+  "frollfunR: 2:",
   "frollmeanExact: running in parallel for input length 10, window 4, hasna 0, narm 0",
+  "frollmean: processing algo 1 took.*",
+  "frollfunR: 3:",
   "frollmeanExact: running in parallel for input length 10, window 3, hasna 0, narm 0",
-  "frollmeanExact: running in parallel for input length 10, window 4, hasna 0, narm 0"
+  "frollmean: processing algo 1 took.*",
+  "frollfunR: 4:",
+  "frollmeanExact: running in parallel for input length 10, window 4, hasna 0, narm 0",
+  "frollmean: processing algo 1 took.*",
+  "frollfunR: processing.*took.*"
 ))
 
 ## test warnings
-test(9999.186, frollmean(c(1:2,NA,4:10), 4, hasNA=FALSE), c(rep(NA_real_, 6), 5.5, 6.5, 7.5, 8.5), warning="hasNA=FALSE used but NA (or other non-finite) value(s) are present in input, use default hasNA=NA to avoid this warning")
-test(9999.187, frollmean(c(1:2,NA,4:10), 2, hasNA=FALSE), c(NA, 1.5, NA, NA, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5), warning="hasNA=FALSE used but NA (or other non-finite) value(s) are present in input, use default hasNA=NA to avoid this warning")
+test(9999.186, frollmean(c(1:2,NA,4:10), 4, hasNA=FALSE), c(rep(NA_real_, 6), 5.5, 6.5, 7.5, 8.5), warning="hasNA=FALSE used but NA.*are present in input, use default hasNA=NA to avoid this warning")
+test(9999.187, frollmean(c(1:2,NA,4:10), 2, hasNA=FALSE), c(NA, 1.5, NA, NA, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5), warning="hasNA=FALSE used but NA.*are present in input, use default hasNA=NA to avoid this warning")
 
 ## validation
 

--- a/inst/tests/froll.Rraw
+++ b/inst/tests/froll.Rraw
@@ -794,6 +794,13 @@ test(9999.185, frollmean(d, 3:4, algo="exact", verbose=TRUE), output=c(
 ## test warnings
 test(9999.186, frollmean(c(1:2,NA,4:10), 4, hasNA=FALSE), c(rep(NA_real_, 6), 5.5, 6.5, 7.5, 8.5), warning="hasNA=FALSE used but NA.*are present in input, use default hasNA=NA to avoid this warning")
 test(9999.187, frollmean(c(1:2,NA,4:10), 2, hasNA=FALSE), c(NA, 1.5, NA, NA, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5), warning="hasNA=FALSE used but NA.*are present in input, use default hasNA=NA to avoid this warning")
+test(9999.188, frollmean(c(1:2,NA,4:10), 4, hasNA=FALSE, algo="exact"), c(rep(NA_real_, 6), 5.5, 6.5, 7.5, 8.5), warning="hasNA=FALSE used but NA.*are present in input, use default hasNA=NA to avoid this warning")
+test(9999.189, frollmean(c(1:2,NA,4:10), 2, hasNA=FALSE, algo="exact"), c(NA, 1.5, NA, NA, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5), warning="hasNA=FALSE used but NA.*are present in input, use default hasNA=NA to avoid this warning")
+test(9999.190, frollmean(c(1:2,NA,4:10), rep(4L,10), adaptive=TRUE, hasNA=FALSE), c(rep(NA_real_, 6), 5.5, 6.5, 7.5, 8.5), warning="*hasNA=FALSE used but NA.*are present in input, use default hasNA=NA to avoid this warning")
+test(9999.191, frollmean(c(1:2,NA,4:10), rep(2L,10), adaptive=TRUE, hasNA=FALSE), c(NA, 1.5, NA, NA, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5), warning="*hasNA=FALSE used but NA.*are present in input, use default hasNA=NA to avoid this warning")
+test(9999.192, frollmean(c(1:2,NA,4:10), rep(4L,10), adaptive=TRUE, hasNA=FALSE, algo="exact"), c(rep(NA_real_, 6), 5.5, 6.5, 7.5, 8.5), warning="*hasNA=FALSE used but NA.*are present in input, use default hasNA=NA to avoid this warning")
+test(9999.193, frollmean(c(1:2,NA,4:10), rep(2L,10), adaptive=TRUE, hasNA=FALSE, algo="exact"), c(NA, 1.5, NA, NA, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5), warning="*hasNA=FALSE used but NA.*are present in input, use default hasNA=NA to avoid this warning")
+
 
 ## validation
 

--- a/man/froll.Rd
+++ b/man/froll.Rd
@@ -38,8 +38,7 @@ frollmean(x, n, fill=NA, algo=c("fast", "exact"), align=c("right",
   \item{adaptive}{ logical, should adaptive rolling function be
     calculated, default \code{FALSE}. See details below. }
   \item{verbose}{ logical, default \code{getOption("datatable.verbose")},
-    \code{TRUE} turns on status and information messages to the console,
-    it also disable parallel processing. }
+    \code{TRUE} turns on status and information messages to the console. }
 }
 \details{
   \code{froll*} functions accepts vectors, lists, data.frames or

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -158,14 +158,14 @@ int getDTthreads();
 void avoid_openmp_hang_within_fork();
 
 // froll.c
-void frollmean(unsigned int algo, double *x, uint_fast64_t nx, double_ans_t *ans, int k, int align, double fill, bool narm, int hasna, bool verbose);
-void frollmeanFast(double *x, uint_fast64_t nx, double_ans_t *ans, int k, double fill, bool narm, int hasna, bool verbose);
-void frollmeanExact(double *x, uint_fast64_t nx, double_ans_t *ans, int k, double fill, bool narm, int hasna, bool verbose);
+void frollmean(unsigned int algo, double *x, uint_fast64_t nx, ans_t *ans, int k, int align, double fill, bool narm, int hasna, bool verbose);
+void frollmeanFast(double *x, uint_fast64_t nx, ans_t *ans, int k, double fill, bool narm, int hasna, bool verbose);
+void frollmeanExact(double *x, uint_fast64_t nx, ans_t *ans, int k, double fill, bool narm, int hasna, bool verbose);
 
 // frolladaptive.c
-void fadaptiverollmean(unsigned int algo, double *x, uint_fast64_t nx, double_ans_t *ans, int *k, double fill, bool narm, int hasna, bool verbose);
-void fadaptiverollmeanFast(double *x, uint_fast64_t nx, double_ans_t *ans, int *k, double fill, bool narm, int hasna, bool verbose);
-void fadaptiverollmeanExact(double *x, uint_fast64_t nx, double_ans_t *ans, int *k, double fill, bool narm, int hasna, bool verbose);
+void fadaptiverollmean(unsigned int algo, double *x, uint_fast64_t nx, ans_t *ans, int *k, double fill, bool narm, int hasna, bool verbose);
+void fadaptiverollmeanFast(double *x, uint_fast64_t nx, ans_t *ans, int *k, double fill, bool narm, int hasna, bool verbose);
+void fadaptiverollmeanExact(double *x, uint_fast64_t nx, ans_t *ans, int *k, double fill, bool narm, int hasna, bool verbose);
 
 // frollR.c
 SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEXP narm, SEXP hasNA, SEXP adaptive, SEXP verbose);

--- a/src/froll.c
+++ b/src/froll.c
@@ -11,15 +11,15 @@
  *   recalculate whole mean for each observation, roundoff correction is adjusted, also support for NaN and Inf
  */
 
-static char *end(char *start) {
+static char *end(char *start) {                                 // used to append verbose message or warnings
   return strchr(start, 0);
 }
 
-void frollmean(unsigned int algo, double *x, uint_fast64_t nx, double_ans_t *ans, int k, int align, double fill, bool narm, int hasna, bool verbose) {
+void frollmean(unsigned int algo, double *x, uint_fast64_t nx, ans_t *ans, int k, int align, double fill, bool narm, int hasna, bool verbose) {
   if (nx < k) {                                                 // if window width bigger than input just return vector of fill values
     if (verbose) snprintf(end(ans->message[0]), 500, "%s: window width longer than input vector, returning all NA vector\n", __func__);
     // implicit n_message limit discussed here: https://github.com/Rdatatable/data.table/issues/3423#issuecomment-487722586
-    for (int i=0; i<nx; i++) ans->ans[i] = fill;
+    for (int i=0; i<nx; i++) ans->dbl_v[i] = fill;
     return;
   }
   double tic = 0;
@@ -30,8 +30,8 @@ void frollmean(unsigned int algo, double *x, uint_fast64_t nx, double_ans_t *ans
   if (ans->status < 3 && align < 1) {                           // align center or left, only when no errors occurred
     int k_ = align==-1 ? k-1 : floor(k/2);                      // offset to shift
     if (verbose) snprintf(end(ans->message[0]), 500, "%s: align %d, shift answer by %d\n", __func__, align, -k_);
-    memmove((char *)ans->ans, (char *)ans->ans + (k_*sizeof(double)), (nx-k_)*sizeof(double)); // apply shift to achieve expected align
-    for (uint_fast64_t i=nx-k_; i<nx; i++) ans->ans[i] = fill;  // fill from right side
+    memmove((char *)ans->dbl_v, (char *)ans->dbl_v + (k_*sizeof(double)), (nx-k_)*sizeof(double)); // apply shift to achieve expected align
+    for (uint_fast64_t i=nx-k_; i<nx; i++) ans->dbl_v[i] = fill;  // fill from right side
   }
   if (verbose) snprintf(end(ans->message[0]), 500, "%s: processing algo %u took %.3fs\n", __func__, algo, omp_get_wtime()-tic);
 }
@@ -42,7 +42,7 @@ void frollmean(unsigned int algo, double *x, uint_fast64_t nx, double_ans_t *ans
  * if NAs detected re-run rollmean implemented as single pass sliding window with NA support
  */
 
-void frollmeanFast(double *x, uint_fast64_t nx, double_ans_t *ans, int k, double fill, bool narm, int hasna, bool verbose) {
+void frollmeanFast(double *x, uint_fast64_t nx, ans_t *ans, int k, double fill, bool narm, int hasna, bool verbose) {
   if (verbose) snprintf(end(ans->message[0]), 500, "%s: running for input length %llu, window %d, hasna %d, narm %d\n",
                                          __func__, (unsigned long long int)nx, k, hasna, (int)narm);
   long double w = 0.0;                                          // sliding window aggregate
@@ -51,20 +51,20 @@ void frollmeanFast(double *x, uint_fast64_t nx, double_ans_t *ans, int k, double
     int i;                                                      // iterator declared here because it is being used after foor loop
     for (i=0; i<k-1; i++) {                                     // loop over leading observation, all partial window only
       w += x[i];                                                // add current row to sliding window
-      ans->ans[i] = fill;                                       // answers are fill for partial window
+      ans->dbl_v[i] = fill;                                     // answers are fill for partial window
     }
     w += x[i];                                                  // i==k-1
-    ans->ans[i] = (double) (w / k);                             // first full sliding window, non-fill rollfun answer
+    ans->dbl_v[i] = (double) (w / k);                           // first full sliding window, non-fill rollfun answer
     if (R_FINITE((double) w)) {                                 // proceed only if no NAs detected in first k obs, otherwise early stopping
       for (uint_fast64_t i=k; i<nx; i++) {                      // loop over obs, complete window, all remaining after partial window
         w -= x[i-k];                                            // remove leaving row from sliding window
         w += x[i];                                              // add current row to sliding window
-        ans->ans[i] = (double) (w / k);                         // rollfun to answer vector
+        ans->dbl_v[i] = (double) (w / k);                       // rollfun to answer vector
       }
       if (!R_FINITE((double) w)) {                              // mark to re-run with NA care
         if (hasna==-1) {                                        // raise warning
           ans->status = 2;
-          snprintf(ans->message[2], 500, "%s: hasNA=FALSE used but NA (or other non-finite) value(s) are present in input, use default hasNA=NA to avoid this warning", __func__);
+          snprintf(end(ans->message[2]), 500, "%s: hasNA=FALSE used but NA (or other non-finite) value(s) are present in input, use default hasNA=NA to avoid this warning", __func__);
         }
         if (verbose) snprintf(end(ans->message[0]), 500, "%s: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs\n", __func__);
         w = 0.0;
@@ -73,7 +73,7 @@ void frollmeanFast(double *x, uint_fast64_t nx, double_ans_t *ans, int k, double
     } else {                                                    // early stopping branch when NAs detected in first k obs
       if (hasna==-1) {                                          // raise warning
         ans->status = 2;
-        snprintf(ans->message[2], 500, "%s: hasNA=FALSE used but NA (or other non-finite) value(s) are present in input, use default hasNA=NA to avoid this warning", __func__);
+        snprintf(end(ans->message[2]), 500, "%s: hasNA=FALSE used but NA (or other non-finite) value(s) are present in input, use default hasNA=NA to avoid this warning", __func__);
       }
       if (verbose) snprintf(end(ans->message[0]), 500, "%s: NA (or other non-finite) value(s) are present in input, skip non-NA attempt and run with extra care for NAs\n", __func__);
       w = 0.0;
@@ -86,21 +86,21 @@ void frollmeanFast(double *x, uint_fast64_t nx, double_ans_t *ans, int k, double
     for (i=0; i<k-1; i++) {                                     // loop over leading observation, all partial window only
       if (R_FINITE(x[i])) w += x[i];                            // add only finite values to window aggregate
       else nc++;                                                // increment NA count in current window
-      ans->ans[i] = fill;                                       // partial window fill all
+      ans->dbl_v[i] = fill;                                     // partial window fill all
     }
     if (R_FINITE(x[i])) w += x[i];                              // i==k-1
     else nc++;
-    if (nc == 0) ans->ans[i] = (double) (w / k);                // no NAs in first full window
-    else if (nc == k) ans->ans[i] = narm ? R_NaN : NA_REAL;     // all values in sliding window are NA, expected output for fun(NA, na.rm=T/F)
-    else ans->ans[i] = narm ? (double) (w / (k - nc)) : NA_REAL; // some values in window are NA
+    if (nc == 0) ans->dbl_v[i] = (double) (w / k);              // no NAs in first full window
+    else if (nc == k) ans->dbl_v[i] = narm ? R_NaN : NA_REAL;   // all values in sliding window are NA, expected output for fun(NA, na.rm=T/F)
+    else ans->dbl_v[i] = narm ? (double) (w / (k - nc)) : NA_REAL; // some values in window are NA
     for (uint_fast64_t i=k; i<nx; i++) {                        // loop over obs, complete window, all remaining after partial window
       if (R_FINITE(x[i])) w += x[i];                            // add only finite to window aggregate
       else nc++;                                                // increment NA count in current window
       if (R_FINITE(x[i-k])) w -= x[i-k];                        // remove only finite from window aggregate
       else nc--;                                                // decrement NA count in current window
-      if (nc == 0) ans->ans[i] = (double) (w / k);              // no NAs in sliding window for present observation
-      else if (nc == k) ans->ans[i] = narm ? R_NaN : NA_REAL;   // all values in window are NA, expected output for fun(NA, na.rm=T/F)
-      else ans->ans[i] = narm ? (double) (w / (k - nc)) : NA_REAL; // some values in window are NA
+      if (nc == 0) ans->dbl_v[i] = (double) (w / k);            // no NAs in sliding window for present observation
+      else if (nc == k) ans->dbl_v[i] = narm ? R_NaN : NA_REAL; // all values in window are NA, expected output for fun(NA, na.rm=T/F)
+      else ans->dbl_v[i] = narm ? (double) (w / (k - nc)) : NA_REAL; // some values in window are NA
     }
   }
 }
@@ -111,12 +111,12 @@ void frollmeanFast(double *x, uint_fast64_t nx, double_ans_t *ans, int k, double
  * if NAs detected and na.rm=TRUE then re-run rollmean implemented as mean of k bos for each observation with NA support
  */
 
-void frollmeanExact(double *x, uint_fast64_t nx, double_ans_t *ans, int k, double fill, bool narm, int hasna, bool verbose) {
+void frollmeanExact(double *x, uint_fast64_t nx, ans_t *ans, int k, double fill, bool narm, int hasna, bool verbose) {
   if (verbose) snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %llu, window %d, hasna %d, narm %d\n",
                                               __func__, (unsigned long long int)nx, k, hasna, (int)narm);
 
-  for (int i=0; i<k-1; i++) {                                   // fill partial window only
-    ans->ans[i] = fill;
+  for (int i=0; i<k-1; i++) {                                 // fill partial window only
+    ans->dbl_v[i] = fill;
   }
   bool truehasna = hasna>0;                                   // flag to re-run with NA support if NAs detected
   if (!truehasna || !narm) {
@@ -133,16 +133,16 @@ void frollmeanExact(double *x, uint_fast64_t nx, double_ans_t *ans, int k, doubl
         for (int j=-k+1; j<=0; j++) {                         // nested loop on window width
           err += x[i+j] - res;                                // measure difference of obs in sub-loop to calculated fun for obs
         }
-        ans->ans[i] = (double) (res + (err / k));             // adjust calculated rollfun with roundoff correction
+        ans->dbl_v[i] = (double) (res + (err / k));           // adjust calculated rollfun with roundoff correction
       } else {
-        if (!narm) ans->ans[i] = (double) (w / k);            // NAs should be propagated
+        if (!narm) ans->dbl_v[i] = (double) (w / k);          // NAs should be propagated
         truehasna = true;                                     // NAs detected for this window, set flag so rest of windows will not be re-run
       }
     }
     if (truehasna) {
-      if (hasna==-1) {                                          // raise warning
+      if (hasna==-1) {                                        // raise warning
         ans->status = 2;
-        snprintf(ans->message[2], 500, "%s: hasNA=FALSE used but NA (or other non-finite) value(s) are present in input, use default hasNA=NA to avoid this warning", __func__);
+        snprintf(end(ans->message[2]), 500, "%s: hasNA=FALSE used but NA (or other non-finite) value(s) are present in input, use default hasNA=NA to avoid this warning", __func__);
       }
       if (verbose) {
         if (narm) snprintf(end(ans->message[0]), 500, "%s: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs\n", __func__);
@@ -165,14 +165,14 @@ void frollmeanExact(double *x, uint_fast64_t nx, double_ans_t *ans, int k, doubl
         for (int j=-k+1; j<=0; j++) {                         // sub-loop on window width
           err += x[i+j] - res;                                // measure roundoff for each obs in window
         }
-        ans->ans[i] = (double) (res + (err / k));             // adjust calculated fun with roundoff correction
+        ans->dbl_v[i] = (double) (res + (err / k));           // adjust calculated fun with roundoff correction
       } else if (nc < k) {
         for (int j=-k+1; j<=0; j++) {                         // sub-loop on window width
           if (!ISNAN(x[i+j])) err += x[i+j] - res;            // measure roundoff for each non-NA obs in window
         }
-        ans->ans[i] = (double) (res + (err / (k - nc)));      // adjust calculated fun with roundoff correction
+        ans->dbl_v[i] = (double) (res + (err / (k - nc)));    // adjust calculated fun with roundoff correction
       } else {                                                // nc == k
-        ans->ans[i] = R_NaN;                                  // all values NAs and narm so produce expected values
+        ans->dbl_v[i] = R_NaN;                                // all values NAs and narm so produce expected values
       }
     }
   }

--- a/src/froll.c
+++ b/src/froll.c
@@ -32,7 +32,7 @@ void frollmean(unsigned int algo, double *x, uint_fast64_t nx, double_ans_t *ans
     memmove((char *)ans->ans, (char *)ans->ans + (k_*sizeof(double)), (nx-k_)*sizeof(double)); // apply shift to achieve expected align
     for (uint_fast64_t i=nx-k_; i<nx; i++) ans->ans[i] = fill;  // fill from right side
   }
-  if (verbose) snprintf(end(ans->message[0]), 500, "%s: processing algo %d took %.3fs\n", __func__, algo, omp_get_wtime()-tic);
+  if (verbose) snprintf(end(ans->message[0]), 500, "%s: processing algo %u took %.3fs\n", __func__, algo, omp_get_wtime()-tic);
 }
 
 /* fast rolling mean - fast

--- a/src/froll.c
+++ b/src/froll.c
@@ -18,6 +18,7 @@ static char *end(char *start) {
 void frollmean(unsigned int algo, double *x, uint_fast64_t nx, double_ans_t *ans, int k, int align, double fill, bool narm, int hasna, bool verbose) {
   if (nx < k) {                                                 // if window width bigger than input just return vector of fill values
     if (verbose) snprintf(end(ans->message[0]), 500, "%s: window width longer than input vector, returning all NA vector\n", __func__);
+    // implicit n_message limit discussed here: https://github.com/Rdatatable/data.table/issues/3423#issuecomment-487722586
     for (int i=0; i<nx; i++) ans->ans[i] = fill;
     return;
   }

--- a/src/frollR.c
+++ b/src/frollR.c
@@ -109,7 +109,8 @@ SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEX
 
   SEXP ans;
   ans = PROTECT(allocVector(VECSXP, nk * nx)); protecti++;      // allocate list to keep results
-  double_ans_t dans[nx*nk];                                     // answer columns as array of double_ans_t struct
+  double_ans_t *dans = malloc(sizeof(double_ans_t)*nx*nk);      // answer columns as array of double_ans_t struct
+  if (!dans) error("%s: Unable to allocate memory answer", __func__); // # nocov
   double* dx[nx];                                               // pointers to source columns
   uint_fast64_t inx[nx];                                        // to not recalculate `length(x[[i]])` we store it in extra array
   if (bverbose) Rprintf("%s: allocating memory for results %dx%d\n", __func__, nx, nk);

--- a/src/frollR.c
+++ b/src/frollR.c
@@ -109,7 +109,7 @@ SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEX
 
   SEXP ans;
   ans = PROTECT(allocVector(VECSXP, nk * nx)); protecti++;      // allocate list to keep results
-  double_ans_t *dans = malloc(sizeof(double_ans_t)*nx*nk);      // answer columns as array of double_ans_t struct
+  ans_t *dans = malloc(sizeof(ans_t)*nx*nk);      // answer columns as array of double_ans_t struct
   if (!dans) error("%s: Unable to allocate memory answer", __func__); // # nocov
   double* dx[nx];                                               // pointers to source columns
   uint_fast64_t inx[nx];                                        // to not recalculate `length(x[[i]])` we store it in extra array
@@ -124,7 +124,7 @@ SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEX
           error("length of integer vector(s) provided as list to 'n' argument must be equal to number of observations provided in 'x'");
       }
       SET_VECTOR_ELT(ans, i*nk+j, allocVector(REALSXP, inx[i]));// allocate answer vector for this column-window
-      dans[i*nk+j] = ((double_ans_t) { .ans=REAL(VECTOR_ELT(ans, i*nk+j)), .status=0, .message={"\0","\0","\0","\0"} });
+      dans[i*nk+j] = ((ans_t) { .dbl_v=REAL(VECTOR_ELT(ans, i*nk+j)), .status=0, .message={"\0","\0","\0","\0"} });
     }
     dx[i] = REAL(VECTOR_ELT(x, i));                             // assign source columns to C pointers
   }

--- a/src/frolladaptive.c
+++ b/src/frolladaptive.c
@@ -12,8 +12,11 @@
  */
 
 void fadaptiverollmean(unsigned int algo, double *x, uint_fast64_t nx, double_ans_t *ans, int *k, double fill, bool narm, int hasna, bool verbose) {
+  double tic = 0;
+  if (verbose) tic = omp_get_wtime();
   if (algo==0) fadaptiverollmeanFast(x, nx, ans, k, fill, narm, hasna, verbose);
   else if (algo==1) fadaptiverollmeanExact(x, nx, ans, k, fill, narm, hasna, verbose);
+  if (verbose) sprintf(ans->message[0], "%s%s: processing algo %d took %.3fs\n", ans->message[0], __func__, algo, omp_get_wtime()-tic);
 }
 
 /* fast adaptive rolling mean - fast
@@ -23,10 +26,9 @@ void fadaptiverollmean(unsigned int algo, double *x, uint_fast64_t nx, double_an
  */
 
 void fadaptiverollmeanFast(double *x, uint_fast64_t nx, double_ans_t *ans, int *k, double fill, bool narm, int hasna, bool verbose) {
-  if (verbose) Rprintf("%s: running for input length %llu, hasna %d, narm %d\n", __func__, nx, hasna, (int) narm);
+  if (verbose) sprintf(ans->message[0], "%s%s: running for input length %llu, hasna %d, narm %d\n", ans->message[0], __func__, (unsigned long long int)nx, hasna, (int) narm);
   bool truehasna = hasna>0;                                     // flag to re-run if NAs detected
   long double w = 0.0;
-  // TODO measure speed of cs as long double
   double *cs = malloc(nx*sizeof(double));                       // cumsum vector, same as double cs[nx] but no segfault
   if (!cs) {
     ans->status = 3;                                            // raise error
@@ -51,7 +53,7 @@ void fadaptiverollmeanFast(double *x, uint_fast64_t nx, double_ans_t *ans, int *
         ans->status = 2;
         sprintf(ans->message[2], "%s: hasNA=FALSE used but NA (or other non-finite) value(s) are present in input, use default hasNA=NA to avoid this warning", __func__);
       }
-      if (verbose) Rprintf("%s: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs\n", __func__);
+      if (verbose) sprintf(ans->message[0], "%s%s: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs\n", ans->message[0], __func__);
       w = 0.0;
       truehasna = true;
     }
@@ -102,7 +104,8 @@ void fadaptiverollmeanFast(double *x, uint_fast64_t nx, double_ans_t *ans, int *
  */
 
 void fadaptiverollmeanExact(double *x, uint_fast64_t nx, double_ans_t *ans, int *k, double fill, bool narm, int hasna, bool verbose) {
-  if (verbose) Rprintf("%s: running in parallel for input length %llu, hasna %d, narm %d\n", __func__, nx, hasna, (int) narm);
+  if (verbose) sprintf(ans->message[0], "%s%s: running in parallel for input length %llu, hasna %d, narm %d\n", ans->message[0], __func__, (unsigned long long int)nx, hasna, (int) narm);
+
   bool truehasna = hasna>0;                                   // flag to re-run if NAs detected
 
   if (!truehasna || !narm) {                                  // narm=FALSE handled here as NAs properly propagated in exact algo
@@ -134,8 +137,8 @@ void fadaptiverollmeanExact(double *x, uint_fast64_t nx, double_ans_t *ans, int 
         sprintf(ans->message[2], "%s: hasNA=FALSE used but NA (or other non-finite) value(s) are present in input, use default hasNA=NA to avoid this warning", __func__);
       }
       if (verbose) {
-        if (narm) Rprintf("%s: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs\n", __func__);
-        else Rprintf("%s: NA (or other non-finite) value(s) are present in input, na.rm was FALSE so in 'exact' implementation NAs were handled already, no need to re-run\n", __func__);
+        if (narm) sprintf(ans->message[0], "%s%s: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs\n", ans->message[0], __func__);
+        else sprintf(ans->message[0], "%s%s: NA (or other non-finite) value(s) are present in input, na.rm was FALSE so in 'exact' implementation NAs were handled already, no need to re-run\n", ans->message[0], __func__);
       }
     }
   }

--- a/src/frolladaptive.c
+++ b/src/frolladaptive.c
@@ -11,12 +11,16 @@
  *   recalculate whole mean for each observation, roundoff correction is adjusted, also support for NaN and Inf
  */
 
+static char *end(char *start) {
+  return strchr(start, 0);
+}
+
 void fadaptiverollmean(unsigned int algo, double *x, uint_fast64_t nx, double_ans_t *ans, int *k, double fill, bool narm, int hasna, bool verbose) {
   double tic = 0;
   if (verbose) tic = omp_get_wtime();
   if (algo==0) fadaptiverollmeanFast(x, nx, ans, k, fill, narm, hasna, verbose);
   else if (algo==1) fadaptiverollmeanExact(x, nx, ans, k, fill, narm, hasna, verbose);
-  if (verbose) sprintf(ans->message[0], "%s%s: processing algo %d took %.3fs\n", ans->message[0], __func__, algo, omp_get_wtime()-tic);
+  if (verbose) snprintf(end(ans->message[0]), 500, "%s: processing algo %d took %.3fs\n", __func__, algo, omp_get_wtime()-tic);
 }
 
 /* fast adaptive rolling mean - fast
@@ -26,13 +30,13 @@ void fadaptiverollmean(unsigned int algo, double *x, uint_fast64_t nx, double_an
  */
 
 void fadaptiverollmeanFast(double *x, uint_fast64_t nx, double_ans_t *ans, int *k, double fill, bool narm, int hasna, bool verbose) {
-  if (verbose) sprintf(ans->message[0], "%s%s: running for input length %llu, hasna %d, narm %d\n", ans->message[0], __func__, (unsigned long long int)nx, hasna, (int) narm);
+  if (verbose) snprintf(end(ans->message[0]), 500, "%s: running for input length %llu, hasna %d, narm %d\n", __func__, (unsigned long long int)nx, hasna, (int) narm);
   bool truehasna = hasna>0;                                     // flag to re-run if NAs detected
   long double w = 0.0;
   double *cs = malloc(nx*sizeof(double));                       // cumsum vector, same as double cs[nx] but no segfault
   if (!cs) {
     ans->status = 3;                                            // raise error
-    sprintf(ans->message[3], "%s: Unable to allocate memory for cumsum", __func__);
+    snprintf(ans->message[3], 500, "%s: Unable to allocate memory for cumsum", __func__);
     free(cs);
     return;
   }
@@ -51,9 +55,9 @@ void fadaptiverollmeanFast(double *x, uint_fast64_t nx, double_ans_t *ans, int *
     } else {                                                    // update truehasna flag if NAs detected
       if (hasna==-1) {                                          // raise warning
         ans->status = 2;
-        sprintf(ans->message[2], "%s: hasNA=FALSE used but NA (or other non-finite) value(s) are present in input, use default hasNA=NA to avoid this warning", __func__);
+        snprintf(ans->message[2], 500, "%s: hasNA=FALSE used but NA (or other non-finite) value(s) are present in input, use default hasNA=NA to avoid this warning", __func__);
       }
-      if (verbose) sprintf(ans->message[0], "%s%s: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs\n", ans->message[0], __func__);
+      if (verbose) snprintf(end(ans->message[0]), 500, "%s: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs\n", __func__);
       w = 0.0;
       truehasna = true;
     }
@@ -63,7 +67,7 @@ void fadaptiverollmeanFast(double *x, uint_fast64_t nx, double_ans_t *ans, int *
     uint_fast64_t *cn = malloc(nx*sizeof(uint_fast64_t));       // cumulative NA counter, used the same way as cumsum, same as uint_fast64_t cn[nx] but no segfault
     if (!cn) {
       ans->status = 3;                                          // raise error
-      sprintf(ans->message[3], "%s: Unable to allocate memory for cum NA counter", __func__);
+      snprintf(ans->message[3], 500, "%s: Unable to allocate memory for cum NA counter", __func__);
       free(cs);
       free(cn);
       return;
@@ -104,7 +108,7 @@ void fadaptiverollmeanFast(double *x, uint_fast64_t nx, double_ans_t *ans, int *
  */
 
 void fadaptiverollmeanExact(double *x, uint_fast64_t nx, double_ans_t *ans, int *k, double fill, bool narm, int hasna, bool verbose) {
-  if (verbose) sprintf(ans->message[0], "%s%s: running in parallel for input length %llu, hasna %d, narm %d\n", ans->message[0], __func__, (unsigned long long int)nx, hasna, (int) narm);
+  if (verbose) snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %llu, hasna %d, narm %d\n", __func__, (unsigned long long int)nx, hasna, (int) narm);
 
   bool truehasna = hasna>0;                                   // flag to re-run if NAs detected
 
@@ -134,11 +138,11 @@ void fadaptiverollmeanExact(double *x, uint_fast64_t nx, double_ans_t *ans, int 
     if (truehasna) {
       if (hasna==-1) {                                          // raise warning
         ans->status = 2;
-        sprintf(ans->message[2], "%s: hasNA=FALSE used but NA (or other non-finite) value(s) are present in input, use default hasNA=NA to avoid this warning", __func__);
+        snprintf(ans->message[2], 500, "%s: hasNA=FALSE used but NA (or other non-finite) value(s) are present in input, use default hasNA=NA to avoid this warning", __func__);
       }
       if (verbose) {
-        if (narm) sprintf(ans->message[0], "%s%s: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs\n", ans->message[0], __func__);
-        else sprintf(ans->message[0], "%s%s: NA (or other non-finite) value(s) are present in input, na.rm was FALSE so in 'exact' implementation NAs were handled already, no need to re-run\n", ans->message[0], __func__);
+        if (narm) snprintf(end(ans->message[0]), 500, "%s: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs\n", __func__);
+        else snprintf(end(ans->message[0]), 500, "%s: NA (or other non-finite) value(s) are present in input, na.rm was FALSE so in 'exact' implementation NAs were handled already, no need to re-run\n", __func__);
       }
     }
   }

--- a/src/frolladaptive.c
+++ b/src/frolladaptive.c
@@ -21,6 +21,7 @@ void fadaptiverollmean(unsigned int algo, double *x, uint_fast64_t nx, double_an
   if (algo==0) fadaptiverollmeanFast(x, nx, ans, k, fill, narm, hasna, verbose);
   else if (algo==1) fadaptiverollmeanExact(x, nx, ans, k, fill, narm, hasna, verbose);
   if (verbose) snprintf(end(ans->message[0]), 500, "%s: processing algo %u took %.3fs\n", __func__, algo, omp_get_wtime()-tic);
+  // implicit n_message limit discussed here: https://github.com/Rdatatable/data.table/issues/3423#issuecomment-487722586
 }
 
 /* fast adaptive rolling mean - fast

--- a/src/frolladaptive.c
+++ b/src/frolladaptive.c
@@ -20,7 +20,7 @@ void fadaptiverollmean(unsigned int algo, double *x, uint_fast64_t nx, double_an
   if (verbose) tic = omp_get_wtime();
   if (algo==0) fadaptiverollmeanFast(x, nx, ans, k, fill, narm, hasna, verbose);
   else if (algo==1) fadaptiverollmeanExact(x, nx, ans, k, fill, narm, hasna, verbose);
-  if (verbose) snprintf(end(ans->message[0]), 500, "%s: processing algo %d took %.3fs\n", __func__, algo, omp_get_wtime()-tic);
+  if (verbose) snprintf(end(ans->message[0]), 500, "%s: processing algo %u took %.3fs\n", __func__, algo, omp_get_wtime()-tic);
 }
 
 /* fast adaptive rolling mean - fast

--- a/src/frolladaptive.c
+++ b/src/frolladaptive.c
@@ -34,12 +34,12 @@ void fadaptiverollmeanFast(double *x, uint_fast64_t nx, double_ans_t *ans, int *
   bool truehasna = hasna>0;                                     // flag to re-run if NAs detected
   long double w = 0.0;
   double *cs = malloc(nx*sizeof(double));                       // cumsum vector, same as double cs[nx] but no segfault
-  if (!cs) {
+  if (!cs) {                                                    // # nocov start
     ans->status = 3;                                            // raise error
     snprintf(ans->message[3], 500, "%s: Unable to allocate memory for cumsum", __func__);
     free(cs);
     return;
-  }
+  }                                                             // # nocov end
   if (!truehasna) {
     for (uint_fast64_t i=0; i<nx; i++) {                        // loop on every observation to calculate cumsum only
       w += x[i];                                                // cumulate in long double
@@ -65,13 +65,13 @@ void fadaptiverollmeanFast(double *x, uint_fast64_t nx, double_ans_t *ans, int *
   if (truehasna) {
     uint_fast64_t nc = 0;                                       // running NA counter
     uint_fast64_t *cn = malloc(nx*sizeof(uint_fast64_t));       // cumulative NA counter, used the same way as cumsum, same as uint_fast64_t cn[nx] but no segfault
-    if (!cn) {
+    if (!cn) {                                                  // # nocov start
       ans->status = 3;                                          // raise error
       snprintf(ans->message[3], 500, "%s: Unable to allocate memory for cum NA counter", __func__);
       free(cs);
       free(cn);
       return;
-    }
+    }                                                           // # nocov end
     for (uint_fast64_t i=0; i<nx; i++) {                        // loop over observations to calculate cumsum and cum NA counter
       if (R_FINITE(x[i])) w += x[i];                            // add observation to running sum
       else nc++;                                                // increment non-finite counter

--- a/src/frolladaptive.c
+++ b/src/frolladaptive.c
@@ -15,7 +15,7 @@ static char *end(char *start) {
   return strchr(start, 0);
 }
 
-void fadaptiverollmean(unsigned int algo, double *x, uint_fast64_t nx, double_ans_t *ans, int *k, double fill, bool narm, int hasna, bool verbose) {
+void fadaptiverollmean(unsigned int algo, double *x, uint_fast64_t nx, ans_t *ans, int *k, double fill, bool narm, int hasna, bool verbose) {
   double tic = 0;
   if (verbose) tic = omp_get_wtime();
   if (algo==0) fadaptiverollmeanFast(x, nx, ans, k, fill, narm, hasna, verbose);
@@ -30,7 +30,7 @@ void fadaptiverollmean(unsigned int algo, double *x, uint_fast64_t nx, double_an
  * if NAs detected re-run rollmean implemented as cumsum with NA support
  */
 
-void fadaptiverollmeanFast(double *x, uint_fast64_t nx, double_ans_t *ans, int *k, double fill, bool narm, int hasna, bool verbose) {
+void fadaptiverollmeanFast(double *x, uint_fast64_t nx, ans_t *ans, int *k, double fill, bool narm, int hasna, bool verbose) {
   if (verbose) snprintf(end(ans->message[0]), 500, "%s: running for input length %llu, hasna %d, narm %d\n", __func__, (unsigned long long int)nx, hasna, (int) narm);
   bool truehasna = hasna>0;                                     // flag to re-run if NAs detected
   long double w = 0.0;
@@ -48,15 +48,15 @@ void fadaptiverollmeanFast(double *x, uint_fast64_t nx, double_ans_t *ans, int *
     }
     if (R_FINITE((double) w)) {                                 // no need to calc this if NAs detected as will re-calc all below in truehasna==1
       #pragma omp parallel for num_threads(getDTthreads())
-      for (uint_fast64_t i=0; i<nx; i++) {                    // loop over observations to calculate final answer
-        if (i+1 == k[i]) ans->ans[i] = cs[i]/k[i];            // current obs window width exactly same as obs position in a vector
-        else if (i+1 > k[i]) ans->ans[i] = (cs[i]-cs[i-k[i]])/k[i]; // window width smaller than position so use cumsum to calculate diff
-        else ans->ans[i] = fill;                              // position in a vector smaller than obs window width - partial window
+      for (uint_fast64_t i=0; i<nx; i++) {                      // loop over observations to calculate final answer
+        if (i+1 == k[i]) ans->dbl_v[i] = cs[i]/k[i];            // current obs window width exactly same as obs position in a vector
+        else if (i+1 > k[i]) ans->dbl_v[i] = (cs[i]-cs[i-k[i]])/k[i]; // window width smaller than position so use cumsum to calculate diff
+        else ans->dbl_v[i] = fill;                              // position in a vector smaller than obs window width - partial window
       }
     } else {                                                    // update truehasna flag if NAs detected
       if (hasna==-1) {                                          // raise warning
         ans->status = 2;
-        snprintf(ans->message[2], 500, "%s: hasNA=FALSE used but NA (or other non-finite) value(s) are present in input, use default hasNA=NA to avoid this warning", __func__);
+        snprintf(end(ans->message[2]), 500, "%s: hasNA=FALSE used but NA (or other non-finite) value(s) are present in input, use default hasNA=NA to avoid this warning", __func__);
       }
       if (verbose) snprintf(end(ans->message[0]), 500, "%s: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs\n", __func__);
       w = 0.0;
@@ -80,21 +80,21 @@ void fadaptiverollmeanFast(double *x, uint_fast64_t nx, double_ans_t *ans, int *
       cn[i] = nc;                                               // cum NA counter
     }
     #pragma omp parallel for num_threads(getDTthreads())
-    for (uint_fast64_t i=0; i<nx; i++) {                      // loop over observations to calculate final answer
-      if (i+1 < k[i]) {                                       // partial window
-        ans->ans[i] = fill;
-      } else if (!narm) {                                     // this branch reduce number of branching in narm=1 below
+    for (uint_fast64_t i=0; i<nx; i++) {                        // loop over observations to calculate final answer
+      if (i+1 < k[i]) {                                         // partial window
+        ans->dbl_v[i] = fill;
+      } else if (!narm) {                                       // this branch reduce number of branching in narm=1 below
         if (i+1 == k[i]) {
-          ans->ans[i] = cn[i]>0 ? NA_REAL : cs[i]/k[i];
+          ans->dbl_v[i] = cn[i]>0 ? NA_REAL : cs[i]/k[i];
         } else if (i+1 > k[i]) {
-          ans->ans[i] = (cn[i] - cn[i-k[i]])>0 ? NA_REAL : (cs[i]-cs[i-k[i]])/k[i];
+          ans->dbl_v[i] = (cn[i] - cn[i-k[i]])>0 ? NA_REAL : (cs[i]-cs[i-k[i]])/k[i];
         }
-      } else if (i+1 == k[i]) {                               // window width equal to observation position in vector
-        int thisk = k[i] - ((int) cn[i]);                     // window width taking NAs into account, we assume single window width is int32, cum NA counter can be int64
-        ans->ans[i] = thisk==0 ? R_NaN : cs[i]/thisk;         // handle all obs NAs and na.rm=TRUE
-      } else if (i+1 > k[i]) {                                // window width smaller than observation position in vector
-        int thisk = k[i] - ((int) (cn[i] - cn[i-k[i]]));      // window width taking NAs into account, we assume single window width is int32, cum NA counter can be int64
-        ans->ans[i] = thisk==0 ? R_NaN : (cs[i]-cs[i-k[i]])/thisk; // handle all obs NAs and na.rm=TRUE
+      } else if (i+1 == k[i]) {                                 // window width equal to observation position in vector
+        int thisk = k[i] - ((int) cn[i]);                       // window width taking NAs into account, we assume single window width is int32, cum NA counter can be int64
+        ans->dbl_v[i] = thisk==0 ? R_NaN : cs[i]/thisk;         // handle all obs NAs and na.rm=TRUE
+      } else if (i+1 > k[i]) {                                  // window width smaller than observation position in vector
+        int thisk = k[i] - ((int) (cn[i] - cn[i-k[i]]));        // window width taking NAs into account, we assume single window width is int32, cum NA counter can be int64
+        ans->dbl_v[i] = thisk==0 ? R_NaN : (cs[i]-cs[i-k[i]])/thisk; // handle all obs NAs and na.rm=TRUE
       }
     }
     free(cn);
@@ -108,7 +108,7 @@ void fadaptiverollmeanFast(double *x, uint_fast64_t nx, double_ans_t *ans, int *
  * uses multiple cores
  */
 
-void fadaptiverollmeanExact(double *x, uint_fast64_t nx, double_ans_t *ans, int *k, double fill, bool narm, int hasna, bool verbose) {
+void fadaptiverollmeanExact(double *x, uint_fast64_t nx, ans_t *ans, int *k, double fill, bool narm, int hasna, bool verbose) {
   if (verbose) snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %llu, hasna %d, narm %d\n", __func__, (unsigned long long int)nx, hasna, (int) narm);
 
   bool truehasna = hasna>0;                                   // flag to re-run if NAs detected
@@ -117,7 +117,7 @@ void fadaptiverollmeanExact(double *x, uint_fast64_t nx, double_ans_t *ans, int 
     #pragma omp parallel for num_threads(getDTthreads())
     for (uint_fast64_t i=0; i<nx; i++) {                      // loop on every observation to produce final answer
       if (narm && truehasna) continue;                        // if NAs detected no point to continue
-      if (i+1 < k[i]) ans->ans[i] = fill;                     // position in a vector smaller than obs window width - partial window
+      if (i+1 < k[i]) ans->dbl_v[i] = fill;                   // position in a vector smaller than obs window width - partial window
       else {
         long double w = 0.0;
         for (int j=-k[i]+1; j<=0; j++) {                      // sub-loop on window width
@@ -129,17 +129,17 @@ void fadaptiverollmeanExact(double *x, uint_fast64_t nx, double_ans_t *ans, int 
           for (int j=-k[i]+1; j<=0; j++) {                    // sub-loop on window width
             err += x[i+j] - res;                              // measure difference of obs in sub-loop to calculated fun for obs
           }
-          ans->ans[i] = (double) (res + (err / k[i]));        // adjust calculated fun with roundoff correction
+          ans->dbl_v[i] = (double) (res + (err / k[i]));      // adjust calculated fun with roundoff correction
         } else {
-          if (!narm) ans->ans[i] = (double) (w / k[i]);       // NAs should be propagated
+          if (!narm) ans->dbl_v[i] = (double) (w / k[i]);     // NAs should be propagated
           truehasna = true;                                   // NAs detected for this window, set flag so rest of windows will not be re-run
         }
       }
     }
     if (truehasna) {
-      if (hasna==-1) {                                          // raise warning
+      if (hasna==-1) {                                        // raise warning
         ans->status = 2;
-        snprintf(ans->message[2], 500, "%s: hasNA=FALSE used but NA (or other non-finite) value(s) are present in input, use default hasNA=NA to avoid this warning", __func__);
+        snprintf(end(ans->message[2]), 500, "%s: hasNA=FALSE used but NA (or other non-finite) value(s) are present in input, use default hasNA=NA to avoid this warning", __func__);
       }
       if (verbose) {
         if (narm) snprintf(end(ans->message[0]), 500, "%s: NA (or other non-finite) value(s) are present in input, re-running with extra care for NAs\n", __func__);
@@ -150,7 +150,7 @@ void fadaptiverollmeanExact(double *x, uint_fast64_t nx, double_ans_t *ans, int 
   if (truehasna && narm) {
     #pragma omp parallel for num_threads(getDTthreads())
     for (uint_fast64_t i=0; i<nx; i++) {                      // loop over observations to produce final answer
-      if (i+1 < k[i]) ans->ans[i] = fill;                     // partial window
+      if (i+1 < k[i]) ans->dbl_v[i] = fill;                   // partial window
       else {
         long double w = 0.0;                                  // window to accumulate values in particular window
         long double err = 0.0;                                // accumulate roundoff error
@@ -165,15 +165,15 @@ void fadaptiverollmeanExact(double *x, uint_fast64_t nx, double_ans_t *ans, int 
           for (int j=-k[i]+1; j<=0; j++) {                    // sub-loop on window width to accumulate roundoff error
             err += x[i+j] - res;                              // measure roundoff for each obs in window
           }
-          ans->ans[i] = (double) (res + (err / k[i]));        // adjust calculated fun with roundoff correction
+          ans->dbl_v[i] = (double) (res + (err / k[i]));      // adjust calculated fun with roundoff correction
         } else if (nc < k[i]) {
           res = w / (k[i]-nc);
           for (int j=-k[i]+1; j<=0; j++) {                    // sub-loop on window width to accumulate roundoff error
             if (!ISNAN(x[i+j])) err += x[i+j] - res;          // measure roundoff for each obs in window
           }
-          ans->ans[i] = (double) (res + (err / (k[i] - nc))); // adjust calculated fun with roundoff correction
+          ans->dbl_v[i] = (double) (res + (err / (k[i] - nc))); // adjust calculated fun with roundoff correction
         } else {                                              // nc == k[i]
-          ans->ans[i] = R_NaN;                                // this branch assume narm so R_NaN always here
+          ans->dbl_v[i] = R_NaN;                              // this branch assume narm so R_NaN always here
         }
       }
     }

--- a/src/nafill.c
+++ b/src/nafill.c
@@ -58,7 +58,7 @@ void nafillDouble(double *x, uint_fast64_t nx, unsigned int type, double fill, a
       ans->dbl_v[i] = ISNA(x[i]) ? ans->dbl_v[i+1] : x[i];
     }
   }
-  if (verbose) sprintf(ans->message[0], "%s: took %.3fs\n", __func__, omp_get_wtime()-tic);
+  if (verbose) snprintf(ans->message[0], 500, "%s: took %.3fs\n", __func__, omp_get_wtime()-tic);
 }
 
 void nafillInteger(int32_t *x, uint_fast64_t nx, unsigned int type, int32_t fill, ans_t *ans, bool verbose) {
@@ -79,7 +79,7 @@ void nafillInteger(int32_t *x, uint_fast64_t nx, unsigned int type, int32_t fill
       ans->int_v[i] = x[i]==NA_INTEGER ? ans->int_v[i+1] : x[i];
     }
   }
-  if (verbose) sprintf(ans->message[0], "%s: took %.3fs\n", __func__, omp_get_wtime()-tic);
+  if (verbose) snprintf(ans->message[0], 500, "%s: took %.3fs\n", __func__, omp_get_wtime()-tic);
 }
 
 SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP inplace, SEXP cols, SEXP verbose) {

--- a/src/nafill.c
+++ b/src/nafill.c
@@ -117,7 +117,8 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP inplace, SEXP cols, SEXP verbo
   int32_t* ix[nx];
   uint_fast64_t inx[nx];
   SEXP ans = R_NilValue;
-  ans_t vans[nx];
+  ans_t *vans = malloc(sizeof(ans_t)*nx);
+  if (!vans) error("%s: Unable to allocate memory answer", __func__); // # nocov
   for (R_len_t i=0; i<nx; i++) {
     inx[i] = xlength(VECTOR_ELT(x, i));
     dx[i] = REAL(VECTOR_ELT(x, i));

--- a/src/types.h
+++ b/src/types.h
@@ -1,14 +1,14 @@
 #include<stdint.h>
 
-typedef struct double_ans_t {
+typedef struct double_ans_t { // used in froll
   double *ans;
-  uint8_t status;   // 0:ok, 1:message, 2:warning, 3:error; unix return signal: {0,1,2}=0, {3}=1
-  char message[4][256]; // STDOUT: output, STDERR: message, warning, error
+  uint8_t status;             // 0:ok, 1:message, 2:warning, 3:error; unix return signal: {0,1,2}=0, {3}=1
+  char message[4][4096];      // STDOUT: output, STDERR: message, warning, error
 } double_ans_t;
 
-typedef struct ans_t {
+typedef struct ans_t {        // used in nafill
   int32_t *int_v;
   double *dbl_v;
-  uint8_t status;   // 0:ok, 1:message, 2:warning, 3:error; unix return signal: {0,1,2}=0, {3}=1
-  char message[4][256]; // STDOUT: output, STDERR: message, warning, error
+  uint8_t status;             // 0:ok, 1:message, 2:warning, 3:error; unix return signal: {0,1,2}=0, {3}=1
+  char message[4][256];       // STDOUT: output, STDERR: message, warning, error
 } ans_t;

--- a/src/types.h
+++ b/src/types.h
@@ -5,6 +5,7 @@ typedef struct double_ans_t { // used in froll
   uint8_t status;             // 0:ok, 1:message, 2:warning, 3:error; unix return signal: {0,1,2}=0, {3}=1
   char message[4][4096];      // STDOUT: output, STDERR: message, warning, error
 } double_ans_t;
+// implicit n_message limit discussed here: https://github.com/Rdatatable/data.table/issues/3423#issuecomment-487722586
 
 typedef struct ans_t {        // used in nafill
   int32_t *int_v;
@@ -12,3 +13,4 @@ typedef struct ans_t {        // used in nafill
   uint8_t status;             // 0:ok, 1:message, 2:warning, 3:error; unix return signal: {0,1,2}=0, {3}=1
   char message[4][256];       // STDOUT: output, STDERR: message, warning, error
 } ans_t;
+

--- a/src/types.h
+++ b/src/types.h
@@ -1,16 +1,10 @@
 #include<stdint.h>
 
-typedef struct double_ans_t { // used in froll
-  double *ans;
+typedef struct ans_t {
+  int32_t *int_v;             // used in nafill
+  double *dbl_v;              // used in froll, nafill
+  int64_t *int64_v;           // not used yet
   uint8_t status;             // 0:ok, 1:message, 2:warning, 3:error; unix return signal: {0,1,2}=0, {3}=1
   char message[4][4096];      // STDOUT: output, STDERR: message, warning, error
-} double_ans_t;
 // implicit n_message limit discussed here: https://github.com/Rdatatable/data.table/issues/3423#issuecomment-487722586
-
-typedef struct ans_t {        // used in nafill
-  int32_t *int_v;
-  double *dbl_v;
-  uint8_t status;             // 0:ok, 1:message, 2:warning, 3:error; unix return signal: {0,1,2}=0, {3}=1
-  char message[4][256];       // STDOUT: output, STDERR: message, warning, error
 } ans_t;
-


### PR DESCRIPTION
closes #3423
unfortunately starting from gcc-8 there are compilation warnings (related [SO](https://stackoverflow.com/a/50509459/2490497))
```
froll.c:16:38: warning: passing argument 1 to restrict-qualified parameter aliases with argument 3 [-Wrestrict]
     if (verbose) sprintf(ans->message[0], "%s%s: window width longer than input vector, returning all NA vector\n", ans->message[0], __func__);
                          ~~~~~~~~~~~~^~~                                                                            ~~~~~~~~~~~~~~~
```
those field are defined as
```c
char message[4][4096];
```
and initialised as `{"\0","\0","\0","\0"}`:
```c
((double_ans_t) { .ans=REAL(VECTOR_ELT(ans, i*nk+j)), .status=0, .message={"\0","\0","\0","\0"} });
```

