### PR TITLE
fix typos in verbose message command

### DIFF
--- a/R/bmerge.R
+++ b/R/bmerge.R
@@ -57,7 +57,7 @@ bmerge = function(i, x, icols, xcols, roll, rollends, nomatch, mult, ops, verbos
       }
     }
     if (xclass == iclass) {
-      if (verbose) cat("i.",names(i)[ic],"has same type (",xclass,") as x.",names(x)[xc],". No coercion needed.")
+      if (verbose) cat("i.",names(i)[ic],"has same type (",xclass,") as x.",names(x)[xc],". No coercion needed.\n", sep="")
       next
     }
     if (xclass=="character" || iclass=="character" ||


### PR DESCRIPTION
With current code, I got a malformed message like...

> i. e_id has same type ( character ) as x. e_id . No coercion needed.i. rank has same type ( integer ) as x. rank . No coercion needed.Calculated ad hoc index in 0.010s elapsed (0.000s cpu)

That is: spaces where there shouldn't be any and no newlines between columns in the loop.

Off-topic: I reviewed the Contributing guidelines, but still have more to learn about PRs, testing etc (... planning to in a couple months). I'm making this edit through the github website, since I figure that's simpler than opening a new issue, but am not running test.data.table() etc.