### PR TITLE
leave opt compiler flag default, follow up of 7810b22

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -138,8 +138,8 @@ test-rel-cran-lin: # currently released R on Linux
     _R_CHECK_CRAN_INCOMING_REMOTE_: "FALSE"   # Other than no URL checking (takes many minutes) or 'Days since last update 0' NOTEs needed, #3284
   before_script:
     - mkdir -p ~/.R
-    - echo 'CFLAGS=-O3'> ~/.R/Makevars   # No -g because -g increases datatable.so size from 0.5MB to 1.5MB and breaches 'installed package size <= 5MB' note
-    - echo 'CXXFLAGS=-O3' >> ~/.R/Makevars
+    - echo 'CFLAGS=-g0'> ~/.R/Makevars   # No -g because -g increases datatable.so size from 0.5MB to 1.5MB and breaches 'installed package size <= 5MB' note
+    - echo 'CXXFLAGS=-g0' >> ~/.R/Makevars
   script:
     - Rscript -e 'source("ci.R"); install.packages(dcf.dependencies("DESCRIPTION", which="most"))'
     - *copy-src


### PR DESCRIPTION
https://github.com/Rdatatable/data.table/commit/7810b224ed59d9ade5375ffd7945cf4e0fa3d785#r33513563
https://gcc.gnu.org/onlinedocs/gcc/Debugging-Options.html#Debugging-Options