### PR TITLE
Link to FAQ 1.11

### DIFF
--- a/man/merge.Rd
+++ b/man/merge.Rd
@@ -67,7 +67,7 @@ control for providing the columns to merge on with the help of the newly impleme
 \code{by.x} and \code{by.y} arguments.
 
 For a more \code{data.table}-centric way of merging two \code{data.table}s, see
-\code{\link{[.data.table}}; e.g., \code{x[y, \dots]}. See FAQ 1.12 for a detailed
+\code{\link{[.data.table}}; e.g., \code{x[y, \dots]}. See FAQ 1.11 for a detailed
 comparison of \code{merge} and \code{x[y, \dots]}.
 
 If any column names provided to \code{by.x} also occur in \code{names(y)} but not in \code{by.y},


### PR DESCRIPTION
I'm pretty sure this is supposed to link to 1.11 ("What is the difference between X[Y] and merge(X, Y)?") not ("Anything else about X[Y, sum(foo*bar)]?")

I'd also be happy to add a link directly to the FAQ (https://cran.r-project.org/web/packages/data.table/vignettes/datatable-faq.html#MergeDiff) if you thought that was useful.