### PR TITLE
remove most usages of <-

### DIFF
--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -91,8 +91,10 @@ round.IDate = function (x, digits=c("weeks", "months", "quarters", "years"), ...
 }
 
 `-.IDate` = function (e1, e2) {
-  if (!inherits(e1, "IDate"))
+  if (!inherits(e1, "IDate")) {
+    if (inherits(e1, 'Date')) return(base::`-.Date`(e1, e2))
     stop("can only subtract from \"IDate\" objects")
+  }
   if (storage.mode(e1) != "integer")
     stop("Internal error: storage mode of IDate is somehow no longer integer") # nocov
   if (nargs() == 1L)

--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -64,7 +64,7 @@ as.list.IDate = function(x, ...) NextMethod()
 
 # rounding -- good for graphing / subsetting
 ## round.IDate = function (x, digits, units=digits, ...) {
-##     if (missing(digits)) digits <- units # workaround to provide a units argument to match the round generic and round.POSIXt
+##     if (missing(digits)) digits = units # workaround to provide a units argument to match the round generic and round.POSIXt
 ##     units = match.arg(digits, c("weeks", "months", "quarters", "years"))
 round.IDate = function (x, digits=c("weeks", "months", "quarters", "years"), ...) {
   units = match.arg(digits)
@@ -263,7 +263,7 @@ as.POSIXct.IDate = function(x, tz = "UTC", time = 0, ...) {
     time = tz # allows you to use time as the 2nd argument
     tz = "UTC"
   }
-  if (tz == "") tz <- "UTC"
+  if (tz == "") tz = "UTC"
   as.POSIXct(as.POSIXlt(x, ...), tz, ...) + time
 }
 

--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -3,14 +3,14 @@
 # IDate -- a simple wrapper class around Date using integer storage
 ###################################################################
 
-as.IDate <- function(x, ...) UseMethod("as.IDate")
+as.IDate = function(x, ...) UseMethod("as.IDate")
 
-as.IDate.default <- function(x, ..., tz = attr(x, "tzone")) {
+as.IDate.default = function(x, ..., tz = attr(x, "tzone")) {
   if (is.null(tz)) tz = "UTC"
   as.IDate(as.Date(x, tz = tz, ...))
 }
 
-as.IDate.numeric <- function(x, origin = "1970-01-01", ...) {
+as.IDate.numeric = function(x, origin = "1970-01-01", ...) {
   if (origin=="1970-01-01") {
     # standard epoch
     x = as.integer(x)
@@ -26,13 +26,13 @@ as.IDate.numeric <- function(x, origin = "1970-01-01", ...) {
   }
 }
 
-as.IDate.Date <- function(x, ...) {
+as.IDate.Date = function(x, ...) {
   x = as.integer(x)                 # if already integer, x will be left unchanged as the original input
   class(x) = c("IDate", "Date")     # class()<- will copy if as.integer() did not create, and may not if it did we hope
   x                                 # always return a new object
 }
 
-as.IDate.POSIXct <- function(x, tz = attr(x, "tzone"), ...) {
+as.IDate.POSIXct = function(x, tz = attr(x, "tzone"), ...) {
   if (is.null(tz)) tz = "UTC"
   if (tz %chin% c("UTC", "GMT")) {
     (setattr(as.integer(x) %/% 86400L, "class", c("IDate", "Date")))  # %/% returns new object so can use setattr() on it; wrap with () to return visibly
@@ -40,34 +40,34 @@ as.IDate.POSIXct <- function(x, tz = attr(x, "tzone"), ...) {
     as.IDate(as.Date(x, tz = tz, ...))
 }
 
-as.IDate.IDate <- function(x, ...) x
+as.IDate.IDate = function(x, ...) x
 
-as.Date.IDate <- function(x, ...) {
+as.Date.IDate = function(x, ...) {
   x = as.numeric(x)
   class(x) = "Date"
   x
 }
 
-mean.IDate <-
-cut.IDate <-
-seq.IDate <-
-c.IDate <-
-rep.IDate <-
-split.IDate <-
-unique.IDate <-
+mean.IDate =
+cut.IDate =
+seq.IDate =
+c.IDate =
+rep.IDate =
+split.IDate =
+unique.IDate =
   function(x, ...) {
     as.IDate(NextMethod())
   }
 
 # fix for #1315
-as.list.IDate <- function(x, ...) NextMethod()
+as.list.IDate = function(x, ...) NextMethod()
 
 # rounding -- good for graphing / subsetting
-## round.IDate <- function (x, digits, units=digits, ...) {
+## round.IDate = function (x, digits, units=digits, ...) {
 ##     if (missing(digits)) digits <- units # workaround to provide a units argument to match the round generic and round.POSIXt
-##     units <- match.arg(digits, c("weeks", "months", "quarters", "years"))
-round.IDate <- function (x, digits=c("weeks", "months", "quarters", "years"), ...) {
-  units <- match.arg(digits)
+##     units = match.arg(digits, c("weeks", "months", "quarters", "years"))
+round.IDate = function (x, digits=c("weeks", "months", "quarters", "years"), ...) {
+  units = match.arg(digits)
   as.IDate(switch(units,
           weeks  = round(x, "year") + 7L * (yday(x) %/% 7L),
           months = ISOdate(year(x), month(x), 1L),
@@ -76,7 +76,7 @@ round.IDate <- function (x, digits=c("weeks", "months", "quarters", "years"), ..
 }
 
 #Adapted from `+.Date`
-`+.IDate` <- function (e1, e2) {
+`+.IDate` = function (e1, e2) {
   if (nargs() == 1L)
     return(e1)
   if (inherits(e1, "difftime") || inherits(e2, "difftime"))
@@ -90,7 +90,7 @@ round.IDate <- function (x, digits=c("weeks", "months", "quarters", "years"), ..
   (setattr(as.integer(unclass(e1) + unclass(e2)), "class", c("IDate", "Date")))  # () wrap to return visibly
 }
 
-`-.IDate` <- function (e1, e2) {
+`-.IDate` = function (e1, e2) {
   if (!inherits(e1, "IDate"))
     stop("can only subtract from \"IDate\" objects")
   if (storage.mode(e1) != "integer")
@@ -119,19 +119,19 @@ round.IDate <- function (x, digits=c("weeks", "months", "quarters", "years"), ..
 #          Stored as seconds in the day
 ###################################################################
 
-as.ITime <- function(x, ...) UseMethod("as.ITime")
+as.ITime = function(x, ...) UseMethod("as.ITime")
 
-as.ITime.default <- function(x, ...) {
+as.ITime.default = function(x, ...) {
   as.ITime(as.POSIXlt(x, ...), ...)
 }
 
-as.ITime.POSIXct <- function(x, tz = attr(x, "tzone"), ...) {
+as.ITime.POSIXct = function(x, tz = attr(x, "tzone"), ...) {
   if (is.null(tz)) tz = "UTC"
   if (tz %chin% c("UTC", "GMT")) as.ITime(unclass(x), ...)
   else as.ITime(as.POSIXlt(x, tz = tz, ...), ...)
 }
 
-as.ITime.numeric <- function(x, ms = 'truncate', ...) {
+as.ITime.numeric = function(x, ms = 'truncate', ...) {
   secs = switch(ms,
                 'truncate' = as.integer(x),
                 'nearest' = as.integer(round(x)),
@@ -141,12 +141,12 @@ as.ITime.numeric <- function(x, ms = 'truncate', ...) {
   (setattr(secs, "class", "ITime")) # the %% here ^^ ensures a local copy is obtained; the truncate as.integer() may not copy
 }
 
-as.ITime.character <- function(x, format, ...) {
-  x <- unclass(x)
+as.ITime.character = function(x, format, ...) {
+  x = unclass(x)
   if (!missing(format)) return(as.ITime(strptime(x, format = format, ...), ...))
   # else allow for mixed formats, such as test 1189 where seconds are caught despite varying format
-  y <- strptime(x, format = "%H:%M:%OS", ...)
-  w <- which(is.na(y))
+  y = strptime(x, format = "%H:%M:%OS", ...)
+  w = which(is.na(y))
   formats = c("%H:%M",
         "%Y-%m-%d %H:%M:%OS",
         "%Y/%m/%d %H:%M:%OS",
@@ -156,17 +156,17 @@ as.ITime.character <- function(x, format, ...) {
         "%Y/%m/%d")
   for (f in formats) {
     if (!length(w)) break
-    new <- strptime(x[w], format = f, ...)
-    nna <- !is.na(new)
+    new = strptime(x[w], format = f, ...)
+    nna = !is.na(new)
     if (any(nna)) {
-      y[ w[nna] ] <- new[nna]
-      w <- w[!nna]
+      y[ w[nna] ] = new[nna]
+      w = w[!nna]
     }
   }
   return(as.ITime(y, ...))
 }
 
-as.ITime.POSIXlt <- function(x, ms = 'truncate', ...) {
+as.ITime.POSIXlt = function(x, ms = 'truncate', ...) {
   secs = switch(ms,
                 'truncate' = as.integer(x$sec),
                 'nearest' = as.integer(round(x$sec)),
@@ -176,7 +176,7 @@ as.ITime.POSIXlt <- function(x, ms = 'truncate', ...) {
   (setattr(with(x, secs + min * 60L + hour * 3600L), "class", "ITime"))  # () wrap to return visibly
 }
 
-as.ITime.times <- function(x, ms = 'truncate', ...) {
+as.ITime.times = function(x, ms = 'truncate', ...) {
   secs = 86400 * (unclass(x) %% 1)
   secs = switch(ms,
                 'truncate' = as.integer(secs),
@@ -187,17 +187,17 @@ as.ITime.times <- function(x, ms = 'truncate', ...) {
   (setattr(secs, "class", "ITime"))  # the first line that creates sec will create a local copy so we can use setattr() to avoid potential copy of class()<-
 }
 
-as.character.ITime <- format.ITime <- function(x, ...) {
+as.character.ITime = format.ITime = function(x, ...) {
   # adapted from chron's format.times
   # Fix for #811. Thanks to @StefanFritsch for the code snippet
-  neg <- x < 0L
-  x  <- abs(unclass(x))
-  hh <- x %/% 3600L
-  mm <- (x - hh * 3600L) %/% 60L
+  neg = x < 0L
+  x  = abs(unclass(x))
+  hh = x %/% 3600L
+  mm = (x - hh * 3600L) %/% 60L
   # #2171 -- trunc gives numeric but %02d requires integer;
   #   as.integer is also faster (but doesn't handle integer overflow)
   #   http://stackoverflow.com/questions/43894077
-  ss <- as.integer(x - hh * 3600L - 60L * mm)
+  ss = as.integer(x - hh * 3600L - 60L * mm)
   res = sprintf('%02d:%02d:%02d', hh, mm, ss)
   # Fix for #1354, so that "NA" input is handled correctly.
   if (is.na(any(neg))) res[is.na(x)] = NA
@@ -206,7 +206,7 @@ as.character.ITime <- format.ITime <- function(x, ...) {
   res
 }
 
-as.data.frame.ITime <- function(x, ...) {
+as.data.frame.ITime = function(x, ...) {
   # This method is just for ggplot2, #1713
   # Avoids the error "cannot coerce class '"ITime"' into a data.frame", but for some reason
   # ggplot2 doesn't seem to call the print method to get axis labels, so still prints integers.
@@ -220,18 +220,18 @@ as.data.frame.ITime <- function(x, ...) {
   ans
 }
 
-print.ITime <- function(x, ...) {
+print.ITime = function(x, ...) {
   print(format(x))
 }
 
-rep.ITime <- function (x, ...)
+rep.ITime = function (x, ...)
 {
   y = rep(unclass(x), ...)
   class(y) = "ITime"   # unlass and rep could feasibly not copy, hence use class<- not setattr()
   y
 }
 
-"[.ITime" <- function(x, ..., drop = TRUE)
+"[.ITime" = function(x, ..., drop = TRUE)
 {
   cl = oldClass(x)
   class(x) = NULL
@@ -240,7 +240,7 @@ rep.ITime <- function (x, ...)
   val
 }
 
-unique.ITime <- function(x, ...) {
+unique.ITime = function(x, ...) {
   ans = NextMethod()
   class(ans) = "ITime"
   ans
@@ -249,31 +249,31 @@ unique.ITime <- function(x, ...) {
 # create a data.table with IDate and ITime columns
 #   should work for most date/time formats like POSIXct
 
-IDateTime <- function(x, ...) UseMethod("IDateTime")
-IDateTime.default <- function(x, ...) {
+IDateTime = function(x, ...) UseMethod("IDateTime")
+IDateTime.default = function(x, ...) {
   data.table(idate = as.IDate(x), itime = as.ITime(x))
 }
 
 # POSIXt support
 
-as.POSIXct.IDate <- function(x, tz = "UTC", time = 0, ...) {
+as.POSIXct.IDate = function(x, tz = "UTC", time = 0, ...) {
   if (missing(time) && inherits(tz, "ITime")) {
-    time <- tz # allows you to use time as the 2nd argument
-    tz <- "UTC"
+    time = tz # allows you to use time as the 2nd argument
+    tz = "UTC"
   }
   if (tz == "") tz <- "UTC"
   as.POSIXct(as.POSIXlt(x, ...), tz, ...) + time
 }
 
-as.POSIXct.ITime <- function(x, tz = "UTC", date = Sys.Date(), ...) {
+as.POSIXct.ITime = function(x, tz = "UTC", date = Sys.Date(), ...) {
   if (missing(date) && inherits(tz, c("Date", "IDate", "POSIXt", "dates"))) {
-    date <- tz # allows you to use date as the 2nd argument
-    tz <- "UTC"
+    date = tz # allows you to use date as the 2nd argument
+    tz = "UTC"
   }
   as.POSIXct(as.POSIXlt(date), tz = tz) + x
 }
 
-as.POSIXlt.ITime <- function(x, ...) {
+as.POSIXlt.ITime = function(x, ...) {
   as.POSIXlt(as.POSIXct(x, ...))
 }
 
@@ -287,7 +287,7 @@ as.POSIXlt.ITime <- function(x, ...) {
 #   lubridate routines do not return integer values.
 ###################################################################
 
-second  <- function(x) {
+second  = function(x) {
   if (inherits(x,'POSIXct') && identical(attr(x,'tzone'),'UTC')) {
     # if we know the object is in UTC, can calculate the hour much faster
     as.integer(x) %% 60L
@@ -295,7 +295,7 @@ second  <- function(x) {
     as.integer(as.POSIXlt(x)$sec)
   }
 }
-minute  <- function(x) {
+minute  = function(x) {
   if (inherits(x,'POSIXct') && identical(attr(x,'tzone'),'UTC')) {
     # ever-so-slightly faster than x %% 3600L %/% 60L
     as.integer(x) %/% 60L %% 60L
@@ -303,7 +303,7 @@ minute  <- function(x) {
     as.POSIXlt(x)$min
   }
 }
-hour <- function(x) {
+hour = function(x) {
   if (inherits(x,'POSIXct') && identical(attr(x,'tzone'),'UTC')) {
     # ever-so-slightly faster than x %% 86400L %/% 3600L
     as.integer(x) %/% 3600L %% 24L
@@ -311,11 +311,11 @@ hour <- function(x) {
     as.POSIXlt(x)$hour
   }
 }
-yday    <- function(x) as.POSIXlt(x)$yday + 1L
-wday    <- function(x) (unclass(as.IDate(x)) + 4L) %% 7L + 1L
-mday    <- function(x) as.POSIXlt(x)$mday
-week    <- function(x) yday(x) %/% 7L + 1L
-isoweek <- function(x) {
+yday    = function(x) as.POSIXlt(x)$yday + 1L
+wday    = function(x) (unclass(as.IDate(x)) + 4L) %% 7L + 1L
+mday    = function(x) as.POSIXlt(x)$mday
+week    = function(x) yday(x) %/% 7L + 1L
+isoweek = function(x) {
   # ISO 8601-conformant week, as described at
   #   https://en.wikipedia.org/wiki/ISO_week_date
   # Approach:
@@ -325,11 +325,11 @@ isoweek <- function(x) {
 
   x = as.IDate(x)   # number of days since 1 Jan 1970 (a Thurs)
   nearest_thurs = as.IDate(7L * (as.integer(x + 3L) %/% 7L))
-  year_start <- as.IDate(format(nearest_thurs, '%Y-01-01'))
+  year_start = as.IDate(format(nearest_thurs, '%Y-01-01'))
   1L + (nearest_thurs - year_start) %/% 7L
 }
 
-month   <- function(x) as.POSIXlt(x)$mon + 1L
-quarter <- function(x) as.POSIXlt(x)$mon %/% 3L + 1L
-year    <- function(x) as.POSIXlt(x)$year + 1900L
+month   = function(x) as.POSIXlt(x)$mon + 1L
+quarter = function(x) as.POSIXlt(x)$mon %/% 3L + 1L
+year    = function(x) as.POSIXlt(x)$year + 1900L
 

--- a/R/as.data.table.R
+++ b/R/as.data.table.R
@@ -1,4 +1,4 @@
-as.data.table =function(x, keep.rownames=FALSE, key=NULL, ...)
+as.data.table = function(x, keep.rownames=FALSE, key=NULL, ...)
 {
   if (is.null(x))
     return(null.data.table())

--- a/R/as.data.table.R
+++ b/R/as.data.table.R
@@ -1,18 +1,18 @@
-as.data.table <-function(x, keep.rownames=FALSE, key=NULL, ...)
+as.data.table =function(x, keep.rownames=FALSE, key=NULL, ...)
 {
   if (is.null(x))
     return(null.data.table())
   UseMethod("as.data.table")
 }
 
-as.data.table.default <- function(x, ...){
+as.data.table.default = function(x, ...){
   as.data.table(as.data.frame(x, ...), ...) # we cannot assume as.data.frame will do copy, thus setDT changed to as.data.table #3230
 }
 
-as.data.table.factor <- as.data.table.ordered <-
-as.data.table.integer <- as.data.table.numeric <-
-as.data.table.logical <- as.data.table.character <-
-as.data.table.Date <- as.data.table.ITime <- function(x, keep.rownames=FALSE, key=NULL, ...) {
+as.data.table.factor = as.data.table.ordered =
+as.data.table.integer = as.data.table.numeric =
+as.data.table.logical = as.data.table.character =
+as.data.table.Date = as.data.table.ITime = function(x, keep.rownames=FALSE, key=NULL, ...) {
   if (is.matrix(x)) {
     return(as.data.table.matrix(x, ...))
   }
@@ -20,8 +20,8 @@ as.data.table.Date <- as.data.table.ITime <- function(x, keep.rownames=FALSE, ke
   nm = names(x)
   # FR #2356 - transfer names of named vector as "rn" column if required
   if (!identical(keep.rownames, FALSE) & !is.null(nm))
-    x <- list(nm, unname(x))
-  else x <- list(x)
+    x = list(nm, unname(x))
+  else x = list(x)
   if (tt == make.names(tt)) {
     # can specify col name to keep.rownames, #575
     nm = if (length(x) == 2L) if (is.character(keep.rownames)) keep.rownames[1L] else "rn"
@@ -31,17 +31,17 @@ as.data.table.Date <- as.data.table.ITime <- function(x, keep.rownames=FALSE, ke
 }
 
 # as.data.table.table - FR #4848
-as.data.table.table <- function(x, keep.rownames=FALSE, key=NULL, ...) {
+as.data.table.table = function(x, keep.rownames=FALSE, key=NULL, ...) {
   # Fix for bug #5408 - order of columns are different when doing as.data.table(with(DT, table(x, y)))
   val = rev(dimnames(provideDimnames(x)))
   if (is.null(names(val)) || !any(nzchar(names(val))))
     setattr(val, 'names', paste0("V", rev(seq_along(val))))
-  ans <- data.table(do.call(CJ, c(val, sorted=FALSE)), N = as.vector(x), key=key)
+  ans = data.table(do.call(CJ, c(val, sorted=FALSE)), N = as.vector(x), key=key)
   setcolorder(ans, c(rev(head(names(ans), -1L)), "N"))
   ans
 }
 
-as.data.table.matrix <- function(x, keep.rownames=FALSE, key=NULL, ...) {
+as.data.table.matrix = function(x, keep.rownames=FALSE, key=NULL, ...) {
   if (!identical(keep.rownames, FALSE)) {
     # can specify col name to keep.rownames, #575
     ans = data.table(rn=rownames(x), x, keep.rownames=FALSE)
@@ -49,12 +49,12 @@ as.data.table.matrix <- function(x, keep.rownames=FALSE, key=NULL, ...) {
       setnames(ans, 'rn', keep.rownames[1L])
     return(ans)
   }
-  d <- dim(x)
-  ncols <- d[2L]
-  ic <- seq_len(ncols)
+  d = dim(x)
+  ncols = d[2L]
+  ic = seq_len(ncols)
   if (!ncols) return(null.data.table())
 
-  value <- vector("list", ncols)
+  value = vector("list", ncols)
   if (mode(x) == "character") {
     # fix for #745 - A long overdue SO post: http://stackoverflow.com/questions/17691050/data-table-still-converts-strings-to-factors
     for (i in ic) value[[i]] <- x[, i]                  # <strike>for efficiency.</strike> For consistency - data.table likes and prefers "character"
@@ -62,11 +62,11 @@ as.data.table.matrix <- function(x, keep.rownames=FALSE, key=NULL, ...) {
   else {
     for (i in ic) value[[i]] <- as.vector(x[, i])       # to drop any row.names that would otherwise be retained inside every column of the data.table
   }
-  col_labels <- dimnames(x)[[2L]]
+  col_labels = dimnames(x)[[2L]]
   setDT(value)
   if (length(col_labels) == ncols) {
     if (any(empty <- !nzchar(col_labels)))
-      col_labels[empty] <- paste0("V", ic[empty])
+      col_labels[empty] = paste0("V", ic[empty])
     setnames(value, col_labels)
   } else {
     setnames(value, paste0("V", ic))
@@ -77,7 +77,7 @@ as.data.table.matrix <- function(x, keep.rownames=FALSE, key=NULL, ...) {
 }
 
 # as.data.table.array - #1418
-as.data.table.array <- function(x, keep.rownames=FALSE, key=NULL, sorted=TRUE, value.name="value", na.rm=TRUE, ...) {
+as.data.table.array = function(x, keep.rownames=FALSE, key=NULL, sorted=TRUE, value.name="value", na.rm=TRUE, ...) {
   dx = dim(x)
   if (length(dx) <= 2L)
     stop("as.data.table.array method should only be called for arrays with 3+ dimensions; use the matrix method for 2-dimensional arrays")
@@ -110,7 +110,7 @@ as.data.table.array <- function(x, keep.rownames=FALSE, key=NULL, sorted=TRUE, v
   ans[]
 }
 
-as.data.table.list <- function(x, keep.rownames=FALSE, key=NULL, ...) {
+as.data.table.list = function(x, keep.rownames=FALSE, key=NULL, ...) {
   wn = sapply(x,is.null)
   if (any(wn)) x = x[!wn]
   if (!length(x)) return( null.data.table() )
@@ -159,7 +159,7 @@ as.data.table.list <- function(x, keep.rownames=FALSE, key=NULL, ...) {
 # from it.. like base R does. This'll break test #527 (see
 # tests and as.data.table.data.frame) I've commented #527
 # for now. This addresses #1078 and #1128
-.resetclass <- function(x, class) {
+.resetclass = function(x, class) {
   if (length(class)!=1L)
     stop("class must be length 1") # nocov
   cx = class(x)
@@ -167,7 +167,7 @@ as.data.table.list <- function(x, keep.rownames=FALSE, key=NULL, ...) {
   unique( c("data.table", "data.frame", tail(cx, length(cx)-n)) )
 }
 
-as.data.table.data.frame <- function(x, keep.rownames=FALSE, key=NULL, ...) {
+as.data.table.data.frame = function(x, keep.rownames=FALSE, key=NULL, ...) {
   if (!identical(keep.rownames, FALSE)) {
     # can specify col name to keep.rownames, #575
     ans = data.table(rn=rownames(x), x, keep.rownames=FALSE, key=key)
@@ -190,7 +190,7 @@ as.data.table.data.frame <- function(x, keep.rownames=FALSE, key=NULL, ...) {
   ans
 }
 
-as.data.table.data.table <- function(x, ...) {
+as.data.table.data.table = function(x, ...) {
   # as.data.table always returns a copy, automatically takes care of #473
   x = copy(x) # #1681
   # fix for #1078 and #1128, see .resetclass() for explanation.

--- a/R/as.data.table.R
+++ b/R/as.data.table.R
@@ -57,7 +57,7 @@ as.data.table.matrix = function(x, keep.rownames=FALSE, key=NULL, ...) {
   value = vector("list", ncols)
   if (mode(x) == "character") {
     # fix for #745 - A long overdue SO post: http://stackoverflow.com/questions/17691050/data-table-still-converts-strings-to-factors
-    for (i in ic) value[[i]] <- x[, i]                  # <strike>for efficiency.</strike> For consistency - data.table likes and prefers "character"
+    for (i in ic) value[[i]] = x[, i]                  # <strike>for efficiency.</strike> For consistency - data.table likes and prefers "character"
   }
   else {
     for (i in ic) value[[i]] <- as.vector(x[, i])       # to drop any row.names that would otherwise be retained inside every column of the data.table

--- a/R/between.R
+++ b/R/between.R
@@ -1,5 +1,5 @@
 # is x[i] in between lower[i] and upper[i] ?
-between <- function(x,lower,upper,incbounds=TRUE) {
+between = function(x,lower,upper,incbounds=TRUE) {
   if (is.logical(x)) stop("between has been x of type logical")
   if (is.logical(lower)) lower = as.integer(lower)   # typically NA (which is logical type)
   if (is.logical(upper)) upper = as.integer(upper)   # typically NA (which is logical type)
@@ -8,7 +8,7 @@ between <- function(x,lower,upper,incbounds=TRUE) {
   # POSIX special handling to auto coerce character
   if (is.px(x) && !is.null(tz<-attr(x, "tzone", TRUE)) && nzchar(tz) &&
       (is.character(lower) || is.character(upper))) {
-    try_posix_cast <- function(x, tz) {tryCatch(
+    try_posix_cast = function(x, tz) {tryCatch(
       list(status=0L, value=as.POSIXct(x, tz = tz)),
       error = function(e) list(status=1L, value=NULL, message=e[["message"]])
     )}
@@ -57,7 +57,7 @@ between <- function(x,lower,upper,incbounds=TRUE) {
 }
 
 # %between% is vectorised, #534.
-"%between%" <- function(x, y) {
+"%between%" = function(x, y) {
   ysub = substitute(y)
   if (is.call(ysub) && ysub[[1L]]==".") {
     ysub[[1L]]=quote(list)
@@ -77,7 +77,7 @@ between <- function(x,lower,upper,incbounds=TRUE) {
 
 # issue FR #707
 # is x[i] found anywhere within [lower, upper] range?
-inrange <- function(x,lower,upper,incbounds=TRUE) {
+inrange = function(x,lower,upper,incbounds=TRUE) {
   query = setDT(list(x=x))
   subject = setDT(list(l=lower, u=upper))
   ops = if (incbounds) c(4L, 2L) else c(5L, 3L) # >=,<= and >,<
@@ -86,7 +86,7 @@ inrange <- function(x,lower,upper,incbounds=TRUE) {
   if (verbose) {cat(timetaken(last.started.at),"\n"); flush.console()}
   ans = bmerge(shallow(subject), query, 1L:2L, c(1L,1L),
       0, c(FALSE, TRUE), 0L, "all", ops, verbose) # fix for #1819, turn on verbose messages
-  xo <- ans$xo
+  xo = ans$xo
   options(datatable.verbose=FALSE)
   setDT(ans[c("starts", "lens")], key=c("starts", "lens"))
   options(datatable.verbose=verbose)
@@ -96,4 +96,4 @@ inrange <- function(x,lower,upper,incbounds=TRUE) {
   idx
 }
 
-"%inrange%" <- function(x,y) inrange(x,y[[1L]],y[[2L]],incbounds=TRUE)
+"%inrange%" = function(x,y) inrange(x,y[[1L]],y[[2L]],incbounds=TRUE)

--- a/R/bmerge.R
+++ b/R/bmerge.R
@@ -1,5 +1,5 @@
 
-bmerge <- function(i, x, icols, xcols, roll, rollends, nomatch, mult, ops, verbose)
+bmerge = function(i, x, icols, xcols, roll, rollends, nomatch, mult, ops, verbose)
 {
   callersi = i
   # Just so that when a double in i which contains integers stored as double, is joined to an integer column
@@ -16,7 +16,7 @@ bmerge <- function(i, x, icols, xcols, roll, rollends, nomatch, mult, ops, verbo
 
   supported = c("logical", "integer", "double", "character", "factor", "integer64")
 
-  getClass <- function(x) {
+  getClass = function(x) {
     ans = typeof(x)
     if      (ans=="integer") { if (is.factor(x))             ans = "factor"    }
     else if (ans=="double")  { if (inherits(x, "integer64")) ans = "integer64" }
@@ -102,7 +102,7 @@ bmerge <- function(i, x, icols, xcols, roll, rollends, nomatch, mult, ops, verbo
   }
 
   ## after all modifications of i, check if i has a proper key on all icols
-  io <- identical(icols, head(chmatch(key(i), names(i)), length(icols)))
+  io = identical(icols, head(chmatch(key(i), names(i)), length(icols)))
 
   ## after all modifications of x, check if x has a proper key on all xcols.
   ## If not, calculate the order. Also for non-equi joins, the order must be calculated.
@@ -113,7 +113,7 @@ bmerge <- function(i, x, icols, xcols, roll, rollends, nomatch, mult, ops, verbo
       xo = integer(0L)
       if (verbose) cat("on= matches existing key, using key\n")
     } else {
-      xo <- NULL
+      xo = NULL
       if (isTRUE(getOption("datatable.use.index"))) {
         xo = getindex(x, names(x)[xcols])
         if (verbose && !is.null(xo)) cat("on= matches existing index, using index\n")
@@ -126,12 +126,12 @@ bmerge <- function(i, x, icols, xcols, roll, rollends, nomatch, mult, ops, verbo
       }
     }
     ## these vaiables are only needed for non-equi joins. Set them to default.
-    nqgrp <- integer(0)
-    nqmaxgrp <- 1L
+    nqgrp = integer(0)
+    nqmaxgrp = 1L
   } else {
     # non-equi operators present.. investigate groups..
-    nqgrp <- integer(0)
-    nqmaxgrp <- 1L
+    nqgrp = integer(0)
+    nqmaxgrp = 1L
     if (verbose) cat("Non-equi join operators detected ... \n")
     if (roll != FALSE) stop("roll is not implemented for non-equi joins yet.")
     if (verbose) {last.started.at=proc.time();cat("  forder took ... ");flush.console()}
@@ -167,7 +167,7 @@ bmerge <- function(i, x, icols, xcols, roll, rollends, nomatch, mult, ops, verbo
   if (verbose) {cat("done in",timetaken(last.started.at),"\n"); flush.console()}
   # TO DO: xo could be moved inside Cbmerge
 
-  ans$xo <- xo  # for further use by [.data.table
+  ans$xo = xo  # for further use by [.data.table
   return(ans)
 }
 

--- a/R/cedta.R
+++ b/R/cedta.R
@@ -19,7 +19,7 @@ cedta.pkgEvalsUserCode = c("gWidgetsWWW","statET","FastRWeb","slidify","rmarkdow
 # which makes them data.table-aware optionally and possibly variably.
 # http://stackoverflow.com/a/13131555/403310
 
-cedta <- function(n=2L) {
+cedta = function(n=2L) {
   # Calling Environment Data Table Aware
   ns = topenv(parent.frame(n))
   if (!isNamespace(ns)) {

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -38,14 +38,14 @@ is.ff = function(x) inherits(x, "ff")  # define this in data.table so that we do
 #    if (is.array(x)) nrow(x) else length(x)
 #}
 
-null.data.table =function() {
+null.data.table = function() {
   ans = list()
   setattr(ans,"class",c("data.table","data.frame"))
   setattr(ans,"row.names",.set_row_names(0L))
   alloc.col(ans)
 }
 
-data.table =function(..., keep.rownames=FALSE, check.names=FALSE, key=NULL, stringsAsFactors=FALSE)
+data.table = function(..., keep.rownames=FALSE, check.names=FALSE, key=NULL, stringsAsFactors=FALSE)
 {
   # NOTE: It may be faster in some circumstances to create a data.table by creating a list l first, and then setattr(l,"class",c("data.table","data.frame")) at the expense of checking.
   # TO DO: rewrite data.table(), one of the oldest functions here. Many people use data.table() to convert data.frame rather than

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1171,7 +1171,7 @@ replace_dot_alias = function(e) {
               } else if (is.environment(k) && exists(as.character(name[[3L]]), k)) {
                 assign(as.character(name[[3L]]), x, k, inherits=FALSE)
               }
-            } # TO DO: else if env$= or list$=
+            } # TO DO: else if env$<- or list$<-
           }
         }
       }

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1151,7 +1151,7 @@ replace_dot_alias = function(e) {
               # Note that the NAMED(dt)>1 doesn't work because .Call
               # always sets to 2 (see R-ints), it seems. Work around
               # may be possible but not yet working. When the NAMED test works, we can drop allocwarn argument too
-              # because that's just passed in as FALSE from [= where we know `*tmp*` isn't really NAMED=2.
+              # because that's just passed in as FALSE from [<- where we know `*tmp*` isn't really NAMED=2.
               # Note also that this growing will happen for missing columns assigned NULL, too. But so rare, we
               # don't mind.
             }
@@ -1886,7 +1886,7 @@ replace_dot_alias = function(e) {
 #    #x[[...]]
 #}
 
-#"[[<-.data.table" <- function(x,i,j,value) {
+#"[[<-.data.table" = function(x,i,j,value) {
 #    if (!cedta()) return(`[[<-.data.frame`(x,i,j,value))
 #    if (!missing(j)) stop("[[i,j]] assignment not available in data.table, put assignment(s) in [i,{...}] instead, more powerful")
 #    cl = oldClass(x)  # [[<-.data.frame uses oldClass rather than class, don't know why but we'll follow suit
@@ -2018,8 +2018,8 @@ tail.data.table = function(x, n=6L, ...) {
   x[i]
 }
 
-"[<-.data.table" <- function (x, i, j, value) {
-  # [= is provided for consistency, but := is preferred as it allows by group and by reference to subsets of columns
+"[<-.data.table" = function (x, i, j, value) {
+  # [<- is provided for consistency, but := is preferred as it allows by group and by reference to subsets of columns
   # with no copy of the (very large, say 10GB) columns at all. := is like an UPDATE in SQL and we like and want two symbols to change.
   if (!cedta()) {
     x = if (nargs()<4L) `[<-.data.frame`(x, i, value=value)
@@ -2075,13 +2075,13 @@ tail.data.table = function(x, n=6L, ...) {
   invisible(x)
   # no copy at all if user calls directly; i.e. `[<-.data.table`(x,i,j,value)
   # or uses data.table := syntax; i.e. DT[i,j:=value]
-  # but, there is one copy by R in [= dispatch to `*tmp*`; i.e. DT[i,j]=value. *Update: not from R > 3.0.2, yay*
+  # but, there is one copy by R in [<- dispatch to `*tmp*`; i.e. DT[i,j]=value. *Update: not from R > 3.0.2, yay*
   # That copy is via main/duplicate.c which preserves truelength but copies length amount. Hence alloc.col(x,length(x)).
   # No warn passed to assign here because we know it'll be copied via *tmp*.
   # := allows subassign to a column with no copy of the column at all,  and by group, etc.
 }
 
-"$<-.data.table" <- function(x, name, value) {
+"$<-.data.table" = function(x, name, value) {
   if (!cedta()) {
     ans = `$<-.data.frame`(x, name, value)
     return(alloc.col(ans))           # over-allocate (again)
@@ -2136,7 +2136,7 @@ dimnames.data.table = function(x) {
   x  # this returned value is now shallow copied by R 3.1.0 via *tmp*. A very welcome change.
 }
 
-"names<-.data.table" <- function(x,value)
+"names<-.data.table" = function(x,value)
 {
   # When non data.table aware packages change names, we'd like to maintain the key.
   # If call is names(DT)[2]="newname", R will call this names<-.data.table function (notice no i) with 'value' already prepared to be same length as ncol

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1,17 +1,17 @@
 if (!exists("trimws", "package:base")) {
   # trimws was new in R 3.2.0. Backport it for internal data.table use in R 3.1.0
-  trimws <- function(x) {
-    mysub <- function(re, x) sub(re, "", x, perl = TRUE)
+  trimws = function(x) {
+    mysub = function(re, x) sub(re, "", x, perl = TRUE)
     mysub("[ \t\r\n]+$", mysub("^[ \t\r\n]+", x))
   }
 }
 
-dim.data.table <- function(x)
+dim.data.table = function(x)
 {
   .Call(Cdim, x)
 }
 
-.global <- new.env()  # thanks to: http://stackoverflow.com/a/12605694/403310
+.global = new.env()  # thanks to: http://stackoverflow.com/a/12605694/403310
 setPackageName("data.table",.global)
 .global$print = ""
 
@@ -23,36 +23,36 @@ setPackageName("data.table",.global)
 # So even though .BY doesn't appear in this file, it should still be NULL here and exported because it's
 # defined in SDenv and can be used by users.
 
-is.data.table <- function(x) inherits(x, "data.table")
-is.ff <- function(x) inherits(x, "ff")  # define this in data.table so that we don't have to require(ff), but if user is using ff we'd like it to work
+is.data.table = function(x) inherits(x, "data.table")
+is.ff = function(x) inherits(x, "ff")  # define this in data.table so that we don't have to require(ff), but if user is using ff we'd like it to work
 
-#NCOL <- function(x) {
+#NCOL = function(x) {
 #    # copied from base, but additionally covers data.table via is.list()
 #    # because NCOL in base explicitly tests using is.data.frame()
 #    if (is.list(x) && !is.ff(x)) return(length(x))
 #    if (is.array(x) && length(dim(x)) > 1L) ncol(x) else as.integer(1L)
 #}
-#NROW <- function(x) {
+#NROW = function(x) {
 #    if (is.data.frame(x) || is.data.table(x)) return(nrow(x))
 #    if (is.list(x) && !is.ff(x)) stop("List is not a data.frame or data.table. Convert first before using NROW")   # list may have different length elements, which data.table and data.frame's resolve.
 #    if (is.array(x)) nrow(x) else length(x)
 #}
 
-null.data.table <-function() {
+null.data.table =function() {
   ans = list()
   setattr(ans,"class",c("data.table","data.frame"))
   setattr(ans,"row.names",.set_row_names(0L))
   alloc.col(ans)
 }
 
-data.table <-function(..., keep.rownames=FALSE, check.names=FALSE, key=NULL, stringsAsFactors=FALSE)
+data.table =function(..., keep.rownames=FALSE, check.names=FALSE, key=NULL, stringsAsFactors=FALSE)
 {
   # NOTE: It may be faster in some circumstances to create a data.table by creating a list l first, and then setattr(l,"class",c("data.table","data.frame")) at the expense of checking.
   # TO DO: rewrite data.table(), one of the oldest functions here. Many people use data.table() to convert data.frame rather than
   # as.data.table which is faster; speed could be better.  Revisit how many copies are taken in for example data.table(DT1,DT2) which
   # cbind directs to.  And the nested loops for recycling lend themselves to being C level.
 
-  x <- list(...)   # doesn't copy named inputs as from R >= 3.1.0 (a very welcome change)
+  x = list(...)   # doesn't copy named inputs as from R >= 3.1.0 (a very welcome change)
   .Call(CcopyNamedInList,x)   # to maintain pre-Rv3.1.0 behaviour, for now. See test 548.2. TODO: revist
   # TODO Something strange with NAMED on components of `...` to investigate. Or, just port data.table() to C.
 
@@ -66,12 +66,12 @@ data.table <-function(..., keep.rownames=FALSE, check.names=FALSE, key=NULL, str
   if (any(nocols<-sapply(x, myNCOL)==0L)) { tt=!nocols; x=x[tt]; nd=lapply(nd,'[',tt); }  # data.table(data.table(), data.table(a=integer())), #3445
   vnames = nd$vnames
   novname = nd$novname  # novname used later to know which were explicitly supplied in the call
-  n <- length(x)
+  n = length(x)
   if (length(vnames) != n) stop("logical error in vnames")   # nocov
   # cast to a list to facilitate naming of columns with dimension --
   #   unlist() at the end automatically handles the need to "push" names
   #   to accommodate the "new" columns
-  vnames <- as.list.default(vnames)
+  vnames = as.list.default(vnames)
   nrows = integer(n)          # vector of lengths of each column. may not be equal if silent repetition is required.
   numcols = integer(n)         # the ncols of each of the inputs (e.g. if inputs contain matrix or data.table)
   for (i in seq_len(n)) {
@@ -90,9 +90,9 @@ data.table <-function(..., keep.rownames=FALSE, check.names=FALSE, key=NULL, str
     } else if (is.function(xi)) {
       x[[i]] = xi = list(xi)
     }
-    nrows[i] <- NROW(xi)    # for a vector (including list() columns) returns the length
+    nrows[i] = NROW(xi)    # for a vector (including list() columns) returns the length
     if (numcols[i]>0L) {
-      namesi <- names(xi)  # works for both data.frame's, matrices and data.tables's
+      namesi = names(xi)  # works for both data.frame's, matrices and data.tables's
       if (length(namesi)==0L) namesi = rep.int("",ncol(xi))
       namesi[is.na(namesi)] = ""
       tt = namesi==""
@@ -101,7 +101,7 @@ data.table <-function(..., keep.rownames=FALSE, check.names=FALSE, key=NULL, str
       else vnames[[i]] = paste(vnames[[i]], namesi, sep=".")
     }
   }
-  nr <- max(nrows)
+  nr = max(nrows)
   ckey = NULL
   recycledkey = FALSE
   for (i in seq_len(n)) {
@@ -113,7 +113,7 @@ data.table <-function(..., keep.rownames=FALSE, check.names=FALSE, key=NULL, str
   }
   for (i in which(nrows < nr)) {
     # TO DO ... recycle in C, but not high priority as large data already regular from database or file
-    xi <- x[[i]]
+    xi = x[[i]]
     if (identical(xi,list())) {
       x[[i]] = vector("list", nr)
       next
@@ -150,9 +150,9 @@ data.table <-function(..., keep.rownames=FALSE, check.names=FALSE, key=NULL, str
   } else {
     value = x
   }
-  vnames <- unlist(vnames)
+  vnames = unlist(vnames)
   if (check.names)   # default FALSE
-    vnames <- make.names(vnames, unique = TRUE)
+    vnames = make.names(vnames, unique = TRUE)
   setattr(value,"names",vnames)
   setattr(value,"row.names",.set_row_names(nr))
   setattr(value,"class",c("data.table","data.frame"))
@@ -180,7 +180,7 @@ data.table <-function(..., keep.rownames=FALSE, check.names=FALSE, key=NULL, str
   alloc.col(value)  # returns a NAMED==0 object, unlike data.frame()
 }
 
-replace_dot_alias <- function(e) {
+replace_dot_alias = function(e) {
   # we don't just simply alias .=list because i) list is a primitive (faster to iterate) and ii) we test for use
   # of "list" in several places so it saves having to remember to write "." || "list" in those places
   if (is.call(e) && !is.function(e[[1L]])) {
@@ -192,7 +192,7 @@ replace_dot_alias <- function(e) {
   e
 }
 
-.massagei <- function(x) {
+.massagei = function(x) {
   # J alias for list as well in i, just if the first symbol
   # if x = substitute(base::order) then as.character(x[[1L]]) == c("::", "base", "order")
   if (is.call(x) && as.character(x[[1L]])[[1L]] %chin% c("J","."))
@@ -218,7 +218,7 @@ replace_dot_alias <- function(e) {
   }
 }
 
-"[.data.table" <- function (x, i, j, by, keyby, with=TRUE, nomatch=getOption("datatable.nomatch"), mult="all", roll=FALSE, rollends=if (roll=="nearest") c(TRUE,TRUE) else if (roll>=0) c(FALSE,TRUE) else c(TRUE,FALSE), which=FALSE, .SDcols, verbose=getOption("datatable.verbose"), allow.cartesian=getOption("datatable.allow.cartesian"), drop=NULL, on=NULL)
+"[.data.table" = function (x, i, j, by, keyby, with=TRUE, nomatch=getOption("datatable.nomatch"), mult="all", roll=FALSE, rollends=if (roll=="nearest") c(TRUE,TRUE) else if (roll>=0) c(FALSE,TRUE) else c(TRUE,FALSE), which=FALSE, .SDcols, verbose=getOption("datatable.verbose"), allow.cartesian=getOption("datatable.allow.cartesian"), drop=NULL, on=NULL)
 {
   # ..selfcount <<- ..selfcount+1  # in dev, we check no self calls, each of which doubles overhead, or could
   # test explicitly if the caller is [.data.table (even stronger test. TO DO.)
@@ -369,7 +369,7 @@ replace_dot_alias <- function(e) {
   }
 
   # setdiff removes duplicate entries, which'll create issues with duplicated names. Use %chin% instead.
-  dupdiff <- function(x, y) x[!x %chin% y]
+  dupdiff = function(x, y) x[!x %chin% y]
 
   if (!missing(i)) {
     xo = NULL
@@ -434,14 +434,14 @@ replace_dot_alias <- function(e) {
                                               notjoin = notjoin, verbose = verbose))){
         ## redirect to the is.data.table(x) == TRUE branch.
         ## Additional flag to adapt things after bmerge:
-        optimizedSubset <- TRUE
-        notjoin <- o$notjoin
-        i <- o$i
-        on <- o$on
+        optimizedSubset = TRUE
+        notjoin = o$notjoin
+        i = o$i
+        on = o$on
         ## the following two are ignored if i is not a data.table.
         ## Since we are converting i to data.table, it is important to set them properly.
-        nomatch <- 0L
-        mult <- "all"
+        nomatch = 0L
+        mult = "all"
     }
     else if (!is.name(isub)) {
       i = tryCatch(eval(.massagei(isub), x, parent.frame()),
@@ -540,7 +540,7 @@ replace_dot_alias <- function(e) {
       }
       i = .shallow(i, retain.key = TRUE)
       ans = bmerge(i, x, leftcols, rightcols, roll, rollends, nomatch, mult, ops, verbose=verbose)
-      xo <- ans$xo ## to make it available for further use.
+      xo = ans$xo ## to make it available for further use.
       # temp fix for issue spotted by Jan, test #1653.1. TODO: avoid this
       # 'setorder', as there's another 'setorder' in generating 'irows' below...
       if (length(ans$indices)) setorder(setDT(ans[1L:3L]), indices)
@@ -625,7 +625,7 @@ replace_dot_alias <- function(e) {
         ## This is done by simply telling data.table to continue as if there was a simple subset
         leftcols  = integer(0L)
         rightcols = integer(0L)
-        i <- irows ## important to make i not a data.table because otherwise Gforce doesn't kick in
+        i = irows ## important to make i not a data.table because otherwise Gforce doesn't kick in
       }
     }
     else {
@@ -1051,9 +1051,9 @@ replace_dot_alias <- function(e) {
 
         # Do not include z in .SD when dt[, z := {.SD; get("x")}, .SDcols = "y"] (#2326, #2338)
         if (is.call(jsub) && length(jsub[[1L]]) == 1L && jsub[[1L]] == ":=" && is.symbol(jsub[[2L]])) {
-          jsub_lhs_symbol <- as.character(jsub[[2L]])
+          jsub_lhs_symbol = as.character(jsub[[2L]])
             if (jsub_lhs_symbol %chin% othervars) {
-            ansvars <- setdiff(ansvars, jsub_lhs_symbol)
+            ansvars = setdiff(ansvars, jsub_lhs_symbol)
           }
         }
         if (length(ansvars)) othervars = ansvars # #1744 fix
@@ -1069,7 +1069,7 @@ replace_dot_alias <- function(e) {
       suppPrint = identity
       if (length(av) && av[1L] == ":=") {
         if (identical(attr(x,".data.table.locked"),TRUE)) stop(".SD is locked. Using := in .SD's j is reserved for possible future use; a tortuously flexible way to modify by group. Use := in j directly to modify by group by reference.")
-        suppPrint <- function(x) { .global$print=address(x); x }
+        suppPrint = function(x) { .global$print=address(x); x }
         # Suppress print when returns ok not on error, bug #2376. Thanks to: http://stackoverflow.com/a/13606880/403310
         # All appropriate returns following this point are wrapped; i.e. return(suppPrint(x)).
 
@@ -1151,7 +1151,7 @@ replace_dot_alias <- function(e) {
               # Note that the NAMED(dt)>1 doesn't work because .Call
               # always sets to 2 (see R-ints), it seems. Work around
               # may be possible but not yet working. When the NAMED test works, we can drop allocwarn argument too
-              # because that's just passed in as FALSE from [<- where we know `*tmp*` isn't really NAMED=2.
+              # because that's just passed in as FALSE from [= where we know `*tmp*` isn't really NAMED=2.
               # Note also that this growing will happen for missing columns assigned NULL, too. But so rare, we
               # don't mind.
             }
@@ -1171,7 +1171,7 @@ replace_dot_alias <- function(e) {
               } else if (is.environment(k) && exists(as.character(name[[3L]]), k)) {
                 assign(as.character(name[[3L]]), x, k, inherits=FALSE)
               }
-            } # TO DO: else if env$<- or list$<-
+            } # TO DO: else if env$= or list$=
           }
         }
       }
@@ -1218,7 +1218,7 @@ replace_dot_alias <- function(e) {
 
   SDenv = new.env(parent=parent.frame())
   # taking care of warnings for posixlt type, #646
-  SDenv$strptime <- function(x, ...) {
+  SDenv$strptime = function(x, ...) {
     warning("POSIXlt column type detected and converted to POSIXct. We do not recommend use of POSIXlt at all because it uses 40 bytes to store one date. Use as.POSIXct to avoid this warning.")
     as.POSIXct(base::strptime(x, ...))
   }
@@ -1537,7 +1537,7 @@ replace_dot_alias <- function(e) {
     oldjsub = jsub
     funi = 1L # Fix for #985
     # convereted the lapply(.SD, ...) to a function and used below, easier to implement FR #2722 then.
-    .massageSD <- function(jsub) {
+    .massageSD = function(jsub) {
       txt = as.list(jsub)[-1L]
       if (length(names(txt))>1L) .Call(Csetcharvec, names(txt), 2L, "")  # fixes bug #4839
       fun = txt[[2L]]
@@ -1685,7 +1685,7 @@ replace_dot_alias <- function(e) {
       else
         cat("lapply optimization is on, j unchanged as '",deparse(jsub,width.cutoff=200L),"'\n",sep="")
     }
-    dotN <- function(x) is.name(x) && x == ".N" # For #5760
+    dotN = function(x) is.name(x) && x == ".N" # For #5760
     # FR #971, GForce kicks in on all subsets, no joins yet. Although joins could work with
     # nomatch=0L even now.. but not switching it on yet, will deal it separately.
     if (getOption("datatable.optimize")>=2 && !is.data.table(i) && !byjoin && length(f__) && !length(lhs)) {
@@ -1698,7 +1698,7 @@ replace_dot_alias <- function(e) {
       } else {
         # Apply GForce
         gfuns = c("sum", "prod", "mean", "median", "var", "sd", ".N", "min", "max", "head", "last", "first", "tail", "[") # added .N for #5760
-        .ok <- function(q) {
+        .ok = function(q) {
           if (dotN(q)) return(TRUE) # For #5760
           # run GForce for simple f(x) calls and f(x, na.rm = TRUE)-like calls where x is a column of .SD
           # is.symbol() is for #1369, #1974 and #2949
@@ -1862,7 +1862,7 @@ replace_dot_alias <- function(e) {
   alloc.col(ans)   # TODO: overallocate in dogroups in the first place and remove this line
 }
 
-.optmean <- function(expr) {   # called by optimization of j inside [.data.table only. Outside for a small speed advantage.
+.optmean = function(expr) {   # called by optimization of j inside [.data.table only. Outside for a small speed advantage.
   if (length(expr)==2L)  # no parameters passed to mean, so defaults of trim=0 and na.rm=FALSE
     return(call(".External",quote(Cfastmean),expr[[2L]], FALSE))
     # return(call(".Internal",expr))  # slightly faster than .External, but R now blocks .Internal in coerce.c from apx Sep 2012
@@ -1879,7 +1879,7 @@ replace_dot_alias <- function(e) {
 #  .C("do_subset2") or better. Tests 604-608 test
 #  that this doesn't regress.
 
-#"[[.data.table" <- function(x,...) {
+#"[[.data.table" = function(x,...) {
 #    if (!cedta()) return(`[[.data.frame`(x,...))
 #    .subset2(x,...)
 #    #class(x)=NULL  # awful, copy
@@ -1896,7 +1896,7 @@ replace_dot_alias <- function(e) {
 #    x
 #}
 
-as.matrix.data.table <- function(x, rownames=NULL, rownames.value=NULL, ...) {
+as.matrix.data.table = function(x, rownames=NULL, rownames.value=NULL, ...) {
   # rownames = the rownames column (most common usage)
   if (!is.null(rownames)) {
     if (!is.null(rownames.value)) stop("rownames and rownames.value cannot both be used at the same time")
@@ -1928,7 +1928,7 @@ as.matrix.data.table <- function(x, rownames=NULL, rownames.value=NULL, ...) {
         rownames = w
       }
       else { # rownames is a column number already
-        rownames <- as.integer(rownames)
+        rownames = as.integer(rownames)
         if (is.na(rownames) || rownames<1L || rownames>ncol(x))
           stop("as.integer(rownames)==", rownames,
                " which is outside the column number range [1,ncol=", ncol(x), "].")
@@ -1941,85 +1941,85 @@ as.matrix.data.table <- function(x, rownames=NULL, rownames.value=NULL, ...) {
   }
   if (!is.null(rownames)) {
     # extract that column and drop it.
-    rownames.value <- x[[rownames]]
-    dm <- dim(x) - c(0, 1)
-    cn <- names(x)[-rownames]
-    X <- x[, .SD, .SDcols = cn]
+    rownames.value = x[[rownames]]
+    dm = dim(x) - c(0, 1)
+    cn = names(x)[-rownames]
+    X = x[, .SD, .SDcols = cn]
   } else {
-    dm <- dim(x)
-    cn <- names(x)
-    X <- x
+    dm = dim(x)
+    cn = names(x)
+    X = x
   }
   if (any(dm == 0L))
     return(array(NA, dim = dm, dimnames = list(rownames.value, cn)))
-  p <- dm[2L]
-  n <- dm[1L]
-  collabs <- as.list(cn)
+  p = dm[2L]
+  n = dm[1L]
+  collabs = as.list(cn)
   class(X) <- NULL
-  non.numeric <- non.atomic <- FALSE
-  all.logical <- TRUE
+  non.numeric = non.atomic = FALSE
+  all.logical = TRUE
   for (j in seq_len(p)) {
     if (is.ff(X[[j]])) X[[j]] <- X[[j]][]   # to bring the ff into memory, since we need to create a matrix in memory
-    xj <- X[[j]]
+    xj = X[[j]]
     if (length(dj <- dim(xj)) == 2L && dj[2L] > 1L) {
       if (inherits(xj, "data.table"))
-        xj <- X[[j]] <- as.matrix(X[[j]])
-      dnj <- dimnames(xj)[[2L]]
-      collabs[[j]] <- paste(collabs[[j]], if (length(dnj) >
+        xj = X[[j]] = as.matrix(X[[j]])
+      dnj = dimnames(xj)[[2L]]
+      collabs[[j]] = paste(collabs[[j]], if (length(dnj) >
         0L)
         dnj
       else seq_len(dj[2L]), sep = ".")
     }
     if (!is.logical(xj))
-      all.logical <- FALSE
+      all.logical = FALSE
     if (length(levels(xj)) > 0L || !(is.numeric(xj) || is.complex(xj) || is.logical(xj)) ||
         (!is.null(cl <- attr(xj, "class")) && any(cl %chin%
         c("Date", "POSIXct", "POSIXlt"))))
-      non.numeric <- TRUE
+      non.numeric = TRUE
     if (!is.atomic(xj))
-      non.atomic <- TRUE
+      non.atomic = TRUE
   }
   if (non.atomic) {
     for (j in seq_len(p)) {
-      xj <- X[[j]]
+      xj = X[[j]]
       if (is.recursive(xj)) { }
-      else X[[j]] <- as.list(as.vector(xj))
+      else X[[j]] = as.list(as.vector(xj))
     }
   }
   else if (all.logical) { }
   else if (non.numeric) {
     for (j in seq_len(p)) {
       if (is.character(X[[j]])) next
-      xj <- X[[j]]
-      miss <- is.na(xj)
-      xj <- if (length(levels(xj))) as.vector(xj) else format(xj)
+      xj = X[[j]]
+      miss = is.na(xj)
+      xj = if (length(levels(xj))) as.vector(xj) else format(xj)
       is.na(xj) <- miss
-      X[[j]] <- xj
+      X[[j]] = xj
     }
   }
-  X <- unlist(X, recursive = FALSE, use.names = FALSE)
+  X = unlist(X, recursive = FALSE, use.names = FALSE)
   dim(X) <- c(n, length(X)/n)
   dimnames(X) <- list(rownames.value, unlist(collabs, use.names = FALSE))
   X
 }
 
 # bug #2375. fixed. same as head.data.frame and tail.data.frame to deal with negative indices
-head.data.table <- function(x, n=6L, ...) {
+head.data.table = function(x, n=6L, ...) {
   if (!cedta()) return(NextMethod())
   stopifnot(length(n) == 1L)
   i = seq_len(if (n<0L) max(nrow(x)+n, 0L) else min(n,nrow(x)))
   x[i, , ]
 }
-tail.data.table <- function(x, n=6L, ...) {
+tail.data.table = function(x, n=6L, ...) {
   if (!cedta()) return(NextMethod())
   stopifnot(length(n) == 1L)
-  n <- if (n<0L) max(nrow(x) + n, 0L) else min(n, nrow(x))
+  n = if (n<0L) max(nrow(x) + n, 0L) else min(n, nrow(x))
   i = seq.int(to=nrow(x), length.out=n)
   x[i]
 }
 
 "[<-.data.table" <- function (x, i, j, value) {
-  # [<- is provided for consistency, but := is preferred as it allows by group and by reference to subsets of columns
+  # [= is provided for consistency, but := is preferred as it allows by group and by reference to subsets of columns
   # with no copy of the (very large, say 10GB) columns at all. := is like an UPDATE in SQL and we like and want two symbols to change.
   if (!cedta()) {
     x = if (nargs()<4L) `[<-.data.frame`(x, i, value=value)
@@ -2058,7 +2058,7 @@ tail.data.table <- function(x, n=6L, ...) {
     identical(names(x),names(value)) &&
     is.sorted(i) &&
     identical(substitute(x),quote(`*tmp*`))) {
-    # DT["a",]$y <- 1.1  winds up creating `*tmp*` subset of rows and assigning _all_ the columns into x and
+    # DT["a",]$y = 1.1  winds up creating `*tmp*` subset of rows and assigning _all_ the columns into x and
     # over-writing the key columns with the same value (not just the single 'y' column).
     # That isn't good for speed; it's an R thing. Solution is to use := instead to avoid all this, but user
     # expects key to be retained in this case because _he_ didn't assign to a key column (the internal base R
@@ -2075,7 +2075,7 @@ tail.data.table <- function(x, n=6L, ...) {
   invisible(x)
   # no copy at all if user calls directly; i.e. `[<-.data.table`(x,i,j,value)
   # or uses data.table := syntax; i.e. DT[i,j:=value]
-  # but, there is one copy by R in [<- dispatch to `*tmp*`; i.e. DT[i,j]<-value. *Update: not from R > 3.0.2, yay*
+  # but, there is one copy by R in [= dispatch to `*tmp*`; i.e. DT[i,j]=value. *Update: not from R > 3.0.2, yay*
   # That copy is via main/duplicate.c which preserves truelength but copies length amount. Hence alloc.col(x,length(x)).
   # No warn passed to assign here because we know it'll be copied via *tmp*.
   # := allows subassign to a column with no copy of the column at all,  and by group, etc.
@@ -2090,7 +2090,7 @@ tail.data.table <- function(x, n=6L, ...) {
   set(x,j=name,value=value)  # important i is missing here
 }
 
-as.data.frame.data.table <- function(x, ...)
+as.data.frame.data.table = function(x, ...)
 {
   ans = copy(x)
   setattr(ans,"row.names",.set_row_names(nrow(x)))   # since R 2.4.0, data.frames can have non-character row names
@@ -2101,7 +2101,7 @@ as.data.frame.data.table <- function(x, ...)
   ans
 }
 
-as.list.data.table <- function(x, ...) {
+as.list.data.table = function(x, ...) {
   # Similar to as.list.data.frame in base. Although a data.table/frame is a list, too, it may be
   # being coerced to raw list type (by calling code) so that "[" and "[[" work in their raw list form,
   # such as lapply does for data.frame. So we do have to remove the class attributes (and thus shallow
@@ -2117,7 +2117,7 @@ as.list.data.table <- function(x, ...) {
 }
 
 
-dimnames.data.table <- function(x) {
+dimnames.data.table = function(x) {
   if (!cedta()) {
     if (!inherits(x, "data.frame"))
       stop("data.table inherits from data.frame (from v1.5), but this data.table does not. Has it been created manually (e.g. by using 'structure' rather than 'data.table') or saved to disk using a prior version of data.table?")
@@ -2148,17 +2148,17 @@ dimnames.data.table <- function(x) {
   x   # this returned value is now shallow copied by R 3.1.0 via *tmp*. A very welcome change.
 }
 
-within.data.table <- function (data, expr, ...)
+within.data.table = function (data, expr, ...)
 # basically within.list but retains key (if any)
 # will be slower than using := or a regular query (see ?within for further info).
 {
   if (!cedta()) return(NextMethod())
-  parent <- parent.frame()
-  e <- evalq(environment(), data, parent)
+  parent = parent.frame()
+  e = evalq(environment(), data, parent)
   eval(substitute(expr), e)  # might (and it's known that some user code does) contain rm()
-  l <- as.list(e)
-  l <- l[!vapply_1b(l, is.null)]
-  nD <- length(del <- setdiff(names(data), (nl <- names(l))))
+  l = as.list(e)
+  l = l[!vapply_1b(l, is.null)]
+  nD = length(del <- setdiff(names(data), (nl <- names(l))))
   ans = copy(data)
   if (length(nl)) ans[,nl] <- l
   if (nD) ans[,del] <- NULL
@@ -2174,63 +2174,63 @@ within.data.table <- function (data, expr, ...)
 }
 
 
-transform.data.table <- function (`_data`, ...)
+transform.data.table = function (`_data`, ...)
 # basically transform.data.frame with data.table instead of data.frame, and retains key
 {
   if (!cedta()) return(NextMethod())
-  e <- eval(substitute(list(...)), `_data`, parent.frame())
-  tags <- names(e)
-  inx <- chmatch(tags, names(`_data`))
-  matched <- !is.na(inx)
+  e = eval(substitute(list(...)), `_data`, parent.frame())
+  tags = names(e)
+  inx = chmatch(tags, names(`_data`))
+  matched = !is.na(inx)
   if (any(matched)) {
     if (isTRUE(attr(`_data`, ".data.table.locked", TRUE))) setattr(`_data`, ".data.table.locked", NULL) # fix for #1641
-    `_data`[,inx[matched]] <- e[matched]
-    `_data` <- data.table(`_data`)
+    `_data`[,inx[matched]] = e[matched]
+    `_data` = data.table(`_data`)
   }
   if (!all(matched)) {
-    ans <- do.call("data.table", c(list(`_data`), e[!matched]))
+    ans = do.call("data.table", c(list(`_data`), e[!matched]))
   } else {
-    ans <- `_data`
+    ans = `_data`
   }
-  key.cols <- key(`_data`)
+  key.cols = key(`_data`)
   if (!any(tags %chin% key.cols)) {
     setattr(ans, "sorted", key.cols)
   }
   ans
 }
 
-subset.data.table <- function (x, subset, select, ...)
+subset.data.table = function (x, subset, select, ...)
 {
-  key.cols <- key(x)
+  key.cols = key(x)
 
   if (missing(subset)) {
-    r <- TRUE
+    r = TRUE
   } else {
-    e <- substitute(subset)
-    r <- eval(e, x, parent.frame())
+    e = substitute(subset)
+    r = eval(e, x, parent.frame())
     if (!is.logical(r))
       stop("'subset' must evaluate to logical")
-    r <- r & !is.na(r)
+    r = r & !is.na(r)
   }
 
   if (missing(select)) {
-    vars <- seq_len(ncol(x))
+    vars = seq_len(ncol(x))
   } else {
-    nl <- as.list(seq_len(ncol(x)))
+    nl = as.list(seq_len(ncol(x)))
     setattr(nl,"names",names(x))
-    vars <- eval(substitute(select), nl, parent.frame())  # e.g.  select=colF:colP
+    vars = eval(substitute(select), nl, parent.frame())  # e.g.  select=colF:colP
     # #891 fix - don't convert numeric vars to column names - will break when there are duplicate columns
-    key.cols <- intersect(key.cols, names(x)[vars]) ## Only keep key.columns found in the select clause
+    key.cols = intersect(key.cols, names(x)[vars]) ## Only keep key.columns found in the select clause
   }
 
-  ans <- x[r, vars, with = FALSE]
+  ans = x[r, vars, with = FALSE]
 
   if (nrow(ans) > 0L) {
     if (!missing(select) && length(key.cols)) {
       ## Set the key on the returned data.table as long as the key
       ## columns that "remain" are the same as the original, or a
       ## prefix of it.
-      is.prefix <- all(key(x)[seq_len(length(key.cols))] == key.cols)
+      is.prefix = all(key(x)[seq_len(length(key.cols))] == key.cols)
       if (is.prefix) {
         setattr(ans, "sorted", key.cols)
       }
@@ -2245,10 +2245,10 @@ subset.data.table <- function (x, subset, select, ...)
 # Also called "complete.cases" in base. Unfortunately it's not a S3 generic.
 # Also handles bit64::integer64. TODO: export this?
 # For internal use only. 'by' requires integer input. No argument checks here yet.
-is_na <- function(x, by=seq_along(x)) .Call(Cdt_na, x, by)
-any_na <- function(x, by=seq_along(x)) .Call(CanyNA, x, by)
+is_na = function(x, by=seq_along(x)) .Call(Cdt_na, x, by)
+any_na = function(x, by=seq_along(x)) .Call(CanyNA, x, by)
 
-na.omit.data.table <- function (object, cols = seq_along(object), invert = FALSE, ...) {
+na.omit.data.table = function (object, cols = seq_along(object), invert = FALSE, ...) {
   # compare to stats:::na.omit.data.frame
   if (!cedta()) return(NextMethod())
   if ( !missing(invert) && is.na(as.logical(invert)) )
@@ -2275,22 +2275,22 @@ na.omit.data.table <- function (object, cols = seq_along(object), invert = FALSE
   }
 }
 
-which_ <- function(x, bool = TRUE) {
+which_ = function(x, bool = TRUE) {
   # fix for #1467, quotes result in "not resolved in current namespace" error
   .Call(Cwhichwrapper, x, bool)
 }
 
-is.na.data.table <- function (x) {
+is.na.data.table = function (x) {
   if (!cedta()) return(`is.na.data.frame`(x))
   do.call("cbind", lapply(x, "is.na"))
 }
 
 # not longer needed as inherits ...
-#    t.data.table <- t.data.frame
-#    Math.data.table <- Math.data.frame
-#    summary.data.table <- summary.data.frame
+#    t.data.table = t.data.frame
+#    Math.data.table = Math.data.frame
+#    summary.data.table = summary.data.frame
 
-Ops.data.table <- function(e1, e2 = NULL)
+Ops.data.table = function(e1, e2 = NULL)
 {
   ans = NextMethod()
   if (cedta() && is.data.frame(ans))
@@ -2298,7 +2298,7 @@ Ops.data.table <- function(e1, e2 = NULL)
   ans
 }
 
-split.data.table <- function(x, f, drop = FALSE, by, sorted = FALSE, keep.by = TRUE, flatten = TRUE, ..., verbose = getOption("datatable.verbose")) {
+split.data.table = function(x, f, drop = FALSE, by, sorted = FALSE, keep.by = TRUE, flatten = TRUE, ..., verbose = getOption("datatable.verbose")) {
   if (!is.data.table(x)) stop("x argument must be a data.table")
   stopifnot(is.logical(drop), is.logical(sorted), is.logical(keep.by),  is.logical(flatten))
   # split data.frame way, using `f` and not `by` argument
@@ -2379,7 +2379,7 @@ split.data.table <- function(x, f, drop = FALSE, by, sorted = FALSE, keep.by = T
 
 # TO DO, add more warnings e.g. for by.data.table(), telling user what the data.table syntax is but letting them dispatch to data.frame if they want
 
-copy <- function(x) {
+copy = function(x) {
   newx = .Call(Ccopy,x)  # copies at length but R's duplicate() also copies truelength over.
                          # TO DO: inside Ccopy it could reset tl to 0 or length, but no matter as selfrefok detects it
                          # TO DO: revisit duplicate.c in R 3.0.3 and see where it's at
@@ -2400,11 +2400,11 @@ copy <- function(x) {
   alloc.col(newx)
 }
 
-point <- function(to, to_idx, from, from_idx) {
+point = function(to, to_idx, from, from_idx) {
   .Call(CpointWrapper, to, to_idx, from, from_idx)
 }
 
-.shallow <- function(x, cols = NULL, retain.key = FALSE, unlock = FALSE) {
+.shallow = function(x, cols = NULL, retain.key = FALSE, unlock = FALSE) {
   isnull = is.null(cols)
   if (!isnull) cols = validate(cols, x)  # NULL is default = all columns
   ans = .Call(Cshallowwrapper, x, cols)  # copies VECSXP only
@@ -2413,7 +2413,7 @@ point <- function(to, to_idx, from, from_idx) {
     if (isnull) return(ans) # handle most frequent case first
     ## get correct key if cols are present
     cols = names(x)[cols]
-    keylength <- which.first(!key(ans) %chin% cols) - 1L
+    keylength = which.first(!key(ans) %chin% cols) - 1L
     if (is.na(keylength)) keylength <- length(key(ans))
     if (!keylength) {
       setattr(ans, "sorted", NULL) ## no key remaining
@@ -2421,12 +2421,12 @@ point <- function(to, to_idx, from, from_idx) {
       setattr(ans, "sorted", head(key(ans), keylength)) ## keep what can be kept
     }
     ## take care of attributes.
-    indices <- names(attributes(attr(ans, "index")))
+    indices = names(attributes(attr(ans, "index")))
     for(index in indices) {
-      indexcols <- strsplit(index, split = "__")[[1L]][-1L]
-      indexlength <- which.first(!indexcols %chin% cols) - 1L
+      indexcols = strsplit(index, split = "__")[[1L]][-1L]
+      indexlength = which.first(!indexcols %chin% cols) - 1L
       if (is.na(indexlength)) next ## all columns are present, nothing to be done
-      reducedindex <- paste0("__", indexcols[seq_len(indexlength)], collapse="") ## the columns until the first missing from the new index
+      reducedindex = paste0("__", indexcols[seq_len(indexlength)], collapse="") ## the columns until the first missing from the new index
       if (reducedindex %chin% indices || !indexlength) {
         ## Either reduced index already present or no columns of the original index remain.
         ## Drop the original index completely
@@ -2448,14 +2448,14 @@ point <- function(to, to_idx, from, from_idx) {
 
 }
 
-shallow <- function(x, cols=NULL) {
+shallow = function(x, cols=NULL) {
   if (!is.data.table(x))
     stop("x is not a data.table. Shallow copy is a copy of the vector of column pointers (only), so is only meaningful for data.table")
   ans = .shallow(x, cols=cols, retain.key = TRUE)
   ans
 }
 
-alloc.col <- function(DT, n=getOption("datatable.alloccol"), verbose=getOption("datatable.verbose"))
+alloc.col = function(DT, n=getOption("datatable.alloccol"), verbose=getOption("datatable.verbose"))
 {
   name = substitute(DT)
   if (identical(name,quote(`*tmp*`))) stop("alloc.col attempting to modify `*tmp*`")
@@ -2467,16 +2467,16 @@ alloc.col <- function(DT, n=getOption("datatable.alloccol"), verbose=getOption("
   .Call(Csetmutable,ans)
 }
 
-selfrefok <- function(DT,verbose=getOption("datatable.verbose")) {
+selfrefok = function(DT,verbose=getOption("datatable.verbose")) {
   .Call(Cselfrefokwrapper,DT,verbose)
 }
 
-truelength <- function(x) .Call(Ctruelength,x)
+truelength = function(x) .Call(Ctruelength,x)
 # deliberately no "truelength<-" method.  alloc.col is the mechanism for that.
 # settruelength() no longer need (and so removed) now that data.table depends on R 2.14.0
 # which initializes tl to zero rather than leaving uninitialized.
 
-setattr <- function(x,name,value) {
+setattr = function(x,name,value) {
   # Wrapper for setAttrib internal R function
   # Sets attribute by reference (no copy)
   # Named setattr (rather than setattrib) at R level to more closely resemble attr<-
@@ -2503,7 +2503,7 @@ setattr <- function(x,name,value) {
   invisible(x)
 }
 
-setnames <- function(x,old,new,skip_absent=FALSE) {
+setnames = function(x,old,new,skip_absent=FALSE) {
   # Sets by reference, maintains truelength, no copy of table at all.
   # But also more convenient than names(DT)[i]="newname"  because we can also do setnames(DT,"oldname","newname")
   # without an onerous match() ourselves. old can be positions, too, but we encourage by name for robustness.
@@ -2514,7 +2514,7 @@ setnames <- function(x,old,new,skip_absent=FALSE) {
     # for setnames(DT,new); e.g., setnames(DT,c("A","B")) where ncol(DT)==2
     if (!is.character(old)) stop("Passed a vector of type '",typeof(old),"'. Needs to be type 'character'.")
     if (length(old) != ncol(x)) stop("Can't assign ",length(old)," names to a ",ncol(x)," column data.table")
-    nx <- names(x)
+    nx = names(x)
     # note that duplicate names are permitted to be created in this usage only
     if (anyNA(nx)) {
       # if x somehow has some NA names, which() needs help to return them, #2475
@@ -2541,7 +2541,7 @@ setnames <- function(x,old,new,skip_absent=FALSE) {
       i = chmatch(old,names(x))
       if (anyNA(i)) {
         if (isTRUE(skip_absent)) {
-          w <- old %chin% names(x)
+          w = old %chin% names(x)
           old = old[w]
           new = new[w]
           i = i[w]
@@ -2577,7 +2577,7 @@ setnames <- function(x,old,new,skip_absent=FALSE) {
   invisible(x)
 }
 
-setcolorder <- function(x, neworder=key(x))
+setcolorder = function(x, neworder=key(x))
 {
   if (anyDuplicated(neworder)) stop("neworder contains duplicates")
   # if (!is.data.table(x)) stop("x is not a data.table")
@@ -2604,7 +2604,7 @@ setcolorder <- function(x, neworder=key(x))
   invisible(x)
 }
 
-set <- function(x,i=NULL,j,value)  # low overhead, loopable
+set = function(x,i=NULL,j,value)  # low overhead, loopable
 {
   if (is.atomic(value)) {
     # protect NAMED of atomic value from .Call's NAMED=2 by wrapping with list()
@@ -2616,7 +2616,7 @@ set <- function(x,i=NULL,j,value)  # low overhead, loopable
   invisible(x)
 }
 
-chmatch <- function(x, table, nomatch=NA_integer_)
+chmatch = function(x, table, nomatch=NA_integer_)
   .Call(Cchmatch, x, table, as.integer(nomatch[1L])) # [1L] to fix #1672
 
 # chmatchdup() behaves like 'pmatch' but only the 'exact' matching part; i.e. a value in
@@ -2624,24 +2624,24 @@ chmatch <- function(x, table, nomatch=NA_integer_)
 # chmatchdup(c("a", "a"), c("a", "a")) # 1,2 - the second 'a' in 'x' has a 2nd match in 'table'
 # chmatchdup(c("a", "a"), c("a", "b")) # 1,NA - the second one doesn't 'see' the first 'a'
 # chmatchdup(c("a", "a"), c("a", "a.1")) # 1,NA - this is where it differs from pmatch - we don't need the partial match.
-chmatchdup <- function(x, table, nomatch=NA_integer_)
+chmatchdup = function(x, table, nomatch=NA_integer_)
   .Call(Cchmatchdup, x, table, as.integer(nomatch[1L]))
 
-"%chin%" <- function(x, table)
+"%chin%" = function(x, table)
   .Call(Cchin, x, table)  # TO DO  if table has 'ul' then match to that
 
-chorder <- function(x) {
+chorder = function(x) {
   o = forderv(x, sort=TRUE, retGrp=FALSE)
   if (length(o)) o else seq_along(x)
 }
 
-chgroup <- function(x) {
+chgroup = function(x) {
   # TO DO: deprecate and remove this. It's exported but doubt anyone uses it. Think the plan was to use it internally, but forderv superceded.
   o = forderv(x, sort=FALSE, retGrp=TRUE)
   if (length(o)) as.vector(o) else seq_along(x)  # as.vector removes the attributes
 }
 
-.rbind.data.table <- function(..., use.names=TRUE, fill=FALSE, idcol=NULL) {
+.rbind.data.table = function(..., use.names=TRUE, fill=FALSE, idcol=NULL) {
   # See FAQ 2.23
   # Called from base::rbind.data.frame
   # fix for #1626.. because some packages (like psych) bind an input
@@ -2650,7 +2650,7 @@ chgroup <- function(x) {
   rbindlist(l, use.names, fill, idcol)
 }
 
-rbindlist <- function(l, use.names="check", fill=FALSE, idcol=NULL) {
+rbindlist = function(l, use.names="check", fill=FALSE, idcol=NULL) {
   if (isFALSE(idcol)) { idcol = NULL }
   else if (!is.null(idcol)) {
     if (isTRUE(idcol)) idcol = ".id"
@@ -2669,24 +2669,24 @@ rbindlist <- function(l, use.names="check", fill=FALSE, idcol=NULL) {
   setDT(ans)[]
 }
 
-vecseq <- function(x,y,clamp) .Call(Cvecseq,x,y,clamp)
+vecseq = function(x,y,clamp) .Call(Cvecseq,x,y,clamp)
 
 # .Call(Caddress, x) increments NAM() when x is vector with NAM(1). Referring object within non-primitive function is enough to increment reference.
-address <- function(x) .Call(Caddress, eval(substitute(x), parent.frame()))
+address = function(x) .Call(Caddress, eval(substitute(x), parent.frame()))
 
-":=" <- function(...) stop('Check that is.data.table(DT) == TRUE. Otherwise, := and `:=`(...) are defined for use in j, once only and in particular ways. See help(":=").')
+":=" = function(...) stop('Check that is.data.table(DT) == TRUE. Otherwise, := and `:=`(...) are defined for use in j, once only and in particular ways. See help(":=").')
 
-setDF <- function(x, rownames=NULL) {
+setDF = function(x, rownames=NULL) {
   if (!is.list(x)) stop("setDF only accepts data.table, data.frame or list of equal length as input")
   if (anyDuplicated(rownames)) stop("rownames contains duplicates")
   if (is.data.table(x)) {
     # copied from as.data.frame.data.table
     if (is.null(rownames)) {
-      rn <- .set_row_names(nrow(x))
+      rn = .set_row_names(nrow(x))
     } else {
       if (length(rownames) != nrow(x))
         stop("rownames incorrect length; expected ", nrow(x), " names, got ", length(rownames))
-      rn <- rownames
+      rn = rownames
     }
     setattr(x, "row.names", rn)
     setattr(x, "class", "data.frame")
@@ -2715,11 +2715,11 @@ setDF <- function(x, rownames=NULL) {
       }
     }
     if (is.null(rownames)) {
-      rn <- .set_row_names(mn)
+      rn = .set_row_names(mn)
     } else {
       if (length(rownames) != mn)
       stop("rownames incorrect length; expected ", mn, " names, got ", length(rownames))
-      rn <- rownames
+      rn = rownames
     }
     setattr(x,"row.names", rn)
     setattr(x,"class","data.frame")
@@ -2727,10 +2727,10 @@ setDF <- function(x, rownames=NULL) {
   invisible(x)
 }
 
-setDT <- function(x, keep.rownames=FALSE, key=NULL, check.names=FALSE) {
+setDT = function(x, keep.rownames=FALSE, key=NULL, check.names=FALSE) {
   name = substitute(x)
   if (is.name(name)) {
-    home <- function(x, env) {
+    home = function(x, env) {
       if (identical(env, emptyenv()))
         stop("Cannot find symbol ", cname, call. = FALSE)
       else if (exists(x, env, inherits=FALSE)) env
@@ -2820,18 +2820,18 @@ setDT <- function(x, keep.rownames=FALSE, key=NULL, check.names=FALSE) {
   invisible(x)
 }
 
-as_list <- function(x) {
+as_list = function(x) {
   lx = vector("list", 1L)
   .Call(Csetlistelt, lx, 1L, x)
   lx
 }
 
 # FR #1353
-rowid <- function(..., prefix=NULL) {
+rowid = function(..., prefix=NULL) {
   rowidv(list(...), prefix=prefix)
 }
 
-rowidv <- function(x, cols=seq_along(x), prefix=NULL) {
+rowidv = function(x, cols=seq_along(x), prefix=NULL) {
   if (!is.null(prefix) && (!is.character(prefix) || length(prefix) != 1L))
     stop("prefix must be NULL or a character vector of length=1.")
   if (is.atomic(x)) {
@@ -2856,11 +2856,11 @@ rowidv <- function(x, cols=seq_along(x), prefix=NULL) {
 }
 
 # FR #686
-rleid <- function(..., prefix=NULL) {
+rleid = function(..., prefix=NULL) {
   rleidv(list(...), prefix=prefix)
 }
 
-rleidv <- function(x, cols=seq_along(x), prefix=NULL) {
+rleidv = function(x, cols=seq_along(x), prefix=NULL) {
   if (!is.null(prefix) && (!is.character(prefix) || length(prefix) != 1L))
     stop("prefix must be NULL or a character vector of length=1.")
   if (is.atomic(x)) {
@@ -2881,26 +2881,26 @@ rleidv <- function(x, cols=seq_along(x), prefix=NULL) {
 }
 
 # GForce functions
-`g[` <- function(x, n) .Call(Cgnthvalue, x, as.integer(n)) # n is of length=1 here.
-ghead <- function(x, n) .Call(Cghead, x, as.integer(n)) # n is not used at the moment
-gtail <- function(x, n) .Call(Cgtail, x, as.integer(n)) # n is not used at the moment
-gfirst <- function(x) .Call(Cgfirst, x)
-glast <- function(x) .Call(Cglast, x)
-gsum <- function(x, na.rm=FALSE) .Call(Cgsum, x, na.rm)
-gmean <- function(x, na.rm=FALSE) .Call(Cgmean, x, na.rm)
-gprod <- function(x, na.rm=FALSE) .Call(Cgprod, x, na.rm)
-gmedian <- function(x, na.rm=FALSE) .Call(Cgmedian, x, na.rm)
-gmin <- function(x, na.rm=FALSE) .Call(Cgmin, x, na.rm)
-gmax <- function(x, na.rm=FALSE) .Call(Cgmax, x, na.rm)
-gvar <- function(x, na.rm=FALSE) .Call(Cgvar, x, na.rm)
-gsd <- function(x, na.rm=FALSE) .Call(Cgsd, x, na.rm)
-gforce <- function(env, jsub, o, f, l, rows) .Call(Cgforce, env, jsub, o, f, l, rows)
+`g[` = function(x, n) .Call(Cgnthvalue, x, as.integer(n)) # n is of length=1 here.
+ghead = function(x, n) .Call(Cghead, x, as.integer(n)) # n is not used at the moment
+gtail = function(x, n) .Call(Cgtail, x, as.integer(n)) # n is not used at the moment
+gfirst = function(x) .Call(Cgfirst, x)
+glast = function(x) .Call(Cglast, x)
+gsum = function(x, na.rm=FALSE) .Call(Cgsum, x, na.rm)
+gmean = function(x, na.rm=FALSE) .Call(Cgmean, x, na.rm)
+gprod = function(x, na.rm=FALSE) .Call(Cgprod, x, na.rm)
+gmedian = function(x, na.rm=FALSE) .Call(Cgmedian, x, na.rm)
+gmin = function(x, na.rm=FALSE) .Call(Cgmin, x, na.rm)
+gmax = function(x, na.rm=FALSE) .Call(Cgmax, x, na.rm)
+gvar = function(x, na.rm=FALSE) .Call(Cgvar, x, na.rm)
+gsd = function(x, na.rm=FALSE) .Call(Cgsd, x, na.rm)
+gforce = function(env, jsub, o, f, l, rows) .Call(Cgforce, env, jsub, o, f, l, rows)
 
-isReallyReal <- function(x) {
+isReallyReal = function(x) {
   .Call(CisReallyReal, x)
 }
 
-.prepareFastSubset <- function(isub, x, enclos, notjoin, verbose = FALSE){
+.prepareFastSubset = function(isub, x, enclos, notjoin, verbose = FALSE){
   ## helper that decides, whether a fast binary search can be performed, if i is a call
   ## For details on the supported queries, see \code{\link{datatable-optimize}}
   ## Additional restrictions are imposed if x is .SD, or if options indicate that no optimization
@@ -2919,44 +2919,44 @@ isReallyReal <- function(x) {
   if (!is.call(isub)) return(NULL)
   if (!is.null(attr(x, '.data.table.locked'))) return(NULL)  # fix for #958, don't create auto index on '.SD'.
   ## a list of all possible operators with their translations into the 'on' clause
-  validOps <- list(op = c("==", "%in%", "%chin%"),
+  validOps = list(op = c("==", "%in%", "%chin%"),
                    on = c("==", "==",   "=="))
 
   ## Determine, whether the nature of isub in general supports fast binary search
-  remainingIsub <- isub
-  i <- list()
-  on <- character(0)
+  remainingIsub = isub
+  i = list()
+  on = character(0)
   nonEqui = FALSE
   while(length(remainingIsub)){
     if(is.call(remainingIsub)){
       if (length(remainingIsub[[1L]]) != 1L) return(NULL) ## only single symbol, either '&' or one of validOps allowed.
       if (remainingIsub[[1L]] != "&"){ ## only a single expression present or a different connection.
-        stub <- remainingIsub
-        remainingIsub <- NULL ## there is no remainder to be evaluated after stub.
+        stub = remainingIsub
+        remainingIsub = NULL ## there is no remainder to be evaluated after stub.
       } else {
         ## multiple expressions with & connection.
         if (notjoin) return(NULL) ## expressions of type DT[!(a==1 & b==2)] currently not supported
-        stub <- remainingIsub[[3L]] ## the single column expression like col == 4
-        remainingIsub <- remainingIsub[[2L]] ## the potentially longer expression with potential additional '&'
+        stub = remainingIsub[[3L]] ## the single column expression like col == 4
+        remainingIsub = remainingIsub[[2L]] ## the potentially longer expression with potential additional '&'
       }
     } else { ## single symbol present
-      stub <- remainingIsub
-      remainingIsub <- NULL
+      stub = remainingIsub
+      remainingIsub = NULL
     }
     ## check the stub if it is fastSubsettable
     if(is.symbol(stub)){
       ## something like DT[x & y]. If x and y are logical columns, we can optimize.
-      col <- as.character(stub)
+      col = as.character(stub)
       if(!col %chin% names(x)) return(NULL)
       if(!is.logical(x[[col]])) return(NULL)
       ## redirect to normal DT[x == TRUE]
-      stub <- call("==", as.symbol(col), TRUE)
+      stub = call("==", as.symbol(col), TRUE)
     }
     if (length(stub[[1L]]) != 1) return(NULL) ## Whatever it is, definitely not one of the valid operators
-    operator <- as.character(stub[[1L]])
+    operator = as.character(stub[[1L]])
     if (!operator %chin% validOps$op) return(NULL) ## operator not supported
     if (!is.name(stub[[2L]])) return(NULL)
-    col <- as.character(stub[[2L]])
+    col = as.character(stub[[2L]])
     if (!col %chin% names(x)) return(NULL) ## any non-column name prevents fast subsetting
     if(col %chin% names(i)) return(NULL) ## repeated appearance of the same column not suported (e.g. DT[x < 3 & x < 5])
     ## now check the RHS of stub
@@ -2988,8 +2988,8 @@ isReallyReal <- function(x) {
       }
     }
     ## if it passed until here, fast subset can be done for this stub
-    i <- c(i, setNames(list(RHS), col))
-    on <- c(on, setNames(paste0(col, validOps$on[validOps$op == operator], col), col))
+    i = c(i, setNames(list(RHS), col))
+    on = c(on, setNames(paste0(col, validOps$on[validOps$op == operator], col), col))
     ## loop continues with remainingIsub
   }
   if (length(i) == 0L) stop("Internal error in .isFastSubsettable. Please report to data.table developers") # nocov
@@ -3002,32 +3002,32 @@ isReallyReal <- function(x) {
   ## Care is needed with names as we construct i
   ## with 'CJ' and 'do.call' and this would cause problems if colNames were 'sorted' or 'unique'
   ## as these two would be interpreted as args for CJ
-  colNames <- names(i)
+  colNames = names(i)
   names(i) <- NULL
-  i$sorted <- FALSE
-  i$unique <- TRUE
-  i <- do.call(CJ, i)
+  i$sorted = FALSE
+  i$unique = TRUE
+  i = do.call(CJ, i)
   setnames(i, colNames)
-  idx <- NULL
+  idx = NULL
   if(is.null(idx)){
       ## check whether key fits the columns in i.
       ## order of key columns makes no difference, as long as they are all upfront in the key, I believe.
       if (all(names(i) %chin% head(key(x), length(i)))){
           if (verbose) {cat("Optimized subsetting with key '", paste0( head(key(x), length(i)), collapse = ", "),"'\n",sep="");flush.console()}
-          idx <- integer(0L) ## integer(0L) not NULL! Indicates that x is ordered correctly.
-          idxCols <- head(key(x), length(i)) ## in correct order!
+          idx = integer(0L) ## integer(0L) not NULL! Indicates that x is ordered correctly.
+          idxCols = head(key(x), length(i)) ## in correct order!
       }
   }
   if (is.null(idx)){
     if (!getOption("datatable.use.index")) return(NULL) # #1422
     ## check whether an exising index can be used
     ## An index can be used if it corresponds exactly to the columns in i (similar to the key above)
-    candidates <- indices(x, vectors = TRUE)
-    idx <- NULL
+    candidates = indices(x, vectors = TRUE)
+    idx = NULL
     for (cand in candidates){
       if (all(names(i) %chin% cand) && length(cand) == length(i)){
-        idx <- attr(attr(x, "index"), paste0("__", cand, collapse = ""))
-        idxCols <- cand
+        idx = attr(attr(x, "index"), paste0("__", cand, collapse = ""))
+        idxCols = cand
         break
       }
     }
@@ -3043,12 +3043,12 @@ isReallyReal <- function(x) {
     setindexv(x, names(i))
     if (verbose) {cat(timetaken(last.started.at),"\n");flush.console()}
     if (verbose) {cat("Optimized subsetting with index '", paste0(names(i), collapse = "__"),"'\n",sep="");flush.console()}
-    idx <- attr(attr(x, "index"), paste0("__", names(i), collapse = ""))
-    idxCols <- names(i)
+    idx = attr(attr(x, "index"), paste0("__", names(i), collapse = ""))
+    idxCols = names(i)
   }
   if(!is.null(idxCols)){
     setkeyv(i, idxCols)
-    on <- on[idxCols] ## make sure 'on' is in the correct order. Otherwise the logic won't recognise that a key / index already exists.
+    on = on[idxCols] ## make sure 'on' is in the correct order. Otherwise the logic won't recognise that a key / index already exists.
   }
   return(list(i  = i,
               on = on,
@@ -3058,7 +3058,7 @@ isReallyReal <- function(x) {
 }
 
 
-.parse_on <- function(onsub, isnull_inames) {
+.parse_on = function(onsub, isnull_inames) {
   ## helper that takes the 'on' string(s) and extracts comparison operators and column names from it.
   #' @param onsub the substituted on
   #' @param isnull_inames bool; TRUE if i has no names.
@@ -3082,65 +3082,65 @@ isReallyReal <- function(x) {
     stop("'on' argument should be a named atomic vector of column names indicating which columns in 'i' should be joined with which columns in 'x'.")
   ## extract the operators and potential variable names from 'on'.
   ## split at backticks to take care about variable names like `col1<=`.
-  pieces <- strsplit(on, "(?=[`])", perl = TRUE)
-  xCols  <- character(length(on))
+  pieces = strsplit(on, "(?=[`])", perl = TRUE)
+  xCols  = character(length(on))
   ## if 'on' is named, the names are the xCols for sure
   if(!is.null(names(on))){
-    xCols <- names(on)
+    xCols = names(on)
   }
-  iCols     <- character(length(on))
-  operators <- character(length(on))
+  iCols     = character(length(on))
+  operators = character(length(on))
   ## loop over the elements and extract operators and column names.
   for(i in seq_along(pieces)){
-    thisCols      <- character(0)
-    thisOperators <- character(0)
-    j <- 1
+    thisCols      = character(0)
+    thisOperators = character(0)
+    j = 1
     while(j <= length(pieces[[i]])){
       if(pieces[[i]][j] == "`"){
         ## start of a variable name with backtick.
-        thisCols <- c(thisCols, pieces[[i]][j+1])
-        j <- j+3 # +1 is the column name, +2 is delimiting "`", +3 is next relevant entry.`
+        thisCols = c(thisCols, pieces[[i]][j+1])
+        j = j+3 # +1 is the column name, +2 is delimiting "`", +3 is next relevant entry.`
       } else {
         ## no backtick
         ## search for operators
-        thisOperators <- c(thisOperators,
+        thisOperators = c(thisOperators,
                            unlist(regmatches(pieces[[i]][j], gregexpr(pat, pieces[[i]][j])),
                                   use.names = FALSE))
         ## search for column names
-        thisCols <- c(thisCols, trimws(strsplit(pieces[[i]][j], pat)[[1]]))
+        thisCols = c(thisCols, trimws(strsplit(pieces[[i]][j], pat)[[1]]))
         ## there can be empty string column names because of trimws, remove them
-        thisCols <- thisCols[thisCols != ""]
-        j <- j+1
+        thisCols = thisCols[thisCols != ""]
+        j = j+1
       }
     }
     if (length(thisOperators) == 0) {
       ## if no operator is given, it must be ==
-      operators[i] <- "=="
+      operators[i] = "=="
     } else if (length(thisOperators) == 1) {
-      operators[i] <- thisOperators
+      operators[i] = thisOperators
     } else {
       ## multiple operators found in one 'on' part. Something is wrong.
       stop("Found more than one operator in one 'on' statement: ", on[i], ". Please specify a single operator.")
     }
     if (length(thisCols) == 2){
       ## two column names found, first is xCol, second is iCol for sure
-      xCols[i] <- thisCols[1]
-      iCols[i] <- thisCols[2]
+      xCols[i] = thisCols[1]
+      iCols[i] = thisCols[2]
     } else if (length(thisCols) == 1){
       ## a single column name found. Can mean different things
       if(xCols[i] != ""){
         ## xCol is given by names(on). thisCols must be iCol
-        iCols[i] <- thisCols[1]
+        iCols[i] = thisCols[1]
       } else if (isnull_inames){
         ## i has no names. It will be given the names V1, V2, ... automatically.
         ## The single column name is the x column. It will match to the ith column in i.
-        xCols[i] <- thisCols[1]
-        iCols[i] <- paste0("V", i)
+        xCols[i] = thisCols[1]
+        iCols[i] = paste0("V", i)
       } else {
         ## i has names and one single column name is given by on.
         ## This means that xCol and iCol have the same name.
-        xCols[i] <- thisCols[1]
-        iCols[i] <- thisCols[1]
+        xCols[i] = thisCols[1]
+        iCols[i] = thisCols[1]
       }
     } else if (length(thisCols) == 0){
       stop("'on' contains no column name: ", on[i], ". Each 'on' clause must contain one or two column names.")
@@ -3152,7 +3152,7 @@ isReallyReal <- function(x) {
   if (any(idx_op %in% c(0L, 6L)))
     stop("Invalid operators ", paste(operators[idx_op %in% c(0L, 6L)], collapse=","), ". Only allowed operators are ", paste(ops[1:5], collapse=""), ".")
   ## the final on will contain the xCol as name, the iCol as value
-  on <- iCols
+  on = iCols
   names(on) <- xCols
   return(list(on = on, ops = idx_op))
 }

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1955,11 +1955,11 @@ as.matrix.data.table = function(x, rownames=NULL, rownames.value=NULL, ...) {
   p = dm[2L]
   n = dm[1L]
   collabs = as.list(cn)
-  class(X) <- NULL
+  class(X) = NULL
   non.numeric = non.atomic = FALSE
   all.logical = TRUE
   for (j in seq_len(p)) {
-    if (is.ff(X[[j]])) X[[j]] <- X[[j]][]   # to bring the ff into memory, since we need to create a matrix in memory
+    if (is.ff(X[[j]])) X[[j]] = X[[j]][]   # to bring the ff into memory, since we need to create a matrix in memory
     xj = X[[j]]
     if (length(dj <- dim(xj)) == 2L && dj[2L] > 1L) {
       if (inherits(xj, "data.table"))
@@ -1993,7 +1993,7 @@ as.matrix.data.table = function(x, rownames=NULL, rownames.value=NULL, ...) {
       xj = X[[j]]
       miss = is.na(xj)
       xj = if (length(levels(xj))) as.vector(xj) else format(xj)
-      is.na(xj) <- miss
+      is.na(xj) = miss
       X[[j]] = xj
     }
   }
@@ -2160,8 +2160,8 @@ within.data.table = function (data, expr, ...)
   l = l[!vapply_1b(l, is.null)]
   nD = length(del <- setdiff(names(data), (nl <- names(l))))
   ans = copy(data)
-  if (length(nl)) ans[,nl] <- l
-  if (nD) ans[,del] <- NULL
+  if (length(nl)) ans[,nl] = l
+  if (nD) ans[,del] = NULL
   if (haskey(data) && all(key(data) %chin% names(ans))) {
     x = TRUE
     for (i in key(data)) {
@@ -2436,7 +2436,7 @@ point = function(to, to_idx, from, from_idx) {
         setattr(attr(ans, "index", exact = TRUE), index, NULL)
       } else {
         ## rename index to reducedindex
-        names(attributes(attr(ans, "index")))[names(attributes(attr(ans, "index"))) == index] <- reducedindex
+        names(attributes(attr(ans, "index")))[names(attributes(attr(ans, "index"))) == index] = reducedindex
       }
     }
   } else { # retain.key == FALSE
@@ -3003,7 +3003,7 @@ isReallyReal = function(x) {
   ## with 'CJ' and 'do.call' and this would cause problems if colNames were 'sorted' or 'unique'
   ## as these two would be interpreted as args for CJ
   colNames = names(i)
-  names(i) <- NULL
+  names(i) = NULL
   i$sorted = FALSE
   i$unique = TRUE
   i = do.call(CJ, i)
@@ -3153,6 +3153,6 @@ isReallyReal = function(x) {
     stop("Invalid operators ", paste(operators[idx_op %in% c(0L, 6L)], collapse=","), ". Only allowed operators are ", paste(ops[1:5], collapse=""), ".")
   ## the final on will contain the xCol as name, the iCol as value
   on = iCols
-  names(on) <- xCols
+  names(on) = xCols
   return(list(on = on, ops = idx_op))
 }

--- a/R/duplicated.R
+++ b/R/duplicated.R
@@ -2,7 +2,7 @@
 warning_oldUniqueByKey = "The deprecated option 'datatable.old.unique.by.key' is being used. Please stop using it and pass 'by=key(DT)' instead for clarity. For more information please search the NEWS file for this option."
 # upgrade the 4 calls below to error after May 2019 ( see note 10 from 1.11.0 May 2018 which said one year from then )
 
-duplicated.data.table <- function(x, incomparables=FALSE, fromLast=FALSE, by=seq_along(x), ...) {
+duplicated.data.table = function(x, incomparables=FALSE, fromLast=FALSE, by=seq_along(x), ...) {
   if (!cedta()) return(NextMethod("duplicated")) #nocov
   if (!identical(incomparables, FALSE)) {
     .NotYetUsed("incomparables != FALSE")
@@ -13,7 +13,7 @@ duplicated.data.table <- function(x, incomparables=FALSE, fromLast=FALSE, by=seq
   }
   if (nrow(x) == 0L || ncol(x) == 0L) return(logical(0L)) # fix for bug #5582
   if (is.na(fromLast) || !is.logical(fromLast)) stop("'fromLast' must be TRUE or FALSE")
-  query <- .duplicated.helper(x, by)
+  query = .duplicated.helper(x, by)
   # fix for bug #5405 - unique on null data table returns error (because of 'forderv')
   # however, in this case we can bypass having to go to forderv at all.
   if (!length(query$by)) return(logical(0L))
@@ -28,12 +28,12 @@ duplicated.data.table <- function(x, incomparables=FALSE, fromLast=FALSE, by=seq
     if (fromLast) f = cumsum(uniqlengths(f, nrow(x)))
     if (length(o)) f = o[f]
   }
-  res <- rep.int(TRUE, nrow(x))
+  res = rep.int(TRUE, nrow(x))
   res[f] = FALSE
   res
 }
 
-unique.data.table <- function(x, incomparables=FALSE, fromLast=FALSE, by=seq_along(x), ...) {
+unique.data.table = function(x, incomparables=FALSE, fromLast=FALSE, by=seq_along(x), ...) {
   if (!cedta()) return(NextMethod("unique")) # nocov
   if (!identical(incomparables, FALSE)) {
     .NotYetUsed("incomparables != FALSE")
@@ -83,8 +83,8 @@ unique.data.table <- function(x, incomparables=FALSE, fromLast=FALSE, by=seq_alo
 ## unique.data.table and duplicated.data.table both needed this. However,
 ## unique.data.table has been refactored to simply call duplicated.data.table
 ## making the refactor unnecessary, but let's leave it here just in case
-.duplicated.helper <- function(x, by) {
-  use.sub.cols <- !is.null(by) # && !isTRUE(by) # Fixing bug #5424
+.duplicated.helper = function(x, by) {
+  use.sub.cols = !is.null(by) # && !isTRUE(by) # Fixing bug #5424
 
   if (use.sub.cols) {
     ## Did the user specify (integer) indexes for the columns?
@@ -93,12 +93,12 @@ unique.data.table <- function(x, incomparables=FALSE, fromLast=FALSE, by=seq_alo
         stop("Integer values between 1 and ncol are required for 'by' when ",
              "column indices. It's often better to use column names.")
       }
-      by <- names(x)[by]
+      by = names(x)[by]
     }
     if (!is.character(by)) {
       stop("Only NULL, column indices or column names are allowed in by")
     }
-    bad.cols <- setdiff(by, names(x))
+    bad.cols = setdiff(by, names(x))
     if (length(bad.cols)) {
       stop("by specifies column names that do not exist. First 5: ",paste(head(bad.cols,5),collapse=","))
     }
@@ -119,13 +119,13 @@ unique.data.table <- function(x, incomparables=FALSE, fromLast=FALSE, by=seq_alo
 # Note that base's anyDuplicated is faster than any(duplicated(.)) (for vectors) - for data.frames it still pastes before calling duplicated
 # In that sense, this anyDuplicated is *not* the same as base's - meaning it's not a different implementation
 # This is just a wrapper. That being said, it should be incredibly fast on data.tables (due to data.table's fast forder)
-anyDuplicated.data.table <- function(x, incomparables=FALSE, fromLast=FALSE, by=seq_along(x), ...) {
+anyDuplicated.data.table = function(x, incomparables=FALSE, fromLast=FALSE, by=seq_along(x), ...) {
   if (!cedta()) return(NextMethod("anyDuplicated")) # nocov
   if (missing(by) && isTRUE(getOption("datatable.old.unique.by.key"))) {
     by = key(x)
     warning(warning_oldUniqueByKey)
   }
-  dups <- duplicated(x, incomparables, fromLast, by, ...)
+  dups = duplicated(x, incomparables, fromLast, by, ...)
   if (fromLast) idx = tail(which(dups), 1L) else idx = head(which(dups), 1L)
   if (!length(idx)) idx=0L
   idx
@@ -135,7 +135,7 @@ anyDuplicated.data.table <- function(x, incomparables=FALSE, fromLast=FALSE, by=
 # of groups in a vector or data.table. Here by data.table,
 # we really mean `.SD` - used in a grouping operation
 # TODO: optimise uniqueN further with GForce.
-uniqueN <- function(x, by = if (is.list(x)) seq_along(x) else NULL, na.rm=FALSE) { # na.rm, #1455
+uniqueN = function(x, by = if (is.list(x)) seq_along(x) else NULL, na.rm=FALSE) { # na.rm, #1455
   if (missing(by) && is.data.table(x) && isTRUE(getOption("datatable.old.unique.by.key"))) {
     by = key(x)
     warning(warning_oldUniqueByKey)

--- a/R/fcast.R
+++ b/R/fcast.R
@@ -1,19 +1,19 @@
-guess <- function(x) {
+guess = function(x) {
   if ("value" %chin% names(x))
     return("value")
   if ("(all)" %chin% names(x))
     return("(all)")
-  var <- names(x)[ncol(x)]
+  var = names(x)[ncol(x)]
   message("Using '", var, "' as value column. Use 'value.var' to override")
   return(var)
 }
 
-dcast <- function(data, formula, fun.aggregate = NULL, ..., margins = NULL,
+dcast = function(data, formula, fun.aggregate = NULL, ..., margins = NULL,
                   subset = NULL, fill = NULL, value.var = guess(data)) {
   UseMethod("dcast", data)
 }
 
-check_formula <- function(formula, varnames, valnames) {
+check_formula = function(formula, varnames, valnames) {
   if (is.character(formula)) formula = as.formula(formula)
   if (!inherits(formula, "formula") || length(formula) != 3L)
     stop("Invalid formula. Cast formula should be of the form LHS ~ RHS, for e.g., a + b ~ c.")  # nocov; couldn't find a way to construct a test formula with length!=3L
@@ -25,7 +25,7 @@ check_formula <- function(formula, varnames, valnames) {
   deparse_formula(as.list(formula)[-1L], varnames, allvars)
 }
 
-deparse_formula <- function(expr, varnames, allvars) {
+deparse_formula = function(expr, varnames, allvars) {
   lvars = lapply(expr, function(this) {
     if (is.call(this)) {
       if (this[[1L]] == quote(`+`))
@@ -41,7 +41,7 @@ deparse_formula <- function(expr, varnames, allvars) {
   lvars = lapply(lvars, function(x) if (length(x) && !is.list(x)) list(x) else x)
 }
 
-value_vars <- function(value.var, varnames) {
+value_vars = function(value.var, varnames) {
   if (is.character(value.var))
     value.var = list(value.var)
   value.var = lapply(value.var, unique)
@@ -52,7 +52,7 @@ value_vars <- function(value.var, varnames) {
   value.var
 }
 
-aggregate_funs <- function(funs, vals, sep="_", ...) {
+aggregate_funs = function(funs, vals, sep="_", ...) {
   if (is.call(funs) && funs[[1L]] == "eval")
     funs = eval(funs[[2L]], parent.frame(2L), parent.frame(2L))
   if (is.call(funs) && as.character(funs[[1L]]) %chin% c("c", "list")) {
@@ -68,7 +68,7 @@ aggregate_funs <- function(funs, vals, sep="_", ...) {
   }
   only_one_fun = length(unlist(funs)) == 1L
   dots = list(...)
-  construct_funs <- function(fun, nm, val) {
+  construct_funs = function(fun, nm, val) {
     ans = vector("list", length(fun)*length(val))
     nms = vector("character", length(ans))
     k = 1L
@@ -86,9 +86,9 @@ aggregate_funs <- function(funs, vals, sep="_", ...) {
     setattr(ans, 'names', nms)
   }
   ans = lapply(seq_along(funs), function(i) {
-    nm <- names(funs[i])
+    nm = names(funs[i])
     if (is.null(nm) || !nzchar(nm)) {
-      nm <- all.names(funs[[i]], max.names=1L, functions=TRUE)
+      nm = all.names(funs[[i]], max.names=1L, functions=TRUE)
     }
     if (!length(nm)) nm <- paste0("fun", i)
     construct_funs(funs[i], nm, vals[[i]])
@@ -96,7 +96,7 @@ aggregate_funs <- function(funs, vals, sep="_", ...) {
   as.call(c(quote(list), unlist(ans)))
 }
 
-dcast.data.table <- function(data, formula, fun.aggregate = NULL, sep = "_", ..., margins = NULL, subset = NULL, fill = NULL, drop = TRUE, value.var = guess(data), verbose = getOption("datatable.verbose")) {
+dcast.data.table = function(data, formula, fun.aggregate = NULL, sep = "_", ..., margins = NULL, subset = NULL, fill = NULL, drop = TRUE, value.var = guess(data), verbose = getOption("datatable.verbose")) {
   if (!is.data.table(data)) stop("'data' must be a data.table.")
   drop = as.logical(rep(drop, length.out=2L))
   if (anyNA(drop)) stop("'drop' must be logical TRUE/FALSE")
@@ -130,8 +130,8 @@ dcast.data.table <- function(data, formula, fun.aggregate = NULL, sep = "_", ...
   }
   setDT(dat)
 
-  m <- as.list(match.call()[-1L])
-  subset <- m[["subset"]][[2L]]
+  m = as.list(match.call()[-1L])
+  subset = m[["subset"]][[2L]]
   if (!is.null(subset)) {
     if (is.name(subset)) subset = as.call(list(quote(`(`), subset))
     idx = which(eval(subset, data, parent.frame())) # any advantage thro' secondary keys?
@@ -151,19 +151,19 @@ dcast.data.table <- function(data, formula, fun.aggregate = NULL, sep = "_", ...
     fun.call = aggregate_funs(fun.call, lvals, sep, ...)
     errmsg = "Aggregating function(s) should take vector inputs and return a single value (length=1). However, function(s) returns length!=1. This value will have to be used to fill any missing combinations, and therefore must be length=1. Either override by setting the 'fill' argument explicitly or modify your function to handle this case appropriately."
     if (is.null(fill)) {
-      fill.default <- suppressWarnings(dat[0L][, eval(fun.call)])
+      fill.default = suppressWarnings(dat[0L][, eval(fun.call)])
       # tryCatch(fill.default <- dat[0L][, eval(fun.call)], error = function(x) stop(errmsg, call.=FALSE))
       if (nrow(fill.default) != 1L) stop(errmsg, call.=FALSE)
     }
     dat = dat[, eval(fun.call), by=c(varnames)]
   }
-  order_ <- function(x) {
+  order_ = function(x) {
     o = forderv(x, retGrp=TRUE, sort=TRUE)
     idx = attr(o, 'starts')
     if (!length(o)) o = seq_along(x)
     o[idx] # subsetVector retains attributes, using R's subset for now
   }
-  cj_uniq <- function(DT) {
+  cj_uniq = function(DT) {
     do.call("CJ", lapply(DT, function(x)
       if (is.factor(x)) {
         xint = seq_along(levels(x))

--- a/R/fmelt.R
+++ b/R/fmelt.R
@@ -2,11 +2,11 @@
 #   of the R version dependency and (2) reshape2::dcast is not generic.
 #   Anyway, reshape2 package is deprecated since December 2017.
 
-melt <- function(data, ..., na.rm = FALSE, value.name = "value") {
+melt = function(data, ..., na.rm = FALSE, value.name = "value") {
   UseMethod("melt", data)
 }
 
-patterns <- function(..., cols=character(0L)) {
+patterns = function(..., cols=character(0L)) {
   # if ... has no names, names(list(...)) will be "";
   #   this assures they'll be NULL instead
   p = unlist(list(...), use.names = any(nzchar(names(...))))
@@ -15,7 +15,7 @@ patterns <- function(..., cols=character(0L)) {
   lapply(p, grep, cols)
 }
 
-melt.data.table <- function(data, id.vars, measure.vars, variable.name = "variable",
+melt.data.table = function(data, id.vars, measure.vars, variable.name = "variable",
        value.name = "value", ..., na.rm = FALSE, variable.factor = TRUE, value.factor = FALSE,
        verbose = getOption("datatable.verbose")) {
   if (!is.data.table(data)) stop("'data' must be a data.table")
@@ -44,7 +44,7 @@ melt.data.table <- function(data, id.vars, measure.vars, variable.name = "variab
       value.name = meas.nm
     }
   }
-  ans <- .Call(Cfmelt, data, id.vars, measure.vars,
+  ans = .Call(Cfmelt, data, id.vars, measure.vars,
       as.logical(variable.factor), as.logical(value.factor),
       variable.name, value.name, as.logical(na.rm),
       as.logical(verbose))

--- a/R/foverlaps.R
+++ b/R/foverlaps.R
@@ -1,4 +1,4 @@
-foverlaps <- function(x, y, by.x=if (!is.null(key(x))) key(x) else key(y), by.y=key(y), maxgap=0L, minoverlap=1L, type=c("any", "within", "start", "end", "equal"), mult=c("all", "first", "last"), nomatch=getOption("datatable.nomatch"), which=FALSE, verbose=getOption("datatable.verbose")) {
+foverlaps = function(x, y, by.x=if (!is.null(key(x))) key(x) else key(y), by.y=key(y), maxgap=0L, minoverlap=1L, type=c("any", "within", "start", "end", "equal"), mult=c("all", "first", "last"), nomatch=getOption("datatable.nomatch"), which=FALSE, verbose=getOption("datatable.verbose")) {
 
   if (!is.data.table(y) || !is.data.table(x)) stop("y and x must both be data.tables. Use `setDT()` to convert list/data.frames to data.tables by reference or as.data.table() to convert to data.tables by copying.")
   maxgap = as.integer(maxgap); minoverlap = as.integer(minoverlap)
@@ -72,14 +72,14 @@ foverlaps <- function(x, y, by.x=if (!is.null(key(x))) key(x) else key(y), by.y=
     } else stop("All entries in column ", yintervals[1L], " should be <= corresponding entries in column ", yintervals[2L], " in data.table 'y'.")
   }
   # POSIXct interval cols error check
-  is.POSIXct <- function(x) inherits(x, "POSIXct")
-  posx_chk <- c(is.POSIXct(xval1), is.POSIXct(xval2), is.POSIXct(yval1), is.POSIXct(yval2))
+  is.POSIXct = function(x) inherits(x, "POSIXct")
+  posx_chk = c(is.POSIXct(xval1), is.POSIXct(xval2), is.POSIXct(yval1), is.POSIXct(yval2))
   if (any(posx_chk) && !all(posx_chk)) {
     stop("Some interval cols are of type POSIXct while others are not. Please ensure all interval cols are (or are not) of POSIXct type")
   }
   # #1143, mismatched timezone
-  getTZ <- function(x) if (is.null(tz <- attr(x, "tzone"))) "" else tz # "" == NULL AFAICT
-  tzone_chk <- c(getTZ(xval1), getTZ(xval2), getTZ(yval1), getTZ(yval2))
+  getTZ = function(x) if (is.null(tz <- attr(x, "tzone"))) "" else tz # "" == NULL AFAICT
+  tzone_chk = c(getTZ(xval1), getTZ(xval2), getTZ(yval1), getTZ(yval2))
   if (any(tzone_chk != tzone_chk[1L])) {
     warning("POSIXct interval cols have mixed timezones. Overlaps are performed on the internal numerical representation of POSIXct objects, therefore printed values may give the impression that values don't overlap but their internal representations will. Please ensure that POSIXct type interval cols have identical 'tzone' attributes to avoid confusion.")
   }
@@ -88,7 +88,7 @@ foverlaps <- function(x, y, by.x=if (!is.null(key(x))) key(x) else key(y), by.y=
   isdouble = FALSE; isposix = FALSE
   if ( any(c("numeric", "POSIXct") %chin% yclass) ) {
     # next representive double > x under the given precision (48,56 or 64-bit in data.table) = x*incr
-    dt_eps <- function() {
+    dt_eps = function() {
       bits = floor(log2(.Machine$double.eps))
       2 ^ (bits + (getNumericRounding() * 8L))
     }
@@ -99,13 +99,13 @@ foverlaps <- function(x, y, by.x=if (!is.null(key(x))) key(x) else key(y), by.y=
   origx = x; x = shallow(x, by.x)
   origy = y; y = shallow(y, by.y)
   roll = switch(type, start=, end=, equal= 0.0, any=, within= +Inf)
-  make_call <- function(names, fun=NULL) {
+  make_call = function(names, fun=NULL) {
     if (is.character(names))
       names = lapply(names, as.name)
     call = c(substitute(fun, list(fun=fun)), names)
     if (!is.null(fun)) as.call(call) else call
   }
-  construct <- function(icols, mcols, type=type) {
+  construct = function(icols, mcols, type=type) {
     icall = make_call(icols)
     setattr(icall, 'names', icols)
     mcall = make_call(mcols, quote(c))
@@ -132,14 +132,14 @@ foverlaps <- function(x, y, by.x=if (!is.null(key(x))) key(x) else key(y), by.y=
   uy = unique(y[, eval(call)])
   setkey(uy)[, `:=`(lookup = list(list(integer(0L))), type_lookup = list(list(integer(0L))), count=0L, type_count=0L)]
   if (verbose) {cat(timetaken(last.started.at),"\n"); flush.console()}
-  matches <- function(ii, xx, del, ...) {
+  matches = function(ii, xx, del, ...) {
     cols = setdiff(names(xx), del)
     xx = .shallow(xx, cols, retain.key = TRUE)
     ans = bmerge(xx, ii, seq_along(xx), seq_along(xx), mult=mult, ops=rep(1L, length(xx)), verbose=verbose, ...)
     # vecseq part should never run here, but still...
     if (ans$allLen1) ans$starts else vecseq(ans$starts, ans$lens, NULL) # nocov
   }
-  indices <- function(x, y, intervals, ...) {
+  indices = function(x, y, intervals, ...) {
     if (type == "start") {
       sidx = eidx = matches(x, y, intervals[2L], rollends=c(FALSE,FALSE), ...) ## TODO: eidx can be set to integer(0L)
     } else if (type == "end") {

--- a/R/frank.R
+++ b/R/frank.R
@@ -1,4 +1,4 @@
-frankv <- function(x, cols=seq_along(x), order=1L, na.last=TRUE, ties.method=c("average", "first", "random", "max", "min", "dense")) {
+frankv = function(x, cols=seq_along(x), order=1L, na.last=TRUE, ties.method=c("average", "first", "random", "max", "min", "dense")) {
   ties.method = match.arg(ties.method)
   if (!length(na.last)) stop('length(na.last) = 0')
   if (length(na.last) != 1L) {
@@ -7,7 +7,7 @@ frankv <- function(x, cols=seq_along(x), order=1L, na.last=TRUE, ties.method=c("
   }
   keep = (na.last == "keep")
   na.last = as.logical(na.last)
-  as_list <- function(x) {
+  as_list = function(x) {
     xx = vector("list", 1L)
     .Call(Csetlistelt, xx, 1L, x)
     xx
@@ -67,7 +67,7 @@ frankv <- function(x, cols=seq_along(x), order=1L, na.last=TRUE, ties.method=c("
   ans
 }
 
-frank <- function(x, ..., na.last=TRUE, ties.method=c("average", "first", "random", "max", "min", "dense")) {
+frank = function(x, ..., na.last=TRUE, ties.method=c("average", "first", "random", "max", "min", "dense")) {
   cols = substitute(list(...))[-1L]
   if (identical(as.character(cols), "NULL")) {
     cols  = NULL

--- a/R/fread.R
+++ b/R/fread.R
@@ -1,4 +1,4 @@
-fread <- function(
+fread = function(
 input="", file=NULL, text=NULL, cmd=NULL, sep="auto", sep2="auto", dec=".", quote="\"", nrows=Inf, header="auto",
 na.strings=getOption("datatable.na.strings","NA"), stringsAsFactors=FALSE, verbose=getOption("datatable.verbose",FALSE),
 skip="__auto__", select=NULL, drop=NULL, colClasses=NULL, integer64=getOption("datatable.integer64","integer64"),
@@ -287,9 +287,9 @@ yaml=FALSE, autostart=NA)
 
   colClassesAs = attr(ans, "colClassesAs")   # should only be present if one or more are != ""
   for (j in which(colClassesAs!="")) {       # # 1634
-    v <- .subset2(ans, j)
+    v = .subset2(ans, j)
     new_class = colClassesAs[j]
-    new_v <- tryCatch({    # different to read.csv; i.e. won't error if a column won't coerce (fallback with warning instead)
+    new_v = tryCatch({    # different to read.csv; i.e. won't error if a column won't coerce (fallback with warning instead)
       switch(new_class,
              "factor" = as_factor(v),
              "complex" = as.complex(v),
@@ -311,10 +311,10 @@ yaml=FALSE, autostart=NA)
 
   if (stringsAsFactors) {
     if (is.double(stringsAsFactors)) { #2025
-      should_be_factor <- function(v) is.character(v) && uniqueN(v) < nr * stringsAsFactors
-      cols_to_factor <- which(vapply(ans, should_be_factor, logical(1L)))
+      should_be_factor = function(v) is.character(v) && uniqueN(v) < nr * stringsAsFactors
+      cols_to_factor = which(vapply(ans, should_be_factor, logical(1L)))
     } else {
-      cols_to_factor <- which(vapply(ans, is.character, logical(1L)))
+      cols_to_factor = which(vapply(ans, is.character, logical(1L)))
     }
     if (verbose) cat("stringsAsFactors=", stringsAsFactors, " converted ", length(cols_to_factor), " column(s): ", brackify(names(ans)[cols_to_factor]), "\n", sep="")
     for (j in cols_to_factor) set(ans, j=j, value=as_factor(.subset2(ans, j)))
@@ -350,7 +350,7 @@ yaml=FALSE, autostart=NA)
 }
 
 # simplified but faster version of `factor()` for internal use.
-as_factor <- function(x) {
+as_factor = function(x) {
   lev = forderv(x, retGrp = TRUE, na.last = NA)
   # get levels, also take care of all sorted condition
   lev = if (length(lev)) x[lev[attributes(lev)$starts]] else x[attributes(lev)$starts]
@@ -359,7 +359,7 @@ as_factor <- function(x) {
   setattr(ans, 'class', 'factor')
 }
 
-as_raw <- function(x) {
+as_raw = function(x) {
   scan(text=x, what=raw(), quiet=TRUE)  # as in read.csv, which ultimately uses src/main/scan.c and strtoraw
 }
 

--- a/R/froll.R
+++ b/R/froll.R
@@ -1,4 +1,4 @@
-froll <- function(fun, x, n, fill=NA, algo=c("fast", "exact"), align=c("right", "left", "center"), na.rm=FALSE, hasNA=NA, adaptive=FALSE, verbose=getOption("datatable.verbose")) {
+froll = function(fun, x, n, fill=NA, algo=c("fast", "exact"), align=c("right", "left", "center"), na.rm=FALSE, hasNA=NA, adaptive=FALSE, verbose=getOption("datatable.verbose")) {
   stopifnot(!missing(fun), is.character(fun), length(fun)==1L, !is.na(fun))
   algo = match.arg(algo)
   align = match.arg(align)
@@ -6,6 +6,6 @@ froll <- function(fun, x, n, fill=NA, algo=c("fast", "exact"), align=c("right", 
   ans
 }
 
-frollmean <- function(x, n, fill=NA, algo=c("fast", "exact"), align=c("right", "left", "center"), na.rm=FALSE, hasNA=NA, adaptive=FALSE, verbose=getOption("datatable.verbose")) {
+frollmean = function(x, n, fill=NA, algo=c("fast", "exact"), align=c("right", "left", "center"), na.rm=FALSE, hasNA=NA, adaptive=FALSE, verbose=getOption("datatable.verbose")) {
   froll(fun="mean", x=x, n=n, fill=fill, algo=algo, align=align, na.rm=na.rm, hasNA=hasNA, adaptive=adaptive, verbose=verbose)
 }

--- a/R/fwrite.R
+++ b/R/fwrite.R
@@ -1,4 +1,4 @@
-fwrite <- function(x, file="", append=FALSE, quote="auto",
+fwrite = function(x, file="", append=FALSE, quote="auto",
            sep=",", sep2=c("","|",""), eol=if (.Platform$OS.type=="windows") "\r\n" else "\n",
            na="", dec=".", row.names=FALSE, col.names=TRUE,
            qmethod=c("double","escape"),

--- a/R/getdots.R
+++ b/R/getdots.R
@@ -1,7 +1,7 @@
 ## NOTE: this has problems when '...' contains quoted names that have special symbols
 ## for a better option see the logic in setkey
 
-getdots <- function()
+getdots = function()
 {
   # return a string vector of the arguments in '...'
   # My long winded way: gsub(" ","",unlist(strsplit(deparse(substitute(list(...))),"[(,)]")))[-1]

--- a/R/groupingsets.R
+++ b/R/groupingsets.R
@@ -94,7 +94,7 @@ groupingsets.data.table = function(x, j, by, sets, .SDcols, id = FALSE, jj, ...)
   int64.cols = vapply(empty, inherits, logical(1L), "integer64")
   int64.cols = names(int64.cols)[int64.cols]
   if (length(int64.cols) && !requireNamespace("bit64", quietly=TRUE))
-    stop("Using integer64 class columns require to have 'bit64' package installed.")
+    stop("Using integer64 class columns require to have 'bit64' package installed.") # nocov
   int64.by.cols = intersect(int64.cols, by)
   # aggregate function called for each grouping set
   aggregate.set = function(by.set) {

--- a/R/groupingsets.R
+++ b/R/groupingsets.R
@@ -1,7 +1,7 @@
-rollup <- function(x, ...) {
+rollup = function(x, ...) {
   UseMethod("rollup")
 }
-rollup.data.table <- function(x, j, by, .SDcols, id = FALSE, ...) {
+rollup.data.table = function(x, j, by, .SDcols, id = FALSE, ...) {
   # input data type basic validation
   if (!is.data.table(x))
     stop("Argument 'x' must be a data.table object")
@@ -16,10 +16,10 @@ rollup.data.table <- function(x, j, by, .SDcols, id = FALSE, ...) {
   groupingsets.data.table(x, by=by, sets=sets, .SDcols=.SDcols, id=id, jj=jj)
 }
 
-cube <- function(x, ...) {
+cube = function(x, ...) {
   UseMethod("cube")
 }
-cube.data.table <- function(x, j, by, .SDcols, id = FALSE, ...) {
+cube.data.table = function(x, j, by, .SDcols, id = FALSE, ...) {
   # input data type basic validation
   if (!is.data.table(x))
     stop("Argument 'x' must be a data.table object")
@@ -36,10 +36,10 @@ cube.data.table <- function(x, j, by, .SDcols, id = FALSE, ...) {
   groupingsets.data.table(x, by=by, sets=sets, .SDcols=.SDcols, id=id, jj=jj)
 }
 
-groupingsets <- function(x, ...) {
+groupingsets = function(x, ...) {
   UseMethod("groupingsets")
 }
-groupingsets.data.table <- function(x, j, by, sets, .SDcols, id = FALSE, jj, ...) {
+groupingsets.data.table = function(x, j, by, sets, .SDcols, id = FALSE, jj, ...) {
   # input data type basic validation
   if (!is.data.table(x))
     stop("Argument 'x' must be a data.table object")
@@ -97,7 +97,7 @@ groupingsets.data.table <- function(x, j, by, sets, .SDcols, id = FALSE, jj, ...
     stop("Using integer64 class columns require to have 'bit64' package installed.")
   int64.by.cols = intersect(int64.cols, by)
   # aggregate function called for each grouping set
-  aggregate.set <- function(by.set) {
+  aggregate.set = function(by.set) {
     if (length(by.set)) {
       r = if (length(.SDcols)) x[, eval(jj), by.set, .SDcols=.SDcols] else x[, eval(jj), by.set]
     } else {

--- a/R/last.R
+++ b/R/last.R
@@ -3,7 +3,7 @@
 # This last is implemented this way for compatibility with xts::last which is S3 generic taking 'n' and 'keep' arguments
 # We'd like last() on vectors to be fast, so that's a direct x[NROW(x)] as it was in data.table, otherwise use xts's.
 # If xts is loaded higher than data.table, xts::last will work but slower.
-last <- function(x, ...) {
+last = function(x, ...) {
   if (nargs()==1L) {
     if (is.vector(x)) {
       if (!length(x)) return(x) else return(x[[length(x)]])  # for vectors, [[ works like [
@@ -20,7 +20,7 @@ last <- function(x, ...) {
 }
 
 # first(), similar to last(), not sure why this wasn't exported in the first place...
-first <- function(x, ...) {
+first = function(x, ...) {
   if (nargs()==1L) {
     if (is.vector(x)) {
       if (!length(x)) return(x) else return(x[[1L]])

--- a/R/like.R
+++ b/R/like.R
@@ -1,7 +1,7 @@
 # Intended for use with a data.table 'where'
 # Don't use * or % like SQL's like.  Uses regexpr syntax - more powerful.
 # returns 'logical' so can be combined with other where clauses.
-like <- function(vector, pattern, ignore.case = FALSE, fixed = FALSE) {
+like = function(vector, pattern, ignore.case = FALSE, fixed = FALSE) {
   if (is.factor(vector)) {
     as.integer(vector) %in% grep(pattern, levels(vector), ignore.case = ignore.case, fixed = fixed)
   } else {

--- a/R/merge.R
+++ b/R/merge.R
@@ -1,4 +1,4 @@
-merge.data.table <- function(x, y, by = NULL, by.x = NULL, by.y = NULL, all = FALSE, all.x = all,
+merge.data.table = function(x, y, by = NULL, by.x = NULL, by.y = NULL, all = FALSE, all.x = all,
                all.y = all, sort = TRUE, suffixes = c(".x", ".y"), no.dups = TRUE, allow.cartesian=getOption("datatable.allow.cartesian"), ...) {
   if (!sort %in% c(TRUE, FALSE))
     stop("Argument 'sort' should be logical TRUE/FALSE")
@@ -89,7 +89,7 @@ merge.data.table <- function(x, y, by = NULL, by.x = NULL, by.y = NULL, all = FA
 
   # Throw warning if there are duplicate column names in 'dt' (i.e. if
   # `suffixes=c("","")`, to match behaviour in base:::merge.data.frame)
-  resultdupnames <- names(dt)[duplicated(names(dt))]
+  resultdupnames = names(dt)[duplicated(names(dt))]
   if (length(resultdupnames)) {
     warning("column names ", paste0("'", resultdupnames, "'", collapse=", "),
             " are duplicated in the result")

--- a/R/onAttach.R
+++ b/R/onAttach.R
@@ -1,6 +1,6 @@
 # nocov start
 
-.onAttach <- function(libname, pkgname) {
+.onAttach = function(libname, pkgname) {
   # Runs when attached to search() path such as by library() or require()
   if (!interactive()) return()
   v = packageVersion("data.table")

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -1,8 +1,8 @@
 # nocov start
 
-.Last.updated <- vector("integer", 1L) # exported variable; number of rows updated by the last := or set(), #1885
+.Last.updated = vector("integer", 1L) # exported variable; number of rows updated by the last := or set(), #1885
 
-.onLoad <- function(libname, pkgname) {
+.onLoad = function(libname, pkgname) {
   # Runs when loaded but not attached to search() path; e.g., when a package just Imports (not Depends on) data.table
   if (!exists("test.data.table", .GlobalEnv, inherits=FALSE) &&    # check when installed package is loaded but skip when developing the package with cc()
       (dllV<-if(is.loaded("CdllVersion",PACKAGE="datatable")).Call(CdllVersion)else"before 1.12.0") != (RV<-packageVersion("data.table"))) {
@@ -100,13 +100,13 @@
   invisible()
 }
 
-getRversion <- function(...) stop("Reminder to data.table developers: don't use getRversion() internally. Add a behaviour test to .onLoad instead.")
+getRversion = function(...) stop("Reminder to data.table developers: don't use getRversion() internally. Add a behaviour test to .onLoad instead.")
 # 1) using getRversion() wasted time when R3.0.3beta was released without the changes we expected in getRversion()>"3.0.2".
 # 2) R-devel and ourselves may wish to tinker with R-devel, turning on and off features in the same version number. So it's better if data.table doesn't hard code expectations into the version number.
 # 3) The discipline of adding a feaure test here helps fully understand the change.
 # 4) Defining getRversion with a stop() here helps prevent new switches on getRversion() being added in future. Easily circumvented but the point is to issue the message above.
 
-.onUnload <- function(libpath) {
+.onUnload = function(libpath) {
   # fix for #474. the shared object name is different from package name
   # So 'detach' doesn't find datatable.so, as it looks by default for data.table.so
   library.dynam.unload("datatable", libpath)

--- a/R/openmp-utils.R
+++ b/R/openmp-utils.R
@@ -1,4 +1,4 @@
-setDTthreads <- function(threads=NULL, restore_after_fork=NULL, percent=NULL) {
+setDTthreads = function(threads=NULL, restore_after_fork=NULL, percent=NULL) {
   if (!missing(percent)) {
     if (!missing(threads)) stop("Provide either threads= or percent= but not both")
     if (length(percent)!=1) stop("percent= is provided but is length ", length(percent))
@@ -10,7 +10,7 @@ setDTthreads <- function(threads=NULL, restore_after_fork=NULL, percent=NULL) {
   }
 }
 
-getDTthreads <- function(verbose=getOption("datatable.verbose")) {
+getDTthreads = function(verbose=getOption("datatable.verbose")) {
   .Call(CgetDTthreads, verbose)
 }
 

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -1,6 +1,6 @@
 # Moved here out from data.table.R on 10 Aug 2017. See data.table.R for history prior to that.
 
-print.data.table <- function(x, topn=getOption("datatable.print.topn"),
+print.data.table = function(x, topn=getOption("datatable.print.topn"),
                nrows=getOption("datatable.print.nrows"),
                class=getOption("datatable.print.class"),
                row.names=getOption("datatable.print.rownames"),
@@ -23,7 +23,7 @@ print.data.table <- function(x, topn=getOption("datatable.print.topn"),
     # This applies just at the prompt. Inside functions, print(DT) will of course print.
     # Other options investigated (could revisit): Cstack_info(), .Last.value gets set first before autoprint, history(), sys.status(),
     #   topenv(), inspecting next statement in caller, using clock() at C level to timeout suppression after some number of cycles
-    SYS <- sys.calls()
+    SYS = sys.calls()
     if (length(SYS) <= 2L ||  # "> DT" auto-print or "> print(DT)" explicit print (cannot distinguish from R 3.2.0 but that's ok)
         ( length(SYS) >= 3L && is.symbol(thisSYS <- SYS[[length(SYS)-2L]][[1L]]) &&
           as.character(thisSYS) == 'source') || # suppress printing from source(echo = TRUE) calls, #2369
@@ -111,11 +111,11 @@ print.data.table <- function(x, topn=getOption("datatable.print.topn"),
   invisible(x)
 }
 
-format.data.table <- function (x, ..., justify="none", timezone = FALSE) {
+format.data.table = function (x, ..., justify="none", timezone = FALSE) {
   if (is.atomic(x) && !is.null(x)) {
     stop("Internal structure doesn't seem to be a list. Possibly corrupt data.table.")
   }
-  format.item <- function(x) {
+  format.item = function(x) {
     if (is.null(x))  # NULL item in a list column
       ""
     else if (is.atomic(x) || inherits(x,"formula")) # FR #2591 - format.data.table issue with columns of class "formula"
@@ -124,7 +124,7 @@ format.data.table <- function (x, ..., justify="none", timezone = FALSE) {
       paste0("<", class(x)[1L], ">")
   }
   # FR #2842 add timezone for posix timestamps
-  format.timezone <- function(col) { # paste timezone to a time object
+  format.timezone = function(col) { # paste timezone to a time object
     tz = attr(col,'tzone', exact = TRUE)
     if (!is.null(tz)) { # date object with tz
       nas = is.na(col)
@@ -135,7 +135,7 @@ format.data.table <- function (x, ..., justify="none", timezone = FALSE) {
   }
   # FR #1091 for pretty printing of character
   # TODO: maybe instead of doing "this is...", we could do "this ... test"?
-  char.trunc <- function(x, trunc.char = getOption("datatable.prettyprint.char")) {
+  char.trunc = function(x, trunc.char = getOption("datatable.prettyprint.char")) {
     trunc.char = max(0L, suppressWarnings(as.integer(trunc.char[1L])), na.rm=TRUE)
     if (!is.character(x) || trunc.char <= 0L) return(x)
     idx = which(nchar(x) > trunc.char)

--- a/R/setkey.R
+++ b/R/setkey.R
@@ -1,4 +1,4 @@
-setkey <- function(x, ..., verbose=getOption("datatable.verbose"), physical=TRUE)
+setkey = function(x, ..., verbose=getOption("datatable.verbose"), physical=TRUE)
 {
   if (is.character(x)) stop("x may no longer be the character name of the data.table. The possibility was undocumented and has been removed.")
   cols = as.character(substitute(list(...))[-1L])
@@ -8,8 +8,8 @@ setkey <- function(x, ..., verbose=getOption("datatable.verbose"), physical=TRUE
 }
 
 # FR #1442
-setindex <- function(...) setkey(..., physical=FALSE)
-setindexv <- function(x, cols, verbose=getOption("datatable.verbose")) {
+setindex = function(...) setkey(..., physical=FALSE)
+setindexv = function(x, cols, verbose=getOption("datatable.verbose")) {
   if (is.list(cols)) {
     sapply(cols, setkeyv, x=x, verbose=verbose, physical=FALSE)
     return(invisible(x))
@@ -19,22 +19,22 @@ setindexv <- function(x, cols, verbose=getOption("datatable.verbose")) {
 }
 
 # remove these 3 after May 2019; see discussion in #3399 and notes in v1.12.2. They were marked experimental after all.
-set2key <- function(...)  stop("set2key() is now deprecated. Please use setindex() instead.")
-set2keyv <- function(...) stop("set2keyv() is now deprecated. Please use setindexv() instead.")
-key2 <- function(...)     stop("key2() is now deprecated. Please use indices() instead.")
+set2key = function(...)  stop("set2key() is now deprecated. Please use setindex() instead.")
+set2keyv = function(...) stop("set2keyv() is now deprecated. Please use setindexv() instead.")
+key2 = function(...)     stop("key2() is now deprecated. Please use indices() instead.")
 
 # upgrade to error after Mar 2020. Has already been warning since 2012, and stronger warning in Mar 2019 (note in news for 1.12.2); #3399
 "key<-" <- function(x,value) {
   warning("key(x)<-value is deprecated and not supported. Please change to use setkey() with perhaps copy(). Has been warning since 2012 and will be an error in future.")
   setkeyv(x,value)
-  # The returned value here from key<- is then copied by R before assigning to x, it seems. That's
+  # The returned value here from key= is then copied by R before assigning to x, it seems. That's
   # why we can't do anything about it without a change in R itself. If we return NULL (or invisible()) from this key<-
   # method, the table gets set to NULL. So, although we call setkeyv(x,cols) here, and that doesn't copy, the
   # returned value (x) then gets copied by R.
-  # So, solution is that caller has to call setkey or setkeyv directly themselves, to avoid <- dispatch and its copy.
+  # So, solution is that caller has to call setkey or setkeyv directly themselves, to avoid = dispatch and its copy.
 }
 
-setkeyv <- function(x, cols, verbose=getOption("datatable.verbose"), physical=TRUE)
+setkeyv = function(x, cols, verbose=getOption("datatable.verbose"), physical=TRUE)
 {
   if (is.null(cols)) {   # this is done on a data.frame when !cedta at top of [.data.table
     if (physical) setattr(x,"sorted",NULL)
@@ -55,7 +55,7 @@ setkeyv <- function(x, cols, verbose=getOption("datatable.verbose"), physical=TR
     cols = colnames(x)   # All columns in the data.table, usually a few when used in this form
   } else {
     # remove backticks from cols
-    cols <- gsub("`", "", cols, fixed = TRUE)
+    cols = gsub("`", "", cols, fixed = TRUE)
     miss = !(cols %chin% colnames(x))
     if (any(miss)) stop("some columns are not in the data.table: ", paste(cols[miss], collapse=","))
   }
@@ -91,7 +91,7 @@ setkeyv <- function(x, cols, verbose=getOption("datatable.verbose"), physical=TR
     # suppress needed for tests 644 and 645 in verbose mode
     cat("forder took", tt["user.self"]+tt["sys.self"], "sec\n")
   } else {
-    o <- forderv(x, cols, sort=TRUE, retGrp=FALSE)
+    o = forderv(x, cols, sort=TRUE, retGrp=FALSE)
   }
   if (!physical) {
     if (is.null(attr(x,"index",exact=TRUE))) setattr(x, "index", integer())
@@ -113,18 +113,18 @@ setkeyv <- function(x, cols, verbose=getOption("datatable.verbose"), physical=TR
   invisible(x)
 }
 
-key <- function(x) attr(x,"sorted",exact=TRUE)
+key = function(x) attr(x,"sorted",exact=TRUE)
 
-indices <- function(x, vectors = FALSE) {
+indices = function(x, vectors = FALSE) {
   ans = names(attributes(attr(x,"index",exact=TRUE)))
   if (is.null(ans)) return(ans) # otherwise character() gets returned by next line
-  ans <- gsub("^__","",ans)     # the leading __ is internal only, so remove that in result
+  ans = gsub("^__","",ans)     # the leading __ is internal only, so remove that in result
   if (isTRUE(vectors))
-    ans <- strsplit(ans, "__", fixed = TRUE)
+    ans = strsplit(ans, "__", fixed = TRUE)
   ans
 }
 
-getindex <- function(x, name) {
+getindex = function(x, name) {
   # name can be "col", or "col1__col2", or c("col1","col2")
   ans = attr(attr(x, 'index'), paste0("__",name,collapse=""), exact=TRUE)
   if (!is.null(ans) && (!is.integer(ans) || (length(ans)!=nrow(x) && length(ans)!=0L))) {
@@ -133,18 +133,18 @@ getindex <- function(x, name) {
   ans
 }
 
-haskey <- function(x) !is.null(key(x))
+haskey = function(x) !is.null(key(x))
 
 # reverse a vector by reference (no copy)
-setrev <- function(x) .Call(Csetrev, x)
+setrev = function(x) .Call(Csetrev, x)
 
 # reorder a vector based on 'order' (integer)
 # to be used in fastorder instead of x[o], but in general, it's better to replace vector subsetting with this..?
 # Basic checks that all items of order are in range 1:n with no NAs are now made inside Creorder.
 # FOR INTERNAL USE ONLY
-setreordervec <- function(x, order) .Call(Creorder, x, order)
+setreordervec = function(x, order) .Call(Creorder, x, order)
 
-# sort = sort.int = sort.list = order = is.unsorted <- function(...)
+# sort = sort.int = sort.list = order = is.unsorted = function(...)
 #    stop("Should never be called by data.table internals. Use is.sorted() on vectors, or forder() for lists and vectors.")
 # Nice idea, but users might use these in i or j e.g. blocking order caused tests 304 to fail.
 # Maybe just a grep through *.R for use of these function internally would be better (TO DO).
@@ -158,7 +158,7 @@ setreordervec <- function(x, order) .Call(Creorder, x, order)
 # The others (order, sort.int etc) are turned off to protect ourselves from using them internally, for speed and for
 # consistency; e.g., consistent twiddling of numeric/integer64, NA at the beginning of integer, locale ordering of character vectors.
 
-is.sorted <- function(x, by=seq_along(x)) {
+is.sorted = function(x, by=seq_along(x)) {
   if (is.list(x)) {
     warning("Use 'if (length(o<-forderv(DT,by))) ...' for efficiency in one step, so you have o as well if not sorted.")
     # could pass through a flag for forderv to return early on first FALSE. But we don't need that internally
@@ -174,7 +174,7 @@ is.sorted <- function(x, by=seq_along(x)) {
   # Important to call forder.c::fsorted here, for consistent character ordering and numeric/integer64 twiddling.
 }
 
-forderv <- function(x, by=seq_along(x), retGrp=FALSE, sort=TRUE, order=1L, na.last=FALSE)
+forderv = function(x, by=seq_along(x), retGrp=FALSE, sort=TRUE, order=1L, na.last=FALSE)
 {
   if (!(sort || retGrp)) stop("At least one of retGrp or sort must be TRUE")
   na.last = as.logical(na.last)
@@ -209,7 +209,7 @@ forderv <- function(x, by=seq_along(x), retGrp=FALSE, sort=TRUE, order=1L, na.la
   .Call(Cforder, x, by, retGrp, sort, order, na.last)  # returns integer() if already sorted, regardless of sort=TRUE|FALSE
 }
 
-forder <- function(x, ..., na.last=TRUE, decreasing=FALSE)
+forder = function(x, ..., na.last=TRUE, decreasing=FALSE)
 {
   if (!is.data.table(x)) stop("x must be a data.table.")
   if (ncol(x) == 0L) stop("Attempting to order a 0-column data.table.")
@@ -234,11 +234,11 @@ forder <- function(x, ..., na.last=TRUE, decreasing=FALSE)
         v = v[[-1L]]
       }
       if (is.name(v)) {
-        ix <- chmatch(as.character(v), xcols, nomatch=0L)
+        ix = chmatch(as.character(v), xcols, nomatch=0L)
         if (ix != 0L) ans <- point(ans, i, x, ix) # see 'point' in data.table.R and C-version pointWrapper in assign.c - avoid copies
         else {
           v = as.call(list(as.name("list"), v))
-          ans <- point(ans, i, eval(v, x, parent.frame()), 1L)
+          ans = point(ans, i, eval(v, x, parent.frame()), 1L)
         }
       } else {
         if (!is.object(eval(v, x, parent.frame()))) {
@@ -255,9 +255,9 @@ forder <- function(x, ..., na.last=TRUE, decreasing=FALSE)
   o
 }
 
-fsort <- function(x, decreasing=FALSE, na.last=FALSE, internal=FALSE, verbose=FALSE, ...)
+fsort = function(x, decreasing=FALSE, na.last=FALSE, internal=FALSE, verbose=FALSE, ...)
 {
-  containsNAs <- FALSE
+  containsNAs = FALSE
   if (typeof(x)=="double" && !decreasing && !(containsNAs<-anyNA(x))) {
       if (internal) stop("Internal code should not be being called on type double")
       return(.Call(Cfsort, x, verbose))
@@ -277,7 +277,7 @@ fsort <- function(x, decreasing=FALSE, na.last=FALSE, internal=FALSE, verbose=FA
   }
 }
 
-setorder <- function(x, ..., na.last=FALSE)
+setorder = function(x, ..., na.last=FALSE)
 # na.last=FALSE here, to be consistent with data.table's default
 # as opposed to DT[order(.)] where na.last=TRUE, to be consistent with base
 {
@@ -304,7 +304,7 @@ setorder <- function(x, ..., na.last=FALSE)
   setorderv(x, cols, order, na.last)
 }
 
-setorderv <- function(x, cols = colnames(x), order=1L, na.last=FALSE)
+setorderv = function(x, cols = colnames(x), order=1L, na.last=FALSE)
 {
   if (is.null(cols)) return(x)
   if (!is.data.frame(x)) stop("x must be a data.frame or data.table")
@@ -317,7 +317,7 @@ setorderv <- function(x, cols = colnames(x), order=1L, na.last=FALSE)
   }
   if (!all(nzchar(cols))) stop("cols contains some blanks.")     # TODO: probably I'm checking more than necessary here.. there are checks in 'forderv' as well
   # remove backticks from cols
-  cols <- gsub("`", "", cols, fixed = TRUE)
+  cols = gsub("`", "", cols, fixed = TRUE)
   miss = !(cols %chin% colnames(x))
   if (any(miss)) stop("some columns are not in the data.table: ", paste(cols[miss], collapse=","))
   if (".xi" %chin% colnames(x)) stop("x contains a column called '.xi'. Conflicts with internal use by data.table.")
@@ -341,12 +341,12 @@ setorderv <- function(x, cols = colnames(x), order=1L, na.last=FALSE)
   invisible(x)
 }
 
-binary <- function(x) .Call(Cbinary, x)
+binary = function(x) .Call(Cbinary, x)
 
-setNumericRounding <- function(x) {.Call(CsetNumericRounding, as.integer(x)); invisible()}
-getNumericRounding <- function() .Call(CgetNumericRounding)
+setNumericRounding = function(x) {.Call(CsetNumericRounding, as.integer(x)); invisible()}
+getNumericRounding = function() .Call(CgetNumericRounding)
 
-SJ <- function(...) {
+SJ = function(...) {
   JDT = as.data.table(list(...))
   setkey(JDT)
 }
@@ -354,17 +354,17 @@ SJ <- function(...) {
 
 # TO DO?: Use the CJ list() replication method for SJ (inside as.data.table.list?, #2109) too to avoid alloc.col
 
-CJ <- function(..., sorted = TRUE, unique = FALSE)
+CJ = function(..., sorted = TRUE, unique = FALSE)
 {
   # Pass in a list of unique values, e.g. ids and dates
   # Cross Join will then produce a join table with the combination of all values (cross product).
   # The last vector is varied the quickest in the table, so dates should be last for roll for example
   l = list(...)
-  emptyList <- FALSE ## fix for #2511
+  emptyList = FALSE ## fix for #2511
   if(any(sapply(l, length) == 0L)){
     ## at least one column is empty The whole thing will be empty in the end
-    emptyList <- TRUE
-    l <- lapply(l, "[", 0L)
+    emptyList = TRUE
+    l = lapply(l, "[", 0L)
   }
   if (unique && !emptyList) l = lapply(l, unique)
 
@@ -408,7 +408,7 @@ CJ <- function(..., sorted = TRUE, unique = FALSE)
   }
   setattr(l, "names", vnames)
 
-  l <- alloc.col(l)  # a tiny bit wasteful to over-allocate a fixed join table (column slots only), doing it anyway for consistency, and it's possible a user may wish to use SJ directly outside a join and would expect consistent over-allocation.
+  l = alloc.col(l)  # a tiny bit wasteful to over-allocate a fixed join table (column slots only), doing it anyway for consistency, and it's possible a user may wish to use SJ directly outside a join and would expect consistent over-allocation.
   if (sorted) {
     if (!dups) setattr(l, 'sorted', names(l))
     else setkey(l) # fix #1513

--- a/R/setkey.R
+++ b/R/setkey.R
@@ -394,7 +394,7 @@ CJ = function(..., sorted = TRUE, unique = FALSE)
       else
         l[[i]] = rep.int(rep.int(y, times = rep.int(x[i], n[i])), times = nrow/(x[i]*n[i]))
       if (!is.null(attribs[[i]])){
-        attributes(l[[i]]) <- attribs[[i]] # reset all attributes that were destroyed by rep.int
+        attributes(l[[i]]) = attribs[[i]] # reset all attributes that were destroyed by rep.int
       }
     }
   }

--- a/R/setkey.R
+++ b/R/setkey.R
@@ -27,11 +27,11 @@ key2 = function(...)     stop("key2() is now deprecated. Please use indices() in
 "key<-" = function(x,value) {
   warning("key(x)<-value is deprecated and not supported. Please change to use setkey() with perhaps copy(). Has been warning since 2012 and will be an error in future.")
   setkeyv(x,value)
-  # The returned value here from key= is then copied by R before assigning to x, it seems. That's
+  # The returned value here from key<- is then copied by R before assigning to x, it seems. That's
   # why we can't do anything about it without a change in R itself. If we return NULL (or invisible()) from this key<-
   # method, the table gets set to NULL. So, although we call setkeyv(x,cols) here, and that doesn't copy, the
   # returned value (x) then gets copied by R.
-  # So, solution is that caller has to call setkey or setkeyv directly themselves, to avoid = dispatch and its copy.
+  # So, solution is that caller has to call setkey or setkeyv directly themselves, to avoid <- dispatch and its copy.
 }
 
 setkeyv = function(x, cols, verbose=getOption("datatable.verbose"), physical=TRUE)

--- a/R/setkey.R
+++ b/R/setkey.R
@@ -24,7 +24,7 @@ set2keyv = function(...) stop("set2keyv() is now deprecated. Please use setindex
 key2 = function(...)     stop("key2() is now deprecated. Please use indices() instead.")
 
 # upgrade to error after Mar 2020. Has already been warning since 2012, and stronger warning in Mar 2019 (note in news for 1.12.2); #3399
-"key<-" <- function(x,value) {
+"key<-" = function(x,value) {
   warning("key(x)<-value is deprecated and not supported. Please change to use setkey() with perhaps copy(). Has been warning since 2012 and will be an error in future.")
   setkeyv(x,value)
   # The returned value here from key= is then copied by R before assigning to x, it seems. That's

--- a/R/setops.R
+++ b/R/setops.R
@@ -3,7 +3,7 @@
 #   dt   [symbol] - a data.table
 # Iff all of 'cols' is present in 'x' return col indices
 # is.data.table(dt) check should be performed in the calling function
-validate <- function(cols, dt) {
+validate = function(cols, dt) {
   argcols = deparse(substitute(cols))
   argdt = deparse(substitute(dt))
   origcols = cols
@@ -17,7 +17,7 @@ validate <- function(cols, dt) {
 }
 
 # setdiff for data.tables, internal at the moment #547, used in not-join
-setdiff_ <- function(x, y, by.x=seq_along(x), by.y=seq_along(y), use.names=FALSE) {
+setdiff_ = function(x, y, by.x=seq_along(x), by.y=seq_along(y), use.names=FALSE) {
   if (!is.data.table(x) || !is.data.table(y)) stop("x and y must both be data.tables")
   # !ncol redundant since all 0-column data.tables have 0 rows
   if (!nrow(x)) return(x)
@@ -47,7 +47,7 @@ setdiff_ <- function(x, y, by.x=seq_along(x), by.y=seq_along(y), use.names=FALSE
 
 # set operators ----
 
-funique <- function(x) {
+funique = function(x) {
   stopifnot(is.data.table(x))
   dup = duplicated(x)
   if (any(dup)) .Call(CsubsetDT, x, which_(dup, FALSE), seq_along(x)) else x
@@ -67,7 +67,7 @@ funique <- function(x) {
   if (.seqn && ".seqn" %chin% names(x)) stop("None of the datasets should contain a column named '.seqn'")
 }
 
-fintersect <- function(x, y, all=FALSE) {
+fintersect = function(x, y, all=FALSE) {
   .set_ops_arg_check(x, y, all, .seqn = TRUE)
   if (!nrow(x) || !nrow(y)) return(x[0L])
   if (all) {
@@ -81,7 +81,7 @@ fintersect <- function(x, y, all=FALSE) {
   }
 }
 
-fsetdiff <- function(x, y, all=FALSE) {
+fsetdiff = function(x, y, all=FALSE) {
   .set_ops_arg_check(x, y, all, .seqn = TRUE)
   if (!nrow(x)) return(x)
   if (!nrow(y)) return(if (!all) funique(x) else x)
@@ -95,14 +95,14 @@ fsetdiff <- function(x, y, all=FALSE) {
   }
 }
 
-funion <- function(x, y, all=FALSE) {
+funion = function(x, y, all=FALSE) {
   .set_ops_arg_check(x, y, all, block_list = !all)
   ans = rbindlist(list(x, y))
   if (!all) ans = funique(ans)
   ans
 }
 
-fsetequal <- function(x, y, all=TRUE) {
+fsetequal = function(x, y, all=TRUE) {
   .set_ops_arg_check(x, y, all)
   if (!all) {
     x = funique(x)
@@ -113,7 +113,7 @@ fsetequal <- function(x, y, all=TRUE) {
 
 # all.equal ----
 
-all.equal.data.table <- function(target, current, trim.levels=TRUE, check.attributes=TRUE, ignore.col.order=FALSE, ignore.row.order=FALSE, tolerance=sqrt(.Machine$double.eps), ...) {
+all.equal.data.table = function(target, current, trim.levels=TRUE, check.attributes=TRUE, ignore.col.order=FALSE, ignore.row.order=FALSE, tolerance=sqrt(.Machine$double.eps), ...) {
   stopifnot(is.logical(trim.levels), is.logical(check.attributes), is.logical(ignore.col.order), is.logical(ignore.row.order), is.numeric(tolerance))
   if (!is.data.table(target) || !is.data.table(current)) stop("'target' and 'current' must both be data.tables")
 

--- a/R/shift.R
+++ b/R/shift.R
@@ -1,4 +1,4 @@
-shift <- function(x, n=1L, fill=NA, type=c("lag", "lead", "shift"), give.names=FALSE) {
+shift = function(x, n=1L, fill=NA, type=c("lag", "lead", "shift"), give.names=FALSE) {
   type = match.arg(type)
   stopifnot(is.numeric(n))
   ans = .Call(Cshift, x, as.integer(n), fill, type)

--- a/R/tables.R
+++ b/R/tables.R
@@ -1,7 +1,7 @@
 # globals to pass NOTE from R CMD check, see http://stackoverflow.com/questions/9439256
 MB = NCOL = NROW = NULL
 
-tables <- function(mb=TRUE, order.col="NAME", width=80,
+tables = function(mb=TRUE, order.col="NAME", width=80,
                    env=parent.frame(), silent=FALSE, index=FALSE)
 {
   # Prints name, size and colnames of all data.tables in the calling environment by default

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -161,7 +161,7 @@ test.data.table = function(verbose=FALSE, pkg="pkg", silent=FALSE, with.other.pa
   # date() is included so we can tell exactly when these tests ran on CRAN. Sometimes a CRAN log can show error but that can be just
   # stale due to not updating yet since a fix in R-devel, for example.
 
-  #attr(ans, "details") <- env
+  #attr(ans, "details") = env
   invisible(ans)
 }
 

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -1,4 +1,4 @@
-test.data.table <- function(verbose=FALSE, pkg="pkg", silent=FALSE, with.other.packages=FALSE, benchmark=FALSE, script="tests.Rraw") {
+test.data.table = function(verbose=FALSE, pkg="pkg", silent=FALSE, with.other.packages=FALSE, benchmark=FALSE, script="tests.Rraw") {
   if (exists("test.data.table", .GlobalEnv,inherits=FALSE)) {
     # package developer
     # nocov start
@@ -43,7 +43,7 @@ test.data.table <- function(verbose=FALSE, pkg="pkg", silent=FALSE, with.other.p
 
   # From R 3.6.0 onwards, we can check that && and || are using only length-1 logicals (in the test suite)
   # rather than relying on x && y being equivalent to x[[1L]] && y[[1L]]  silently.
-  orig__R_CHECK_LENGTH_1_LOGIC2_ <- Sys.getenv("_R_CHECK_LENGTH_1_LOGIC2_", unset = NA_character_)
+  orig__R_CHECK_LENGTH_1_LOGIC2_ = Sys.getenv("_R_CHECK_LENGTH_1_LOGIC2_", unset = NA_character_)
   Sys.setenv("_R_CHECK_LENGTH_1_LOGIC2_" = TRUE)
   # This environment variable is restored to its previous state (including not defined) after sourcing test script
 
@@ -166,7 +166,7 @@ test.data.table <- function(verbose=FALSE, pkg="pkg", silent=FALSE, with.other.p
 }
 
 # nocov start
-compactprint <- function(DT, topn=2L) {
+compactprint = function(DT, topn=2L) {
   tt = vapply_1c(DT,function(x)class(x)[1L])
   tt[tt=="integer64"] = "i64"
   tt = substring(tt, 1L, 3L)
@@ -205,7 +205,7 @@ gc_mem = function() {
   # nocov end
 }
 
-test <- function(num,x,y=TRUE,error=NULL,warning=NULL,output=NULL,message=NULL) {
+test = function(num,x,y=TRUE,error=NULL,warning=NULL,output=NULL,message=NULL) {
   # Usage:
   # i) tests that x equals y when both x and y are supplied, the most common usage
   # ii) tests that x is TRUE when y isn't supplied

--- a/R/timetaken.R
+++ b/R/timetaken.R
@@ -1,4 +1,4 @@
-timetaken <- function(started.at)
+timetaken = function(started.at)
 {
   if (!inherits(started.at,"proc_time")) stop("Use started.at=proc.time() not Sys.time() (POSIXt and slow)")  # nocov
   format = function(secs) {

--- a/R/transpose.R
+++ b/R/transpose.R
@@ -1,4 +1,4 @@
-transpose <- function(l, fill=NA, ignore.empty=FALSE) {
+transpose = function(l, fill=NA, ignore.empty=FALSE) {
   ans = .Call(Ctranspose, l, fill, ignore.empty)
   if (is.data.table(l)) setDT(ans)
   else if (is.data.frame(l)) {
@@ -10,7 +10,7 @@ transpose <- function(l, fill=NA, ignore.empty=FALSE) {
   ans[]
 }
 
-tstrsplit <- function(x, ..., fill=NA, type.convert=FALSE, keep, names=FALSE) {
+tstrsplit = function(x, ..., fill=NA, type.convert=FALSE, keep, names=FALSE) {
   ans = transpose(strsplit(as.character(x), ...), fill=fill, ignore.empty=FALSE)
   if (!missing(keep)) {
     keep = suppressWarnings(as.integer(keep))

--- a/R/uniqlist.R
+++ b/R/uniqlist.R
@@ -1,5 +1,5 @@
 
-uniqlist <- function (l, order = -1L)
+uniqlist = function (l, order = -1L)
 {
   # Assumes input list is ordered by each list item (or by 'order' if supplied), and that all list elements are the same length
   # Finds the non-duplicate rows. Was called duplist but now grows vector - doesn't over-allocate result vector and
@@ -11,14 +11,14 @@ uniqlist <- function (l, order = -1L)
   if (!is.list(l))
     stop("l not type list")
   if (!length(l))  return(list(0L))
-  ans <- .Call(Cuniqlist, l, as.integer(order))
+  ans = .Call(Cuniqlist, l, as.integer(order))
   ans
 }
 
 # implemented for returning the lengths of groups obtained from uniqlist (for internal use only)
-uniqlengths <- function(x, len) {
+uniqlengths = function(x, len) {
   # check for type happens in C, but still converting to integer here to be sure.
-  ans <- .Call(Cuniqlengths, as.integer(x), as.integer(len))
+  ans = .Call(Cuniqlengths, as.integer(x), as.integer(len))
   ans
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -10,15 +10,15 @@ if (base::getRversion() < "3.5.0") {
   isTRUE  = function(x) is.logical(x) && length(x)==1L && !is.na(x) && x    # backport R's new implementation of isTRUE
   isFALSE = function(x) is.logical(x) && length(x)==1L && !is.na(x) && !x   # backport isFALSE that was added in R 3.5.0
 }
-isTRUEorNA    <- function(x) is.logical(x) && length(x)==1L && (is.na(x) || x)
-isTRUEorFALSE <- function(x) is.logical(x) && length(x)==1L && !is.na(x)
+isTRUEorNA    = function(x) is.logical(x) && length(x)==1L && (is.na(x) || x)
+isTRUEorFALSE = function(x) is.logical(x) && length(x)==1L && !is.na(x)
 
 if (base::getRversion() < "3.2.0") {  # Apr 2015
   isNamespaceLoaded = function(x) x %chin% loadedNamespaces()
 }
 
 # which.first
-which.first <- function(x)
+which.first = function(x)
 {
   if (!is.logical(x)) {
     stop("x not boolean")
@@ -27,7 +27,7 @@ which.first <- function(x)
 }
 
 # which.last
-which.last <- function(x)
+which.last = function(x)
 {
   if (!is.logical(x)) {
     stop("x not boolean")
@@ -48,17 +48,17 @@ require_bit64_if_needed = function(DT) {
 }
 
 # vapply for return value character(1)
-vapply_1c <- function (x, fun, ..., use.names = TRUE) {
+vapply_1c = function (x, fun, ..., use.names = TRUE) {
   vapply(X = x, FUN = fun, ..., FUN.VALUE = NA_character_, USE.NAMES = use.names)
 }
 
 # vapply for return value logical(1)
-vapply_1b <- function (x, fun, ..., use.names = TRUE) {
+vapply_1b = function (x, fun, ..., use.names = TRUE) {
   vapply(X = x, FUN = fun, ..., FUN.VALUE = NA, USE.NAMES = use.names)
 }
 
 # vapply for return value integer(1)
-vapply_1i <- function (x, fun, ..., use.names = TRUE) {
+vapply_1i = function (x, fun, ..., use.names = TRUE) {
   vapply(X = x, FUN = fun, ..., FUN.VALUE = NA_integer_, USE.NAMES = use.names)
 }
 
@@ -66,8 +66,8 @@ more = function(f) system(paste("more",f))    # nocov  (just a dev helper)
 
 # helper used to auto-name columns in data.table(x,y) as c("x","y"), CJ(x,y) and similar
 # naming of unnested matrices still handled by data.table()
-name_dots <- function(...) {
-  dot_sub <- as.list(substitute(list(...)))[-1L]
+name_dots = function(...) {
+  dot_sub = as.list(substitute(list(...)))[-1L]
   vnames = names(dot_sub)
   if (is.null(vnames)) {
     vnames = rep.int("", length(dot_sub))

--- a/R/xts.R
+++ b/R/xts.R
@@ -1,4 +1,4 @@
-as.data.table.xts <- function(x, keep.rownames = TRUE, key=NULL, ...) {
+as.data.table.xts = function(x, keep.rownames = TRUE, key=NULL, ...) {
   stopifnot(requireNamespace("xts"), !missing(x), xts::is.xts(x))
   # as.data.frame.xts will handle copying, and
   #   the error check above ensures as.data.frame.xts is applied
@@ -12,7 +12,7 @@ as.data.table.xts <- function(x, keep.rownames = TRUE, key=NULL, ...) {
   r[]
 }
 
-as.xts.data.table <- function(x, ...) {
+as.xts.data.table = function(x, ...) {
   stopifnot(requireNamespace("xts"), !missing(x), is.data.table(x))
   if (!xts::is.timeBased(x[[1L]])) stop("data.table must have a time based column in first position, use `setcolorder` function to change the order, or see ?timeBased for supported types")
   colsNumeric = vapply_1b(x, is.numeric)[-1L] # exclude first col, xts index

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -29,6 +29,7 @@ if (exists("test.data.table", .GlobalEnv, inherits=FALSE)) {
   dcast.data.table = data.table:::dcast.data.table
   forder = data.table:::forder
   forderv = data.table:::forderv
+  format.data.table = data.table:::format.data.table
   getdots = data.table:::getdots
   groupingsets.data.table = data.table:::groupingsets.data.table
   guess = data.table:::guess
@@ -54,6 +55,7 @@ if (exists("test.data.table", .GlobalEnv, inherits=FALSE)) {
   which_ = data.table:::which_
   which.first = data.table:::which.first
   which.last = data.table:::which.last
+  `-.IDate` = data.table:::`-.IDate`
 
   # Also, for functions that are masked by other packages, we need to map the data.table one. Or else,
   # the other package's function would be picked up. As above, we only need to do this because we desire
@@ -8589,6 +8591,10 @@ setnames(x, '.seqn')
 setnames(y, '.seqn')
 test(1626.89, fintersect(x, y), error = "column named '.seqn'")
 
+# empty x shortout
+x = y = data.table(a = 1)
+test(1626.90, fsetdiff(x[0L], y), x[0L])
+
 
 # fix for #1087 and #1465
 test(1627.1, charToRaw(names(fread(testDir("issue_1087_utf8_bom.csv")))[1L]), as.raw(97L))
@@ -14872,6 +14878,9 @@ test(2046.10, as.data.table(tt, key="N"),
 test(2047.1, as.data.table(list(character(0L))), data.table(V1 = character(0L)))
 test(2047.2, as.data.table(list()), data.table(NULL))
 test(2047.3, as.data.table(rbind(1L)), data.table(V1 = 1L))
+mm = rbind(1:2)
+colnames(mm) = c('a', '')
+test(2047.4, as.data.table(mm), data.table(a = 1L, V2 = 2L))
 
 # recyle internal error; #3543
 DT = data.table(A=1:3, existingCol=list(0,1,2))
@@ -14899,6 +14908,23 @@ test(2050.3, rbind(DT[0], DT[1])[,levels(f)], c("a","b","c"))  # ok before
 test(2050.4, rbind(DT[0], DT[0])[,levels(f)], c("a","b","c"))  # now ok again (only when nrow=0 were unused levels dropped)
 test(2050.5, rbindlist(list(DT[0], DT[0]))[,levels(f)], c("a","b","c"))  # now ok again
 test(2050.6, rbind(DT[1], data.table(f=factor(letters[10:11]))[0])[,levels(f)], c("a","b","c","j","k")) # now includes "j","k" again
+
+# coverage tests
+## abusing -.Date, format.data.table, rleidv
+test(2051.1, `-.IDate`(.Date(0), 1L), .Date(-1))
+test(2051.2, `-.IDate`(1L, 1L), error = 'only subtract from "IDate"')
+
+test(2051.3, format.data.table(1L), error = 'Possibly corrupt data.table')
+
+test(2051.4, rleidv(prefix = 1L), error = 'prefix must be NULL or')
+
+## passing Date to second argument of as.POSIXct.ITime
+t = as.ITime(0L)
+test(2051.5, as.POSIXct(t, .Date(0L)), .POSIXct(0, 'UTC'))
+
+## forder of dynamic expression
+DT = data.table(a = 1:3)
+test(2051.6, DT[order(sin(a/pi))], DT)
 
 ###################################
 #  Add new tests above this line  #

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -14913,15 +14913,11 @@ test(2050.6, rbind(DT[1], data.table(f=factor(letters[10:11]))[0])[,levels(f)], 
 ## abusing -.Date, format.data.table, rleidv
 test(2051.1, `-.IDate`(.Date(0), 1L), .Date(-1))
 test(2051.2, `-.IDate`(1L, 1L), error = 'only subtract from "IDate"')
-
 test(2051.3, format.data.table(1L), error = 'Possibly corrupt data.table')
-
 test(2051.4, rleidv(prefix = 1L), error = 'prefix must be NULL or')
-
 ## passing Date to second argument of as.POSIXct.ITime
 t = as.ITime(0L)
 test(2051.5, as.POSIXct(t, .Date(0L)), .POSIXct(0, 'UTC'))
-
 ## forder of dynamic expression
 DT = data.table(a = 1:3)
 test(2051.6, DT[order(sin(a/pi))], DT)


### PR DESCRIPTION
Closes #3590 

On the way home I thought of a simple regex to accomplish this, after a few tweaks it's still pretty simple (this is for mac `sed` so the command may need adjustment on other platforms):

```
for f in R/*; do sed -i '' -E 's/^([^(]+[^<[)])<-([^."`]|$)/\1=\2/g' $f; done
```

`[^(]+` ensures it's not defined within-line as a function argument; `[^<[)` ensure it's not `[<-`, `<<-`, or `()<-`. ``[^."`]`` covers cases like `"key<-"` and `dimnames<-.data.table`.

There's one false positive (`fread.R`):

```
      warning = fun <- function(e) {
```

^ this is defining `fun` for the `warning` for `tryCatch` which is then recycled to `error`

After this `grep -r "<-" R | wc -l` is down to 145 from 628.

There are some false negatives:

```
R/fcast.R:    if (!length(nm)) nm <- paste0("fun", i)
R/IDateTime.R:  if (tz == "") tz <- "UTC"
R/data.table.R:  names(i) <- NULL
```

Some of these can be hit with a regex targeting the part of the line _after_ `<-`:

```
for f in R/*; do sed -i '' -E 's/ <-([^()]*[^,])$/ =\1/g' $f; done
```

After this we're down to `grep -r "<-" R | wc -l` = 135

Still a small number of false negatives, fine to ignore. 135 is still tediously large to do by hand & most are true positives.

```
R/setkey.R:        if (ix != 0L) ans <- point(ans, i, x, ix) # see 'point' in data.table.R and C-version pointWrapper in assign.c - avoid copies
```