### PR TITLE
fixed invalid trim

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -93,6 +93,8 @@
 
 8. GForce optimization of `median` did not retain the class; e.g. `median` of `Date` or `POSIXct` would return a raw number rather than retain the date class, [#3079](https://github.com/Rdatatable/data.table/issues/3079). Thanks to @Henrik-P for reporting.
 
+9. `DT[, format(mean(date,""%b-%Y")), by=group]` could fail with `invalid 'trim' argument`, [#1876](https://github.com/Rdatatable/data.table/issues/1876). Thanks to Ross Holmberg for reporting.
+
 #### NOTES
 
 1. `rbindlist`'s `use.names="check"` now emits its message for automatic column names (`"V[0-9]+"`) too, [#3484](https://github.com/Rdatatable/data.table/pull/3484). See news item 5 of v1.12.2 below.

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1176,7 +1176,7 @@ replace_dot_alias <- function(e) {
               cat("Growing vector of column pointers from truelength ", truelength(x), " to ", n, ". A shallow copy has been taken, see ?alloc.col. Only a potential issue if two variables point to the same data (we can't yet detect that well) and if not you can safely ignore this. To avoid this message you could alloc.col() first, deep copy first using copy(), wrap with suppressWarnings() or increase the 'datatable.alloccol' option.\n")
               # #1729 -- copying to the wrong environment here can cause some confusion
               if (ok == -1L) cat("Note that the shallow copy will assign to the environment from which := was called. That means for example that if := was called within a function, the original table may be unaffected.\n")
-              
+
               # Verbosity should not issue warnings, so cat rather than warning.
               # TO DO: Add option 'datatable.pedantic' to turn on warnings like this.
 
@@ -1790,7 +1790,6 @@ replace_dot_alias <- function(e) {
           cat("Old mean optimization is on, left j unchanged.\n")
       }
       assign("Cfastmean", Cfastmean, SDenv)
-      assign("mean", base::mean.default, SDenv)
       # Old comments still here for now ...
       # Here in case nomeanopt=TRUE or some calls to mean weren't detected somehow. Better but still slow.
       # Maybe change to :

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -5328,6 +5328,8 @@ test(1362.14, names(DT[, c(list(bla=.I, mean(y)), lapply(.SD, sum)), by=x]), c("
 # Add test to ensure that mean() gets replaced with fastmean when GForce won't be used.
 test(1362.15, DT[, c(list(.I, mean(y)), lapply(.SD, mean)), by=x, verbose=TRUE],
   output="Old mean optimization changed j from 'list(.I, mean(y), mean(y), mean(z))' to 'list(.I, .External(Cfastmean, y, FALSE), .External(Cfastmean, y, FALSE), .External(Cfastmean, z, FALSE))'")
+DT[, w:=c(3i,4i,5i,6i,7i)]
+test(1362.16, DT[, .(mean(w), y*2), by=x], error="fastmean was passed type complex, not numeric or logical")
 
 # setDT(DT), when input is already a data.table checks if selfrefok and if not, does alloc.col again.
 DT = list(data.frame(x=1:5, y=6:10))

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -14577,6 +14577,14 @@ DT[, time:=as.POSIXct(date)]
 test(2041.1, DT[, median(date), by=g], data.table(g=c("a","b"), V1=as.Date(c("2018-01-03","2018-01-25"))))
 test(2041.2, DT[, median(time), by=g], DT[c(2,5),.(g=g, V1=time)])
 
+# 'invalid trim argument' with optimization level 1; #1876
+test(2042.1, DT[ , as.character(mean(date)), by=g, verbose=TRUE ],
+             data.table(g=c("a","b"), V1=c("2018-01-04","2018-01-21")),
+             output=msg<-"GForce is on, left j unchanged.*Old mean optimization is on, left j unchanged")
+test(2042.2, DT[ , format(mean(date),"%b-%Y")], "Jan-2018")
+test(2042.3, DT[ , format(mean(date),"%b-%Y"), by=g, verbose=TRUE ],  # just this case generated the error
+             data.table(g=c("a","b"), V1=c("Jan-2018","Jan-2018")), output=msg)
+
 
 ###################################
 #  Add new tests above this line  #

--- a/src/fastmean.c
+++ b/src/fastmean.c
@@ -40,8 +40,9 @@ SEXP fastmean(SEXP args)
     narm=LOGICAL(tmp)[0];
   }
   PROTECT(ans = allocNAVector(REALSXP, 1));
+  copyMostAttrib(x, ans);
   if (!isInteger(x) && !isReal(x) && !isLogical(x)) {
-    warning("argument is not numeric or logical: returning NA");
+    warning("fastmean was passed '%s' not numeric or logical; returning NA", type2char(TYPEOF(x)));
     UNPROTECT(1);
     return(ans);
   }
@@ -112,7 +113,6 @@ SEXP fastmean(SEXP args)
       error("Type '%s' not supported in fastmean", type2char(TYPEOF(x)));
     }
   }
-  copyMostAttrib(x, ans);
   UNPROTECT(1);
   return(ans);
 }
@@ -136,6 +136,4 @@ SEXP fastmean(SEXP args)
       COMPLEX(ans)[0].i = (double) si;
       break;
 */
-
-
 

--- a/src/fastmean.c
+++ b/src/fastmean.c
@@ -36,15 +36,13 @@ SEXP fastmean(SEXP args)
   if (length(args)>2) {
     tmp = CADDR(args);
     if (!isLogical(tmp) || LENGTH(tmp)!=1 || LOGICAL(tmp)[0]==NA_LOGICAL)
-      error("narm should be TRUE or FALSE");
+      error("narm should be TRUE or FALSE");  // # nocov ; [.data.table should construct the .External call correctly
     narm=LOGICAL(tmp)[0];
   }
   PROTECT(ans = allocNAVector(REALSXP, 1));
   copyMostAttrib(x, ans);
   if (!isInteger(x) && !isReal(x) && !isLogical(x)) {
-    warning("fastmean was passed '%s' not numeric or logical; returning NA", type2char(TYPEOF(x)));
-    UNPROTECT(1);
-    return(ans);
+    error("fastmean was passed type %s, not numeric or logical", type2char(TYPEOF(x)));
   }
   l = LENGTH(x);
   if (narm) {
@@ -82,7 +80,7 @@ SEXP fastmean(SEXP args)
       REAL(ans)[0] = (double) s;
       break;
     default:
-      error("Type '%s' not supported in fastmean", type2char(TYPEOF(x)));
+      error("Internal error: type '%s' not caught earlier in fastmean", type2char(TYPEOF(x)));  // # nocov
     }
   } else {  // narm==FALSE
     switch(TYPEOF(x)) {
@@ -110,7 +108,7 @@ SEXP fastmean(SEXP args)
       REAL(ans)[0] = (double) s;
       break;
     default:
-      error("Type '%s' not supported in fastmean", type2char(TYPEOF(x)));
+      error("Internal error: type '%s' not caught earlier in fastmean", type2char(TYPEOF(x)));  // # nocov
     }
   }
   UNPROTECT(1);


### PR DESCRIPTION
Closes #1876
Follow up to #3546

`mean` was being assigned `mean.default` and this caused the `Date` class to be dropped. So then `format` dispatched to the numeric format (with 2nd argument `trim`) rather than the `Date` format (with 2nd argument `format`).

I moved the copyMostAttrib up in fastmean.c too but that wasn't the cause here because fastmean wasn't being invoked.  It was the assign of mean under optimization level 1 which happened in [.data.table.