### PR TITLE
fwrite supports complex-valued columns, part of #3690

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,7 +36,7 @@
 
     * Gains `bom` argument to add a *byte order mark* (BOM) at the beginning of the file to signal that the file is encoded in UTF-8, [#3488](https://github.com/Rdatatable/data.table/issues/3488). Thanks to Stefan Fleck for requesting and Philippe Chataignon for implementing.
     
-    * Supports writing complex-valued columns, part of [#3690](https://github.com/Rdatatable/data.table/issues/3690).
+    * Now supports type `complex`, [#3690](https://github.com/Rdatatable/data.table/issues/3690).
 
 4. Assigning to one item of a list column no longer requires the RHS to be wrapped with `list` or `.()`, [#950](https://github.com/Rdatatable/data.table/issues/950).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,8 @@
     * Gains `yaml` argument matching that of `fread`, [#3534](https://github.com/Rdatatable/data.table/issues/3534). See the item in `fread` for a bit more detail; here, we'd like to reiterate that feedback is appreciated in the initial phase of rollout for this feature.
 
     * Gains `bom` argument to add a *byte order mark* (BOM) at the beginning of the file to signal that the file is encoded in UTF-8, [#3488](https://github.com/Rdatatable/data.table/issues/3488). Thanks to Stefan Fleck for requesting and Philippe Chataignon for implementing.
+    
+    * Supports writing complex-valued columns, part of [#3690](https://github.com/Rdatatable/data.table/issues/3690).
 
 4. Assigning to one item of a list column no longer requires the RHS to be wrapped with `list` or `.()`, [#950](https://github.com/Rdatatable/data.table/issues/950).
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -9595,7 +9595,7 @@ unlink(f)
 
 # complex column support for fwrite, part of #3690
 DT = data.table(a = 1:3, z = 0:2 - (2:0)*1i)
-test(1658.55, fwrite(DT), output = '0-2i.*2,1-1i.*3,2+0i')
+test(1658.55, fwrite(DT), output = 'a,z\n1,0-2i\n2,1-1i\n3,2+0i')
 test(1658.56, fwrite(data.table(exp(1) - pi*1i)), output = '2.718[0-9]*-3.141[0-9]*i')
 ## formerly 1658.46
 DT = data.table(a=1:3, b=list(1:4, c(3.14, 100e10), c(3i,4i,5i)))

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -9566,6 +9566,8 @@ test(1658.44, file.info(f3)$size, file.info(f1)$size)
 unlink(c(f1,f2,f3))
 DT = data.table(a=1:3, b=list(1:4, c(3.14, 100e10), c("foo", "bar", "baz")))
 test(1658.45, fwrite(DT), output=c("a,b","1,1|2|3|4","2,3.14|1e+12","3,foo|bar|baz"))
+DT[3,b:=as.raw(0:2)]
+test(1658.46, fwrite(DT), error="Row 3 of list column is type 'raw'")
 DT[3,b:=factor(letters[1:3])]
 test(1658.47, fwrite(DT), error="Row 3 of list column is type 'factor'")
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -9594,12 +9594,14 @@ if (test_R.utils) test(1658.54, fread(f), setnames(DT,c("V1","V2")))
 unlink(f)
 
 # complex column support for fwrite, part of #3690
-DT = data.table(a = 1:3, z = 0:2 - (2:0)*1i)
-test(1658.55, fwrite(DT), output = 'a,z\n1,0-2i\n2,1-1i\n3,2+0i')
-test(1658.56, fwrite(data.table(exp(1) - pi*1i)), output = '2.718[0-9]*-3.141[0-9]*i')
+DT = data.table(a=1:3, z=0:2 - (2:0)*1i)
+test(1658.55, fwrite(DT), output='a,z\n1,0-2i\n2,1-1i\n3,2+0i')
+test(1658.56, fwrite(data.table(exp(1) - pi*1i)), output='2.718[0-9]*-3.141[0-9]*i')
 ## formerly 1658.46
 DT = data.table(a=1:3, b=list(1:4, c(3.14, 100e10), c(3i,4i,5i)))
 test(1658.57, fwrite(DT), output='0+3i|0+4i|0+5i')
+DT[ , b := c(1i, -1-1i, NA)]
+test(1658.58, fwrite(DT), output='a,b\n1,0\\+1i\n2,-1-1i\n3,$')
 
 ## End fwrite tests
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -9595,11 +9595,11 @@ unlink(f)
 
 # complex column support for fwrite, part of #3690
 DT = data.table(a = 1:3, z = 0:2 - (2:0)*1i)
-test(1658.54, fwrite(DT), output = '0-2i.*2,1-1i.*3,2+0i')
-test(1658.55, fwrite(data.table(exp(1) - pi*1i)), output = '2.718[0-9]*-3.141[0-9]*i')
+test(1658.55, fwrite(DT), output = '0-2i.*2,1-1i.*3,2+0i')
+test(1658.56, fwrite(data.table(exp(1) - pi*1i)), output = '2.718[0-9]*-3.141[0-9]*i')
 ## formerly 1658.46
 DT = data.table(a=1:3, b=list(1:4, c(3.14, 100e10), c(3i,4i,5i)))
-test(1658.56, fwrite(DT), output='0+3i|0+4i|0+5i')
+test(1658.57, fwrite(DT), output='0+3i|0+4i|0+5i')
 
 ## End fwrite tests
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -9605,6 +9605,11 @@ test(1658.57, fwrite(DT), output='0+3i|0+4i|0+5i')
 DT[ , b := c(1i, -1-1i, NA)]
 test(1658.58, fwrite(DT), output='a,b\n1,0\\+1i\n2,-1-1i\n3,$')
 
+# more coverage
+test(1658.59, fwrite(data.table(a=list('a')), verbose=TRUE),
+     output='fields will be quoted if the field contains either sep.*sep2.*list column')
+test(1658.60, fwrite(data.table(r=as.raw(0))), error = "'raw' - not yet implemented")
+
 ## End fwrite tests
 
 # tests for #679, inrange(), FR #707

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -9566,8 +9566,6 @@ test(1658.44, file.info(f3)$size, file.info(f1)$size)
 unlink(c(f1,f2,f3))
 DT = data.table(a=1:3, b=list(1:4, c(3.14, 100e10), c("foo", "bar", "baz")))
 test(1658.45, fwrite(DT), output=c("a,b","1,1|2|3|4","2,3.14|1e+12","3,foo|bar|baz"))
-DT[3,b:=c(3i,4i,5i)]
-test(1658.46, fwrite(DT), error="Row 3 of list column is type 'complex'")
 DT[3,b:=factor(letters[1:3])]
 test(1658.47, fwrite(DT), error="Row 3 of list column is type 'factor'")
 
@@ -9594,6 +9592,14 @@ DT = data.table(l=letters, n=1:26)
 test(1658.53, fwrite(DT, file=f<-tempfile(fileext=".gz"), bom=TRUE, col.names=FALSE), NULL)
 if (test_R.utils) test(1658.54, fread(f), setnames(DT,c("V1","V2")))
 unlink(f)
+
+# complex column support for fwrite, part of #3690
+DT = data.table(a = 1:3, z = 0:2 - (2:0)*1i)
+test(1658.54, fwrite(DT), output = '0-2i.*2,1-1i.*3,2+0i')
+test(1658.55, fwrite(data.table(exp(1) - pi*1i)), output = '2.718[0-9]*-3.141[0-9]*i')
+## formerly 1658.46
+DT = data.table(a=1:3, b=list(1:4, c(3.14, 100e10), c(3i,4i,5i)))
+test(1658.56, fwrite(DT), output='0+3i|0+4i|0+5i')
 
 ## End fwrite tests
 

--- a/man/fwrite.Rd
+++ b/man/fwrite.Rd
@@ -3,8 +3,6 @@
 \title{Fast CSV writer}
 \description{
 As \code{write.csv} but much faster (e.g. 2 seconds versus 1 minute) and just as flexible. Modern machines almost surely have more than one CPU so \code{fwrite} uses them; on all operating systems including Linux, Mac and Windows.
-
-This is new functionality as of Nov 2016. We may need to refine argument names and defaults.
 }
 \usage{
 fwrite(x, file = "", append = FALSE, quote = "auto",

--- a/src/fwrite.c
+++ b/src/fwrite.c
@@ -7,7 +7,6 @@
 #include <math.h>      // isfinite, isnan
 #include <stdlib.h>    // abs
 #include <string.h>    // strlen, strerror
-#include <complex.h>
 
 #ifdef WIN32
 #include <sys/types.h>
@@ -302,12 +301,12 @@ void writeFloat64(double *col, int64_t row, char **pch)
   *pch = ch;
 }
 
-void writeComplex(double complex *col, int64_t row, char **pch)
+void writeComplex(Rcomplex *col, int64_t row, char **pch)
 {
-  double complex x = col[row];
-  double im = cimag(x);
+  Rcomplex x = col[row];
+  double im = x.i;
   char *ch = *pch;
-  writeFloat64Scalar(creal(x), &ch);
+  writeFloat64Scalar(x.r, &ch);
   // writeFloat64Scalar handled NA for the real part
   if (!ISNA(im)) {
     // let writeFloat64 handle the - sign for negative imaginary part

--- a/src/fwrite.c
+++ b/src/fwrite.c
@@ -7,6 +7,7 @@
 #include <math.h>      // isfinite, isnan
 #include <stdlib.h>    // abs
 #include <string.h>    // strlen, strerror
+#include <complex.h>
 
 #ifdef WIN32
 #include <sys/types.h>
@@ -168,7 +169,7 @@ void genLookups() {
 }
 */
 
-void writeFloat64(double *col, int64_t row, char **pch)
+void writeFloat64Scalar(double x, char **pch)
 {
   // hand-rolled / specialized for speed
   // *pch is safely the output destination with enough space (ensured via calculating maxLineLen up front)
@@ -178,7 +179,6 @@ void writeFloat64(double *col, int64_t row, char **pch)
   //  ii) no C libary calls such as sprintf() where the fmt string has to be interpretted over and over
   // iii) no need to return variables or flags.  Just writes.
   //  iv) shorter, easier to read and reason with in one self contained place.
-  double x = col[row];
   char *ch = *pch;
   if (!isfinite(x)) {
     if (isnan(x)) {
@@ -289,6 +289,26 @@ void writeFloat64(double *col, int64_t row, char **pch)
       }
     }
   }
+  *pch = ch;
+}
+
+void writeFloat64(double *col, int64_t row, char **pch)
+{
+  double x = col[row];
+  char *ch = *pch;
+  writeFloat64Scalar(x, &ch);
+  *pch = ch;
+}
+
+void writeComplex(double complex *col, int64_t row, char **pch)
+{
+  double complex x = col[row];
+  char *ch = *pch;
+  writeFloat64Scalar(creal(x), &ch);
+  // let writeFloat64 handle the - sign for negative imaginary part
+  if (cimag(x) >= 0.0) *ch++ = '+';
+  writeFloat64Scalar(cimag(x), &ch);
+  *ch++ = 'i';
   *pch = ch;
 }
 

--- a/src/fwrite.c
+++ b/src/fwrite.c
@@ -303,12 +303,16 @@ void writeFloat64(double *col, int64_t row, char **pch)
 void writeComplex(double complex *col, int64_t row, char **pch)
 {
   double complex x = col[row];
+  double im = cimag(x);
   char *ch = *pch;
   writeFloat64Scalar(creal(x), &ch);
-  // let writeFloat64 handle the - sign for negative imaginary part
-  if (cimag(x) >= 0.0) *ch++ = '+';
-  writeFloat64Scalar(cimag(x), &ch);
-  *ch++ = 'i';
+  // writeFloat64Scalar handled NA for the real part
+  if (!ISNA(im)) {
+    // let writeFloat64 handle the - sign for negative imaginary part
+    if (im >= 0.0) *ch++ = '+';
+    writeFloat64Scalar(im, &ch);
+    *ch++ = 'i';
+  }
   *pch = ch;
 }
 

--- a/src/fwrite.c
+++ b/src/fwrite.c
@@ -52,6 +52,7 @@ inline void write_chars(const char *x, char **pch)
   *pch = ch;
 }
 
+// #nocov start
 void writeBool8(int8_t *col, int64_t row, char **pch)
 {
   int8_t x = col[row];
@@ -59,6 +60,7 @@ void writeBool8(int8_t *col, int64_t row, char **pch)
   *ch++ = '0'+(x==1);
   *pch = ch-(x==INT8_MIN);  // if NA then step back, to save a branch
 }
+// #nocov end
 
 void writeBool32(int32_t *col, int64_t row, char **pch)
 {

--- a/src/fwrite.h
+++ b/src/fwrite.h
@@ -9,12 +9,14 @@
 
 typedef void (*writer_fun_t)(void *, int64_t, char **);
 
+// in the order of writer_fun_t in fwriteR.c
 void writeBool8();
 void writeBool32();
 void writeBool32AsString();
 void writeInt32();
 void writeInt64();
 void writeFloat64();
+void writeComplex();
 void writeITime();
 void writeDateInt32();
 void writeDateFloat64();
@@ -33,6 +35,7 @@ typedef enum {   // same order as fun[] above
   WF_Int32,
   WF_Int64,
   WF_Float64,
+  WF_Complex,
   WF_ITime,
   WF_DateInt32,
   WF_DateFloat64,
@@ -50,6 +53,7 @@ static const int writerMaxLen[] = {  // same order as fun[] and WFs above; max f
   11, //&writeInt32            "-2147483647"
   20, //&writeInt64            "-9223372036854775807"
   29, //&writeFloat64          "-3.141592653589793115998E-123" [max sf 22 consistent with options()$digits]
+  60, //&writeComplex          "-3.141592653589793115998E-123+2.7182818284590450907956i" [3x writeFloat64,+,i]
   32, //&writeITime
   16, //&writeDateInt32
   16, //&writeDateFloat64

--- a/src/fwriteR.c
+++ b/src/fwriteR.c
@@ -55,6 +55,7 @@ writer_fun_t funs[] = {
   &writeInt32,
   &writeInt64,
   &writeFloat64,
+  &writeComplex,
   &writeITime,
   &writeDateInt32,
   &writeDateFloat64,
@@ -130,6 +131,8 @@ static int32_t whichWriter(SEXP column) {
     if (INHERITS(column, char_Date))     return WF_DateFloat64;
     if (INHERITS(column, char_POSIXct))  return WF_POSIXct;
     return WF_Float64;
+  case CPLXSXP:
+    return WF_Complex;
   case STRSXP:
     return WF_String;
   case VECSXP:

--- a/src/fwriteR.c
+++ b/src/fwriteR.c
@@ -96,7 +96,7 @@ const int getMaxListItemLen(const SEXP *col, const int64_t n) {
     int32_t wf = whichWriter(this);
     if (TYPEOF(this)==VECSXP || wf==INT32_MIN || isFactor(this)) {
       error("Row %d of list column is type '%s' - not yet implemented. fwrite() can write list columns containing items which are atomic vectors of" \
-            " type logical, integer, integer64, double and character.", i+1, isFactor(this) ? "factor" : type2char(TYPEOF(this)));
+            " type logical, integer, integer64, double, complex and character.", i+1, isFactor(this) ? "factor" : type2char(TYPEOF(this)));
     }
     int width = writerMaxLen[wf];
     if (width==0) {


### PR DESCRIPTION
#3690 

Not 100% confident I did the new writer & adapting `writeFloat64` correctly (particularly I wasn't sure why I needed to `*pch = ch` both in `writeFloat64` and `writeFloat64Scalar`. Extra eyes appreciated