### PR TITLE
clarify error when rbindlist(l) is not a list()

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2675,7 +2675,7 @@ chgroup = function(x) {
 
 rbindlist = function(l, use.names="check", fill=FALSE, idcol=NULL) {
   if (is.null(l)) return(null.data.table())
-  if (!is.list(l)) stop("Input is not a list")
+  if (class(l)[1L]!="list") stop("Input is ", class(l)[1L]," but should be a plain list of items to be stacked")
   if (isFALSE(idcol)) { idcol = NULL }
   else if (!is.null(idcol)) {
     if (isTRUE(idcol)) idcol = ".id"

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2674,6 +2674,7 @@ chgroup = function(x) {
 }
 
 rbindlist = function(l, use.names="check", fill=FALSE, idcol=NULL) {
+  if(!is.list(l)) stop("Input is not a list")
   if (isFALSE(idcol)) { idcol = NULL }
   else if (!is.null(idcol)) {
     if (isTRUE(idcol)) idcol = ".id"

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2674,7 +2674,8 @@ chgroup = function(x) {
 }
 
 rbindlist = function(l, use.names="check", fill=FALSE, idcol=NULL) {
-  if(!is.list(l)) stop("Input is not a list")
+  if (is.null(l)) return(null.data.table())
+  if (!is.list(l)) stop("Input is not a list")
   if (isFALSE(idcol)) { idcol = NULL }
   else if (!is.null(idcol)) {
     if (isTRUE(idcol)) idcol = ".id"

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -14978,6 +14978,15 @@ test(2054, DT[order(C)[1:5], B, verbose=TRUE], c('b', 'b', 'c', 'c', 'a'),
            output = 'order optimisation is on')
 
 
+# rbindlist improved error message, #3638
+DT = data.table(a = 1)
+test(2055.1, rbindlist(list(DT,1)), error="Item 2 of input is not a data.frame, data.table or list")
+test(2055.2, rbindlist(DT), error="Input is not a list")
+
+
+
+
+
 ###################################
 #  Add new tests above this line  #
 ###################################

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -14977,14 +14977,10 @@ DT = data.table(
 test(2054, DT[order(C)[1:5], B, verbose=TRUE], c('b', 'b', 'c', 'c', 'a'),
            output = 'order optimisation is on')
 
-
 # rbindlist improved error message, #3638
-DT = data.table(a = 1)
-test(2055.1, rbindlist(list(DT,1)), error="Item 2 of input is not a data.frame, data.table or list")
-test(2055.2, rbindlist(DT), error="Input is not a list")
-
-
-
+DT = data.table(a=1)
+test(2059.1, rbindlist(list(DT,1)), error="Item 2 of input is not a data.frame, data.table or list")
+test(2059.2, rbindlist(DT), error="Input is data.table but should be a plain list of items to be stacked")
 
 
 ###################################


### PR DESCRIPTION
hi, in the code below, users hit [this error message](https://github.com/Rdatatable/data.table/blob/2619f1a594fa1e2967c11fb3339522f240e2afa0/src/rbindlist.c#L31) that says `data.table` and `data.frame` objects are OK when they're actually not..  thanks for the amazing software!


	library(data.table)


	# correct error message
	rbindlist( list( 1 ) )
	# Error in rbindlist(x) : 
	#   Item 1 of input is not a data.frame, data.table or list

	
	# confusing error message, since item 1 is a data.frame
	rbindlist( mtcars )
	# Error in rbindlist(x) : 
	#   Item 1 of input is not a data.frame, data.table or list

	class(mtcars)
	# [1] "data.frame"

	x <- data.table( mtcars )

	# confusing error message, since item 1 is a data.table
	rbindlist( x )
	# Error in rbindlist(x) : 
	#   Item 1 of input is not a data.frame, data.table or list

	class( x )
	# [1] "data.table" "data.frame"


	# works as expected
	rbindlist( list( mtcars ) )
	rbindlist( list( x ) )