### PR TITLE
cedta() catches another case where utils could be top-level namespace

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -120,6 +120,8 @@
 
 15. `rbind` and `rbindlist` of zero-row items now retain (again) the unused levels of any (zero-length) factor columns, [#3508](https://github.com/Rdatatable/data.table/issues/3508). This was a regression in v1.12.2 just for zero-row items. Unused factor levels were already retained for items having `nrow>=1`. Thanks to Gregory Demin for reporting.
 
+16. Running the `:=` examples with `example` and `local=TRUE` works as expected, [#2972](https://github.com/Rdatatable/data.table/issues/2972). Thanks @vlulla for the report.
+
 #### NOTES
 
 1. `rbindlist`'s `use.names="check"` now emits its message for automatic column names (`"V[0-9]+"`) too, [#3484](https://github.com/Rdatatable/data.table/pull/3484). See news item 5 of v1.12.2 below.

--- a/R/cedta.R
+++ b/R/cedta.R
@@ -41,7 +41,7 @@ cedta = function(n=2L) {
     tryCatch("data.table" %chin% get(".Depends",paste("package",nsname,sep=":"),inherits=FALSE),error=function(e)FALSE)  # both ns$.Depends and get(.Depends,ns) are not sufficient
   if (!ans && getOption("datatable.verbose")) {
     cat("cedta decided '",nsname,"' wasn't data.table aware. Here is call stack with [[1L]] applied:\n",sep="")
-    print(sapply(sc, "[[", 1L))
+    print(sapply(sc, "[[", 1L)) # nocov
     # so we can trace the namespace name that may need to be added (very unusually)
   }
   ans

--- a/R/cedta.R
+++ b/R/cedta.R
@@ -19,6 +19,7 @@ cedta.pkgEvalsUserCode = c("gWidgetsWWW","statET","FastRWeb","slidify","rmarkdow
 # which makes them data.table-aware optionally and possibly variably.
 # http://stackoverflow.com/a/13131555/403310
 
+# cedta = Calling Environment Data.Table-Aware?
 cedta = function(n=2L) {
   # Calling Environment Data Table Aware
   ns = topenv(parent.frame(n))
@@ -26,18 +27,21 @@ cedta = function(n=2L) {
     # e.g. DT queries at the prompt (.GlobalEnv) and knitr's eval(,envir=globalenv()) but not DF[...] inside knitr::kable v1.6
     return(TRUE)
   }
+  sc = sys.calls()
   nsname = getNamespaceName(ns)
   ans = nsname == "data.table" ||
     "data.table" %chin% names(getNamespaceImports(ns)) ||   # most common and recommended cases first for speed
-    (nsname == "utils" && exists("debugger.look",parent.frame(n+1L))) ||
+    (nsname == "utils" && 
+       (exists("debugger.look", parent.frame(n+1L)) || 
+          (length(sc) >= 8L && sc[[length(sc) - 7L]][[1L]] == 'example'))) || # example for #2972
     (nsname == "base"  && all(c("FUN", "X") %chin% ls(parent.frame(n)))  ) || # lapply
-    (nsname %chin% cedta.pkgEvalsUserCode && any(sapply(sys.calls(), function(x) is.name(x[[1L]]) && (x[[1L]]=="eval" || x[[1L]]=="evalq")))) ||
+    (nsname %chin% cedta.pkgEvalsUserCode && any(sapply(sc, function(x) is.name(x[[1L]]) && (x[[1L]]=="eval" || x[[1L]]=="evalq")))) ||
     nsname %chin% cedta.override ||
     isTRUE(ns$.datatable.aware) ||  # As of Sep 2018: RCAS, caretEnsemble, dtplyr, rstanarm, rbokeh, CEMiTool, rqdatatable, RImmPort, BPRMeth, rlist
     tryCatch("data.table" %chin% get(".Depends",paste("package",nsname,sep=":"),inherits=FALSE),error=function(e)FALSE)  # both ns$.Depends and get(.Depends,ns) are not sufficient
   if (!ans && getOption("datatable.verbose")) {
     cat("cedta decided '",nsname,"' wasn't data.table aware. Here is call stack with [[1L]] applied:\n",sep="")
-    print(sapply(sys.calls(), "[[", 1L))
+    print(sapply(sc, "[[", 1L))
     # so we can trace the namespace name that may need to be added (very unusually)
   }
   ans

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -14922,6 +14922,12 @@ test(2051.5, as.POSIXct(t, structure(0L, class="Date")), .POSIXct(0, 'UTC'))
 DT = data.table(a = 1:3)
 test(2051.6, DT[order(sin(a/pi))], DT)
 
+# example(local = TRUE) triggered cedta -> FALSE -> examples run with error, #2972
+res = tryCatch(example(':=', package='data.table', local=TRUE))
+test(2052.1, !inherits(res, 'error'))
+res = tryCatch(example('CJ', package='data.table', local=TRUE))
+test(2052.2, !inherits(res, 'error'))
+
 ###################################
 #  Add new tests above this line  #
 ###################################


### PR DESCRIPTION
Closes #2972

Running `example(":=", package="data.table", local=TRUE)` winds up with `ns` as `utils`, a new case to `cedta`. `local = FALSE` has `ns` `NULL`.

Is it safe to run `example` in the tests? feels a bit off. 