### PR TITLE
Follow-up to #3572

### DIFF
--- a/vignettes/datatable-sd-usage.Rmd
+++ b/vignettes/datatable-sd-usage.Rmd
@@ -169,7 +169,7 @@ lm_coef = sapply(models, function(rhs) {
   Pitching[ , coef(lm(ERA ~ ., data = .SD))['W'], .SDcols = c('W', rhs)]
 })
 barplot(lm_coef, names.arg = sapply(models, paste, collapse = '/'),
-        main = 'Wins Coefficient\nWiith Various Covariates',
+        main = 'Wins Coefficient\nWith Various Covariates',
         col = col16, las = 2L, cex.names = .8)
 ```
 
@@ -177,7 +177,7 @@ The coefficient always has the expected sign (better pitchers tend to have more 
 
 ## Conditional Joins
 
-`data.table` syntax is beautiful for its simplicity and robustness. The syntax `x[i]` flexibly handles two common approaches to subsetting -- when `i` is a `logical` vector, `x[i]` will return those rows of `x` corresponding to where `i` is `TRUE`; when `i` is _another `data.table`_, a (right) `join` is performed (in the plain form, using the `key`s of `x` and `i`, otherwise, when `on = ` is specified, using matches of those columns).
+`data.table` syntax is beautiful for its simplicity and robustness. The syntax `x[i]` flexibly handles three common approaches to subsetting -- when `i` is a `logical` vector, `x[i]` will return those rows of `x` corresponding to where `i` is `TRUE`; when `i` is _another `data.table`_ (or a `list`), a (right) `join` is performed (in the plain form, using the `key`s of `x` and `i`, otherwise, when `on = ` is specified, using matches of those columns); and when `i` is a character, it is interpreted as shorthand for `x[list(i)]`, i.e., as a join.
 
 This is great in general, but falls short when we wish to perform a _conditional join_, wherein the exact nature of the relationship among tables depends on some characteristics of the rows in one or more columns.
 
@@ -235,7 +235,7 @@ Teams[ , .SD[which.max(R)], by = teamID]
 
 Note that this approach can of course be combined with `.SDcols` to return only portions of the `data.table` for each `.SD` (with the caveat that `.SDcols` should be fixed across the various subsets)
 
-_NB_: `.SD[1L]` is currently optimized by [_`GForce`_](https://jangorecki.gitlab.io/data.table/library/data.table/html/datatable-optimize.html) ([see also](https://stackoverflow.com/questions/22137591/about-gforce-in-data-table-1-9-2)), `data.table` internals which massively speed up the most common grouped operations like `sum` or `mean` -- see `?GForce` for more details and keep an eye on/voice support for feature improvement requests for updates on this front: [1](https://github.com/Rdatatable/data.table/issues/735), [2](https://github.com/Rdatatable/data.table/issues/2778), [3](https://github.com/Rdatatable/data.table/issues/523), [4](https://github.com/Rdatatable/data.table/issues/971), [5](https://github.com/Rdatatable/data.table/issues/1197), [6](https://github.com/Rdatatable/data.table/issues/1414)
+_NB_: `.SD[1L]` is currently optimized by [_`GForce`_](https://Rdatatable.gitlab.io/data.table/library/data.table/html/datatable-optimize.html) ([see also](https://stackoverflow.com/questions/22137591/about-gforce-in-data-table-1-9-2)), `data.table` internals which massively speed up the most common grouped operations like `sum` or `mean` -- see `?GForce` for more details and keep an eye on/voice support for feature improvement requests for updates on this front: [1](https://github.com/Rdatatable/data.table/issues/735), [2](https://github.com/Rdatatable/data.table/issues/2778), [3](https://github.com/Rdatatable/data.table/issues/523), [4](https://github.com/Rdatatable/data.table/issues/971), [5](https://github.com/Rdatatable/data.table/issues/1197), [6](https://github.com/Rdatatable/data.table/issues/1414)
 
 ## Grouped Regression
 


### PR DESCRIPTION
Jan had some extra feedback on #3572.

Regarding the `<code>` block in the header, I think that's just a GitLab issue. `title` YAML field is supposed to go into the browser tab, I thought... I guess GitLab is not [using MultiMarkdown](https://stackoverflow.com/questions/17097894/markdown-tag-for-document-title), or something like that? The `datatable-intro` vignette has the [same issue on Gitlab](https://rdatatable.gitlab.io/data.table/library/data.table/doc/datatable-intro.html) but it renders correctly [on CRAN](https://cran.r-project.org/web/packages/data.table/vignettes/datatable-intro.html), so ignoring that part. 