### PR TITLE
nafill retain attributes, closes #3617, int64, nanotime

### DIFF
--- a/R/shift.R
+++ b/R/shift.R
@@ -41,3 +41,7 @@ setnafill = function(x, type=c("const","locf","nocb"), fill=NA, cols=seq_along(x
 colnamesInt = function(x, cols) {
   .Call(CcolnamesInt, x, cols)
 }
+
+coerceFill = function(x) {
+  .Call(CcoerceFillR, x)
+}

--- a/inst/tests/nafill.Rraw
+++ b/inst/tests/nafill.Rraw
@@ -48,6 +48,12 @@ l = list(x, y[1:8], z[1:6])
 test(1.41, nafill(l, "locf"), lapply(l, nafill, "locf"))
 test(1.42, nafill(l, "nocb"), lapply(l, nafill, "nocb"))
 test(1.43, nafill(l, fill=0), lapply(l, nafill, fill=0))
+l = list(a=c(1:2,NA,4:5), b=as.Date(c(1:2,NA,4:5), origin="1970-01-01"), d=c(NA,2L,NA,4L,NA), e=as.Date(c(NA,2L,NA,4L,NA), origin="1970-01-01")) # Date retain class #3617
+test(1.44, nafill(l, "locf"), list(c(1:2,2L,4:5), structure(c(1,2,2,4,5), class="Date"), c(NA,2L,2L,4L,4L), structure(c(NA,2,2,4,4), class="Date")))
+test(1.45, nafill(l, "nocb"), list(c(1:2,4L,4:5), structure(c(1,2,4,4,5), class="Date"), c(2L,2L,4L,4L,NA), structure(c(2,2,4,4,NA), class="Date")))
+test(1.46, nafill(l, fill=0), list(c(1:2,0L,4:5), structure(c(1,2,0,4,5), class="Date"), c(0L,2L,0L,4L,0L), structure(c(0,2,0,4,0), class="Date")))
+test(1.47, nafill(l, fill=as.Date(0, origin="1970-01-01")), list(c(1:2,0L,4:5), structure(c(1,2,0,4,5), class="Date"), c(0L,2L,0L,4L,0L), structure(c(0,2,0,4,0), class="Date")))
+test(1.48, nafill(l, fill=as.Date("2019-06-05")), list(c(1:2,18052L,4:5), structure(c(1,2,18052,4,5), class="Date"), c(18052L,2L,18052L,4L,18052L), structure(c(18052,2,18052,4,18052), class="Date")))
 
 # setnafill
 dt = data.table(V1=1:10, V2=10:1, V3=1:10/2)

--- a/inst/tests/nafill.Rraw
+++ b/inst/tests/nafill.Rraw
@@ -13,6 +13,15 @@ if (exists("test.data.table", .GlobalEnv, inherits=FALSE)) {
   colnamesInt = data.table:::colnamesInt
 }
 
+sugg = c(
+  "bit64",
+  "nanotime"
+)
+for (s in sugg) {
+  assign(paste0("test_",s), loaded<-suppressWarnings(suppressMessages(require(s, character.only=TRUE))))
+  if (!loaded) cat("\n**** Suggested package",s,"is not installed. Tests using it will be skipped.\n\n")
+}
+
 x = 1:10
 x[c(1:2, 5:6, 9:10)] = NA
 test(1.01, nafill(x, "locf"), INT(NA,NA,3,4,4,4,7,8,8,8))
@@ -54,6 +63,25 @@ test(1.45, nafill(l, "nocb"), list(c(1:2,4L,4:5), structure(c(1,2,4,4,5), class=
 test(1.46, nafill(l, fill=0), list(c(1:2,0L,4:5), structure(c(1,2,0,4,5), class="Date"), c(0L,2L,0L,4L,0L), structure(c(0,2,0,4,0), class="Date")))
 test(1.47, nafill(l, fill=as.Date(0, origin="1970-01-01")), list(c(1:2,0L,4:5), structure(c(1,2,0,4,5), class="Date"), c(0L,2L,0L,4L,0L), structure(c(0,2,0,4,0), class="Date")))
 test(1.48, nafill(l, fill=as.Date("2019-06-05")), list(c(1:2,18052L,4:5), structure(c(1,2,18052,4,5), class="Date"), c(18052L,2L,18052L,4L,18052L), structure(c(18052,2,18052,4,18052), class="Date")))
+if (test_bit64) {
+  l = list(a=as.integer64(c(1:2,NA,4:5)), b=as.integer64(c(NA,2L,NA,4L,NA)))
+  test(1.81, lapply(nafill(l, "locf"), as.character), lapply(list(c(1:2,2L,4:5), c(NA,2L,2L,4L,4L)), as.character))
+  test(1.82, lapply(nafill(l, "nocb"), as.character), lapply(list(c(1:2,4L,4:5), c(2L,2L,4L,4L,NA)), as.character))
+  test(1.83, lapply(nafill(l, fill=0), as.character), lapply(list(c(1:2,0L,4:5), c(0L,2L,0L,4L,0L)), as.character))
+  test(1.84, lapply(nafill(l, fill=as.integer64(0)), as.character), lapply(list(c(1:2,0L,4:5), c(0L,2L,0L,4L,0L)), as.character))
+  test(1.85, lapply(nafill(l, fill=as.integer64("3000000000")), as.character), list(c("1","2","3000000000","4","5"), c("3000000000","2","3000000000","4","3000000000")))
+  l = lapply(l, `+`, as.integer64("3000000000"))
+  test(1.86, lapply(nafill(l, "locf"), as.character), list(c("3000000001","3000000002","3000000002","3000000004","3000000005"), c(NA_character_,"3000000002","3000000002","3000000004","3000000004")))
+  test(1.87, lapply(nafill(l, "nocb"), as.character), list(c("3000000001","3000000002","3000000004","3000000004","3000000005"), c("3000000002","3000000002","3000000004","3000000004",NA_character_)))
+  test(1.88, lapply(nafill(l, fill=as.integer64("3000000000")), as.character), list(c("3000000001","3000000002","3000000000","3000000004","3000000005"), c("3000000000","3000000002","3000000000","3000000004","3000000000")))
+}
+if (test_nanotime) {
+  l = list(a=nanotime(c(1:2,NA,4:5)), b=nanotime(c(NA,2L,NA,4L,NA)))
+  test(1.91, lapply(nafill(l, "locf"), as.character), lapply(list(nanotime(c(1:2,2L,4:5)), nanotime(c(NA,2L,2L,4L,4L))), as.character))
+  test(1.92, lapply(nafill(l, "nocb"), as.character), lapply(list(nanotime(c(1:2,4L,4:5)), nanotime(c(2L,2L,4L,4L,NA))), as.character))
+  test(1.93, lapply(nafill(l, fill=0), as.character), lapply(list(nanotime(c(1:2,0L,4:5)), nanotime(c(0L,2L,0L,4L,0L))), as.character))
+  test(1.94, lapply(nafill(l, fill=nanotime(0)), as.character), lapply(list(nanotime(c(1:2,0L,4:5)), nanotime(c(0L,2L,0L,4L,0L))), as.character))
+}
 
 # setnafill
 dt = data.table(V1=1:10, V2=10:1, V3=1:10/2)
@@ -73,6 +101,9 @@ test(2.06, {setnafill(dt, "nocb", cols=c("V2","V3")); dt}, db[, c(list(V1), nafi
 db[, "V4" := c(letters[1:3],NA,letters[5:7],NA,letters[9:10])]
 dt = copy(db)
 test(2.07, {setnafill(dt, "locf", cols=c("V2","V3")); dt}, db[, c(list(V1), nafill(.SD, "locf"), list(V4)), .SDcols=c("V2","V3")])
+l = list(a=c(1:2,NA,4:5), b=as.Date(c(1:2,NA,4:5), origin="1970-01-01"), d=c(NA,2L,NA,4L,NA), e=as.Date(c(NA,2L,NA,4L,NA), origin="1970-01-01")) # Date retain class #3617
+setnafill(l, fill=as.Date("2019-06-05"))
+test(2.08, unname(l), list(c(1:2,18052L,4:5), structure(c(1,2,18052,4,5), class="Date"), c(18052L,2L,18052L,4L,18052L), structure(c(18052,2,18052,4,18052), class="Date")))
 
 # exceptions test coverage
 x = 1:10

--- a/inst/tests/nafill.Rraw
+++ b/inst/tests/nafill.Rraw
@@ -11,6 +11,7 @@ if (exists("test.data.table", .GlobalEnv, inherits=FALSE)) {
   test = data.table:::test
   INT = data.table:::INT
   colnamesInt = data.table:::colnamesInt
+  coerceFill = data.table:::coerceFill
 }
 
 sugg = c(
@@ -31,7 +32,7 @@ test(1.04, nafill(x, fill=5), INT(5,5,3,4,5,5,7,8,5,5))
 test(1.05, nafill(x, fill=NA_integer_), x)
 test(1.06, nafill(x, fill=NA), x)
 test(1.07, nafill(x, fill=NA_real_), x)
-test(1.08, nafill(x, fill=Inf), x, warning="NAs introduced by coercion to integer range")
+test(1.08, nafill(x, fill=Inf), x)
 test(1.09, nafill(x, fill=NaN), x)
 y = x/2
 test(1.11, nafill(y, "locf"), c(NA,NA,3,4,4,4,7,8,8,8)/2)
@@ -65,17 +66,24 @@ test(1.47, nafill(l, fill=as.Date(0, origin="1970-01-01")), list(c(1:2,0L,4:5), 
 test(1.48, nafill(l, fill=as.Date("2019-06-05")), list(c(1:2,18052L,4:5), structure(c(1,2,18052,4,5), class="Date"), c(18052L,2L,18052L,4L,18052L), structure(c(18052,2,18052,4,18052), class="Date")))
 if (test_bit64) {
   l = list(a=as.integer64(c(1:2,NA,4:5)), b=as.integer64(c(NA,2L,NA,4L,NA)))
-  test(1.81, lapply(nafill(l, "locf"), as.character), lapply(list(c(1:2,2L,4:5), c(NA,2L,2L,4L,4L)), as.character))
-  test(1.82, lapply(nafill(l, "nocb"), as.character), lapply(list(c(1:2,4L,4:5), c(2L,2L,4L,4L,NA)), as.character))
-  test(1.83, lapply(nafill(l, fill=0), as.character), lapply(list(c(1:2,0L,4:5), c(0L,2L,0L,4L,0L)), as.character))
-  test(1.84, lapply(nafill(l, fill=as.integer64(0)), as.character), lapply(list(c(1:2,0L,4:5), c(0L,2L,0L,4L,0L)), as.character))
-  test(1.85, lapply(nafill(l, fill=as.integer64("3000000000")), as.character), list(c("1","2","3000000000","4","5"), c("3000000000","2","3000000000","4","3000000000")))
+  test(1.61, lapply(nafill(l, "locf"), as.character), lapply(list(c(1:2,2L,4:5), c(NA,2L,2L,4L,4L)), as.character))
+  test(1.62, lapply(nafill(l, "nocb"), as.character), lapply(list(c(1:2,4L,4:5), c(2L,2L,4L,4L,NA)), as.character))
+  test(1.63, lapply(nafill(l, fill=0), as.character), lapply(list(c(1:2,0L,4:5), c(0L,2L,0L,4L,0L)), as.character))
+  test(1.64, lapply(nafill(l, fill=as.integer64(0)), as.character), lapply(list(c(1:2,0L,4:5), c(0L,2L,0L,4L,0L)), as.character))
+  test(1.65, lapply(nafill(l, fill=as.integer64("3000000000")), as.character), list(c("1","2","3000000000","4","5"), c("3000000000","2","3000000000","4","3000000000")))
   l = lapply(l, `+`, as.integer64("3000000000"))
-  test(1.86, lapply(nafill(l, "locf"), as.character), list(c("3000000001","3000000002","3000000002","3000000004","3000000005"), c(NA_character_,"3000000002","3000000002","3000000004","3000000004")))
-  test(1.87, lapply(nafill(l, "nocb"), as.character), list(c("3000000001","3000000002","3000000004","3000000004","3000000005"), c("3000000002","3000000002","3000000004","3000000004",NA_character_)))
-  test(1.88, lapply(nafill(l, fill=as.integer64("3000000000")), as.character), list(c("3000000001","3000000002","3000000000","3000000004","3000000005"), c("3000000000","3000000002","3000000000","3000000004","3000000000")))
-  test(1.89, nafill(as.integer64(c(1,2,NA,4)), fill=3), as.integer64(1:4)) # TODO
-  test(1.90, nafill(as.integer64(c(1,2,NA,4)), fill=3L), as.integer64(1:4)) # TODO
+  test(1.66, lapply(nafill(l, "locf"), as.character), list(c("3000000001","3000000002","3000000002","3000000004","3000000005"), c(NA_character_,"3000000002","3000000002","3000000004","3000000004")))
+  test(1.67, lapply(nafill(l, "nocb"), as.character), list(c("3000000001","3000000002","3000000004","3000000004","3000000005"), c("3000000002","3000000002","3000000004","3000000004",NA_character_)))
+  test(1.68, lapply(nafill(l, fill=as.integer64("3000000000")), as.character), list(c("3000000001","3000000002","3000000000","3000000004","3000000005"), c("3000000000","3000000002","3000000000","3000000004","3000000000")))
+  test(1.69, nafill(c(1L,2L,NA,4L), fill=as.integer64(3L)), 1:4)
+  test(1.70, nafill(c(1L,2L,NA,4L), fill=as.integer64(NA)), c(1:2,NA,4L))
+  test(1.71, nafill(c(1,2,NA,4), fill=as.integer64(3)), c(1,2,3,4))
+  test(1.72, nafill(c(1,2,NA,4), fill=as.integer64(NA)), c(1,2,NA,4))
+  test(1.73, nafill(as.integer64(c(1,2,NA,4)), fill=3), as.integer64(1:4))
+  test(1.74, nafill(as.integer64(c(1,2,NA,4)), fill=3L), as.integer64(1:4))
+  test(1.75, nafill(as.integer64(c(1,2,NA,4)), fill=NA_integer_), as.integer64(c(1:2,NA,4L)))
+  test(1.76, nafill(as.integer64(c(1,2,NA,4)), fill=NA_real_), as.integer64(c(1:2,NA,4L)))
+  test(1.77, nafill(as.integer64(c(1,2,NA,4)), fill=NA), as.integer64(c(1:2,NA,4L)))
 }
 if (test_nanotime) {
   l = list(a=nanotime(c(1:2,NA,4:5)), b=nanotime(c(NA,2L,NA,4L,NA)))
@@ -115,7 +123,7 @@ test(3.03, setnafill(x, "locf"), error="in-place update is supported only for li
 test(3.04, nafill(letters[1:5], fill=0), error="must be numeric type, or list/data.table")
 test(3.05, setnafill(list(letters[1:5]), fill=0), error="must be numeric type, or list/data.table")
 test(3.06, nafill(x, fill=1:2), error="fill must be a vector of length 1")
-test(3.07, nafill(x, fill="asd"), error="fill must be numeric")
+test(3.07, nafill(x, fill="asd"), error="fill argument must be numeric")
 
 # colnamesInt helper
 dt = data.table(a=1, b=2, d=3)
@@ -147,3 +155,22 @@ test(5.01, nafill(dt, "locf", verbose=TRUE), output="nafillInteger: took.*nafill
 test(5.02, setnafill(dt, "locf", verbose=TRUE), output="nafillInteger: took.*nafillDouble: took.*nafillR.*took")
 test(5.03, nafill(dt, "locf", verbose=NA), error="verbose must be TRUE or FALSE")
 
+# coerceFill
+if (test_bit64) {
+  test(6.01, coerceFill(1:2), error="fill argument must be length 1")
+  test(6.02, coerceFill("a"), error="fill argument must be numeric")
+  test(6.11, identical(coerceFill(NA), list(NA_integer_, NA_real_, as.integer64(NA))))
+  test(6.21, identical(coerceFill(3L), list(3L, 3, as.integer64(3))))
+  test(6.22, identical(coerceFill(0L), list(0L, 0, as.integer64(0))))
+  test(6.23, identical(coerceFill(NA_integer_), list(NA_integer_, NA_real_, as.integer64(NA))))
+  test(6.31, identical(coerceFill(as.integer64(3)), list(3L, 3, as.integer64(3))))
+  test(6.32, identical(coerceFill(as.integer64(3000000003)), list(NA_integer_, 3000000003, as.integer64("3000000003"))))
+  test(6.33, identical(coerceFill(as.integer64(0)), list(0L, 0, as.integer64(0))))
+  test(6.34, identical(coerceFill(as.integer64(NA)), list(NA_integer_, NA_real_, as.integer64(NA))))
+  test(6.41, identical(coerceFill(3), list(3L, 3, as.integer64(3))))
+  test(6.42, identical(coerceFill(0), list(0L, 0, as.integer64(0))))
+  test(6.43, identical(coerceFill(NA_real_), list(NA_integer_, NA_real_, as.integer64(NA))))
+  test(6.44, identical(coerceFill(NaN), list(NA_integer_, NaN, as.integer64(NA))))
+  test(6.45, identical(coerceFill(Inf), list(NA_integer_, Inf, as.integer64(NA))))
+  test(6.46, identical(coerceFill(-Inf), list(NA_integer_, -Inf, as.integer64(NA))))
+}

--- a/inst/tests/nafill.Rraw
+++ b/inst/tests/nafill.Rraw
@@ -63,9 +63,6 @@ test(1.45, nafill(l, "nocb"), list(c(1:2,4L,4:5), structure(c(1,2,4,4,5), class=
 test(1.46, nafill(l, fill=0), list(c(1:2,0L,4:5), structure(c(1,2,0,4,5), class="Date"), c(0L,2L,0L,4L,0L), structure(c(0,2,0,4,0), class="Date")))
 test(1.47, nafill(l, fill=as.Date(0, origin="1970-01-01")), list(c(1:2,0L,4:5), structure(c(1,2,0,4,5), class="Date"), c(0L,2L,0L,4L,0L), structure(c(0,2,0,4,0), class="Date")))
 test(1.48, nafill(l, fill=as.Date("2019-06-05")), list(c(1:2,18052L,4:5), structure(c(1,2,18052,4,5), class="Date"), c(18052L,2L,18052L,4L,18052L), structure(c(18052,2,18052,4,18052), class="Date")))
-
-test(1.50, )
-
 if (test_bit64) {
   l = list(a=as.integer64(c(1:2,NA,4:5)), b=as.integer64(c(NA,2L,NA,4L,NA)))
   test(1.81, lapply(nafill(l, "locf"), as.character), lapply(list(c(1:2,2L,4:5), c(NA,2L,2L,4L,4L)), as.character))

--- a/inst/tests/nafill.Rraw
+++ b/inst/tests/nafill.Rraw
@@ -31,7 +31,7 @@ test(1.04, nafill(x, fill=5), INT(5,5,3,4,5,5,7,8,5,5))
 test(1.05, nafill(x, fill=NA_integer_), x)
 test(1.06, nafill(x, fill=NA), x)
 test(1.07, nafill(x, fill=NA_real_), x)
-test(1.08, nafill(x, fill=Inf), x)
+test(1.08, nafill(x, fill=Inf), x, warning="NAs introduced by coercion to integer range")
 test(1.09, nafill(x, fill=NaN), x)
 y = x/2
 test(1.11, nafill(y, "locf"), c(NA,NA,3,4,4,4,7,8,8,8)/2)
@@ -63,6 +63,9 @@ test(1.45, nafill(l, "nocb"), list(c(1:2,4L,4:5), structure(c(1,2,4,4,5), class=
 test(1.46, nafill(l, fill=0), list(c(1:2,0L,4:5), structure(c(1,2,0,4,5), class="Date"), c(0L,2L,0L,4L,0L), structure(c(0,2,0,4,0), class="Date")))
 test(1.47, nafill(l, fill=as.Date(0, origin="1970-01-01")), list(c(1:2,0L,4:5), structure(c(1,2,0,4,5), class="Date"), c(0L,2L,0L,4L,0L), structure(c(0,2,0,4,0), class="Date")))
 test(1.48, nafill(l, fill=as.Date("2019-06-05")), list(c(1:2,18052L,4:5), structure(c(1,2,18052,4,5), class="Date"), c(18052L,2L,18052L,4L,18052L), structure(c(18052,2,18052,4,18052), class="Date")))
+
+test(1.50, )
+
 if (test_bit64) {
   l = list(a=as.integer64(c(1:2,NA,4:5)), b=as.integer64(c(NA,2L,NA,4L,NA)))
   test(1.81, lapply(nafill(l, "locf"), as.character), lapply(list(c(1:2,2L,4:5), c(NA,2L,2L,4L,4L)), as.character))
@@ -74,6 +77,8 @@ if (test_bit64) {
   test(1.86, lapply(nafill(l, "locf"), as.character), list(c("3000000001","3000000002","3000000002","3000000004","3000000005"), c(NA_character_,"3000000002","3000000002","3000000004","3000000004")))
   test(1.87, lapply(nafill(l, "nocb"), as.character), list(c("3000000001","3000000002","3000000004","3000000004","3000000005"), c("3000000002","3000000002","3000000004","3000000004",NA_character_)))
   test(1.88, lapply(nafill(l, fill=as.integer64("3000000000")), as.character), list(c("3000000001","3000000002","3000000000","3000000004","3000000005"), c("3000000000","3000000002","3000000000","3000000004","3000000000")))
+  test(1.89, nafill(as.integer64(c(1,2,NA,4)), fill=3), as.integer64(1:4)) # TODO
+  test(1.90, nafill(as.integer64(c(1,2,NA,4)), fill=3L), as.integer64(1:4)) # TODO
 }
 if (test_nanotime) {
   l = list(a=nanotime(c(1:2,NA,4:5)), b=nanotime(c(NA,2L,NA,4L,NA)))

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -194,6 +194,7 @@ SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEX
 
 // nafill.c
 SEXP colnamesInt(SEXP x, SEXP cols);
+SEXP coerceFillR(SEXP fill);
 void nafillDouble(double *x, uint_fast64_t nx, unsigned int type, double fill, ans_t *ans, bool verbose);
 void nafillInteger(int32_t *x, uint_fast64_t nx, unsigned int type, int32_t fill, ans_t *ans, bool verbose);
 SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP inplace, SEXP cols, SEXP verbose);

--- a/src/init.c
+++ b/src/init.c
@@ -167,6 +167,7 @@ R_CallMethodDef callMethods[] = {
 {"CdllVersion", (DL_FUNC) &dllVersion, -1},
 {"CnafillR", (DL_FUNC) &nafillR, -1},
 {"CcolnamesInt", (DL_FUNC) &colnamesInt, -1},
+{"CcoerceFillR", (DL_FUNC) &coerceFillR, -1},
 {"CinitLastUpdated", (DL_FUNC) &initLastUpdated, -1},
 {NULL, NULL, 0}
 };

--- a/src/nafill.c
+++ b/src/nafill.c
@@ -1,5 +1,4 @@
 #include "data.table.h"
-#include <Rdefines.h>
 
 SEXP colnamesInt(SEXP x, SEXP cols) {
   if (!isNewList(x)) error("'x' argument must be data.table");
@@ -164,7 +163,7 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP inplace, SEXP cols, SEXP verbo
 
   double tic=0.0, toc=0.0;
   if (bverbose) tic = omp_get_wtime();
-  #pragma omp parallel for if (nx>1) schedule(auto) num_threads(getDTthreads())
+  #pragma omp parallel for if (nx>1) num_threads(getDTthreads())
   for (R_len_t i=0; i<nx; i++) {
     switch (TYPEOF(VECTOR_ELT(x, i))) {
     case REALSXP :
@@ -176,6 +175,10 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP inplace, SEXP cols, SEXP verbo
     }
   }
   if (bverbose) toc = omp_get_wtime();
+
+  for (R_len_t i=0; i<nx; i++) {
+    if (!isNull(ATTRIB(VECTOR_ELT(x, i)))) copyMostAttrib(VECTOR_ELT(x, i), VECTOR_ELT(ans, i));
+  }
 
   for (R_len_t i=0; i<nx; i++) {
     if (bverbose && (vans[i].message[0][0] != '\0')) Rprintf("%s: %d: %s", __func__, i+1, vans[i].message[0]);

--- a/src/nafill.c
+++ b/src/nafill.c
@@ -59,7 +59,6 @@ void nafillDouble(double *x, uint_fast64_t nx, unsigned int type, double fill, a
   }
   if (verbose) snprintf(ans->message[0], 500, "%s: took %.3fs\n", __func__, omp_get_wtime()-tic);
 }
-
 void nafillInteger(int32_t *x, uint_fast64_t nx, unsigned int type, int32_t fill, ans_t *ans, bool verbose) {
   double tic=0.0;
   if (verbose) tic = omp_get_wtime();
@@ -76,6 +75,26 @@ void nafillInteger(int32_t *x, uint_fast64_t nx, unsigned int type, int32_t fill
     ans->int_v[nx-1] = x[nx-1];
     for (int_fast64_t i=nx-2; i>=0; i--) {
       ans->int_v[i] = x[i]==NA_INTEGER ? ans->int_v[i+1] : x[i];
+    }
+  }
+  if (verbose) snprintf(ans->message[0], 500, "%s: took %.3fs\n", __func__, omp_get_wtime()-tic);
+}
+void nafillInteger64(int64_t *x, uint_fast64_t nx, unsigned int type, int64_t fill, ans_t *ans, bool verbose) {
+  double tic=0.0;
+  if (verbose) tic = omp_get_wtime();
+  if (type==0) { // const
+    for (uint_fast64_t i=0; i<nx; i++) {
+      ans->int64_v[i] = x[i]==NA_INTEGER64 ? fill : x[i];
+    }
+  } else if (type==1) { // locf
+    ans->int64_v[0] = x[0];
+    for (uint_fast64_t i=1; i<nx; i++) {
+      ans->int64_v[i] = x[i]==NA_INTEGER64 ? ans->int64_v[i-1] : x[i];
+    }
+  } else if (type==2) { // nocb
+    ans->int64_v[nx-1] = x[nx-1];
+    for (int_fast64_t i=nx-2; i>=0; i--) {
+      ans->int64_v[i] = x[i]==NA_INTEGER64 ? ans->int64_v[i+1] : x[i];
     }
   }
   if (verbose) snprintf(ans->message[0], 500, "%s: took %.3fs\n", __func__, omp_get_wtime()-tic);
@@ -114,6 +133,7 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP inplace, SEXP cols, SEXP verbo
 
   double* dx[nx];
   int32_t* ix[nx];
+  int64_t* i64x[nx];
   uint_fast64_t inx[nx];
   SEXP ans = R_NilValue;
   ans_t *vans = malloc(sizeof(ans_t)*nx);
@@ -122,16 +142,17 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP inplace, SEXP cols, SEXP verbo
     inx[i] = xlength(VECTOR_ELT(x, i));
     dx[i] = REAL(VECTOR_ELT(x, i));
     ix[i] = INTEGER(VECTOR_ELT(x, i));
+    i64x[i] = (int64_t *)REAL(VECTOR_ELT(x, i));
   }
   if (!binplace) {
     ans = PROTECT(allocVector(VECSXP, nx)); protecti++;
     for (R_len_t i=0; i<nx; i++) {
       SET_VECTOR_ELT(ans, i, allocVector(TYPEOF(VECTOR_ELT(x, i)), inx[i]));
-      vans[i] = ((ans_t) { .dbl_v=REAL(VECTOR_ELT(ans, i)), .int_v=INTEGER(VECTOR_ELT(ans, i)), .status=0, .message={"\0","\0","\0","\0"} });
+      vans[i] = ((ans_t) { .dbl_v=REAL(VECTOR_ELT(ans, i)), .int_v=INTEGER(VECTOR_ELT(ans, i)), .int64_v=(int64_t *)REAL(VECTOR_ELT(ans, i)), .status=0, .message={"\0","\0","\0","\0"} });
     }
   } else {
     for (R_len_t i=0; i<nx; i++) {
-      vans[i] = ((ans_t) { .dbl_v=dx[i], .int_v=ix[i], .status=0, .message={"\0","\0","\0","\0"} });
+      vans[i] = ((ans_t) { .dbl_v=dx[i], .int_v=ix[i], .int64_v=i64x[i], .status=0, .message={"\0","\0","\0","\0"} });
     }
   }
 
@@ -146,16 +167,20 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP inplace, SEXP cols, SEXP verbo
 
   double dfill=NA_REAL;
   int32_t ifill=NA_INTEGER;
+  int64_t i64fill=NA_INTEGER64;
   if (itype==0) {
     if (isInteger(fill)) {
       ifill = INTEGER(fill)[0];
       dfill = INTEGER(fill)[0]==NA_INTEGER ? NA_REAL : (double)INTEGER(fill)[0];
+      i64fill = ((int64_t *)INTEGER(fill))[0];
     } else if (isReal(fill)) {
       ifill = ISNA(REAL(fill)[0]) ? NA_INTEGER : (int32_t)REAL(fill)[0];
       dfill = REAL(fill)[0];
+      i64fill = ((int64_t *)REAL(fill))[0];
     } else if (isLogical(fill) && LOGICAL(fill)[0]==NA_LOGICAL){
       ifill = NA_INTEGER;
       dfill = NA_REAL;
+      i64fill = NA_INTEGER64;
     } else {
       error("fill must be numeric");
     }
@@ -165,19 +190,26 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP inplace, SEXP cols, SEXP verbo
   if (bverbose) tic = omp_get_wtime();
   #pragma omp parallel for if (nx>1) num_threads(getDTthreads())
   for (R_len_t i=0; i<nx; i++) {
-    switch (TYPEOF(VECTOR_ELT(x, i))) {
-    case REALSXP :
-      nafillDouble(dx[i], inx[i], itype, dfill, &vans[i], bverbose);
-      break;
-    case INTSXP :
+    SEXP this_x = VECTOR_ELT(x, i);
+    switch (TYPEOF(this_x)) {
+    case REALSXP : {
+      if (INHERITS(this_x, char_integer64) || INHERITS(this_x, char_nanotime)) {
+        nafillInteger64(i64x[i], inx[i], itype, i64fill, &vans[i], bverbose);
+      } else {
+        nafillDouble(dx[i], inx[i], itype, dfill, &vans[i], bverbose);
+      }
+    } break;
+    case INTSXP : {
       nafillInteger(ix[i], inx[i], itype, ifill, &vans[i], bverbose);
-      break;
+    } break;
     }
   }
   if (bverbose) toc = omp_get_wtime();
 
-  for (R_len_t i=0; i<nx; i++) {
-    if (!isNull(ATTRIB(VECTOR_ELT(x, i)))) copyMostAttrib(VECTOR_ELT(x, i), VECTOR_ELT(ans, i));
+  if (!binplace) {
+    for (R_len_t i=0; i<nx; i++) {
+      if (!isNull(ATTRIB(VECTOR_ELT(x, i)))) copyMostAttrib(VECTOR_ELT(x, i), VECTOR_ELT(ans, i));
+    }
   }
 
   for (R_len_t i=0; i<nx; i++) {

--- a/src/nafill.c
+++ b/src/nafill.c
@@ -163,13 +163,9 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP inplace, SEXP cols, SEXP verbo
 
   bool binplace = LOGICAL(inplace)[0];
   SEXP x = R_NilValue;
-  int ncols_int=0;
-  int ncols_double=0;
   if (isVectorAtomic(obj)) {
     if (binplace) error("'x' argument is atomic vector, in-place update is supported only for list/data.table");
-    else if (isReal(obj)) ncols_double=1;
-    else if (isInteger(obj)) ncols_int=1;
-    else error("'x' argument must be numeric type, or list/data.table of numeric types");
+    else if (!isReal(obj) && !isInteger(obj)) error("'x' argument must be numeric type, or list/data.table of numeric types");
     x = PROTECT(allocVector(VECSXP, 1)); protecti++; // wrap into list
     SET_VECTOR_ELT(x, 0, obj);
   } else {
@@ -178,9 +174,7 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP inplace, SEXP cols, SEXP verbo
     int *icols = INTEGER(ricols);
     for (int i=0; i<length(ricols); i++) {
       SEXP this_col = VECTOR_ELT(obj, icols[i]-1);
-      if (isReal(this_col)) ncols_double++;
-      else if (isInteger(this_col)) ncols_int++;
-      else error("'x' argument must be numeric type, or list/data.table of numeric types");
+      if (!isReal(this_col) && !isInteger(this_col)) error("'x' argument must be numeric type, or list/data.table of numeric types");
       SET_VECTOR_ELT(x, i, this_col);
     }
   }


### PR DESCRIPTION
closes #3617
adds support for int64 and nanotime
fixes previous improper coercion of `fill` argument in some edge cases