### PR TITLE
utils.R coverage

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -167,8 +167,6 @@ S3method(unique, ITime)
 # getdots
 # NCOL
 # NROW
-# take
-# trim
 # which.first
 # which.last
 

--- a/R/fread.R
+++ b/R/fread.R
@@ -271,7 +271,7 @@ yaml=FALSE, autostart=NA)
               fill,showProgress,nThread,verbose,warnings2errors,logical01,select,drop,colClasses,integer64,encoding,keepLeadingZeros)
   if (!length(ans)) return(null.data.table())  # test 1743.308 drops all columns
   nr = length(ans[[1L]])
-  if ((!"bit64" %chin% loadedNamespaces()) && any(sapply(ans,inherits,"integer64"))) require_bit64()  # nocov
+  require_bit64_if_needed(ans)
   setattr(ans,"row.names",.set_row_names(nr))
 
   if (isTRUE(data.table)) {

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -7,7 +7,7 @@ print.data.table <- function(x, topn=getOption("datatable.print.topn"),
                col.names=getOption("datatable.print.colnames"),
                print.keys=getOption("datatable.print.keys"),
                quote=FALSE,
-               timezone=FALSE, ...) {    
+               timezone=FALSE, ...) {
   # topn  - print the top topn and bottom topn rows with '---' inbetween (5)
   # nrows - under this the whole (small) table is printed, unless topn is provided (100)
   # class - should column class be printed underneath column name? (FALSE)
@@ -67,9 +67,7 @@ print.data.table <- function(x, topn=getOption("datatable.print.topn"),
     printdots = FALSE
   }
   toprint=format.data.table(toprint, na.encode=FALSE, timezone = timezone, ...)  # na.encode=FALSE so that NA in character cols print as <NA>
-
-  if ((!"bit64" %chin% loadedNamespaces()) && any(sapply(x,inherits,"integer64"))) require_bit64()
-  # When we depend on R 3.2.0 (Apr 2015) we can use isNamespaceLoaded() added then, instead of %chin% above
+  require_bit64_if_needed(x)
 
   # FR #5020 - add row.names = logical argument to print.data.table
   if (isTRUE(row.names)) rownames(toprint)=paste0(format(rn,right=TRUE,scientific=FALSE),":") else rownames(toprint)=rep.int("", nrow(toprint))

--- a/R/setkey.R
+++ b/R/setkey.R
@@ -379,7 +379,7 @@ CJ <- function(..., sorted = TRUE, unique = FALSE)
     if (nrow > .Machine$integer.max) {
       stop("Cross product of elements provided to CJ() would result in ",nrow," rows which exceeds .Machine$integer.max == ",.Machine$integer.max)
     }
-    x = c(rev(take(cumprod(rev(n)))), 1L)
+    x = c(rev(  head(cumprod(rev(n)),-1)  ), 1L)
     for (i in seq_along(x)) {
       y = l[[i]]
       # fix for #1513

--- a/R/utils.R
+++ b/R/utils.R
@@ -13,6 +13,10 @@ if (base::getRversion() < "3.5.0") {
 isTRUEorNA    <- function(x) is.logical(x) && length(x)==1L && (is.na(x) || x)
 isTRUEorFALSE <- function(x) is.logical(x) && length(x)==1L && !is.na(x)
 
+if (base::getRversion() < "3.2.0") {  # Apr 2015
+  isNamespaceLoaded = function(x) x %chin% loadedNamespaces()
+}
+
 # which.first
 which.first <- function(x)
 {
@@ -31,33 +35,13 @@ which.last <- function(x)
   length(x) - match(TRUE, rev(x)) + 1L
 }
 
-# trim
-trim <- function(x) {
-  # Removes whitespace at the beginning and end of strings
-  # Assigning to x[] to retain the original dimensions, rownames and colnames
-  x[] = gsub(" +$", "", x)
-  x[] = gsub("^ +", "", x)
-  x
-}
-
-# take (I don't see it being used anywhere)
-take <- function(x, n=1L)
-{
-  # returns the head of head, without the last n observations
-  # convenient when inlining expressions
-  # NROW, for vectors, returns the vector length, but we cater for non-table like lists also here
-  # TO DO: allow taking along any dimension e.g. all but last column, rather than all but last row.
-  if (is.list(x) && !is.data.frame(x)  && !is.data.table(x)) l = length(x)
-  else l = NROW(x)
-  if (l < n) stop("Cannot take ",n," from ",l)
-  head(x, l-n)
-}
-# TODO: Implement take as UseMethod. Specific methods for each type.
-
-require_bit64 = function() {
-  # called in fread and print when they see integer64 columns are present
-  if (!requireNamespace("bit64",quietly=TRUE))
-  warning("Some columns are type 'integer64' but package bit64 is not installed. Those columns will print as strange looking floating point data. There is no need to reload the data. Simply install.packages('bit64') to obtain the integer64 print method and print the data again.")
+require_bit64_if_needed = function(DT) {
+  # called in fread and print.data.table
+  if (!isNamespaceLoaded("bit64") && any(sapply(DT,inherits,"integer64"))) {
+    if (!requireNamespace("bit64",quietly=TRUE)) {
+      warning("Some columns are type 'integer64' but package bit64 is not installed. Those columns will print as strange looking floating point data. There is no need to reload the data. Simply install.packages('bit64') to obtain the integer64 print method and print the data again.")  # nocov
+    }
+  }
 }
 
 # vapply for return value character(1)

--- a/R/utils.R
+++ b/R/utils.R
@@ -38,9 +38,12 @@ which.last <- function(x)
 require_bit64_if_needed = function(DT) {
   # called in fread and print.data.table
   if (!isNamespaceLoaded("bit64") && any(sapply(DT,inherits,"integer64"))) {
+    # nocov start
+    # a test was attempted to cover the requireNamespace() by using unloadNamespace() first, but that fails when nanotime is loaded because nanotime also uses bit64
     if (!requireNamespace("bit64",quietly=TRUE)) {
-      warning("Some columns are type 'integer64' but package bit64 is not installed. Those columns will print as strange looking floating point data. There is no need to reload the data. Simply install.packages('bit64') to obtain the integer64 print method and print the data again.")  # nocov
+      warning("Some columns are type 'integer64' but package bit64 is not installed. Those columns will print as strange looking floating point data. There is no need to reload the data. Simply install.packages('bit64') to obtain the integer64 print method and print the data again.")
     }
+    # nocov end
   }
 }
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -48,7 +48,6 @@ if (exists("test.data.table", .GlobalEnv, inherits=FALSE)) {
   .shallow = data.table:::.shallow
   split.data.table = data.table:::split.data.table
   test = data.table:::test
-  trim = data.table:::trim
   uniqlengths = data.table:::uniqlengths
   uniqlist = data.table:::uniqlist
   which_ = data.table:::which_
@@ -7130,10 +7129,8 @@ dt2 = as.data.table(dt1); setattr(dt2, 'sorted', NULL)
 test(1533.1, setkeyv(dt1, character(0)), dt2, warning = "cols is a character vector")
 test(1533.2, setkeyv(dt1, "x", verbose=TRUE), setkey(dt2, x), output = "forder took")
 
-# coverage for internal trim, test 1534 removed as custom %+% has been removed
-test(1535.1, trim("  abcde "), "abcde")
-test(1535.2, trim("  abcde"), "abcde")
-test(1535.3, trim("abcde "), "abcde")
+# test 1534 removed as custom %+% has been removed
+# test 1535 removed as internal trim() not used
 
 # remaining test for covering duplicated.data.table
 dt = data.table(x=1:5, y=6:10)


### PR DESCRIPTION
Removed internal functions `trim` and `take`, neither exported. `take` did what `head(..., -1)` does.
Moved common code before two calls to require_bit64 inside the function.
Uses `isNamespaceLoaded` for efficiency from R 3.2 and backports it to R < 3.2.
