### PR TITLE
Closes #3639 -- proper handling of CPLXSXP in dogroups

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -192,7 +192,7 @@
 
 24. `column not found` could incorrectly occur in rare non-equi-join cases, [#3635](https://github.com/Rdatatable/data.table/issues/3635). Thanks to @UweBlock for the report.
 
-25. Complex columns used in `j` during grouping would get mangled, [#3639](https://github.com/Rdatatable/data.table/issues/3639). We still do not support grouping `by` a complex column; please file a feature request if you would use this in your own work. Thanks to @eliocamp for filing the bug report.
+25. Complex columns used in `j` during grouping would get mangled, [#3639](https://github.com/Rdatatable/data.table/issues/3639). A related bug prevented assigning complex values using `:=` except for full-column plonks. We still do not support grouping `by` a complex column; please file a feature request if you would use this in your own work. Thanks to @eliocamp for filing the bug report.
 
 #### NOTES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -192,6 +192,8 @@
 
 24. `column not found` could incorrectly occur in rare non-equi-join cases, [#3635](https://github.com/Rdatatable/data.table/issues/3635). Thanks to @UweBlock for the report.
 
+25. Complex columns used in `j` during grouping would get mangled, [#3639](https://github.com/Rdatatable/data.table/issues/3639). We still do not support grouping `by` a complex column; please file a feature request if you would use this in your own work. Thanks to @eliocamp for filing the bug report.
+
 #### NOTES
 
 1. `rbindlist`'s `use.names="check"` now emits its message for automatic column names (`"V[0-9]+"`) too, [#3484](https://github.com/Rdatatable/data.table/pull/3484). See news item 5 of v1.12.2 below.

--- a/NEWS.md
+++ b/NEWS.md
@@ -192,7 +192,7 @@
 
 24. `column not found` could incorrectly occur in rare non-equi-join cases, [#3635](https://github.com/Rdatatable/data.table/issues/3635). Thanks to @UweBlock for the report.
 
-25. Complex columns used in `j` during grouping would get mangled, [#3639](https://github.com/Rdatatable/data.table/issues/3639). A related bug prevented assigning complex values using `:=` except for full-column plonks. We still do not support grouping `by` a complex column; please file a feature request if you would use this in your own work. Thanks to @eliocamp for filing the bug report.
+25. Complex columns used in `j` during grouping would get mangled, [#3639](https://github.com/Rdatatable/data.table/issues/3639). A related bug prevented assigning complex values using `:=` except for full-column plonks. We still do not support grouping `by` a complex column. Thanks to @eliocamp for filing the bug report.
 
 #### NOTES
 

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -889,7 +889,6 @@ replace_order = function(isub, verbose, env) {
       } # else maybe a call to transform or something which returns a list.
       av = all.vars(jsub,TRUE)  # TRUE fixes bug #1294 which didn't see b in j=fns[[b]](c)
       use.I = ".I" %chin% av
-      # browser()
       if (any(c(".SD","eval","get","mget") %chin% av)) {
         if (missing(.SDcols)) {
           # here we need to use 'dupdiff' instead of 'setdiff'. Ex: setdiff(c("x", "x"), NULL) will give 'x'.

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -15200,6 +15200,15 @@ d2 = data.table(r = 1:5, s = seq(0L, 20L, 5L))
 test(2062.1, d1[d2, on = .(a <= s, b >= s), j = .SD],   ans<-data.table(a=INT(0,5,10,10,15,20), b=INT(0,5,10,10,15,20)))
 test(2062.2, d1[d2, on = .(a <= s, b >= s)][, .(a, b)], ans)
 
+# #3639 -- complex values in grouping
+set.seed(42)
+DT = CJ(x = 1:10, a = c("a", "b"), b = 1:2)
+DT[ , z := complex(rnorm(1:.N), rnorm(1:.N))]
+## can simplify this test after #1444
+test(2063.1, all.equal(setkey(copy(DT), NULL), DT[, .(x = x, z = z), by = .(a, b)][order(x, a, b)], ignore.col.order = TRUE))
+test(2063.2, DT[ , base::sum(z), by = a], data.table(a = c('a', 'b'), V1 = c(5.0582228485073+0i, -1.8644229822705+0i)))
+test(2063.3, DT[ , sum(Mod(z)), by = b], data.table(b = 1:2, V2 = c(16.031422657932, 13.533483145656)))
+
 
 ###################################
 #  Add new tests above this line  #

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -15207,7 +15207,7 @@ DT[ , z := complex(rnorm(1:.N), rnorm(1:.N))]
 ## can simplify this test after #1444
 test(2063.1, all.equal(setkey(copy(DT), NULL), DT[, .(x = x, z = z), by = .(a, b)][order(x, a, b)], ignore.col.order = TRUE))
 test(2063.2, DT[ , base::sum(z), by = a], data.table(a = c('a', 'b'), V1 = c(5.0582228485073+0i, -1.8644229822705+0i)))
-test(2063.3, DT[ , sum(Mod(z)), by = b], data.table(b = 1:2, V2 = c(16.031422657932, 13.533483145656)))
+test(2063.3, DT[ , sum(Mod(z)), by = b], data.table(b = 1:2, V1 = c(16.031422657932, 13.533483145656)))
 
 
 ###################################

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -15211,8 +15211,8 @@ test(2063.3, DT[ , sum(Mod(z)), by = b], data.table(b = 1:2, V1 = c(16.031422657
 # also works for assignment, as noted in #3690
 DT[ , z_sum := base::sum(z), by = .(a, b)]
 test(2063.4, DT[ , z_sum := base::sum(z), by = .(a, b)][1:3, z_sum],
-     c(3.05896822455656+0i, -2.81616342436407+0i, -3.04864360704606+0i))
-test(2063.4, DT[1L, z_sum := 1i][1L, z_sum], 1i)
+     c(1.8791864549242+0i, 3.17903639358309+0i, -4.18868631527035+0i))
+test(2063.5, DT[1L, z_sum := 1i][1L, z_sum], 1i)
 
 ###################################
 #  Add new tests above this line  #

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -7335,7 +7335,8 @@ DT3 = rbindlist(list(DT2, list(x="d", y=7L, mul=100L)))
 DT3 = DT3[sample(nrow(DT3))]
 DT1[ , x_num := match(x, letters) + .1]
 DT3[ , x_num := match(x, letters) + .1]
-test(1540.36, DT1[DT3, .(x_num), by=.EACHI, on=c(x_num="x_num")])
+test(1540.36, DT1[DT3[1:3], .(y = x_num), by=.EACHI, on=c(x_num="x_num")],
+     data.table(x_num = c(3.1, 4.1, 3.1), y = c(2.1, NA, NA)))
 
 # to do: add tests for :=
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -15208,7 +15208,11 @@ DT[ , z := complex(rnorm(1:.N), rnorm(1:.N))]
 test(2063.1, all.equal(setkey(copy(DT), NULL), DT[, .(x = x, z = z), by = .(a, b)][order(x, a, b)], ignore.col.order = TRUE))
 test(2063.2, DT[ , base::sum(z), by = a], data.table(a = c('a', 'b'), V1 = c(5.0582228485073+0i, -1.8644229822705+0i)))
 test(2063.3, DT[ , sum(Mod(z)), by = b], data.table(b = 1:2, V1 = c(16.031422657932, 13.533483145656)))
-
+# also works for assignment, as noted in #3690
+DT[ , z_sum := base::sum(z), by = .(a, b)]
+test(2063.4, DT[ , z_sum := base::sum(z), by = .(a, b)][1:3, z_sum],
+     c(3.05896822455656+0i, -2.81616342436407+0i, -3.04864360704606+0i))
+test(2063.4, DT[1L, z_sum := 1i][1L, z_sum], 1i)
 
 ###################################
 #  Add new tests above this line  #

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -15208,11 +15208,20 @@ DT[ , z := complex(rnorm(1:.N), rnorm(1:.N))]
 test(2063.1, all.equal(setkey(copy(DT), NULL), DT[, .(x = x, z = z), by = .(a, b)][order(x, a, b)], ignore.col.order = TRUE))
 test(2063.2, DT[ , base::sum(z), by = a], data.table(a = c('a', 'b'), V1 = c(5.0582228485073+0i, -1.8644229822705+0i)))
 test(2063.3, DT[ , sum(Mod(z)), by = b], data.table(b = 1:2, V1 = c(16.031422657932, 13.533483145656)))
+## mimicking test 171.3 for coverage
+DT = data.table(A=c(25L,85L,25L,25L,85L), B=c("a","a","b","c","c"), z=0:4 + (4:0)*1i)
+test(2063.4, DT[ , data.table(A, z)[A==25, z] + data.table(A, z)[A==85, z], by=B],
+     data.table(B = c('a', 'c'), V1 = c(1, 7) + (c(7, 1))*1i))
+## mimicking test 771 for coverage
+a = data.table(first=1:6, third=c(1i,1,1i,3,3i,4), key="first")
+b = data.table(first=c(3,4,4,5,6,7,8), second=1:7, key="first")
+test(2063.5, b[ , third:=a[b, third, by=.EACHI]], error="Supplied 2 items to be assigned to 7 items of")
+
 # also works for assignment, as noted in #3690
 DT[ , z_sum := base::sum(z), by = .(a, b)]
-test(2063.4, DT[ , z_sum := base::sum(z), by = .(a, b)][1:3, z_sum],
+test(2063.6, DT[ , z_sum := base::sum(z), by = .(a, b)][1:3, z_sum],
      c(1.8791864549242+0i, 3.17903639358309+0i, -4.18868631527035+0i))
-test(2063.5, DT[1L, z_sum := 1i][1L, z_sum], 1i)
+test(2063.7, DT[1L, z_sum := 1i][1L, z_sum], 1i)
 
 ###################################
 #  Add new tests above this line  #

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -7326,6 +7326,16 @@ test(1540.35, DT1[DT3, lapply(.SD, function(x) x * mul),
                  by=.EACHI, on=c(x="q", y="r"), roll=TRUE],
              DT1.copy[DT3, lapply(.SD, function(x) x * mul),
                  by=.EACHI, roll=TRUE])
+## more coverage tests for by = .EACHI, on = c(LHS = 'RHS') for numeric type
+set.seed(45L)
+DT1 = data.table(x=sample(letters[1:3], 15, TRUE), y=sample(6:10, 15, TRUE),
+                 a=sample(100, 15), b=runif(15))
+DT2 = CJ(x=letters[1:3], y=6:10)[, mul := sample(20, 15)][sample(15L, 5L)]
+DT3 = rbindlist(list(DT2, list(x="d", y=7L, mul=100L)))
+DT3 = DT3[sample(nrow(DT3))]
+DT1[ , x_num := match(x, letters) + .1]
+DT3[ , x_num := match(x, letters) + .1]
+test(1540.36, DT1[DT3, .(x_num), by=.EACHI, on=c(x_num="x_num")])
 
 # to do: add tests for :=
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -15209,8 +15209,8 @@ test(2063.1, all.equal(setkey(copy(DT), NULL), DT[, .(x = x, z = z), by = .(a, b
 test(2063.2, DT[ , base::sum(z), by = a], data.table(a = c('a', 'b'), V1 = c(5.0582228485073+0i, -1.8644229822705+0i)))
 test(2063.3, DT[ , sum(Mod(z)), by = b], data.table(b = 1:2, V1 = c(16.031422657932, 13.533483145656)))
 ## mimicking test 171.3 for coverage
-DT = data.table(A=c(25L,85L,25L,25L,85L), B=c("a","a","b","c","c"), z=0:4 + (4:0)*1i)
-test(2063.4, DT[ , data.table(A, z)[A==25, z] + data.table(A, z)[A==85, z], by=B],
+x = data.table(A=c(25L,85L,25L,25L,85L), B=c("a","a","b","c","c"), z=0:4 + (4:0)*1i)
+test(2063.4, x[ , data.table(A, z)[A==25, z] + data.table(A, z)[A==85, z], by=B],
      data.table(B = c('a', 'c'), V1 = c(1, 7) + (c(7, 1))*1i))
 ## mimicking test 771 for coverage
 a = data.table(first=1:6, third=c(1i,1,1i,3,3i,4), key="first")

--- a/src/assign.c
+++ b/src/assign.c
@@ -1013,7 +1013,6 @@ void writeNA(SEXP v, const int from, const int n)
   } break;
   case CPLXSXP: {
     Rcomplex *vd = COMPLEX(v);
-    Rcomplex NA_CPLX = {NA_REAL, NA_REAL};
     for (int i=from; i<=to; ++i) vd[i] = NA_CPLX;
   } break;
   case STRSXP :

--- a/src/assign.c
+++ b/src/assign.c
@@ -1,7 +1,6 @@
 #include "data.table.h"
 #include <Rdefines.h>
 #include <Rmath.h>
-#include <complex.h>
 
 static void finalizer(SEXP p)
 {
@@ -945,8 +944,8 @@ const char *memrecycle(SEXP target, SEXP where, int start, int len, SEXP source)
       }
     } break;
     case CPLXSXP: {
-      double complex *td = (double complex *)COMPLEX(target);
-      const double complex *sd = (double complex *)COMPLEX(source);
+      Rcomplex *td = COMPLEX(target);
+      const Rcomplex *sd = COMPLEX(source);
       for (int i=0; i<len; i++) {
         const int w = wd[i];
         if (w<1) continue;
@@ -1013,8 +1012,9 @@ void writeNA(SEXP v, const int from, const int n)
     }
   } break;
   case CPLXSXP: {
-    double complex *vd = (double complex *)COMPLEX(v);
-    for (int i=from; i<=to; ++i) vd[i] = NA_REAL + NA_REAL*I;
+    Rcomplex *vd = COMPLEX(v);
+    Rcomplex NA_CPLX = {NA_REAL, NA_REAL};
+    for (int i=from; i<=to; ++i) vd[i] = NA_CPLX;
   } break;
   case STRSXP :
     // character columns are initialized with blank string (""). So replace the all-"" with all-NA_character_

--- a/src/assign.c
+++ b/src/assign.c
@@ -1,6 +1,7 @@
 #include "data.table.h"
 #include <Rdefines.h>
 #include <Rmath.h>
+#include <complex.h>
 
 static void finalizer(SEXP p)
 {
@@ -943,6 +944,15 @@ const char *memrecycle(SEXP target, SEXP where, int start, int len, SEXP source)
         td[w-1] = sd[i&mask];
       }
     } break;
+    case CPLXSXP: {
+      double complex *td = (double complex *)COMPLEX(target);
+      const double complex *sd = (double complex *)COMPLEX(source);
+      for (int i=0; i<len; i++) {
+        const int w = wd[i];
+        if (w<1) continue;
+        td[w-1] = sd[i&mask];
+      }
+    } break;
     case STRSXP : {
       const SEXP *sd = STRING_PTR(source);
       for (int i=0; i<len; i++) {
@@ -1001,6 +1011,10 @@ void writeNA(SEXP v, const int from, const int n)
       double *vd = REAL(v);
       for (int i=from; i<=to; ++i) vd[i] = NA_REAL;
     }
+  } break;
+  case CPLXSXP: {
+    double complex *vd = (double complex *)COMPLEX(v);
+    for (int i=from; i<=to; ++i) vd[i] = NA_REAL + NA_REAL*I;
   } break;
   case STRSXP :
     // character columns are initialized with blank string (""). So replace the all-"" with all-NA_character_

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -63,6 +63,12 @@ typedef R_xlen_t RLEN;
 #define ALTREP(x) 0  // for R<3.5.0, see issue #2866 and grep for "ALTREP" to see comments where it's used
 #endif
 
+// for complex type support; copied from r-source/src/main/Rcomplex.h
+#if defined(__GNUC__) && (defined(__sun__) || defined(__hpux__) || defined(Win32))
+# undef  I
+# define I (__extension__ 1.0iF)
+#endif
+
 // init.c
 SEXP char_integer64;
 SEXP char_ITime;

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -63,12 +63,6 @@ typedef R_xlen_t RLEN;
 #define ALTREP(x) 0  // for R<3.5.0, see issue #2866 and grep for "ALTREP" to see comments where it's used
 #endif
 
-// for complex type support; copied from r-source/src/main/Rcomplex.h
-#if defined(__GNUC__) && (defined(__sun__) || defined(__hpux__) || defined(Win32))
-# undef  I
-# define I (__extension__ 1.0iF)
-#endif
-
 // init.c
 SEXP char_integer64;
 SEXP char_ITime;

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -92,6 +92,7 @@ double LLtoD(long long x);
 bool GetVerbose();
 double NA_INT64_D;
 long long NA_INT64_LL;
+Rcomplex NA_CPLX;  // initialized in init.c; see there for comments
 
 // cj.c
 SEXP cj(SEXP base_list);

--- a/src/dogroups.c
+++ b/src/dogroups.c
@@ -185,7 +185,7 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
           SET_VECTOR_ELT(VECTOR_ELT(xSD,j),0,R_NilValue);
           break;
         default:
-          error("Logical error. Type of column should have been checked by now");
+          error("Logical error. Type of column should have been checked by now"); // #nocov
         }
       }
     } else {

--- a/src/dogroups.c
+++ b/src/dogroups.c
@@ -144,7 +144,6 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
           REAL(VECTOR_ELT(SDall,j))[0] = NA_REAL;
           break;
         case CPLXSXP : {
-          Rcomplex NA_CPLX = {NA_REAL, NA_REAL};
           COMPLEX(VECTOR_ELT(SDall, j))[0] = NA_CPLX;
         } break;
         case STRSXP :
@@ -172,7 +171,6 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
           REAL(VECTOR_ELT(xSD,j))[0] = NA_REAL;
           break;
         case CPLXSXP : {
-          Rcomplex NA_CPLX = {NA_REAL, NA_REAL};
           COMPLEX(VECTOR_ELT(xSD, j))[0] = NA_CPLX;
         }  break;
         case STRSXP :
@@ -438,11 +436,9 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
           for (int r=0; r<maxn; ++r) td[r] = NA_REAL;
         } break;
         case CPLXSXP : {
-        Rcomplex *td = COMPLEX(target) + thisansloc;
-        Rcomplex NA_CPLX = {NA_REAL, NA_REAL};
-        for (int r=0; r<maxn; ++r) td[r] = NA_CPLX;
-        //for (int r=0; r<,maxn; ++r) { creal(td[r]) = NA_REAL; cimag(td[r]) = NA_REAL; }
-      } break;
+          Rcomplex *td = COMPLEX(target) + thisansloc;
+          for (int r=0; r<maxn; ++r) td[r] = NA_CPLX;
+        } break;
         case STRSXP :
           for (int r=0; r<maxn; ++r) SET_STRING_ELT(target,thisansloc+r,NA_STRING);
           break;

--- a/src/dogroups.c
+++ b/src/dogroups.c
@@ -4,6 +4,12 @@
 #include <time.h>
 #include <complex.h>
 
+// copied from r-source/src/main/Rcomplex.h
+#if defined(__GNUC__) && (defined(__sun__) || defined(__hpux__) || defined(Win32))
+# undef  I
+# define I (__extension__ 1.0iF)
+#endif
+
 SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEXP xjiscols, SEXP grporder, SEXP order, SEXP starts, SEXP lens, SEXP jexp, SEXP env, SEXP lhs, SEXP newnames, SEXP on, SEXP verbose)
 {
   R_len_t rownum, ngrp, nrowgroups, njval=0, ngrpcols, ansloc=0, maxn, estn=-1, thisansloc, grpn, thislen, igrp, origIlen=0, origSDnrow=0;
@@ -440,6 +446,11 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
           double *td = REAL(target)+thisansloc;
           for (int r=0; r<maxn; ++r) td[r] = NA_REAL;
         } break;
+        case CPLXSXP : {
+        double complex *td = (double complex *)(COMPLEX(target) + thisansloc);
+        for (int r=0; r<maxn; ++r) { td[r] = NA_REAL + NA_REAL*I; }
+        //for (int r=0; r<,maxn; ++r) { creal(td[r]) = NA_REAL; cimag(td[r]) = NA_REAL; }
+      } break;
         case STRSXP :
           for (int r=0; r<maxn; ++r) SET_STRING_ELT(target,thisansloc+r,NA_STRING);
           break;

--- a/src/dogroups.c
+++ b/src/dogroups.c
@@ -4,12 +4,6 @@
 #include <time.h>
 #include <complex.h>
 
-// copied from r-source/src/main/Rcomplex.h
-#if defined(__GNUC__) && (defined(__sun__) || defined(__hpux__) || defined(Win32))
-# undef  I
-# define I (__extension__ 1.0iF)
-#endif
-
 SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEXP xjiscols, SEXP grporder, SEXP order, SEXP starts, SEXP lens, SEXP jexp, SEXP env, SEXP lhs, SEXP newnames, SEXP on, SEXP verbose)
 {
   R_len_t rownum, ngrp, nrowgroups, njval=0, ngrpcols, ansloc=0, maxn, estn=-1, thisansloc, grpn, thislen, igrp, origIlen=0, origSDnrow=0;

--- a/src/dogroups.c
+++ b/src/dogroups.c
@@ -145,6 +145,11 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
         case REALSXP :
           REAL(VECTOR_ELT(SDall,j))[0] = NA_REAL;
           break;
+        case CPLXSXP :
+          // no NA_COMPLEX; have to set r & i parts to NA_REAL individually
+          COMPLEX(VECTOR_ELT(SDall, j))[0].r = NA_REAL;
+          COMPLEX(VECTOR_ELT(SDall, j))[0].i = NA_REAL;
+          break;
         case STRSXP :
           SET_STRING_ELT(VECTOR_ELT(SDall,j),0,NA_STRING);
           break;
@@ -168,6 +173,10 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
           break;
         case REALSXP :
           REAL(VECTOR_ELT(xSD,j))[0] = NA_REAL;
+          break;
+        case CPLXSXP :
+          COMPLEX(VECTOR_ELT(xSD, j))[0].r = NA_REAL;
+          COMPLEX(VECTOR_ELT(xSD, j))[0].i = NA_REAL;
           break;
         case STRSXP :
           SET_STRING_ELT(VECTOR_ELT(xSD,j),0,NA_STRING);

--- a/src/init.c
+++ b/src/init.c
@@ -168,7 +168,7 @@ R_CallMethodDef callMethods[] = {
 {"CcolnamesInt", (DL_FUNC) &colnamesInt, -1},
 {"CcoerceFillR", (DL_FUNC) &coerceFillR, -1},
 {"CinitLastUpdated", (DL_FUNC) &initLastUpdated, -1},
-{"Ccj", (DL_FUNC) &cj, -1},  
+{"Ccj", (DL_FUNC) &cj, -1},
 {"Ccoalesce", (DL_FUNC) &coalesce, -1},
 {NULL, NULL, 0}
 };
@@ -254,6 +254,9 @@ void attribute_visible R_init_datatable(DllInfo *info)
   if (NA_INT64_D != -0.0) error("NA_INT64_D (negative -0.0) is not ==-0.0.");
   if (ISNAN(NA_INT64_D)) error("ISNAN(NA_INT64_D) is TRUE but should not be");
   if (isnan(NA_INT64_D)) error("isnan(NA_INT64_D) is TRUE but should not be");
+
+  NA_CPLX.r = NA_REAL;  // NA_REAL is defined as R_NaReal which is not a strict constant and thus initializer {NA_REAL, NA_REAL} can't be used in .h
+  NA_CPLX.i = NA_REAL;  // https://github.com/Rdatatable/data.table/pull/3689/files#r304117234
 
   setNumericRounding(PROTECT(ScalarInteger(0))); // #1642, #1728, #1463, #485
   UNPROTECT(1);

--- a/src/subset.c
+++ b/src/subset.c
@@ -77,7 +77,6 @@ static void subsetVectorRaw(SEXP ans, SEXP source, SEXP idx, const bool anyNA)
   case CPLXSXP : {
     Rcomplex *sp = COMPLEX(source);
     Rcomplex *ap = COMPLEX(ans);
-    Rcomplex NA_CPLX = { NA_REAL, NA_REAL };
     PARLOOP(NA_CPLX)
   } break;
   case RAWSXP : {


### PR DESCRIPTION
#3639

Haven't quite figured out the ins and outs of `CPLXSXP` and `COMPLEX()` usage yet but I think this gets at the kernel of the issue -- `dogroups` assumes `SIZEOF` is either 4 or 8, not so for `CPLXSXP` (16). Will come back to this.

FWIW `grep -Er "==\s?4" src` only turns up `reorder` and `dogroups`, so I think this and #3688 should cover this class of issue.