### PR TITLE
Change zbuffsize formula

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -9535,6 +9535,12 @@ close(f2con)
 test(1658.52, file.info(f1)$size, file.info(f2)$size)
 unlink(c(f1, f2))
 
+# compression error -5 due to only 3 bytes (bom) in first block; #3599
+DT = data.table(l=letters, n=1:26)
+test(1658.53, fwrite(DT, file=f<-tempfile(fileext=".gz"), bom=TRUE, col.names=FALSE), NULL)
+test(1658.54, fread(f), setnames(DT,c("V1","V2")))
+unlink(f)
+
 ## End fwrite tests
 
 # tests for #679, inrange(), FR #707

--- a/src/fwrite.c
+++ b/src/fwrite.c
@@ -703,16 +703,15 @@ void fwriteMain(fwriteMainArgs args)
       int ret1=0, ret2=0;
       if (args.is_gzip) {
         z_stream stream;
-        if(init_stream(&stream)) {
-          free(buff);
-          STOP("Can't allocate gzip stream structure");
-        }
+        if(init_stream(&stream)) { free(buff); STOP("Can't allocate gzip stream structure"); } // # nocov
         size_t zbuffSize = deflateBound(&stream, headerLen);
         char *zbuff = malloc(zbuffSize);
+        // # nocov start
         if (!zbuff) {
             free(buff);
             STOP("Unable to allocate %d MiB for zbuffer: %s", zbuffSize / 1024 / 1024, strerror(errno));
         }
+        // # nocov end
         size_t zbuffUsed = zbuffSize;
         ret1 = compressbuff(&stream, zbuff, &zbuffUsed, buff, (int)(ch-buff));
         if (ret1 == Z_OK)
@@ -768,7 +767,7 @@ void fwriteMain(fwriteMainArgs args)
   if(args.is_gzip){
     z_stream stream;
     if(init_stream(&stream))
-      STOP("Can't allocate gzip stream structure");
+      STOP("Can't allocate gzip stream structure"); // # nocov
     zbuffSize = deflateBound(&stream, buffSize);
     deflateEnd(&stream);
   }
@@ -832,7 +831,7 @@ void fwriteMain(fwriteMainArgs args)
       if (args.is_gzip && !failed) {
         z_stream mystream;
         if(init_stream(&mystream)) {
-          failed = -998;
+          failed = -998; // # nocov
         }
         if (!failed) {
             myzbuffUsed = zbuffSize;

--- a/src/fwrite.c
+++ b/src/fwrite.c
@@ -533,37 +533,27 @@ void writeCategString(void *col, int64_t row, char **pch)
   write_string(getCategString(col, row), pch);
 }
 
-int compressbuff(void* dest, size_t *destLen, const void* source, size_t sourceLen)
+int init_stream(z_stream *stream) {
+  stream->zalloc = Z_NULL;
+  stream->zfree = Z_NULL;
+  stream->opaque = Z_NULL;
+
+  // 31 comes from : windows bits 15 | 16 gzip format
+  int err = deflateInit2(stream, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 31, 8, Z_DEFAULT_STRATEGY);
+  return err;  // # nocov
+}
+
+int compressbuff(z_stream *stream, void* dest, size_t *destLen, const void* source, size_t sourceLen)
 {
-  z_stream stream;
-  stream.zalloc = (alloc_func)0;
-  stream.zfree = (free_func)0;
-  stream.opaque = (voidpf)0;
+  int err = 0;
 
-  int err = deflateInit2(&stream, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 31, 8, Z_DEFAULT_STRATEGY);
-  if (err != Z_OK)
-    return err;  // # nocov
+  stream->next_out = dest;
+  stream->avail_out = *destLen;
+  stream->next_in = (z_const Bytef *)source;
+  stream->avail_in = sourceLen;
 
-  stream.next_out = dest;
-  stream.avail_out = 0;
-  stream.next_in = (z_const Bytef *)source;
-  stream.avail_in = 0;
-  size_t left = *destLen;
-  const uInt uInt_max = (uInt)-1;  // stream.avail_out is type uInt
-  do {
-    if (stream.avail_out == 0) {
-      stream.avail_out = left>uInt_max ? uInt_max : left;
-      left -= stream.avail_out;
-    }
-    if (stream.avail_in == 0) {
-      stream.avail_in = sourceLen>uInt_max ? uInt_max : sourceLen;
-      sourceLen -= stream.avail_in;
-    }
-    err = deflate(&stream, sourceLen ? Z_NO_FLUSH : Z_FINISH);
-  } while (err == Z_OK);
-
-  *destLen = stream.total_out;
-  deflateEnd(&stream);
+  err = deflate(stream, Z_FINISH);
+  *destLen = stream->total_out;
   return err == Z_STREAM_END ? Z_OK : err;
 }
 
@@ -712,12 +702,22 @@ void fwriteMain(fwriteMainArgs args)
     } else {
       int ret1=0, ret2=0;
       if (args.is_gzip) {
-        size_t zbuffSize = headerLen + headerLen/10 + 16;
+        z_stream stream;
+        if(init_stream(&stream)) {
+          free(buff);
+          STOP("Can't allocate gzip stream structure");
+        }
+        size_t zbuffSize = deflateBound(&stream, headerLen);
         char *zbuff = malloc(zbuffSize);
-        if (!zbuff) {free(buff); STOP("Unable to allocate %d MiB for zbuffer: %s", zbuffSize / 1024 / 1024, strerror(errno));}
+        if (!zbuff) {
+            free(buff);
+            STOP("Unable to allocate %d MiB for zbuffer: %s", zbuffSize / 1024 / 1024, strerror(errno));
+        }
         size_t zbuffUsed = zbuffSize;
-        ret1 = compressbuff(zbuff, &zbuffUsed, buff, (int)(ch-buff));
-        if (ret1==0) ret2 = WRITE(f, zbuff, (int)zbuffUsed);
+        ret1 = compressbuff(&stream, zbuff, &zbuffUsed, buff, (int)(ch-buff));
+        if (ret1 == Z_OK)
+            ret2 = WRITE(f, zbuff, (int)zbuffUsed);
+        deflateEnd(&stream);
         free(zbuff);
       } else {
         ret2 = WRITE(f,  buff, (int)(ch-buff));
@@ -739,6 +739,8 @@ void fwriteMain(fwriteMainArgs args)
     if (f!=-1 && CLOSE(f)) STOP("%s: '%s'", strerror(errno), args.filename);
     return;
   }
+
+  // Writing rows
 
   // Decide buffer size and rowsPerBatch for each thread
   // Once rowsPerBatch is decided it can't be changed
@@ -772,9 +774,16 @@ void fwriteMain(fwriteMainArgs args)
     void *myzBuff = NULL;
 
     if(args.is_gzip && !failed){
-      myzbuffSize = buffSize + buffSize/10 + 16;
-      myzBuff = malloc(myzbuffSize);
-      if (myzBuff==NULL) failed=-errno;
+      z_stream mystream;
+      if(init_stream(&mystream)) {
+        failed = 999;
+      }
+      if (!failed) {
+        myzbuffSize = deflateBound(&mystream, buffSize);
+        myzBuff = malloc(myzbuffSize);
+        if (myzBuff==NULL) failed=-errno;
+      }
+      deflateEnd(&mystream);
     }
     // Do not rely on availability of '#omp cancel' new in OpenMP v4.0 (July 2013).
     // OpenMP v4.0 is in gcc 4.9+ (https://gcc.gnu.org/wiki/openmp) but
@@ -817,8 +826,15 @@ void fwriteMain(fwriteMainArgs args)
       }
       // compress buffer if gzip
       if (args.is_gzip && !failed) {
-        myzbuffUsed = myzbuffSize;
-        failed = compressbuff(myzBuff, &myzbuffUsed, myBuff, (int)(ch-myBuff));
+        z_stream mystream;
+        if(init_stream(&mystream)) {
+          failed = 998;
+        }
+        if (!failed) {
+            myzbuffUsed = myzbuffSize;
+            failed = compressbuff(&mystream, myzBuff, &myzbuffUsed, myBuff, (int)(ch-myBuff));
+        }
+        deflateEnd(&mystream);
       }
       #pragma omp ordered
       {

--- a/src/fwrite.c
+++ b/src/fwrite.c
@@ -703,19 +703,19 @@ void fwriteMain(fwriteMainArgs args)
       int ret1=0, ret2=0;
       if (args.is_gzip) {
         z_stream stream;
-        if(init_stream(&stream)) { free(buff); STOP("Can't allocate gzip stream structure"); } // # nocov
+        if(init_stream(&stream)) {
+          free(buff);                                    // # nocov
+          STOP("Can't allocate gzip stream structure");  // # nocov
+        }
         size_t zbuffSize = deflateBound(&stream, headerLen);
         char *zbuff = malloc(zbuffSize);
-        // # nocov start
         if (!zbuff) {
-            free(buff);
-            STOP("Unable to allocate %d MiB for zbuffer: %s", zbuffSize / 1024 / 1024, strerror(errno));
+          free(buff);                                                                                   // # nocov
+          STOP("Unable to allocate %d MiB for zbuffer: %s", zbuffSize / 1024 / 1024, strerror(errno));  // # nocov
         }
-        // # nocov end
         size_t zbuffUsed = zbuffSize;
         ret1 = compressbuff(&stream, zbuff, &zbuffUsed, buff, (int)(ch-buff));
-        if (ret1 == Z_OK)
-            ret2 = WRITE(f, zbuff, (int)zbuffUsed);
+        if (ret1==Z_OK) ret2 = WRITE(f, zbuff, (int)zbuffUsed);
         deflateEnd(&stream);
         free(zbuff);
       } else {
@@ -834,8 +834,8 @@ void fwriteMain(fwriteMainArgs args)
           failed = -998; // # nocov
         }
         if (!failed) {
-            myzbuffUsed = zbuffSize;
-            failed = compressbuff(&mystream, myzBuff, &myzbuffUsed, myBuff, (int)(ch-myBuff));
+          myzbuffUsed = zbuffSize;
+          failed = compressbuff(&mystream, myzBuff, &myzbuffUsed, myBuff, (int)(ch-myBuff));
         }
         deflateEnd(&mystream);
       }


### PR DESCRIPTION
Closes #3599 

With original buffer size = 3, previous formula gives 19 and compress ends with *buffer error*.

In zlib, there is a *deflateBound* function which computes the right size but needs a zlib stream structure. This PR uses this function and adapts gzip compression.

So we split *compressbuff* function in 2 functions :

* *init_stream* which initializes a zlib stream structure and can be  passed to *deflateBound*

* compressbuff which makes the compression

*compressbuff* has been simplified because we are sure that buffer doesn't exceeds maxint (4G) because max buffer size is 1G. With Z_FINISH, we are sure that all the buffer is compressed in one pass (or this is an unrecoverable error), so the do loop can be removed.

*deflateEnd* call is not more in *compressbuff* and is called when stream has been used (in fwriteMain).