### PR TITLE
Added [<-.IDate so that rbind.data.frame retains integer IDate

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -161,6 +161,7 @@ S3method(seq, IDate)
 S3method(split, IDate)
 S3method(unique, IDate)
 S3method(unique, ITime)
+S3method('[<-', IDate)
 
 # duplist
 # getdots

--- a/NEWS.md
+++ b/NEWS.md
@@ -122,6 +122,8 @@
 
 16. `rbind` and `rbindlist` of an item containing an ordered factor with levels containing an `NA` (as opposed to an NA integer) could segfault, [#3601](https://github.com/Rdatatable/data.table/issues/3601). This was a a regression in v1.12.2. Thanks to Damian Betebenner for reporting.
 
+17. `rbind.data.frame` on `IDate` columns corrupted the `integer` storage mode, [#2008](https://github.com/Rdatatable/data.table/issues/2008). Thanks to @rmcgehee for reporting.
+
 #### NOTES
 
 1. `rbindlist`'s `use.names="check"` now emits its message for automatic column names (`"V[0-9]+"`) too, [#3484](https://github.com/Rdatatable/data.table/pull/3484). See news item 5 of v1.12.2 below.

--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -40,7 +40,7 @@ as.IDate.POSIXct = function(x, tz = attr(x, "tzone"), ...) {
     as.IDate(as.Date(x, tz = tz, ...))
 }
 
-as.IDate.IDate = function(x, ...) as.integer(x)
+as.IDate.IDate = function(x, ...) x
 
 as.Date.IDate = function(x, ...) {
   x = as.numeric(x)
@@ -55,11 +55,13 @@ c.IDate =
 rep.IDate =
 split.IDate =
 unique.IDate =
-`[<-.IDate` = 
   function(x, ...) {
     as.IDate(NextMethod())
   }
 
+# for #2008 -- Internal rbind calls [<-,
+#   which winds up (1) converting to numeric and (2) keeping IDate class
+#   Define our own method to prevent value ever coercing to double
 `[<-.IDate` = function(x, i, value) {
   if (!length(value)) return(x)
   value = as.integer(as.IDate(value))

--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -59,9 +59,7 @@ unique.IDate =
     as.IDate(NextMethod())
   }
 
-# for #2008 -- Internal rbind calls [<-,
-#   which winds up (1) converting to numeric and (2) keeping IDate class
-#   Define our own method to prevent value ever coercing to double
+# define this [<- method to prevent base R's internal rbind coercing integer IDate to double, #2008
 `[<-.IDate` = function(x, i, value) {
   if (!length(value)) return(x)
   value = as.integer(as.IDate(value))

--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -40,7 +40,7 @@ as.IDate.POSIXct = function(x, tz = attr(x, "tzone"), ...) {
     as.IDate(as.Date(x, tz = tz, ...))
 }
 
-as.IDate.IDate = function(x, ...) x
+as.IDate.IDate = function(x, ...) as.integer(x)
 
 as.Date.IDate = function(x, ...) {
   x = as.numeric(x)
@@ -55,6 +55,7 @@ c.IDate =
 rep.IDate =
 split.IDate =
 unique.IDate =
+`[<-.IDate` = 
   function(x, ...) {
     as.IDate(NextMethod())
   }

--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -60,6 +60,15 @@ unique.IDate =
     as.IDate(NextMethod())
   }
 
+`[<-.IDate` = function(x, i, value) {
+  if (!length(value)) return(x)
+  value = as.integer(as.IDate(value))
+  setattr(x, 'class', NULL)
+  x[i] = value
+  setattr(x, 'class', c('IDate', 'Date'))
+  x
+}
+
 # fix for #1315
 as.list.IDate = function(x, ...) NextMethod()
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -993,16 +993,17 @@ test(343, DT[,(mynewcol):=21L], data.table(b=1:3,newname=21L))
 mycols = 1:2
 test(344, DT[,(mycols):=NULL], data.table(NULL))
 
-
-# It seems that the .Internal rbind of two data.frame coerces IDate to numeric. Tried defining
-# "[<-.IDate" as per Tom's suggestion, and c.IDate to no avail (maybe because the .Internal code
-# in bind.c doesn't look up package methods?). Anyway, as from 1.8.1, double are allowed in keys, so
-# these still work but for a different reason than before 1.8.1: the results are IDate stored as double,
-# rather than before when is worked because by and setkey coerced double to integer.
-# Now, as from 1.12.4, the integer IDate in i is retained as integer rather than letting the double IDate persist.
+# this test originally tested that IDate would come back as
+#   double from rbind(DF, DF) where DF is a data.frame
+#   with IDate column. This is exactly the bug reported in #2008,
+#   but the bug is elusive to track down so it took a long time
+#   to fix and the resulting IDate being stored as double
+#   was kept as a test here. With #2008, now we check it 
+#   in fact stays as an integer.
 DF = data.frame(x=as.IDate(c("2010-01-01","2010-01-02")), y=1:6)
 DT = as.data.table(rbind(DF,DF))
-test(345, DT[,sum(y),by=x], data.table(x=as.IDate(c("2010-01-01","2010-01-02")),V1=c(18L,24L))})
+test(345, DT[,sum(y),by=x], data.table(x=as.IDate(c("2010-01-01","2010-01-02")),V1=c(18L,24L)))
+# Also, as from 1.12.4, the integer IDate in i is retained as integer here as well.
 test(346, setkey(DT,x)[J(as.IDate("2010-01-02"))], data.table(x=as.IDate(rep("2010-01-02",6L)), y=rep(c(2L,4L,6L),2), key="x"))
 
 # Test .N==0 with nomatch=NA|0, # tests for #963 added as well

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -1002,7 +1002,7 @@ test(344, DT[,(mycols):=NULL], data.table(NULL))
 # Now, as from 1.12.4, the integer IDate in i is retained as integer rather than letting the double IDate persist.
 DF = data.frame(x=as.IDate(c("2010-01-01","2010-01-02")), y=1:6)
 DT = as.data.table(rbind(DF,DF))
-test(345, DT[,sum(y),by=x], {.x=as.IDate(c("2010-01-01","2010-01-02"));mode(.x)="double";data.table(x=.x,V1=c(18L,24L))})
+test(345, DT[,sum(y),by=x], data.table(x=as.IDate(c("2010-01-01","2010-01-02")),V1=c(18L,24L))})
 test(346, setkey(DT,x)[J(as.IDate("2010-01-02"))], data.table(x=as.IDate(rep("2010-01-02",6L)), y=rep(c(2L,4L,6L),2), key="x"))
 
 # Test .N==0 with nomatch=NA|0, # tests for #963 added as well

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -993,17 +993,11 @@ test(343, DT[,(mynewcol):=21L], data.table(b=1:3,newname=21L))
 mycols = 1:2
 test(344, DT[,(mycols):=NULL], data.table(NULL))
 
-# this test originally tested that IDate would come back as
-#   double from rbind(DF, DF) where DF is a data.frame
-#   with IDate column. This is exactly the bug reported in #2008,
-#   but the bug is elusive to track down so it took a long time
-#   to fix and the resulting IDate being stored as double
-#   was kept as a test here. With #2008, now we check it 
-#   in fact stays as an integer.
+# this originally tested that IDate would come back as double from rbind(DF, DF)
+# Now #2008 is fixed in v1.12.4 it now checks it stays as an integer.
 DF = data.frame(x=as.IDate(c("2010-01-01","2010-01-02")), y=1:6)
 DT = as.data.table(rbind(DF,DF))
 test(345, DT[,sum(y),by=x], data.table(x=as.IDate(c("2010-01-01","2010-01-02")),V1=c(18L,24L)))
-# Also, as from 1.12.4, the integer IDate in i is retained as integer here as well.
 test(346, setkey(DT,x)[J(as.IDate("2010-01-02"))], data.table(x=as.IDate(rep("2010-01-02",6L)), y=rep(c(2L,4L,6L),2), key="x"))
 
 # Test .N==0 with nomatch=NA|0, # tests for #963 added as well
@@ -14966,11 +14960,11 @@ test(2052, rbindlist(list(dt1, dt2), fill=TRUE),
            data.table(V1=c(dt1$V1, dt2$V1),
                       V46=structure(c(3L,1L,1L,NA,3L,NA,NA,NA,NA,NA), .Label=c("Low","Typical","High",NA), class = c("ordered", "factor"))))
 
-# [<-.IDate method solves #2008 --
-# rbind.data.frame doesn't respect integer storage mode of IDate
+# rbind.data.frame didn't respect integer storage mode of IDate, #2008
 DF = data.frame(date = as.IDate(0L))
 test(2053.1, storage.mode(rbind(DF, DF)$date), 'integer')
 test(2053.2, DF$date[1L] <- integer(), integer())
+
 
 ###################################
 #  Add new tests above this line  #

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -14932,6 +14932,9 @@ test(2052, rbindlist(list(dt1, dt2), fill=TRUE),
            data.table(V1=c(dt1$V1, dt2$V1),
                       V46=structure(c(3L,1L,1L,NA,3L,NA,NA,NA,NA,NA), .Label=c("Low","Typical","High",NA), class = c("ordered", "factor"))))
 
+# rbind.data.frame doesn't respect integer storage mode of IDate
+DF = data.frame(date = as.IDate(0L))
+test(2053, storage.mode(rbind(DF, DF)$date), 'integer')
 
 ###################################
 #  Add new tests above this line  #

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -14933,9 +14933,11 @@ test(2052, rbindlist(list(dt1, dt2), fill=TRUE),
            data.table(V1=c(dt1$V1, dt2$V1),
                       V46=structure(c(3L,1L,1L,NA,3L,NA,NA,NA,NA,NA), .Label=c("Low","Typical","High",NA), class = c("ordered", "factor"))))
 
+# [<-.IDate method solves #2008 --
 # rbind.data.frame doesn't respect integer storage mode of IDate
 DF = data.frame(date = as.IDate(0L))
-test(2053, storage.mode(rbind(DF, DF)$date), 'integer')
+test(2053.1, storage.mode(rbind(DF, DF)$date), 'integer')
+test(2053.2, DF$date[1L] <- integer(), integer())
 
 ###################################
 #  Add new tests above this line  #


### PR DESCRIPTION
Closes #2008 

I still don't _really_ understand why these changes are necessary (and both are in fact necessary).

I posted this on r-devel, might be some insight there: https://stat.ethz.ch/pipermail/r-devel/2019-May/077866.html