### PR TITLE
Closes #3664 -- diligently avoid partial argument matching

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -222,7 +222,7 @@
 
 11. We intend to deprecate the `datatable.nomatch` option, [more info](https://github.com/Rdatatable/data.table/pull/3578/files). A message is now printed upon use of the option (once per session) as a first step. It asks you to please stop using the option and to pass `nomatch=NULL` explicitly if you require inner join. Outer join (`nomatch=NA`) has always been the default because it is safer; it does not drop missing data silently. The problem is that the option is global; i.e., if a user changes the default using this option for their own use, that can change the behavior of joins inside packages that use `data.table` too. This is the only `data.table` option with this concern.
 
-12. Cleaned up internal code to only use exact argument matching (especially using `exact=TRUE` for calls to `attr`). This is for both safety and efficiency, [#3664](https://github.com/Rdatatable/data.table/issues/3664). Thanks to @vlulla who ferreted this out by using the `warnPartialMatchArgs` and `warnPartialMatchAttr` options.
+12. The test suite of 9k tests now runs with three R options on: `warnPartialMatchArgs`, `warnPartialMatchAttr`, and `warnPartialMatchDollar`. This ensures that we don't rely on partial argument matching in internal code, for robustness and efficiency, and so that users can turn these options on for their code in production, [#3664](https://github.com/Rdatatable/data.table/issues/3664). Thanks to Vijay Lulla for the suggestion, and Michael Chirico for fixing 48 internal calls to `attr()` which were missing `exact=TRUE`, for example. Thanks to R-core for adding these options to R 2.6.0 (Oct 2007).
 
 
 ### Changes in [v1.12.2](https://github.com/Rdatatable/data.table/milestone/14?closed=1)  (07 Apr 2019)

--- a/NEWS.md
+++ b/NEWS.md
@@ -220,6 +220,8 @@
 
 11. We intend to deprecate the `datatable.nomatch` option, [more info](https://github.com/Rdatatable/data.table/pull/3578/files). A message is now printed upon use of the option (once per session) as a first step. It asks you to please stop using the option and to pass `nomatch=NULL` explicitly if you require inner join. Outer join (`nomatch=NA`) has always been the default because it is safer; it does not drop missing data silently. The problem is that the option is global; i.e., if a user changes the default using this option for their own use, that can change the behavior of joins inside packages that use `data.table` too. This is the only `data.table` option with this concern.
 
+12. Cleaned up internal code to only use exact argument matching (especially using `exact=TRUE` for calls to `attr`). This is for both safety and efficiency, [#3664](https://github.com/Rdatatable/data.table/issues/3664). Thanks to @vlulla who ferreted this out by using the `warnPartialMatchArgs` and `warnPartialMatchAttr` options.
+
 
 ### Changes in [v1.12.2](https://github.com/Rdatatable/data.table/milestone/14?closed=1)  (07 Apr 2019)
 

--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -5,7 +5,7 @@
 
 as.IDate = function(x, ...) UseMethod("as.IDate")
 
-as.IDate.default = function(x, ..., tz = attr(x, "tzone")) {
+as.IDate.default = function(x, ..., tz = attr(x, "tzone", exact=TRUE)) {
   if (is.null(tz)) tz = "UTC"
   as.IDate(as.Date(x, tz = tz, ...))
 }
@@ -32,7 +32,7 @@ as.IDate.Date = function(x, ...) {
   x                                 # always return a new object
 }
 
-as.IDate.POSIXct = function(x, tz = attr(x, "tzone"), ...) {
+as.IDate.POSIXct = function(x, tz = attr(x, "tzone", exact=TRUE), ...) {
   if (is.null(tz)) tz = "UTC"
   if (tz %chin% c("UTC", "GMT")) {
     (setattr(as.integer(x) %/% 86400L, "class", c("IDate", "Date")))  # %/% returns new object so can use setattr() on it; wrap with () to return visibly
@@ -135,7 +135,7 @@ as.ITime.default = function(x, ...) {
   as.ITime(as.POSIXlt(x, ...), ...)
 }
 
-as.ITime.POSIXct = function(x, tz = attr(x, "tzone"), ...) {
+as.ITime.POSIXct = function(x, tz = attr(x, "tzone", exact=TRUE), ...) {
   if (is.null(tz)) tz = "UTC"
   if (tz %chin% c("UTC", "GMT")) as.ITime(unclass(x), ...)
   else as.ITime(as.POSIXlt(x, tz = tz, ...), ...)
@@ -302,7 +302,7 @@ as.POSIXlt.ITime = function(x, ...) {
 ###################################################################
 
 second  = function(x) {
-  if (inherits(x,'POSIXct') && identical(attr(x,'tzone'),'UTC')) {
+  if (inherits(x, 'POSIXct') && identical(attr(x, 'tzone', exact=TRUE), 'UTC')) {
     # if we know the object is in UTC, can calculate the hour much faster
     as.integer(x) %% 60L
   } else {
@@ -310,7 +310,7 @@ second  = function(x) {
   }
 }
 minute  = function(x) {
-  if (inherits(x,'POSIXct') && identical(attr(x,'tzone'),'UTC')) {
+  if (inherits(x, 'POSIXct') && identical(attr(x, 'tzone', exact=TRUE), 'UTC')) {
     # ever-so-slightly faster than x %% 3600L %/% 60L
     as.integer(x) %/% 60L %% 60L
   } else {
@@ -318,7 +318,7 @@ minute  = function(x) {
   }
 }
 hour = function(x) {
-  if (inherits(x,'POSIXct') && identical(attr(x,'tzone'),'UTC')) {
+  if (inherits(x, 'POSIXct') && identical(attr(x, 'tzone', exact=TRUE), 'UTC')) {
     # ever-so-slightly faster than x %% 86400L %/% 3600L
     as.integer(x) %/% 3600L %% 24L
   } else {

--- a/R/between.R
+++ b/R/between.R
@@ -6,7 +6,7 @@ between = function(x,lower,upper,incbounds=TRUE) {
   is.px = function(x) inherits(x, "POSIXct")
   is.i64 = function(x) inherits(x, "integer64")
   # POSIX special handling to auto coerce character
-  if (is.px(x) && !is.null(tz<-attr(x, "tzone", TRUE)) && nzchar(tz) &&
+  if (is.px(x) && !is.null(tz<-attr(x, "tzone", exact=TRUE)) && nzchar(tz) &&
       (is.character(lower) || is.character(upper))) {
     try_posix_cast = function(x, tz) {tryCatch(
       list(status=0L, value=as.POSIXct(x, tz = tz)),
@@ -30,7 +30,7 @@ between = function(x,lower,upper,incbounds=TRUE) {
       ((is.null(x) || !nzchar(x)) && (is.null(y) || !nzchar(y)) && (is.null(z) || !nzchar(z))) ||
         (identical(x, y) && identical(x, z))
     }
-    if (!tz_match(attr(x, "tzone", TRUE), attr(lower, "tzone", TRUE), attr(upper, "tzone", TRUE))) {
+    if (!tz_match(attr(x, "tzone", exact=TRUE), attr(lower, "tzone", exact=TRUE), attr(upper, "tzone", exact=TRUE))) {
       stop("'between' function arguments have mismatched timezone attribute, align all arguments to same timezone")
     }
   }

--- a/R/bmerge.R
+++ b/R/bmerge.R
@@ -138,13 +138,13 @@ bmerge = function(i, x, icols, xcols, roll, rollends, nomatch, mult, ops, verbos
     # TODO: could check/reuse secondary indices, but we need 'starts' attribute as well!
     xo = forderv(x, xcols, retGrp=TRUE)
     if (verbose) {cat(timetaken(last.started.at),"\n"); flush.console()}
-    xg = attr(xo, 'starts')
+    xg = attr(xo, 'starts', exact=TRUE)
     resetcols = head(xcols, non_equi-1L)
     if (length(resetcols)) {
       # TODO: can we get around having to reorder twice here?
       # or at least reuse previous order?
       if (verbose) {last.started.at=proc.time();cat("  Generating group lengths ... ");flush.console()}
-      resetlen = attr(forderv(x, resetcols, retGrp=TRUE), 'starts')
+      resetlen = attr(forderv(x, resetcols, retGrp=TRUE), 'starts', exact=TRUE)
       resetlen = .Call(Cuniqlengths, resetlen, nrow(x))
       if (verbose) {cat("done in",timetaken(last.started.at),"\n"); flush.console()}
     } else resetlen = integer(0L)

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -993,12 +993,13 @@ replace_order = function(isub, verbose, env) {
       newnames = NULL
       suppPrint = identity
       if (length(av) && av[1L] == ":=") {
-        if (identical(attr(x,".data.table.locked"),TRUE)) stop(".SD is locked. Using := in .SD's j is reserved for possible future use; a tortuously flexible way to modify by group. Use := in j directly to modify by group by reference.")
+        if (identical(attr(x, ".data.table.locked", exact=TRUE), TRUE)) stop(".SD is locked. Using := in .SD's j is reserved for possible future use; a tortuously flexible way to modify by group. Use := in j directly to modify by group by reference.")
         suppPrint = function(x) { .global$print=address(x); x }
         # Suppress print when returns ok not on error, bug #2376. Thanks to: http://stackoverflow.com/a/13606880/403310
         # All appropriate returns following this point are wrapped; i.e. return(suppPrint(x)).
 
         if (is.null(names(jsub))) {
+          #print(microbenchmark::get_nanotime())
           # regular LHS:=RHS usage, or `:=`(...) with no named arguments (an error)
           # `:=`(LHS,RHS) is valid though, but more because can't see how to detect that, than desire
           if (length(jsub)!=3L) stop("In `:=`(col1=val1, col2=val2, ...) form, all arguments must be named.")
@@ -1010,12 +1011,15 @@ replace_order = function(isub, verbose, env) {
             # e.g. (MyVar):= or get("MyVar"):=
             lhs = eval(lhs, parent.frame(), parent.frame())
           }
+          #print(microbenchmark::get_nanotime())
         } else {
+          #print(microbenchmark::get_nanotime())
           # `:=`(c2=1L,c3=2L,...)
           lhs = names(jsub)[-1L]
-          if (any(lhs=="")) stop("In `:=`(col1=val1, col2=val2, ...) form, all arguments must be named.")
+          if (!all(nzchar(lhs))) stop("In `:=`(col1=val1, col2=val2, ...) form, all arguments must be named.")
           names(jsub)=""
           jsub[[1L]]=as.name("list")
+          #print(microbenchmark::get_nanotime())
         }
         av = all.vars(jsub,TRUE)
         if (!is.atomic(lhs)) stop("LHS of := must be a symbol, or an atomic vector (column names or positions).")
@@ -1393,7 +1397,7 @@ replace_order = function(isub, verbose, env) {
           cat("Finding group sizes from the positions (can be avoided to save RAM) ... ")
           flush.console()  # for windows
         }
-        f__ = attr(o__, "starts")
+        f__ = attr(o__, "starts", exact=TRUE)
         len__ = uniqlengths(f__, xnrow)
         if (verbose) {cat(timetaken(last.started.at),"\n"); flush.console()}
         if (!bysameorder && !keyby) {
@@ -1741,7 +1745,7 @@ replace_order = function(isub, verbose, env) {
     if (any(names(x)[cols] %chin% key(x)))
       setkey(x,NULL)
     # fixes #1479. Take care of secondary indices, TODO: cleaner way of doing this
-    attrs = attr(x, 'index')
+    attrs = attr(x, 'index', exact=TRUE)
     skeys = names(attributes(attrs))
     if (!is.null(skeys)) {
       hits  = unlist(lapply(paste0("__", names(x)[cols]), function(x) grep(x, skeys, fixed = TRUE)))
@@ -1899,7 +1903,7 @@ as.matrix.data.table = function(x, rownames=NULL, rownames.value=NULL, ...) {
     if (!is.logical(xj))
       all.logical = FALSE
     if (length(levels(xj)) > 0L || !(is.numeric(xj) || is.complex(xj) || is.logical(xj)) ||
-        (!is.null(cl <- attr(xj, "class")) && any(cl %chin%
+        (!is.null(cl <- attr(xj, "class", exact=TRUE)) && any(cl %chin%
         c("Date", "POSIXct", "POSIXlt"))))
       non.numeric = TRUE
     if (!is.atomic(xj))
@@ -2108,7 +2112,7 @@ transform.data.table = function (`_data`, ...)
   inx = chmatch(tags, names(`_data`))
   matched = !is.na(inx)
   if (any(matched)) {
-    if (isTRUE(attr(`_data`, ".data.table.locked", TRUE))) {
+    if (isTRUE(attr(`_data`, ".data.table.locked", exact=TRUE))) {
       setattr(`_data`, ".data.table.locked", NULL) # fix for #1641, now covered by test 104.2
     }
     `_data`[,inx[matched]] = e[matched]
@@ -2348,7 +2352,7 @@ point = function(to, to_idx, from, from_idx) {
       setattr(ans, "sorted", head(key(ans), keylength)) ## keep what can be kept
     }
     ## take care of attributes.
-    indices = names(attributes(attr(ans, "index")))
+    indices = names(attributes(attr(ans, "index", exact=TRUE)))
     for(index in indices) {
       indexcols = strsplit(index, split = "__")[[1L]][-1L]
       indexlength = which.first(!indexcols %chin% cols) - 1L
@@ -2357,13 +2361,13 @@ point = function(to, to_idx, from, from_idx) {
       if (reducedindex %chin% indices || !indexlength) {
         ## Either reduced index already present or no columns of the original index remain.
         ## Drop the original index completely
-        setattr(attr(ans, "index", exact = TRUE), index, NULL)
-      } else if(length(attr(attr(ans, "index"), index))) {
+        setattr(attr(ans, "index", exact=TRUE), index, NULL)
+      } else if(length(attr(attr(ans, "index", exact=TRUE), index, exact=TRUE))) {
         ## index is not length 0. Drop it since shortening could lead to spurious reordering in discarded columns (#2336)
-        setattr(attr(ans, "index", exact = TRUE), index, NULL)
+        setattr(attr(ans, "index", exact=TRUE), index, NULL)
       } else {
         ## rename index to reducedindex
-        names(attributes(attr(ans, "index")))[names(attributes(attr(ans, "index"))) == index] = reducedindex
+        names(attributes(attr(ans, "index")))[names(attributes(attr(ans, "index", exact=TRUE))) == index] = reducedindex
       }
     }
   } else { # retain.key == FALSE
@@ -2411,7 +2415,7 @@ setattr = function(x,name,value) {
   # User can also call `attr<-` function directly, but that copies (maybe just when NAMED>0, which is always for data.frame, I think).  See "Confused by NAMED" thread on r-devel 24 Nov 2011.
   # We tend to use setattr() internally in data.table.R because often we construct a data.table and it hasn't
   # got names yet. setnames() is the user interface which checks integrity and doesn't let you drop names for example.
-  if (name=="names" && is.data.table(x) && length(attr(x,"names")) && !is.null(value))
+  if (name=="names" && is.data.table(x) && length(attr(x, "names", exact=TRUE)) && !is.null(value))
     setnames(x,value)
     # Using setnames here so that truelength of names can be retained, to carry out integrity checks such as not
     # creating names longer than the number of columns of x, and to change the key, too
@@ -2484,10 +2488,10 @@ setnames = function(x,old,new,skip_absent=FALSE) {
   m = chmatch(names(x)[i], key(x))
   w = which(!is.na(m))
   if (length(w))
-    .Call(Csetcharvec, attr(x,"sorted"), m[w], new[w])
+    .Call(Csetcharvec, attr(x, "sorted", exact=TRUE), m[w], new[w])
 
   # update secondary keys
-  idx = attr(x,"index")
+  idx = attr(x, "index", exact=TRUE)
   for (k in names(attributes(idx))) {
     tt = strsplit(k,split="__")[[1L]][-1L]
     m = chmatch(names(x)[i], tt)
@@ -2495,12 +2499,12 @@ setnames = function(x,old,new,skip_absent=FALSE) {
     if (length(w)) {
       tt[m[w]] = new[w]
       newk = paste0("__",tt,collapse="")
-      setattr(idx, newk, attr(idx, k))
+      setattr(idx, newk, attr(idx, k, exact=TRUE))
       setattr(idx, k, NULL)
     }
   }
 
-  .Call(Csetcharvec, attr(x,"names"), as.integer(i), new)
+  .Call(Csetcharvec, attr(x, "names", exact=TRUE), as.integer(i), new)
   invisible(x)
 }
 
@@ -2776,7 +2780,7 @@ rowidv = function(x, cols=seq_along(x), prefix=NULL) {
     cols = as.integer(cols)
   }
   xorder = forderv(x, by=cols, sort=FALSE, retGrp=TRUE) # speedup on char with sort=FALSE
-  xstart = attr(xorder, 'start')
+  xstart = attr(xorder, 'starts', exact=TRUE)
   if (!length(xorder)) xorder = seq_along(x[[1L]])
   ids = .Call(Cfrank, xorder, xstart, uniqlengths(xstart, length(xorder)), "sequence")
   if (!is.null(prefix))
@@ -2846,7 +2850,7 @@ isReallyReal = function(x) {
   #'        ATTENTION: If nothing else helps, an auto-index is created on x unless options prevent this.
   if(getOption("datatable.optimize") < 3L) return(NULL) ## at least level three optimization required.
   if (!is.call(isub)) return(NULL)
-  if (!is.null(attr(x, '.data.table.locked'))) return(NULL)  # fix for #958, don't create auto index on '.SD'.
+  if (!is.null(attr(x, '.data.table.locked', exact=TRUE))) return(NULL)  # fix for #958, don't create auto index on '.SD'.
   ## a list of all possible operators with their translations into the 'on' clause
   validOps = list(op = c("==", "%in%", "%chin%"),
                    on = c("==", "==",   "=="))
@@ -2955,7 +2959,7 @@ isReallyReal = function(x) {
     idx = NULL
     for (cand in candidates){
       if (all(names(i) %chin% cand) && length(cand) == length(i)){
-        idx = attr(attr(x, "index"), paste0("__", cand, collapse = ""))
+        idx = attr(attr(x, "index", exact=TRUE), paste0("__", cand, collapse = ""), exact = TRUE)
         idxCols = cand
         break
       }
@@ -2972,7 +2976,7 @@ isReallyReal = function(x) {
     setindexv(x, names(i))
     if (verbose) {cat(timetaken(last.started.at),"\n");flush.console()}
     if (verbose) {cat("Optimized subsetting with index '", paste0(names(i), collapse = "__"),"'\n",sep="");flush.console()}
-    idx = attr(attr(x, "index"), paste0("__", names(i), collapse = ""))
+    idx = attr(attr(x, "index", exact=TRUE), paste0("__", names(i), collapse = ""), exact=TRUE)
     idxCols = names(i)
   }
   if(!is.null(idxCols)){

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -999,7 +999,6 @@ replace_order = function(isub, verbose, env) {
         # All appropriate returns following this point are wrapped; i.e. return(suppPrint(x)).
 
         if (is.null(names(jsub))) {
-          #print(microbenchmark::get_nanotime())
           # regular LHS:=RHS usage, or `:=`(...) with no named arguments (an error)
           # `:=`(LHS,RHS) is valid though, but more because can't see how to detect that, than desire
           if (length(jsub)!=3L) stop("In `:=`(col1=val1, col2=val2, ...) form, all arguments must be named.")
@@ -1011,15 +1010,12 @@ replace_order = function(isub, verbose, env) {
             # e.g. (MyVar):= or get("MyVar"):=
             lhs = eval(lhs, parent.frame(), parent.frame())
           }
-          #print(microbenchmark::get_nanotime())
         } else {
-          #print(microbenchmark::get_nanotime())
           # `:=`(c2=1L,c3=2L,...)
           lhs = names(jsub)[-1L]
-          if (!all(nzchar(lhs))) stop("In `:=`(col1=val1, col2=val2, ...) form, all arguments must be named.")
+          if (any(lhs=="")) stop("In `:=`(col1=val1, col2=val2, ...) form, all arguments must be named.")
           names(jsub)=""
           jsub[[1L]]=as.name("list")
-          #print(microbenchmark::get_nanotime())
         }
         av = all.vars(jsub,TRUE)
         if (!is.atomic(lhs)) stop("LHS of := must be a symbol, or an atomic vector (column names or positions).")

--- a/R/duplicated.R
+++ b/R/duplicated.R
@@ -23,8 +23,8 @@ duplicated.data.table = function(x, incomparables=FALSE, fromLast=FALSE, by=seq_
     if (fromLast) f = cumsum(uniqlengths(f, nrow(x)))
   } else {
     o = forderv(x, by=query$by, sort=FALSE, retGrp=TRUE)
-    if (attr(o, 'maxgrpn') == 1L) return(rep.int(FALSE, nrow(x)))
-    f = attr(o,"starts")
+    if (attr(o, 'maxgrpn', exact=TRUE) == 1L) return(rep.int(FALSE, nrow(x)))
+    f = attr(o, "starts", exact=TRUE)
     if (fromLast) f = cumsum(uniqlengths(f, nrow(x)))
     if (length(o)) f = o[f]
   }
@@ -47,8 +47,8 @@ unique.data.table = function(x, incomparables=FALSE, fromLast=FALSE, by=seq_alon
   # if by=key(x), forderv tests for orderedness within it quickly and will short-circuit
   # there isn't any need in unique() to call uniqlist like duplicated does; uniqlist returns a new nrow(x) vector anyway and isn't
   # as efficient as forderv returning empty o when input is already ordered
-  if (attr(o, 'maxgrpn') == 1L) return(copy(x))  # return copy so that unique(x)[, col := val] doesn't affect original data.table, #3383.
-  f = attr(o,"starts")
+  if (attr(o, 'maxgrpn', exact=TRUE) == 1L) return(copy(x))  # return copy so that unique(x)[, col := val] doesn't affect original data.table, #3383.
+  f = attr(o, "starts", exact=TRUE)
   if (fromLast) f = cumsum(uniqlengths(f, nrow(x)))
   if (length(o)) f = o[f]
   if (length(o <- forderv(f))) f = f[o]  # don't sort the uniques too
@@ -149,7 +149,7 @@ uniqueN = function(x, by = if (is.list(x)) seq_along(x) else NULL, na.rm=FALSE) 
   }
   if (is.null(by)) by = seq_along(x)
   o = forderv(x, by=by, retGrp=TRUE, na.last=if (!na.rm) FALSE else NA)
-  starts = attr(o, 'starts')
+  starts = attr(o, 'starts', exact=TRUE)
   if (!na.rm) {
     length(starts)
   } else {

--- a/R/fcast.R
+++ b/R/fcast.R
@@ -142,7 +142,7 @@ dcast.data.table = function(data, formula, fun.aggregate = NULL, sep = "_", ...,
   fill.default = NULL
   if (is.null(fun.call)) {
     oo = forderv(dat, by=varnames, retGrp=TRUE)
-    if (attr(oo, 'maxgrpn') > 1L) {
+    if (attr(oo, 'maxgrpn', exact=TRUE) > 1L) {
       message("Aggregate function missing, defaulting to 'length'")
       fun.call = quote(length)
     }
@@ -159,7 +159,7 @@ dcast.data.table = function(data, formula, fun.aggregate = NULL, sep = "_", ...,
   }
   order_ = function(x) {
     o = forderv(x, retGrp=TRUE, sort=TRUE)
-    idx = attr(o, 'starts')
+    idx = attr(o, 'starts', exact=TRUE)
     if (!length(o)) o = seq_along(x)
     o[idx] # subsetVector retains attributes, using R's subset for now
   }

--- a/R/foverlaps.R
+++ b/R/foverlaps.R
@@ -78,7 +78,7 @@ foverlaps = function(x, y, by.x=if (!is.null(key(x))) key(x) else key(y), by.y=k
     stop("Some interval cols are of type POSIXct while others are not. Please ensure all interval cols are (or are not) of POSIXct type")
   }
   # #1143, mismatched timezone
-  getTZ = function(x) if (is.null(tz <- attr(x, "tzone"))) "" else tz # "" == NULL AFAICT
+  getTZ = function(x) if (is.null(tz <- attr(x, "tzone", exact=TRUE))) "" else tz # "" == NULL AFAICT
   tzone_chk = c(getTZ(xval1), getTZ(xval2), getTZ(yval1), getTZ(yval2))
   if (any(tzone_chk != tzone_chk[1L])) {
     warning("POSIXct interval cols have mixed timezones. Overlaps are performed on the internal numerical representation of POSIXct objects, therefore printed values may give the impression that values don't overlap but their internal representations will. Please ensure that POSIXct type interval cols have identical 'tzone' attributes to avoid confusion.")

--- a/R/frank.R
+++ b/R/frank.R
@@ -43,7 +43,7 @@ frankv = function(x, cols=seq_along(x), order=1L, na.last=TRUE, ties.method=c("a
     cols = c(cols, ncol(x))
   }
   xorder  = forderv(x, by=cols, order=order, sort=TRUE, retGrp=TRUE, na.last=if (isFALSE(na.last)) na.last else TRUE)
-  xstart  = attr(xorder, 'starts')
+  xstart  = attr(xorder, 'starts', exact=TRUE)
   xsorted = FALSE
   if (!length(xorder)) {
     xsorted = TRUE

--- a/R/fread.R
+++ b/R/fread.R
@@ -285,7 +285,7 @@ yaml=FALSE, autostart=NA)
     setattr(ans, 'names', make.names(names(ans), unique=TRUE))
   }
 
-  colClassesAs = attr(ans, "colClassesAs")   # should only be present if one or more are != ""
+  colClassesAs = attr(ans, "colClassesAs", exact=TRUE)   # should only be present if one or more are != ""
   for (j in which(colClassesAs!="")) {       # # 1634
     v = .subset2(ans, j)
     new_class = colClassesAs[j]

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -125,7 +125,7 @@ format.data.table = function (x, ..., justify="none", timezone = FALSE) {
   }
   # FR #2842 add timezone for posix timestamps
   format.timezone = function(col) { # paste timezone to a time object
-    tz = attr(col,'tzone', exact = TRUE)
+    tz = attr(col,'tzone', exact=TRUE)
     if (!is.null(tz)) { # date object with tz
       nas = is.na(col)
       col = paste0(as.character(col)," ",tz) # parse to character

--- a/R/setkey.R
+++ b/R/setkey.R
@@ -43,7 +43,7 @@ setkeyv = function(x, cols, verbose=getOption("datatable.verbose"), physical=TRU
   }
   if (!is.data.table(x)) stop("x is not a data.table")
   if (!is.character(cols)) stop("cols is not a character vector. Please see further information in ?setkey.")
-  if (physical && identical(attr(x,".data.table.locked"),TRUE)) stop("Setting a physical key on .SD is reserved for possible future use; to modify the original data's order by group. Try setindex() instead. Or, set*(copy(.SD)) as a (slow) last resort.")
+  if (physical && identical(attr(x, ".data.table.locked", exact=TRUE),TRUE)) stop("Setting a physical key on .SD is reserved for possible future use; to modify the original data's order by group. Try setindex() instead. Or, set*(copy(.SD)) as a (slow) last resort.")
   if (!length(cols)) {
     warning("cols is a character vector of zero length. Removed the key, but use NULL instead, or wrap with suppressWarnings() to avoid this warning.")
     setattr(x,"sorted",NULL)
@@ -64,15 +64,15 @@ setkeyv = function(x, cols, verbose=getOption("datatable.verbose"), physical=TRU
   if (identical(key(x),cols)) {
     if (!physical) {
       ## create index as integer() because already sorted by those columns
-      if (is.null(attr(x,"index",exact=TRUE))) setattr(x, "index", integer())
-      setattr(attr(x,"index",exact=TRUE), paste0("__", cols, collapse=""), integer())
+      if (is.null(attr(x, "index", exact=TRUE))) setattr(x, "index", integer())
+      setattr(attr(x, "index", exact=TRUE), paste0("__", cols, collapse=""), integer())
     }
     return(invisible(x))
   } else if(identical(head(key(x), length(cols)), cols)){
     if (!physical) {
       ## create index as integer() because already sorted by those columns
-      if (is.null(attr(x,"index",exact=TRUE))) setattr(x, "index", integer())
-      setattr(attr(x,"index",exact=TRUE), paste0("__", cols, collapse=""), integer())
+      if (is.null(attr(x, "index", exact=TRUE))) setattr(x, "index", integer())
+      setattr(attr(x, "index", exact=TRUE), paste0("__", cols, collapse=""), integer())
     } else {
       ## key is present but x has a longer key. No sorting needed, only attribute is changed to shorter key.
       setattr(x,"sorted",cols)
@@ -101,8 +101,8 @@ setkeyv = function(x, cols, verbose=getOption("datatable.verbose"), physical=TRU
     o = getindex(x, newkey)
   }
   if (!physical) {
-    if (is.null(attr(x,"index",exact=TRUE))) setattr(x, "index", integer())
-    setattr(attr(x,"index",exact=TRUE), paste0("__", cols, collapse=""), o)
+    if (is.null(attr(x, "index", exact=TRUE))) setattr(x, "index", integer())
+    setattr(attr(x, "index", exact=TRUE), paste0("__", cols, collapse=""), o)
     return(invisible(x))
   }
   setattr(x,"index",NULL)   # TO DO: reorder existing indexes likely faster than rebuilding again. Allow optionally. Simpler for now to clear.
@@ -120,10 +120,10 @@ setkeyv = function(x, cols, verbose=getOption("datatable.verbose"), physical=TRU
   invisible(x)
 }
 
-key = function(x) attr(x,"sorted",exact=TRUE)
+key = function(x) attr(x, "sorted", exact=TRUE)
 
 indices = function(x, vectors = FALSE) {
-  ans = names(attributes(attr(x,"index",exact=TRUE)))
+  ans = names(attributes(attr(x, "index", exact=TRUE)))
   if (is.null(ans)) return(ans) # otherwise character() gets returned by next line
   ans = gsub("^__","",ans)     # the leading __ is internal only, so remove that in result
   if (isTRUE(vectors))
@@ -133,7 +133,7 @@ indices = function(x, vectors = FALSE) {
 
 getindex = function(x, name) {
   # name can be "col", or "col1__col2", or c("col1","col2")
-  ans = attr(attr(x, 'index'), paste0("__",name,collapse=""), exact=TRUE)
+  ans = attr(attr(x, 'index', exact=TRUE), paste0("__",name,collapse=""), exact=TRUE)
   if (!is.null(ans) && (!is.integer(ans) || (length(ans)!=nrow(x) && length(ans)!=0L))) {
     stop("Internal error: index '",name,"' exists but is invalid")   # nocov
   }
@@ -380,11 +380,11 @@ CJ = function(..., sorted = TRUE, unique = FALSE)
     if (sorted) {
       if (!is.atomic(y)) stop("'sorted' is TRUE but element ", i, " is non-atomic, which can't be sorted; try setting sorted = FALSE")
       o = forderv(y, retGrp=TRUE)
-      thisdups = attr(o,'maxgrpn')>1L
+      thisdups = attr(o, 'maxgrpn', exact=TRUE)>1L
       if (thisdups) {
         dups = TRUE
-        if (length(o)) l[[i]] = if (unique) y[o[attr(o,"starts")]] else y[o]
-        else if (unique) l[[i]] = y[attr(o,"starts")]  # test 1525.5
+        if (length(o)) l[[i]] = if (unique) y[o[attr(o, "starts", exact=TRUE)]] else y[o]
+        else if (unique) l[[i]] = y[attr(o, "starts", exact=TRUE)]  # test 1525.5
       } else {
         if (length(o)) l[[i]] = y[o]
       }

--- a/R/tables.R
+++ b/R/tables.R
@@ -37,7 +37,7 @@ tables = function(mb=TRUE, order.col="NAME", width=80,
     tt[ , NROW := pretty_format(NROW, width=4L)]
     tt[ , NCOL := pretty_format(NCOL, width=4L)]
     if (mb) tt[ , MB := pretty_format(MB, width=2L)]
-    print(tt, class=FALSE, nrow=Inf)
+    print(tt, class=FALSE, nrows=Inf)
     if (mb) cat("Total: ", prettyNum(sum(info$MB), big.mark=","), "MB\n", sep="")
   }
   invisible(info)

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -161,7 +161,7 @@ test.data.table = function(verbose=FALSE, pkg="pkg", silent=FALSE, with.other.pa
   # date() is included so we can tell exactly when these tests ran on CRAN. Sometimes a CRAN log can show error but that can be just
   # stale due to not updating yet since a fix in R-devel, for example.
 
-  #attr(ans, "details") = env
+  #attr(ans, "details", exact=TRUE) = env
   invisible(ans)
 }
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -480,7 +480,7 @@ test(168.3, as.character(DT[,as.POSIXct(idate,tz="UTC")]), c("2011-11-18","2011-
 
 # test of . in formula, using inheritance
 DT = data.table(y=1:100,x=101:200,y=201:300,grp=1:5)
-test(169,DT[,as.list(lm(y~0+.,.SD)$coef),by=grp][2,x]-2<1e-10, TRUE)
+test(169,DT[,as.list(lm(y~0+.,.SD)$coefficients),by=grp][2,x]-2<1e-10, TRUE)
 
 DT <- data.table( a=1:4, d=c("A","B","C","D") )
 g <- quote( list( d ) )
@@ -951,7 +951,7 @@ test(319, DT[b!=99L,b:=99L], data.table(b=99L,c=11:16,d=42L,e=21:26))
 
 # previous within functionality restored, #1498
 DT = data.table(a=1:10)
-test(320, within(DT, {b <- 1:10; c <- a + b})[,list(a,b,c)], data.table(a=1:10,b=1:10,c=as.integer(seq(2,20,length=10))))
+test(320, within(DT, {b <- 1:10; c <- a + b})[,list(a,b,c)], data.table(a=1:10,b=1:10,c=as.integer(seq(2,20,length.out=10))))
 # not sure why within makes columns in order a,c,b, but it seems to be a data.frame thing, too.
 test(321, transform(DT,b=42L,e=a), data.table(a=1:10,b=42L,e=1:10))
 DT = data.table(a=1:5, b=1:5)
@@ -1122,7 +1122,7 @@ test(384, DT[,{mySD=copy(.SD);mySD[1,b:=99L];mySD},by=a], data.table(a=rep(1:3,1
 DT = data.table(x=1:2, y=1:6)
 test(385, DT[x==1, y := x], data.table(x=1:2,y=c(1L,2L,1L,4L,1L,6L)))
 test(386.1, DT[c(FALSE,TRUE)], error="i evaluates to.*Recycling of logical i is no longer allowed.*use rep.*[.]N")
-test(386.2, DT[rep(c(FALSE,TRUE),length=.N),y:=99L], data.table(x=1:2,y=c(1L,99L,1L,99L,1L,99L)))
+test(386.2, DT[rep(c(FALSE,TRUE),length.out=.N),y:=99L], data.table(x=1:2,y=c(1L,99L,1L,99L,1L,99L)))
 
 # test that column names have the appearance of being local in j (can assign to them ok), bug #1624
 DT = data.table(name=c(rep('a', 3), rep('b', 2), rep('c', 5)), flag=FALSE)
@@ -2198,7 +2198,7 @@ test(788, DT[!J(2)], data.table(A=c(1L,1L,3L,3L),B=c(1L,2L,5L,6L),key="A"))
 test(789, DT[!(2:6)], DT[1])
 test(790, DT[!(2:6)], DT[!2:6])   # nicer than DT[-2:6] applying - to 2 first
 test(791, DT[!6], DT[1:5])
-test(792.1, DT[!rep(c(TRUE,FALSE),length=.N)], DT[rep(c(FALSE,TRUE),length=.N)])
+test(792.1, DT[!rep(c(TRUE,FALSE),length.out=.N)], DT[rep(c(FALSE,TRUE),length.out=.N)])
 test(792.2, DT[!A>=2], DT[A<2])
 test(793, setkey(DT[,A:=letters[A]],A)[!c("b","c")], DT["a"])
 test(794, DT[!"b"], DT[c("a","c")])
@@ -2964,55 +2964,55 @@ test(1034, as.data.table(x<-as.character(sample(letters, 5))), data.table(V1=x))
   DT[, l_1 := DT[, list(c=list(rep(i_1, sample(5,1)))), by = i_1]$c] # generate list cols
   DT[, l_2 := DT[, list(c=list(rep(c_1, sample(5,1)))), by = i_1]$c]
 
-  test(1035.01, melt(DT, id=1:2, measure=3:4), melt(DT, id=c("i_1", "i_2"), measure=c("f_1", "c_1")))
+  test(1035.01, melt(DT, id.vars=1:2, measure.vars=3:4), melt(DT, id.vars=c("i_1", "i_2"), measure.vars=c("f_1", "c_1")))
 
   ans1 = cbind(DT[, c(1,2,8), with=FALSE], variable=factor("l_1"))
   ans1[, value := DT$l_1]
-  test(1035.02, melt(DT, id=c("i_1", "i_2", "l_2"), measure=c("l_1")), ans1)
+  test(1035.02, melt(DT, id.vars=c("i_1", "i_2", "l_2"), measure.vars=c("l_1")), ans1)
 
   # melt retains attributes if all are of same type (new)
   ans2 = data.table(c_1=DT$c_1, variable=rep(c("d_1", "d_2"), each=N), value=as.Date(c(DT$d_1, DT$d_2)))[!is.na(value)]
-  test(1035.03, melt(DT, id=4, measure=5:6, na.rm=TRUE, variable.factor=FALSE), ans2)
+  test(1035.03, melt(DT, id.vars=4, measure.vars=5:6, na.rm=TRUE, variable.factor=FALSE), ans2)
 
   DT2 <- data.table(x=1:5, y=1+5i) # unimplemented class
-  test(1035.04, melt(DT2, id=1), error="Unknown column type 'complex'")
+  test(1035.04, melt(DT2, id.vars=1), error="Unknown column type 'complex'")
 
   # more tests
   DT[, f_2 := factor(sample(letters, N), ordered=TRUE)]
   DT[, id := 1:N]
-  ans1 = cbind(melt(DT, id="id", measure=5:6, value.name="value1"), melt(DT, id=integer(0), measure=7:8, value.name="value2")[, variable:=NULL])
+  ans1 = cbind(melt(DT, id.vars="id", measure.vars=5:6, value.name="value1"), melt(DT, id.vars=integer(0), measure.vars=7:8, value.name="value2")[, variable:=NULL])
   levels(ans1$variable) = as.character(1:2)
-  test(1035.05, ans1, melt(DT, id="id", measure=list(5:6, 7:8)))
-  test(1035.06, ans1, melt(DT, id="id", measure=list(5:6, 7:8), na.rm=TRUE)) # should've no effect
-  test(1035.07, ans1, melt(DT, id="id", measure=patterns("d_", "l_")))
+  test(1035.05, ans1, melt(DT, id.vars="id", measure.vars=list(5:6, 7:8)))
+  test(1035.06, ans1, melt(DT, id.vars="id", measure.vars=list(5:6, 7:8), na.rm=TRUE)) # should've no effect
+  test(1035.07, ans1, melt(DT, id.vars="id", measure.vars=patterns("d_", "l_")))
   # melt retains ordered factors!
-  test(1035.08, melt(DT, id="id", measure=c("f_1", "f_2"), value.factor=TRUE)$value, factor(c(as.character(DT$f_1), as.character(DT$f_2)), ordered=TRUE))
+  test(1035.08, melt(DT, id.vars="id", measure.vars=c("f_1", "f_2"), value.factor=TRUE)$value, factor(c(as.character(DT$f_1), as.character(DT$f_2)), ordered=TRUE))
   # if measure is integer(0) just returns a duplicated data.table with all idcols
-  test(1035.09, melt(DT, id=1:6, measure=integer(0)), shallow(DT, 1:6))
+  test(1035.09, melt(DT, id.vars=1:6, measure.vars=integer(0)), shallow(DT, 1:6))
   # measure.var list with single entry recycles to maximum length
-  ans = cbind(melt(DT, id="id", measure=c("c_1", "c_1"))[, variable := NULL], melt(DT, id=integer(0), measure=c("f_1", "f_2")))
+  ans = cbind(melt(DT, id.vars="id", measure.vars=c("c_1", "c_1"))[, variable := NULL], melt(DT, id.vars=integer(0), measure.vars=c("f_1", "f_2")))
   setnames(ans, c("id", "value1", "variable", "value2"))
   setcolorder(ans, c("id", "variable", "value1", "value2"))
   levels(ans$variable) = as.character(1:2)
-  test(1035.10, melt(DT, id="id", measure=list(c("c_1", "c_1"), c("f_1", "f_2"))), ans)
+  test(1035.10, melt(DT, id.vars="id", measure.vars=list(c("c_1", "c_1"), c("f_1", "f_2"))), ans)
 
   # non ordered factors
   DT[, f_2 := factor(sample(letters, N), ordered=FALSE)]
-  test(1035.11, melt(DT, id="id", measure=c("f_1", "f_2"), value.factor=TRUE)$value, factor(c(as.character(DT$f_1), as.character(DT$f_2)), ordered=FALSE))
+  test(1035.11, melt(DT, id.vars="id", measure.vars=c("f_1", "f_2"), value.factor=TRUE)$value, factor(c(as.character(DT$f_1), as.character(DT$f_2)), ordered=FALSE))
 
   # test to ensure attributes on non-factor id-columns are preserved after melt; was test 1222
   DT <- data.table(x=1:3, y=letters[1:3], z1=8:10, z2=11:13)
   setattr(DT$x, 'foo', 'bla1')
   setattr(DT$y, 'bar', 1:4)
-  test(1035.12, attr(melt(DT, id=1:2)$x, "foo"), "bla1")
-  test(1035.13, attr(melt(DT, id=1:2)$y, "bar"), 1:4)
+  test(1035.12, attr(melt(DT, id.vars=1:2)$x, "foo"), "bla1")
+  test(1035.13, attr(melt(DT, id.vars=1:2)$y, "bar"), 1:4)
 
   # bug #699 - melt segfaults when vars are not in dt; was test 1316
   x = data.table(a=c(1,2),b=c(2,3),c=c(3,4))
-  test(1035.14, melt(x, id="d"), error="One or more values")
-  test(1035.15, melt(x, measure="d"), error="One or more values")
-  test(1035.16, melt(x, id="a", measure="d"), error="One or more values")
-  test(1035.17, melt(x, id="d", measure="a"), error="One or more values")
+  test(1035.14, melt(x, id.vars="d"), error="One or more values")
+  test(1035.15, melt(x, measure.vars="d"), error="One or more values")
+  test(1035.16, melt(x, id.vars="a", measure.vars="d"), error="One or more values")
+  test(1035.17, melt(x, id.vars="d", measure.vars="a"), error="One or more values")
 
   # fix for #780; was test 1371
   DT = data.table(x=rep(c("a","b","c"),each=3), y=c(1,3,6), v=1:9)
@@ -3025,7 +3025,7 @@ test(1034, as.data.table(x<-as.character(sample(letters, 5))), data.table(V1=x))
                          "are not all of the same type. By order of hierarchy"))
   # Fix for #1055; was test 1495
   DT <- data.table(A = 1:2, B = 3:4, D = 5:6, D = 7:8)
-  test(1035.20, melt(DT, id=1:2), data.table(A=1:2, B=3:4,
+  test(1035.20, melt(DT, id.vars=1:2), data.table(A=1:2, B=3:4,
       variable=factor(rep(1L, 4L), labels="D"), value=5:8))
 
   # segfault of unprotected var caught with the help of address sanitizer; was test 1509
@@ -3038,15 +3038,15 @@ test(1034, as.data.table(x<-as.character(sample(letters, 5))), data.table(V1=x))
 
   # improper levels fix, #1359; was test 1563
   dt = data.table(id=1:3, x=NA_character_, y=c('a', NA_character_, 'c'))
-  test(1035.22, melt(dt, id.var="id", na.rm=TRUE), data.table(id=c(1L,3L), variable=factor(c("y", "y")), value=c("a", "c")))
+  test(1035.22, melt(dt, id.vars="id", na.rm=TRUE), data.table(id=c(1L,3L), variable=factor(c("y", "y")), value=c("a", "c")))
 
   # fixing segfault due to negative id and measure vars that I detected by accident; was test 1569
   dt = data.table(x=1:5, y=6:10, z=11:15)
-  test(1035.23, melt(dt, id=-1, measure=NULL), error="One or more values in 'id.vars'")
-  test(1035.24, melt(dt, id=-1, measure=-1), error="One or more values in 'id.vars'")
-  test(1035.25, melt(dt, id=NULL, measure=-1), error="One or more values in 'measure.vars'")
-  test(1035.26, melt(dt, id=5, measure=-1), error="One or more values in 'id.vars'")
-  test(1035.27, melt(dt, id=1, measure=-1), error="One or more values in 'measure.vars'")
+  test(1035.23, melt(dt, id.vars=-1, measure.vars=NULL), error="One or more values in 'id.vars'")
+  test(1035.24, melt(dt, id.vars=-1, measure.vars=-1), error="One or more values in 'id.vars'")
+  test(1035.25, melt(dt, id.vars=NULL, measure.vars=-1), error="One or more values in 'measure.vars'")
+  test(1035.26, melt(dt, id.vars=5, measure.vars=-1), error="One or more values in 'id.vars'")
+  test(1035.27, melt(dt, id.vars=1, measure.vars=-1), error="One or more values in 'measure.vars'")
 
   if (test_R.utils) {
     # dup names in variable used to generate malformed factor error and/or segfault, #1754;  was test 1570
@@ -3071,7 +3071,7 @@ test(1034, as.data.table(x<-as.character(sample(letters, 5))), data.table(V1=x))
   # more from #1754; was test 1571
   DT = fread(testDir("melt_1754_synth.csv"))
   test(1037.101, names(DT)[duplicated(names(DT))], c("smoking75","smoking80","smoking88"))
-  test(1037.102, dim(ans<-melt(DT, id.vars=c("state","income","retailprice","percent_15_19","beercons"), measure=patterns("^smoking"))), INT(1326,7))
+  test(1037.102, dim(ans<-melt(DT, id.vars=c("state","income","retailprice","percent_15_19","beercons"), measure.vars=patterns("^smoking"))), INT(1326,7))
   test(1037.103, print(ans[c(1,1326)]), output="state.*income.*retailprice.*percent_15_19.*beercons.*variable.*value.*1.*9.6.*89.34.*smoking88.*smoking00.*41.6")
 
   # more from #1754; was test 1572
@@ -3333,16 +3333,16 @@ test(1100, dt1[dt2,roll=-Inf,rollends=c(FALSE,TRUE)]$ind, INT(NA,NA,1,2,2,2,2,2,
     "6" = as.Date(c(NA, NA, "2014-06-15", NA)), key="ID"))
 
   names(ChickWeight) <- tolower(names(ChickWeight))
-  DT = melt(as.data.table(ChickWeight), id=2:4) # calls melt.data.table
+  DT = melt(as.data.table(ChickWeight), id.vars=2:4) # calls melt.data.table
 
   # changed 'mean' to 'sum' to avoid valgrind floating point precision based error.
-  test(1102.01, dcast(DT, time ~ variable, fun=sum)[c(1,2,11,.N)], data.table(time=c(0,2,20,21),weight=c(2053,2461,9647,9841), key="time"))
-  test(1102.02, dcast(DT, diet ~ variable, fun=sum), data.table(diet=factor(1:4), weight=c(22582, 14714, 17154, 15961), key="diet"))
+  test(1102.01, dcast(DT, time ~ variable, fun.aggregate=sum)[c(1,2,11,.N)], data.table(time=c(0,2,20,21),weight=c(2053,2461,9647,9841), key="time"))
+  test(1102.02, dcast(DT, diet ~ variable, fun.aggregate=sum), data.table(diet=factor(1:4), weight=c(22582, 14714, 17154, 15961), key="diet"))
   test(1102.03,   dcast(DT, diet+chick ~ time, drop=FALSE)[c(1,.N),c(1:4,13:14)],
                ans<-data.table(diet=factor(c(1,4)), chick=ordered(c(18,48),levels=levels(DT$chick)), "0"=39, "2"=c(35,50), "20"=c(NA,303), "21"=c(NA,322), key="diet,chick"))
   test(1102.04, dcast(DT, diet+chick ~ time, drop=FALSE, fill=0)[c(1,.N),c(1:4,13:14)], ans[1, c("20","21"):=0])
   # add test for 'subset=' in dcast
-  test(1102.05, dcast(DT, time + chick ~ variable+diet, fun=sum, subset=.(time> 20))[c(1,2,44,.N)],
+  test(1102.05, dcast(DT, time + chick ~ variable+diet, fun.aggregate=sum, subset=.(time> 20))[c(1,2,44,.N)],
                data.table(time=21, chick=ordered(c(13,9,42,48), levels=levels(DT$chick)), weight_1=c(96,98,0,0), weight_2=0, weight_3=0, weight_4=c(0,0,281,322), key="time,chick"))
 
   # testing without aggregation
@@ -3364,7 +3364,7 @@ test(1100, dt1[dt2,roll=-Inf,rollends=c(FALSE,TRUE)]$ind, INT(NA,NA,1,2,2,2,2,2,
   # more tests for `dcast` with formula being character and errors when formula is a hybrid
   set.seed(1)
   DT = data.table(a=rep(1:5, each=5), b=runif(25))
-  test(1102.11, dcast(DT, " a~ . ", value.var="b", fun=length), data.table(a=1:5, `.`=5L, key="a"))
+  test(1102.11, dcast(DT, " a~ . ", value.var="b", fun.aggregate=length), data.table(a=1:5, `.`=5L, key="a"))
   test(1102.12, dcast(DT, "a ~  c ", value.var="b"), error="not found or of unknown type")
   test(1102.13, dcast(DT, a ~  a, value.var="c"), error="are not found in 'data'")
 
@@ -3372,14 +3372,14 @@ test(1100, dt1[dt2,roll=-Inf,rollends=c(FALSE,TRUE)]$ind, INT(NA,NA,1,2,2,2,2,2,
   set.seed(1L)
   DT = data.table(a=factor(sample(letters[1:3], 10, replace=TRUE), letters[1:5]),
                   b=factor(sample(tail(letters, 5), 10, replace=TRUE)))
-  test(1102.14, dcast(DT, a~b, drop=FALSE, fun=length, value.var="b"),
+  test(1102.14, dcast(DT, a~b, drop=FALSE, fun.aggregate=length, value.var="b"),
                 data.table(a=factor(letters[1:5]), v=INT(0,1,0,0,0), w=INT(1,1,1,0,0), x=INT(0,0,1,0,0), y=INT(2,1,1,0,0), z=INT(0,1,0,0,0), key="a"))
 
   # reverse the levels
   set.seed(1L)
   DT = data.table(a=factor(sample(letters[1:3], 10, replace=TRUE), letters[5:1]),
                   b=factor(sample(tail(letters, 5), 10, replace=TRUE)))
-  test(1102.15, dcast(DT, a~b, drop=FALSE, value.var="b", fun=length),
+  test(1102.15, dcast(DT, a~b, drop=FALSE, value.var="b", fun.aggregate=length),
                 data.table(a=factor(c("e","d","c","b","a"),levels=levels(DT$a)), v=INT(0,0,0,1,0), w=INT(0,0,1,1,1), x=INT(0,0,1,0,0), y=INT(0,0,1,1,2), z=INT(0,0,0,1,0), key="a"))
 
   # more factor cols
@@ -3465,22 +3465,22 @@ test(1100, dt1[dt2,roll=-Inf,rollends=c(FALSE,TRUE)]$ind, INT(NA,NA,1,2,2,2,2,2,
   set.seed(1)
   DT = data.table(x=sample(5,20,TRUE), y=sample(2,20,TRUE),
                   z=sample(letters[1:2], 20,TRUE), d1 = runif(20), d2=1L)
-  test(1102.31, dcast(DT, x + y ~ z, fun=sum, value.var=c("d1","d2"))[c(1,.N)][, 3:4:=lapply(.SD,round,4), .SDcols=c("d1_a","d1_b")][],
+  test(1102.31, dcast(DT, x + y ~ z, fun.aggregate=sum, value.var=c("d1","d2"))[c(1,.N)][, 3:4:=lapply(.SD,round,4), .SDcols=c("d1_a","d1_b")][],
                 data.table(x=INT(1,5), y=INT(1,1), d1_a=c(0.0,0.4785), d1_b=c(0.8753,0.9804), d2_a=INT(0,1), d2_b=INT(1,3), key="x,y"))
   # multiple fun.agg
-  test(1102.32, dcast(DT, x + y ~ z, fun=list(sum, mean), value.var="d1")[c(1,.N)][, 3:6:=lapply(.SD,round,3), .SDcols=3:6][],
+  test(1102.32, dcast(DT, x + y ~ z, fun.aggregate=list(sum, mean), value.var="d1")[c(1,.N)][, 3:6:=lapply(.SD,round,3), .SDcols=3:6][],
                 data.table(x=INT(1,5), y=INT(1,1), d1_sum_a=c(0.0,0.479), d1_sum_b=c(0.875,0.980),d1_mean_a=c(NaN,0.479),d1_mean_b=c(0.875,0.327), key="x,y"))
   # multiple fun.agg and value.var (all combinations)
-  test(1102.33, dcast(DT, x + y ~ z, fun=list(sum, mean), value.var=c("d1", "d2"))[c(1,.N)][, c(3,4,7:10):=lapply(.SD,round,3), .SDcols=c(3,4,7:10)][],
+  test(1102.33, dcast(DT, x + y ~ z, fun.aggregate=list(sum, mean), value.var=c("d1", "d2"))[c(1,.N)][, c(3,4,7:10):=lapply(.SD,round,3), .SDcols=c(3,4,7:10)][],
                 data.table(x=INT(1,5), y=INT(1,1), d1_sum_a=c(0.0,0.479), d1_sum_b=c(0.875,0.980),d2_sum_a=INT(0,1),d2_sum_b=INT(1,3),
                           d1_mean_a=c(NaN,0.479),d1_mean_b=c(0.875,0.327),d2_mean_a=c(NaN,1),d2_mean_b=c(1,1), key="x,y"))
   # multiple fun.agg and value.var (one-to-one)
-  test(1102.34, dcast(DT, x + y ~ z, fun=list(sum, mean), value.var=list("d1", "d2"))[c(1,.N)][, 3:4:=lapply(.SD,round,3), .SDcols=3:4][],
+  test(1102.34, dcast(DT, x + y ~ z, fun.aggregate=list(sum, mean), value.var=list("d1", "d2"))[c(1,.N)][, 3:4:=lapply(.SD,round,3), .SDcols=3:4][],
                 data.table(x=INT(1,5), y=INT(1,1), d1_sum_a=c(0.0,0.479), d1_sum_b=c(0.875,0.980),d2_mean_a=c(NaN,1),d2_mean_b=c(1,1), key="x,y"))
 
   # Additional test after fixing fun.agg creation - using the example here: https://github.com/Rdatatable/data.table/issues/716
   DT = data.table(x=1:5, y=paste("v", 1:5, sep=""), v1=6:10, v2=11:15, k1=letters[1:5], k2=letters[6:10])
-  DT.m = melt(DT, id=1:2, measure=list(3:4, 5:6))
+  DT.m = melt(DT, id.vars=1:2, measure.vars=list(3:4, 5:6))
   test(1102.35, dcast(DT.m, x ~ y, fun.aggregate = list(sum, function(x) paste(x, collapse="")), value.var=list("value1", "value2")),
                 data.table(x=1:5, value1_sum_v1=INT(17,0,0,0,0), value1_sum_v2=INT(0,19,0,0,0), value1_sum_v3=INT(0,0,21,0,0),
                 value1_sum_v4=INT(0,0,0,23,0), value1_sum_v5=INT(0,0,0,0,25), value2_function_v1=c("af","","","",""),
@@ -3491,18 +3491,18 @@ test(1100, dt1[dt2,roll=-Inf,rollends=c(FALSE,TRUE)]$ind, INT(NA,NA,1,2,2,2,2,2,
   DT = as.data.table(airquality)
   ans = suppressWarnings(melt(DT, id=c("Month", "Day"), na.rm=TRUE))  # warning regards coercion to double
   ans = ans[ , .(min=min(value), max=max(value)), by=.(Month, variable)]
-  ans = melt(ans, id=1:2, variable.name="variable2")
+  ans = melt(ans, id.vars=1:2, variable.name="variable2")
   ans = dcast(ans, Month ~ variable + variable2)
   setnames(ans, c("Month", paste(names(ans)[-1L], sep="_")))
   valvars = c("Ozone", "Solar.R", "Wind", "Temp")
-  ans2 = suppressWarnings(dcast(DT, Month ~ ., fun=list(min, max), na.rm=TRUE, value.var=valvars))
+  ans2 = suppressWarnings(dcast(DT, Month ~ ., fun.aggregate=list(min, max), na.rm=TRUE, value.var=valvars))
   setcolorder(ans, names(ans2))
   test(1102.36, key(ans), "Month")
   test(1102.37, ans, ans2[, names(ans2)[-1L] := lapply(.SD, as.numeric), .SDcols=-1L])
 
   # test for #1210, sep argument for dcast
   DT = data.table(x=sample(5,20,TRUE), y=sample(2,20,TRUE), z=sample(letters[1:2],20,TRUE), d1=runif(20), d2=1L)
-  test(1102.38, names(dcast(DT, x ~ y + z, fun=length, value.var = "d2", sep=".")),
+  test(1102.38, names(dcast(DT, x ~ y + z, fun.aggregate=length, value.var = "d2", sep=".")),
                 c("x", "1.a", "1.b", "2.a", "2.b"))
 }
 
@@ -3753,19 +3753,19 @@ test(1143.4, DT[,`:=`(lx=tail(x,1L)), by=y], ans[, lx := x])
 # FR #2356 - retain names of named vector as column with keep.rownames=TRUE
 x <- 1:5
 setattr(x, 'names', letters[1:5])
-test(1144.1, as.data.table(x, keep=TRUE), data.table(rn=names(x), x=unname(x)))
+test(1144.1, as.data.table(x, keep.rownames=TRUE), data.table(rn=names(x), x=unname(x)))
 x <- as.numeric(x)
 setattr(x, 'names', letters[1:5])
-test(1144.2, as.data.table(x, keep=TRUE), data.table(rn=names(x), x=unname(x)))
+test(1144.2, as.data.table(x, keep.rownames=TRUE), data.table(rn=names(x), x=unname(x)))
 x <- as.character(x)
 setattr(x, 'names', letters[1:5])
-test(1144.3, as.data.table(x, keep=TRUE), data.table(rn=names(x), x=unname(x)))
+test(1144.3, as.data.table(x, keep.rownames=TRUE), data.table(rn=names(x), x=unname(x)))
 x <- as.factor(x)
 setattr(x, 'names', letters[1:5])
-test(1144.4, as.data.table(x, keep=TRUE), data.table(rn=names(x), x=unname(x)))
+test(1144.4, as.data.table(x, keep.rownames=TRUE), data.table(rn=names(x), x=unname(x)))
 x <- as.Date(1:5, origin="2013-01-01")
 setattr(x, 'names', letters[1:5])
-test(1144.5, as.data.table(x, keep=TRUE), data.table(rn=names(x), x=unname(x)))
+test(1144.5, as.data.table(x, keep.rownames=TRUE), data.table(rn=names(x), x=unname(x)))
 
 # Fix for bug #5114 - .data.table.locked ISSUE
 DT <- data.table(x=1:5, y=6:10)
@@ -4609,7 +4609,7 @@ test(1268.22, dt[, c(as.list(c), lapply(.SD, mean)), by=a],
 
 # Wide range numeric and integer64, to test all bits
 old_rounding = getNumericRounding()
-x = sample( c(seq(-1e100, 1e100, length=1e5), c(seq(-1e-100,1e-100,length=1e5))) )
+x = sample( c(seq(-1e100, 1e100, length.out=1e5), c(seq(-1e-100,1e-100,length.out=1e5))) )
 setNumericRounding(0)
 test(1269, forderv(x), base::order(x))
 setNumericRounding(2)   # not affected by rounding
@@ -6386,7 +6386,7 @@ DT = data.table(x=c("a", "a", "b", "b"), v1=sample(4), v2=sample(4))
 cols = c("v1", "v2")
 test(1462.1, DT[, mget(cols, as.environment(-1))], DT[, cols, with=FALSE])   # as.environment needed for testing on pre-R3.0.0 which we don't want to depend on yet
 test(1462.2, DT[, mget(cols[1], as.environment(-1))], DT[, cols[1], with=FALSE])
-test(1462.3, DT[, sum(unlist(mget(cols, as.environment(-1)))), by=x], DT[, sum(unlist(.SD)), by=x, .SDcol=cols])
+test(1462.3, DT[, sum(unlist(mget(cols, as.environment(-1)))), by=x], DT[, sum(unlist(.SD)), by=x, .SDcols=cols])
 
 # test for 'shift'
 x=1:5
@@ -6992,22 +6992,22 @@ test(1507.3, tstrsplit(x, "-", type.convert=TRUE), list(letters[1:5], 1:5))
 # implementing #575, keep.rownames can take a name
 x = matrix(1:6, ncol=2)
 rownames(x) = letters[3:1]
-test(1508.1, as.data.table(x, keep="bla"), data.table(bla=letters[3:1], x))
+test(1508.1, as.data.table(x, keep.rownames="bla"), data.table(bla=letters[3:1], x))
 x = as.data.frame(x)
-test(1508.2, as.data.table(x, keep="bla"), data.table(bla=letters[3:1], x))
+test(1508.2, as.data.table(x, keep.rownames="bla"), data.table(bla=letters[3:1], x))
 x = sample(10); setattr(x, 'names', letters[1:10])
-test(1508.3, as.data.table(x, keep="bla"), data.table(bla=letters[1:10], x=unname(x)))
+test(1508.3, as.data.table(x, keep.rownames="bla"), data.table(bla=letters[1:10], x=unname(x)))
 # also for setDT
 df = data.frame(x=1:5, y=6:10, row.names=letters[5:1])
 ans = data.table(foo=letters[5:1], df)
-test(1508.4, setDT(df, keep="foo"), ans)
+test(1508.4, setDT(df, keep.rownames="foo"), ans)
 
 # #1509 test added for melt above.
 
 # #1510 transpose converts NULL to NAs
 ll = list(1:2, NULL, 3:4)
 test(1510.1, transpose(ll), list(c(1L, NA, 3L), c(2L, NA, 4L)))
-test(1510.2, transpose(ll, ignore=TRUE), list(c(1L, 3L), c(2L, 4L)))
+test(1510.2, transpose(ll, ignore.empty=TRUE), list(c(1L, 3L), c(2L, 4L)))
 
 # setorder can reorder data.frames too, #1018
 DF = data.frame(x=sample(3,10,TRUE), y=sample(letters[1:2], 10, TRUE))
@@ -7210,7 +7210,7 @@ dt = data.table(x=1:5, y=6:10)
 test(1536, duplicated(dt, incomparables=TRUE), error = "argument 'incomparables != FALSE'")
 
 # test for covering melt 100%
-test(1537 , names(melt(dt, id=1L, variable.name = "x", value.name="x")), c("x", "x.1", "x.2"), output = "Duplicate column names")
+test(1537 , names(melt(dt, id.vars=1L, variable.name = "x", value.name="x")), c("x", "x.1", "x.2"), output = "Duplicate column names")
 
 # test for tables()
 test(1538, tables(), output = "Total:")
@@ -7641,9 +7641,9 @@ str2="YYYY MM DD HH mm             19490             40790
 test(1555.13, fread(str1), fread(str2))
 
 # fix for #1330
-test(1556.1, fread(testDir("issue_1330_fread.txt"), nrow=2), ans<-data.table(a=1:2, b=1:2))
-test(1556.2, fread(testDir("issue_1330_fread.txt"), nrow=3), ans, warning=w<-"Stopped early on line 4. Expected 2.*found 0.*First discarded non-empty line: <<3.*3>>")
-test(1556.3, fread(testDir("issue_1330_fread.txt"), nrow=4), ans, warning=w)
+test(1556.1, fread(testDir("issue_1330_fread.txt"), nrows=2L), ans<-data.table(a=1:2, b=1:2))
+test(1556.2, fread(testDir("issue_1330_fread.txt"), nrows=3L), ans, warning=w<-"Stopped early on line 4. Expected 2.*found 0.*First discarded non-empty line: <<3.*3>>")
+test(1556.3, fread(testDir("issue_1330_fread.txt"), nrows=4L), ans, warning=w)
 
 # FR #768
 str="1,2\n3,4\n"
@@ -7659,10 +7659,10 @@ ans = data.table(AAA=INT(c(4,7,rep(1,17),31,21)),
                  BBB=INT(c(5,8,rep(2,17),32,22)),
                  CCC=INT(c(6,9,rep(3,17),33,23)))
 test(1558.1, fread(f), ans, warning=w<-"Stopped early on line 23. Expected 3 fields but found 2[.].*First discarded non-empty line: <<ZZZ.*YYY>>")
-test(1558.2, fread(f, nrow=21L), ans)
-test(1558.3, fread(f, nrow=21L, fill=TRUE), ans)
-test(1558.4, fread(f, nrow=22L), ans, warning=w)
-test(1558.5, fread(f, nrow=22L, fill=TRUE), rbind(ans, list("ZZZ","YYY",NA)))
+test(1558.2, fread(f, nrows=21L), ans)
+test(1558.3, fread(f, nrows=21L, fill=TRUE), ans)
+test(1558.4, fread(f, nrows=22L), ans, warning=w)
+test(1558.5, fread(f, nrows=22L, fill=TRUE), rbind(ans, list("ZZZ","YYY",NA)))
 
 # FR # 1338 -- check.names argument of setDT
 ans=data.table(X=1:3,"X.1"=1:3)
@@ -7718,7 +7718,7 @@ test(1563.406, dcast(DT, x ~ rowid(x, prefix="group"), value.var="z"), data.tabl
 
 # Fix for #1346;  was test 1562
 DT = data.table(id=1:3, g1=4:6, g2=7:9)
-test(1563.501, melt(DT, measure=patterns("^g[12]"), variable.factor=FALSE), data.table(id=1:3, variable=rep(c("g1","g2"),each=3L), value=4:9))
+test(1563.501, melt(DT, measure.vars=patterns("^g[12]"), variable.factor=FALSE), data.table(id=1:3, variable=rep(c("g1","g2"),each=3L), value=4:9))
 
 # fix for #1341
 dt <- data.table(a = 1:10)
@@ -9326,7 +9326,7 @@ nqjoin_test <- function(x, y, k=1L, test_no, mult="all") {
   }
   nq <- function(x, y, cols, ops, nomatch=0L, mult="all") {
     sd_cols = c(paste0("x.", cols), setdiff(names(x), cols))
-    ans = x[y, mget(sd_cols, as.environment(-1)), on = paste0(cols, ops, cols), allow=TRUE, nomatch=nomatch, mult=mult]
+    ans = x[y, mget(sd_cols, as.environment(-1)), on = paste0(cols, ops, cols), allow.cartesian=TRUE, nomatch=nomatch, mult=mult]
     setnames(ans, gsub("^x[.]", "", names(ans)))
     setcolorder(ans, names(x))[]
   }
@@ -9810,7 +9810,7 @@ test(1680.1, foo(x), melt(x, measure.vars=patterns("^y", "^z")))
 # melt warning prints only first 5 cols, #1752
 DT = fread(testDir("melt-warning-1752.tsv"))
 ans = suppressWarnings(melt(DT[, names(DT) %like% "(^Id[0-9]*$)|GEOGRAPHIC AREA CODES", with=FALSE], id=1:2))
-test(1681, melt(DT[, names(DT) %like% "(^Id[0-9]*$)|GEOGRAPHIC AREA CODES", with=FALSE], id=1:2),
+test(1681, melt(DT[, names(DT) %like% "(^Id[0-9]*$)|GEOGRAPHIC AREA CODES", with=FALSE], id.vars=1:2),
     ans, warning="are not all of the same type")
 
 # non-equi joins with by=.EACHI, not as exhaustive, but given the previous
@@ -9992,7 +9992,7 @@ test(1698.1, key(x[!y]), key(x[!y, on = "id"]))
 
 # minor enhancement to dcast, #1821
 dt = data.table(x=c(1,1,1,2,2,2), y=1:6, z=6:1)
-test(1699.1, dcast(dt, x ~ ., value.var="z", fun=list(sd, mean)), data.table(x=c(1,2), z_sd=1, z_mean=c(5,2), key="x"))
+test(1699.1, dcast(dt, x ~ ., value.var="z", fun.aggregate=list(sd, mean)), data.table(x=c(1,2), z_sd=1, z_mean=c(5,2), key="x"))
 
 # minor enhancement to dcast, #1810
 dt = data.table(
@@ -10001,7 +10001,7 @@ dt = data.table(
   subtype = c("1","2","2","2","1","1","2"),
   type = c("A","A","A","A","B","B","B")
 )
-test(1700.1, dcast(dt, type ~ subtype, value.var = c("var1", "var2"), fun = function(v) paste0(unique(v), collapse = "|")),
+test(1700.1, dcast(dt, type ~ subtype, value.var = c("var1", "var2"), fun.aggregate = function(v) paste0(unique(v), collapse = "|")),
     data.table(type=c("A","B"), var1_1=c("a", "d|e"), var1_2=c("b|c", "f"),
                 var2_1=c("aa", "ee"), var2_2=c("bb|cc|dd","ff"), key="type"))
 
@@ -11996,10 +11996,10 @@ test(1870.3, fread("A,B,\n,,\n,500,3.4"), data.table(A=NA, B=c(NA,500L), V3=c(NA
 txt = "V1, V2, V3\n2,3,4\nV4, V5, V6, V7\n4,5,6,7\n8,9,10,11\n"
 test(1871.01, fread(txt), data.table(V1=2L, V2=3L, V3=4L), warning="Stopped early on line 3. Expected 3 fields but found 4.*First discarded.*V4, V5")
 test(1871.02, fread(txt, skip=2), ans<-data.table(V4=INT(4,8), V5=INT(5,9), V6=INT(6,10), V7=INT(7,11)))
-test(1871.03, fread(txt, skip=2, nrow=1), ans[1,])
-test(1871.04, fread(txt, skip=2, nrow=3), ans)
+test(1871.03, fread(txt, skip=2, nrows=1L), ans[1,])
+test(1871.04, fread(txt, skip=2, nrows=3L), ans)
 test(1871.05, fread(txt, skip=3), ans <- data.table(V1=INT(4,8), V2=INT(5,9), V3=INT(6,10), V4=INT(7,11)))
-test(1871.06, fread(txt, skip=3, nrow=1), ans[1,])
+test(1871.06, fread(txt, skip=3, nrows=1L), ans[1,])
 test(1871.07, fread(txt, nrows=1), data.table(V1=2L, V2=3L, V3=4L))
 test(1871.08, fread(txt, skip=0), data.table(V1=2L, V2=3L, V3=4L), warning="Stopped early.*line 3. Expected 3 fields but found 4.*discarded.*<<V4, V5, V6, V7>>")
 test(1871.09, fread(txt, skip=0, nrows=1), ans<-data.table(V1=2L, V2=3L, V3=4L))
@@ -13823,11 +13823,11 @@ myFun2 <- function(data, vars) {
 funs = list(sum, mean)
 vars = list("d1", "d2")
 
-test(1987.1, names(dcast.data.table(dt, x + y ~ z, fun=funs, value.var=vars)),
+test(1987.1, names(dcast.data.table(dt, x + y ~ z, fun.aggregate=funs, value.var=vars)),
              c("x", "y", "d1_fun1_a", "d1_fun1_b", "d2_fun2_a", "d2_fun2_b"))
-test(1987.2, dcast.data.table(dt, x + y ~ z, fun=sum, value.var=vars[[1]]),
+test(1987.2, dcast.data.table(dt, x + y ~ z, fun.aggregate=sum, value.var=vars[[1]]),
              myFun1(dt, vars[[1]]))
-test(1987.3, dcast.data.table(dt, x + y ~ z, fun=list(f1=sum, first=function(x) x[1L]), value.var=vars), myFun2(dt, vars))
+test(1987.3, dcast.data.table(dt, x + y ~ z, fun.aggregate=list(f1=sum, first=function(x) x[1L]), value.var=vars), myFun2(dt, vars))
 
 # testing frankv/forder behavior with NA/NaN; earlier tests compare consistency with base::rank,
 # but we intentionally break from base w.r.t. ranking NAs (we consider NAs to be tied, ditto NaN)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -15194,6 +15194,32 @@ l = replicate(ceiling(log10(.Machine$integer.max)), rep(1L, 10L), simplify = FAL
 l$unique = TRUE
 test(2061, do.call(CJ, l), setkey(unique(as.data.table(head(l, -1L)))))
 
+# #3664 -- explicitly test some commonly-used partial argument matches, see ?options
+old = options(warnPartialMatchArgs=FALSE,
+              warnPartialMatchAttr=FALSE,
+              warnPartialMatchDollar=FALSE)
+## id --> id.vars, measure --> measure.vars
+DT <- data.table(
+  i_1 = c(1:(N-1L), NA),
+  i_2 = c(NA,(N:(2L*N-2L))),
+  f_1 = factor(sample(c(letters[1:3], NA), N, TRUE)),
+  c_1 = sample(c(letters[1:3], NA), N, TRUE),
+  d_1 = as.Date(c(1:3,NA,4:5), origin="2013-09-01"),
+  d_2 = as.Date(6:1, origin="2012-01-01")
+)
+test(2062.1, melt(DT, id=1:2, measure=3:4), melt(DT, id=c("i_1", "i_2"), measure=c("f_1", "c_1")))
+## fun --> fun.aggregate
+DT = melt(as.data.table(ChickWeight), id.vars=2:4)
+test(2062.2, dcast(DT, Time ~ variable, fun=sum)[c(1,2,11,.N)], data.table(Time=c(0,2,20,21), weight=c(2053,2461,9647,9841), key="Time"))
+## keep --> keep.rownames
+x <- 1:5
+setattr(x, 'names', letters[1:5])
+test(2062.3, as.data.table(x, keep=TRUE), data.table(rn=names(x), x=unname(x)))
+## ignore --> ignore.empty
+ll = list(1:2, NULL, 3:4)
+test(2062.4, transpose(ll, ignore=TRUE), list(c(1L, 3L), c(2L, 4L)))
+options(old)
+
 ###################################
 #  Add new tests above this line  #
 ###################################

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -15200,17 +15200,16 @@ old = options(warnPartialMatchArgs=FALSE,
               warnPartialMatchDollar=FALSE)
 ## id --> id.vars, measure --> measure.vars
 DT <- data.table(
-  i_1 = c(1:(N-1L), NA),
-  i_2 = c(NA,(N:(2L*N-2L))),
-  f_1 = factor(sample(c(letters[1:3], NA), N, TRUE)),
-  c_1 = sample(c(letters[1:3], NA), N, TRUE),
-  d_1 = as.Date(c(1:3,NA,4:5), origin="2013-09-01"),
-  d_2 = as.Date(6:1, origin="2012-01-01")
+  i_1 = c(1:17, NA),
+  i_2 = c(NA, 18:34),
+  f_1 = factor(c('a', 'c', 'b', NA, 'c', 'b', 'c', 'c', NA, 'c', NA, 'c', 'a', 'b', NA, NA, NA, 'a')),
+  c_1 = c("a", "c", NA, NA, NA, "c", "b", NA, "a", "b", NA, "a", "c", "b", "c", "b", "a", "b")
 )
 test(2062.1, melt(DT, id=1:2, measure=3:4), melt(DT, id=c("i_1", "i_2"), measure=c("f_1", "c_1")))
 ## fun --> fun.aggregate
 DT = melt(as.data.table(ChickWeight), id.vars=2:4)
-test(2062.2, dcast(DT, Time ~ variable, fun=sum)[c(1,2,11,.N)], data.table(Time=c(0,2,20,21), weight=c(2053,2461,9647,9841), key="Time"))
+setnames(DT, tolower(names(DT)))
+test(2062.2, dcast(DT, time ~ variable, fun=sum)[c(1,2,11,.N)], data.table(time=c(0,2,20,21), weight=c(2053,2461,9647,9841), key="time"))
 ## keep --> keep.rownames
 x <- 1:5
 setattr(x, 'names', letters[1:5])

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -96,8 +96,11 @@ oldOptions = options(
   datatable.optimize = Inf,
   datatable.verbose = FALSE,
   datatable.alloccol = 1024L,
-  datatable.print.class = FALSE,  #  This is TRUE in cc.R and we like TRUE. But output= tests need to be updated (they assume FALSE currently)
-  datatable.rbindlist.check = NULL
+  datatable.print.class = FALSE,  # this is TRUE in cc.R and we like TRUE. But output= tests need to be updated (they assume FALSE currently)
+  datatable.rbindlist.check = NULL,
+  warnPartialMatchArgs = TRUE,    # ensure we don't rely on partial argument matching in internal code, #3664
+  warnPartialMatchAttr = TRUE,
+  warnPartialMatchDollar = TRUE
 )
 # some tests (e.g. 1066, 1293) rely on capturing output that will be garbled with small width
 if (getOption('width') < 80L) options(width = 80L)
@@ -10904,6 +10907,7 @@ test(1751.4, fread({fwrite(DT, f<-tempfile());f}), DT)  # the important thing
 unlink(f)
 
 if (test_nanotime) {
+  old = options(warnPartialMatchArgs=FALSE)  # option off temporarily pending https://github.com/eddelbuettel/nanotime/pull/49
   DT = data.table(A=nanotime(tt<-c("2016-09-28T15:30:00.000000070Z",
                                    "2016-09-29T23:59:00.000000001Z",
                                    "2016-09-29T23:59:00.000000999Z",
@@ -10916,6 +10920,7 @@ if (test_nanotime) {
                                    "1969-12-31T12:13:14.000000001Z",
                                    "1967-03-15T00:00:00.300000002Z",
                                    "1967-03-15T23:59:59.300000002Z")))
+  options(old)
   test(1752, capture.output(fwrite(DT, verbose=FALSE))[-1], tt)
 }
 

--- a/man/IDateTime.Rd
+++ b/man/IDateTime.Rd
@@ -49,7 +49,7 @@
 }
 \usage{
 as.IDate(x, \dots)
-\method{as.IDate}{default}(x, \dots, tz = attr(x, "tzone"))
+\method{as.IDate}{default}(x, \dots, tz = attr(x, "tzone", exact=TRUE))
 \method{as.IDate}{Date}(x, \dots)
 \method{as.Date}{IDate}(x, \dots)
 \method{as.POSIXct}{IDate}(x, tz = "UTC", time = 0, \dots)


### PR DESCRIPTION
#3664 

Confirmed we're doing OK for `attr` with:

```
grep -r "\battr[(]" R | grep -v "exact=TRUE"
```

There's one call to `attr` that's not using `exact = TRUE` inside of `.shallow`, since it's actually being called as `attr<-` (didn't look so at first glance but it threw "too many arguments" error when I first tried).

A bunch of partial matches were being used in `test.data.table()`. With the commit here, `test.data.table()` runs fine using the options suggested by @vlulla.