### PR TITLE
Fix for Intel compiler bug

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -129,7 +129,6 @@
     # TRUE
     ```
 
-
 #### BUG FIXES
 
 1. `first`, `last`, `head` and `tail` by group no longer error in some cases, [#2030](https://github.com/Rdatatable/data.table/issues/2030) [#3462](https://github.com/Rdatatable/data.table/issues/3462). Thanks to @franknarf1 for reporting.
@@ -188,6 +187,8 @@
     # 1:     1    a,b
     # 2:     2      a
     ```
+
+23. Incorrect sorting/grouping results due to a bug in Intel's `icc` compiler 2019 (Version 19.0.4.243 Build 20190416) has been worked around thanks to a report and fix by Sebastian Freundt, [#3647](https://github.com/Rdatatable/data.table/issues/3647). Please run `data.table::test.data.table()`. If that passes, your installation does not have the problem.
 
 #### NOTES
 

--- a/src/forder.c
+++ b/src/forder.c
@@ -902,8 +902,13 @@ void radix_r(const int from, const int to, const int radix) {
       // Always ascending sort here (even when sortType==-1) because descending was prepared in write_key
       my_counts[my_key[0]] = 1;
       int i=1;
-      while (skip && i<my_n) { my_counts[my_key[i]]++; skip=(my_key[i]>=my_key[i-1]); i++; }
       while (i<my_n)         { my_counts[my_key[i]]++; i++; }  // as soon as not-ordered is detected (likely quickly when it isn't sorted), save the >= comparison
+      for (i=1; i<my_n; i++) {
+        if (my_key[i]<my_key[i-1]) {
+          skip=false;
+          break;
+        }
+      }
       TEND(11)
     } else {
       for (int i=0; i<my_n; i++) {

--- a/src/forder.c
+++ b/src/forder.c
@@ -900,14 +900,11 @@ void radix_r(const int from, const int to, const int radix) {
     TEND(10)
     if (sortType!=0) {
       // Always ascending sort here (even when sortType==-1) because descending was prepared in write_key
-      my_counts[my_key[0]] = 1;
-      int i=1;
-      while (i<my_n)         { my_counts[my_key[i]]++; i++; }  // as soon as not-ordered is detected (likely quickly when it isn't sorted), save the >= comparison
-      for (i=1; i<my_n; i++) {
-        if (my_key[i]<my_key[i-1]) {
-          skip=false;
-          break;
-        }
+      for (int i=0; i<my_n; ++i) my_counts[my_key[i]]++;  // minimal branch-free loop first, #3647
+      for (int i=1; i<my_n; ++i) {
+        if (my_key[i]<my_key[i-1]) { skip=false; break; }
+        // stop early as soon as not-ordered is detected; likely quickly when it isn't sorted
+        // otherwise, it's worth checking if it is ordered because skip saves time later
       }
       TEND(11)
     } else {


### PR DESCRIPTION
Closes #3647 
Calculate `skip` condition after and separate from key counting.