### PR TITLE
add default to all switch statements in src; coverage

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -15403,6 +15403,20 @@ DT = data.table(d=sample(seq(as.Date("2015-01-01"), as.Date("2015-01-05"), by="d
 test(2070.01, typeof(DT$d), "double")
 test(2070.02, DT[, .N, keyby=d, verbose=TRUE], output="Column 1.*date.*8 byte double.*no fractions are present.*4 byte integer.*to save space and time")
 
+# coverage along with switch+default pairing
+test(2071.01, dcast(data.table(id=1, grp=1, e=expression(1)), id ~ grp, value.var='e'), error="Unsupported column type in fcast val: 'expression'")
+test(2071.02, is_na(data.table(expression(1))), error="Unsupported column type 'expression'")
+test(2071.03, is_na(data.table(1L), 2L), error="Item 1 of 'cols' is 2 which is outside")
+test(2071.04, is_na(list(1L, 1:2)), error="Column 2 of input list x is length 2, inconsistent")
+test(2071.05, any_na(data.table(1L), 2L), error="Item 1 of 'cols' is 2 which is outside")
+test(2071.06, any_na(list(1L, 1:2)), error="Column 2 of input list x is length 2, inconsistent")
+test(2071.07, any_na(data.table(as.raw(0L))), FALSE)
+test(2071.08, any_na(data.table(c(1+1i, NA))))
+test(2071.09, any_na(data.table(expression(1))), error="Unsupported column type 'expression'")
+test(2071.10, dcast(data.table(a=1, b=1, l=list(list(1))), a ~ b, value.var='l'),
+     data.table(a=1, `1`=list(list(1)), key='a'))
+test(2071.11, dcast(data.table(a = 1, b = 2, c = 3), a ~ b, value.var = 'c', fill = '2'),
+     data.table(a=1, `2`=3, key='a'))
 
 ###################################
 #  Add new tests above this line  #

--- a/src/assign.c
+++ b/src/assign.c
@@ -1021,8 +1021,8 @@ void writeNA(SEXP v, const int from, const int n)
     // If there's ever a way added to R API to pass NA_STRING to allocVector() to tell it to initialize with NA not "", would be great
     for (int i=from; i<=to; ++i) SET_STRING_ELT(v, i, NA_STRING);
     break;
-  case VECSXP :
-    // list columns already have each item initialized to NULL
+  case VECSXP : case EXPRSXP :
+    // list & expression columns already have each item initialized to NULL
     break;
   default :
     error("Internal error: writeNA passed a vector of type '%s'", type2char(TYPEOF(v)));  // # nocov

--- a/src/bmerge.c
+++ b/src/bmerge.c
@@ -265,10 +265,11 @@ void bmerge_r(int xlowIn, int xuppIn, int ilowIn, int iuppIn, int col, int thisg
     }
     if (col>-1 && op[col] != EQ) {
       switch (op[col]) {
-        case LE : xlow = xlowIn; break;
-        case LT : xupp = xlow + 1; xlow = xlowIn; break;
-        case GE : if (ival.i != NA_INTEGER) xupp = xuppIn; break;
-        case GT : xlow = xupp - 1; if (ival.i != NA_INTEGER) xupp = xuppIn; break;
+      case LE : xlow = xlowIn; break;
+      case LT : xupp = xlow + 1; xlow = xlowIn; break;
+      case GE : if (ival.i != NA_INTEGER) xupp = xuppIn; break;
+      case GT : xlow = xupp - 1; if (ival.i != NA_INTEGER) xupp = xuppIn; break;
+      default : error("Internal error in bmerge_r for '%s' column. Unrecognized value op[col]=%d", type2char(TYPEOF(xc)), op[col]); // #nocov
       }
       // for LE/LT cases, we need to ensure xlow excludes NA indices, != EQ is checked above already
       if (op[col] <= 3 && xlow<xupp-1 && ival.i != NA_INTEGER && INTEGER(xc)[XIND(xlow+1)] == NA_INTEGER) {
@@ -376,6 +377,7 @@ void bmerge_r(int xlowIn, int xuppIn, int ilowIn, int iuppIn, int col, int thisg
       case LT : xupp = xlow + 1; if (!isivalNA) xlow = xlowIn; break;
       case GE : if (!isivalNA) xupp = xuppIn; break;
       case GT : xlow = xupp - 1; if (!isivalNA) xupp = xuppIn; break;
+      default : error("Internal error in bmerge_r for '%s' column. Unrecognized value op[col]=%d", type2char(TYPEOF(xc)), op[col]); // #nocov
       }
       // for LE/LT cases, we need to ensure xlow excludes NA indices, != EQ is checked above already
       if (op[col] <= 3 && xlow<xupp-1 && !isivalNA && (!isInt64 ? ISNAN(dxc[XIND(xlow+1)]) : (DtoLL(dxc[XIND(xlow+1)]) == NA_INT64_LL))) {
@@ -546,6 +548,8 @@ void bmerge_r(int xlowIn, int xuppIn, int ilowIn, int iuppIn, int col, int thisg
     if (iupp<iuppIn)
       bmerge_r(xlowIn, xuppIn, iupp-1, iuppIn, col, 1, lowmax && xupp-1==xlowIn, uppmax);
     break;
+  // do nothing
+  default : break;
   }
 }
 

--- a/src/bmerge.c
+++ b/src/bmerge.c
@@ -548,8 +548,7 @@ void bmerge_r(int xlowIn, int xuppIn, int ilowIn, int iuppIn, int col, int thisg
     if (iupp<iuppIn)
       bmerge_r(xlowIn, xuppIn, iupp-1, iuppIn, col, 1, lowmax && xupp-1==xlowIn, uppmax);
     break;
-  // do nothing
-  default : break;
+  default : break;  // do nothing
   }
 }
 

--- a/src/fcast.c
+++ b/src/fcast.c
@@ -59,7 +59,7 @@ SEXP fcast(SEXP lhs, SEXP val, SEXP nrowArg, SEXP ncolArg, SEXP idxArg, SEXP fil
         }
       }
     } break;
-    case STRSXP: {
+    case STRSXP:
       for (int j=0; j<ncols; ++j) {
         SET_VECTOR_ELT(ans, nlhs+j+i*ncols, target=allocVector(TYPEOF(thiscol), nrows) );
         copyMostAttrib(thiscol, target);
@@ -68,8 +68,8 @@ SEXP fcast(SEXP lhs, SEXP val, SEXP nrowArg, SEXP ncolArg, SEXP idxArg, SEXP fil
           SET_STRING_ELT(target, k, (thisidx == NA_INTEGER) ? STRING_ELT(thisfill, 0) : STRING_ELT(thiscol, thisidx-1));
         }
       }
-    }  break;
-    case VECSXP: {
+      break;
+    case VECSXP:
       for (int j=0; j<ncols; ++j) {
         SET_VECTOR_ELT(ans, nlhs+j+i*ncols, target=allocVector(TYPEOF(thiscol), nrows) );
         copyMostAttrib(thiscol, target);
@@ -78,7 +78,7 @@ SEXP fcast(SEXP lhs, SEXP val, SEXP nrowArg, SEXP ncolArg, SEXP idxArg, SEXP fil
           SET_VECTOR_ELT(target, k, (thisidx == NA_INTEGER) ? VECTOR_ELT(thisfill, 0) : VECTOR_ELT(thiscol, thisidx-1));
         }
       }
-    }  break;
+      break;
     default: error("Unsupported column type in fcast val: '%s'", type2char(TYPEOF(thiscol))); // #nocov
     }
     if (count) UNPROTECT(1);

--- a/src/fcast.c
+++ b/src/fcast.c
@@ -5,7 +5,6 @@
 
 // TO DO: margins
 SEXP fcast(SEXP lhs, SEXP val, SEXP nrowArg, SEXP ncolArg, SEXP idxArg, SEXP fill, SEXP fill_d, SEXP is_agg) {
-
   int nrows=INTEGER(nrowArg)[0], ncols=INTEGER(ncolArg)[0];
   int nlhs=length(lhs), nval=length(val), *idx = INTEGER(idxArg);
   SEXP target;
@@ -60,7 +59,7 @@ SEXP fcast(SEXP lhs, SEXP val, SEXP nrowArg, SEXP ncolArg, SEXP idxArg, SEXP fil
         }
       }
     } break;
-    case STRSXP:
+    case STRSXP: {
       for (int j=0; j<ncols; ++j) {
         SET_VECTOR_ELT(ans, nlhs+j+i*ncols, target=allocVector(TYPEOF(thiscol), nrows) );
         copyMostAttrib(thiscol, target);
@@ -69,8 +68,8 @@ SEXP fcast(SEXP lhs, SEXP val, SEXP nrowArg, SEXP ncolArg, SEXP idxArg, SEXP fil
           SET_STRING_ELT(target, k, (thisidx == NA_INTEGER) ? STRING_ELT(thisfill, 0) : STRING_ELT(thiscol, thisidx-1));
         }
       }
-      break;
-    case VECSXP:
+    }  break;
+    case VECSXP: {
       for (int j=0; j<ncols; ++j) {
         SET_VECTOR_ELT(ans, nlhs+j+i*ncols, target=allocVector(TYPEOF(thiscol), nrows) );
         copyMostAttrib(thiscol, target);
@@ -79,7 +78,8 @@ SEXP fcast(SEXP lhs, SEXP val, SEXP nrowArg, SEXP ncolArg, SEXP idxArg, SEXP fil
           SET_VECTOR_ELT(target, k, (thisidx == NA_INTEGER) ? VECTOR_ELT(thisfill, 0) : VECTOR_ELT(thiscol, thisidx-1));
         }
       }
-      break;
+    }  break;
+    default: error("Unsupported column type in fcast val: '%s'", type2char(TYPEOF(thiscol))); // #nocov
     }
     if (count) UNPROTECT(1);
   }

--- a/src/frank.c
+++ b/src/frank.c
@@ -62,7 +62,7 @@ SEXP dt_na(SEXP x, SEXP cols) {
     }
       break;
     default:
-      error("Unknown column type '%s'", type2char(TYPEOF(v)));
+      error("Unsupported column type '%s'", type2char(TYPEOF(v)));
     }
   }
   UNPROTECT(1);
@@ -127,6 +127,7 @@ SEXP frank(SEXP xorderArg, SEXP xstartArg, SEXP xlenArg, SEXP ties_method) {
     //       INTEGER(ans)[xorder[j]-1] = k++;
     //   }
     //   break;
+    default: error("Internal error: unknown ties value in frank: %d", ties); // #nocov
     }
   }
   UNPROTECT(1);
@@ -198,7 +199,7 @@ SEXP anyNA(SEXP x, SEXP cols) {
     }
       break;
     default:
-      error("Unknown column type '%s'", type2char(TYPEOF(v)));
+      error("Unsupported column type '%s'", type2char(TYPEOF(v)));
     }
     if (LOGICAL(ans)[0]) break;
   }

--- a/src/frollR.c
+++ b/src/frollR.c
@@ -113,7 +113,7 @@ SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEX
   if (!dans) error("%s: Unable to allocate memory answer", __func__); // # nocov
   double* dx[nx];                                               // pointers to source columns
   uint_fast64_t inx[nx];                                        // to not recalculate `length(x[[i]])` we store it in extra array
-  if (verbose) Rprintf("%s: allocating memory for results %dx%d\n", __func__, nx, nk);
+  if (bverbose) Rprintf("%s: allocating memory for results %dx%d\n", __func__, nx, nk);
   for (R_len_t i=0; i<nx; i++) {
     inx[i] = xlength(VECTOR_ELT(x, i));                         // for list input each vector can have different length
     for (R_len_t j=0; j<nk; j++) {

--- a/src/frollR.c
+++ b/src/frollR.c
@@ -113,7 +113,7 @@ SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEX
   if (!dans) error("%s: Unable to allocate memory answer", __func__); // # nocov
   double* dx[nx];                                               // pointers to source columns
   uint_fast64_t inx[nx];                                        // to not recalculate `length(x[[i]])` we store it in extra array
-  if (bverbose) Rprintf("%s: allocating memory for results %dx%d\n", __func__, nx, nk);
+  if (verbose) Rprintf("%s: allocating memory for results %dx%d\n", __func__, nx, nk);
   for (R_len_t i=0; i<nx; i++) {
     inx[i] = xlength(VECTOR_ELT(x, i));                         // for list input each vector can have different length
     for (R_len_t j=0; j<nk; j++) {
@@ -188,10 +188,11 @@ SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEX
         if (!badaptive) frollsum(ialgo, dx[i], inx[i], &dans[i*nk+j], iik[j], ialign, dfill, bnarm, ihasna, bverbose);
         else fadaptiverollsum(ialgo, dx[i], inx[i], &dans[i*nk+j], ikl[j], dfill, bnarm, ihasna, bverbose);
         break;
+      default: error("Internal error: Unknown sfun value in froll: %d", sfun); // #nocov
       }
     }
   }
-  
+
   for (R_len_t i=0; i<nx; i++) {                                // raise errors and warnings, as of now messages are not being produced
     for (R_len_t j=0; j<nk; j++) {
       if (bverbose && (dans[i*nk+j].message[0][0] != '\0')) Rprintf("%s: %d:\n%s", __func__, i*nk+j+1, dans[i*nk+j].message[0]);
@@ -200,7 +201,7 @@ SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEX
       if (dans[i*nk+j].status == 3) error("%s: %d: %s", __func__, i*nk+j+1, dans[i*nk+j].message[3]); // # nocov because only caused by malloc
     }
   }
-  
+
   if (bverbose) Rprintf("%s: processing of %d column(s) and %d window(s) took %.3fs\n", __func__, nx, nk, omp_get_wtime()-tic);
 
   UNPROTECT(protecti);

--- a/src/ijoin.c
+++ b/src/ijoin.c
@@ -34,15 +34,15 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
   count = (int *)INTEGER(VECTOR_ELT(ux, uxcols-2));
   type_count = (int *)INTEGER(VECTOR_ELT(ux, uxcols-1));
   switch (mult) {
-  case FIRST: {
+  case FIRST:
     switch(type) {
-    case EQUAL: {
+    case EQUAL:
       for (i=0; i<xrows; i++) {
         count[from[i]-1]++; count[to[i]-1]++;
         type_count[from[i]-1]++; type_count[to[i]-1]++;
       }
-    } break;
-    case START: case END: case ANY: case WITHIN: {
+     break;
+    case START: case END: case ANY: case WITHIN:
       for (i=0; i<xrows; i++) {
         for (j=from[i]; j<=to[i]; j++) {
           count[j-1]++;
@@ -52,28 +52,28 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
         for (i=0; i<uxrows; i++)                      // TODO: this allocation can be avoided if we take care of FIRST/LAST accordingly in 'overlaps'
           if (count[i]) type_count[i] = 1;
       }
-    }  break;
+      break;
     default: error("Internal error: unknown type in mult=%d in lookup: %d", mult, type); // #nocov
     }
-  } break;
+   break;
 
-  case LAST : {
+  case LAST :
     switch (type) {
-    case ANY: {
+    case ANY:
       for (i=0; i<xrows; i++) {
         for (j=from[i]; j<=to[i]; j++) {
           count[j-1]++;
           if (from[i]==j && !type_count[j-1]) type_count[j-1]++;
         }
       }
-    } break;
-    case EQUAL: {
+     break;
+    case EQUAL:
       for (i=0; i<xrows; i++) {
         count[from[i]-1]++; count[to[i]-1]++;
         type_count[from[i]-1]++; type_count[to[i]-1]++;
       }
-    } break;
-    case START: case END: case WITHIN: {
+     break;
+    case START: case END: case WITHIN:
       for (i=0; i<xrows; i++) {
         for (j=from[i]; j<=to[i]; j++) {
           count[j-1]++;
@@ -83,27 +83,27 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
         for (i=0; i<uxrows; i++)              // TODO: this allocation can be avoided if we take care of FIRST/LAST accordingly in 'overlaps'
           if (count[i]) type_count[i] = 1;
       }
-    } break;
+     break;
     default: error("Internal error: unknown type in mult=%d in lookup: %d", mult, type); // #nocov
     }
-  } break;
+   break;
 
-  case ALL : {
+  case ALL :
     switch (type) {
-    case START: case END: {
+    case START: case END:
       for (i=0; i<xrows; i++) {
         for (j=from[i]; j<=to[i]; j++) {
           count[j-1]++; type_count[j-1]++;       // alternatively, we could simply do with type_count=count ?
         }
       }
-    } break;
-    case EQUAL: {
+     break;
+    case EQUAL:
       for (i=0; i<xrows; i++) {
         count[from[i]-1]++; count[to[i]-1]++;
         type_count[from[i]-1]++; type_count[to[i]-1]++;
       }
-    } break;
-    case ANY : {
+     break;
+    case ANY :
       for (i=0; i<xrows; i++) {
         k = from[i];
         for (j=from[i]; j<=to[i]; j++) {
@@ -111,17 +111,17 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
           if (k==j) type_count[j-1]++;
         }
       }
-    } break;
-    case WITHIN : {
+     break;
+    case WITHIN :
       for (i=0; i<xrows; i++) {
         for (j=from[i]; j<=to[i]; j++) {
           count[j-1]++;
         }
       }
-    } break;
+     break;
     default: error("Internal error: unknown type in mult=%d in lookup: %d", mult, type); // #nocov
     }
-  } break;
+   break;
   default: error("Internal error: unknown mult in lookup: %d", mult); // #nocov
   }
   pass1 = clock() - start;
@@ -144,27 +144,27 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
   start = clock();
   idx = Calloc(uxrows, R_len_t); // resets bits, =0
   switch (type) {
-  case ANY: case START: case END: case WITHIN: {
+  case ANY: case START: case END: case WITHIN:
     for (i=0; i<xrows; i++) {
       for (j=from[i]; j<=to[i]; j++) {
         vv = VECTOR_ELT(lookup, j-1);  // cache misses - memory efficiency? but 'lookups' are tiny - takes 0.036s on A.thaliana GFF for entire process)
         INTEGER(vv)[idx[j-1]++] = i+1;
       }
     }
-  } break;
-  case EQUAL: {
+   break;
+  case EQUAL:
     for (i=0; i<xrows; i++) {
       INTEGER(VECTOR_ELT(lookup, from[i]-1))[idx[from[i]-1]++] = i+1;
       INTEGER(VECTOR_ELT(lookup, to[i]-1))[idx[to[i]-1]++] = i+1;
     }
-  } break;
+   break;
   default: error("Internal error: unknown type lookup should have been caught earlier: %d", type); // #nocov
   }
   Free(idx);
   // generate type_lookup
   if (type != WITHIN) {
     switch (mult) {
-    case FIRST : {
+    case FIRST :
       for (i=0; i<uxrows; i++) {
         if (!count[i]) continue;
         vv = VECTOR_ELT(lookup, i);
@@ -173,9 +173,9 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
           INTEGER(tt)[0] = INTEGER(vv)[0];
         }
       }
-    } break;
+     break;
 
-    case LAST : {
+    case LAST :
       for (i=0; i<uxrows; i++) {
         if (!count[i]) continue;
         vv = VECTOR_ELT(lookup, i);
@@ -184,15 +184,15 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
           INTEGER(tt)[0] = INTEGER(vv)[count[i]-1];
         }
       }
-    }
-    case ALL : {
+
+    case ALL :
       switch (type) {
-      case START: case END: case EQUAL: {
+      case START: case END: case EQUAL:
         for (i=0; i<uxrows; i++)
           SET_VECTOR_ELT(type_lookup, i, VECTOR_ELT(lookup, i));
-      } break;
+       break;
 
-      case ANY : {
+      case ANY :
         for (i=0; i<uxrows; i++) {
           vv = VECTOR_ELT(lookup, i);
           tt = VECTOR_ELT(type_lookup, i);
@@ -200,19 +200,19 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
           for (j=count[i]-type_count[i]; j<count[i]; j++)
             INTEGER(tt)[k++] = INTEGER(vv)[j];
         }
-      } break;
+       break;
 
-      case WITHIN : {
+      case WITHIN :
         // for (i=0; i<uxrows; i++) {
         //     vv = VECTOR_ELT(lookup, i);
         //     tt = VECTOR_ELT(type_lookup, i);
         //     for (j=0; j<type_count[i]; j++)
         //         INTEGER(tt)[j] = INTEGER(vv)[j];
         // }
-      } break; // #nocov
+       break; // #nocov
       default: error("Internal error: unknown type in mult=%d in lookup should have been caught earlier: %d", mult, type); // #nocov
       }
-    } break;
+     break;
     default: error("Internal error: unknown mult in lookup: %d", mult); // #nocov
     }
   }
@@ -256,12 +256,12 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
   if (mult == ALL) {
     totlen=0;
     switch (type) {
-    case START: case END: {
+    case START: case END:
       for (i=0; i<rows; i++)
         totlen += (from[i] > 0 && type_count[from[i]-1]) ? type_count[from[i]-1] : 1;
-    } break;
+     break;
 
-    case EQUAL: {
+    case EQUAL:
       for (i=0; i<rows; i++) {
         len = totlen; wlen=0, j=0, m=0;
         k = (from[i]>0) ? from[i] : 1;
@@ -282,9 +282,9 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
         if (len == totlen)
           ++totlen;
       }
-    } break;
+     break;
 
-    case ANY: {
+    case ANY:
       for (i=0; i<rows; i++) {
         len = totlen;
         // k = (from[i] > 0) ? from[i] : 1;
@@ -296,9 +296,9 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
         if (len == totlen)
           ++totlen;
       }
-    } break;
+     break;
 
-    case WITHIN: {
+    case WITHIN:
       for (i=0; i<rows; i++) {
         len = totlen; j=0; m=0;
         k = from[i];
@@ -320,7 +320,7 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
         if (len == totlen)
           ++totlen;
       }
-    } break;
+     break;
     default: error("Internal error: unknown type in mult=ALL in overlaps: %d", mult, type); // #nocov
     }
   } else totlen = rows;
@@ -340,9 +340,9 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
   //   - enhance performance for special cases, and
   //   - easy to fix any bugs in the future
   switch (mult) {
-  case ALL: {
+  case ALL:
     switch (type) {
-    case START : case END : {
+    case START : case END :
       for (i=0; i<rows; i++) {
         len = thislen;
         if (from[i] > 0) {
@@ -360,9 +360,9 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
           ++thislen;
         }
       }
-    } break;
+     break;
 
-    case EQUAL : {
+    case EQUAL :
       for (i=0; i<rows; i++) {
         len = thislen;
         if (from[i] > 0 && to[i] > 0) {
@@ -396,9 +396,9 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
            ++thislen;
          }
       }
-    } break;
+     break;
 
-    case ANY : {
+    case ANY :
       for (i=0; i<rows; i++) {
         len = thislen;
         // k = (from[i]>0) ? from[i] : 1;
@@ -426,9 +426,9 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
           ++thislen;
         }
       }
-    } break;
+     break;
 
-    case WITHIN : {
+    case WITHIN :
       for (i=0; i<rows; i++) {
         len = thislen;
         k=from[i];
@@ -461,14 +461,14 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
            ++thislen;
          }
       }
-    } break;
+     break;
     default: error("Internal error: unknown type in mult=%d in overlaps: %d", mult, type); // #nocov
     }
-  } break;
+   break;
 
-  case FIRST: {
+  case FIRST:
     switch (type) {
-    case START: case END: {
+    case START: case END:
       for (i=0; i<rows; i++) {
         len = thislen;
         INTEGER(f1__)[thislen] = i+1;
@@ -483,9 +483,9 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
           ++thislen;
         }
       }
-    } break;
+     break;
 
-    case EQUAL : {
+    case EQUAL :
       for (i=0; i<rows; i++) {
         len = thislen;
         INTEGER(f1__)[thislen] = i+1;
@@ -515,9 +515,9 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
            ++thislen;
          }
       }
-    } break;
+     break;
 
-    case ANY: {
+    case ANY:
       for (i=0; i<rows; i++) {
         len = thislen;
         INTEGER(f1__)[thislen] = i+1;
@@ -536,9 +536,9 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
           ++thislen;
         }
       }
-    } break;
+     break;
 
-    case WITHIN: {
+    case WITHIN:
       for (i=0; i<rows; i++) {
         len = thislen;
         INTEGER(f1__)[thislen] = i+1;
@@ -568,14 +568,14 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
           ++thislen;
         }
       }
-    } break;
+     break;
     default: error("Internal error: unknown type in mult=%d in overlaps: %d", mult, type); // #nocov
     }
-  } break;
+   break;
 
-  case LAST: {
+  case LAST:
     switch (type) {
-    case START: case END: {
+    case START: case END:
       for (i=0; i<rows; i++) {
         len = thislen;
         INTEGER(f1__)[thislen] = i+1;
@@ -590,9 +590,9 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
           ++thislen;
         }
       }
-    }  break;
+      break;
 
-    case EQUAL : {
+    case EQUAL :
       // Debugging reference for future-me
       // R -d lldb
       // run -f file.R
@@ -630,7 +630,7 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
            ++thislen;
          }
       }
-    } break;
+     break;
 
       // OLD logic for 'any,last' which had to check for maximum for each 'i'. Better logic below.
       // for 'first' we need to just get the minimum of first non-zero-length element, but not the same case for 'last'.
@@ -654,7 +654,7 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
       // }
       // break;
 
-    case ANY: {
+    case ANY:
       for (i=0; i<rows; i++) {
         len = thislen;
         INTEGER(f1__)[thislen] = i+1;
@@ -685,9 +685,9 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
           ++thislen;
         }
       }
-    } break;
+     break;
 
-    case WITHIN: {
+    case WITHIN:
       for (i=0; i<rows; i++) {
         len = thislen;
         INTEGER(f1__)[thislen] = i+1;
@@ -717,10 +717,10 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
            ++thislen;
          }
       }
-    } break;
+     break;
     default: error("Internal error: unknown type in mult=%d in overlaps: %d", mult, type); // #nocov
     }
-  } break;
+   break;
   default: error("Internal error: unknown mult in overlaps: %d", mult); // #nocov
   }
   end2 = clock() - start;

--- a/src/ijoin.c
+++ b/src/ijoin.c
@@ -41,7 +41,7 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
         count[from[i]-1]++; count[to[i]-1]++;
         type_count[from[i]-1]++; type_count[to[i]-1]++;
       }
-     break;
+      break;
     case START: case END: case ANY: case WITHIN:
       for (i=0; i<xrows; i++) {
         for (j=from[i]; j<=to[i]; j++) {
@@ -55,7 +55,7 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
       break;
     default: error("Internal error: unknown type in mult=%d in lookup: %d", mult, type); // #nocov
     }
-   break;
+    break;
 
   case LAST :
     switch (type) {
@@ -66,13 +66,13 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
           if (from[i]==j && !type_count[j-1]) type_count[j-1]++;
         }
       }
-     break;
+      break;
     case EQUAL:
       for (i=0; i<xrows; i++) {
         count[from[i]-1]++; count[to[i]-1]++;
         type_count[from[i]-1]++; type_count[to[i]-1]++;
       }
-     break;
+      break;
     case START: case END: case WITHIN:
       for (i=0; i<xrows; i++) {
         for (j=from[i]; j<=to[i]; j++) {
@@ -83,10 +83,9 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
         for (i=0; i<uxrows; i++)              // TODO: this allocation can be avoided if we take care of FIRST/LAST accordingly in 'overlaps'
           if (count[i]) type_count[i] = 1;
       }
-     break;
-    default: error("Internal error: unknown type in mult=%d in lookup: %d", mult, type); // #nocov
+      break;
     }
-   break;
+    break;
 
   case ALL :
     switch (type) {
@@ -96,13 +95,13 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
           count[j-1]++; type_count[j-1]++;       // alternatively, we could simply do with type_count=count ?
         }
       }
-     break;
+      break;
     case EQUAL:
       for (i=0; i<xrows; i++) {
         count[from[i]-1]++; count[to[i]-1]++;
         type_count[from[i]-1]++; type_count[to[i]-1]++;
       }
-     break;
+      break;
     case ANY :
       for (i=0; i<xrows; i++) {
         k = from[i];
@@ -111,17 +110,17 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
           if (k==j) type_count[j-1]++;
         }
       }
-     break;
+      break;
     case WITHIN :
       for (i=0; i<xrows; i++) {
         for (j=from[i]; j<=to[i]; j++) {
           count[j-1]++;
         }
       }
-     break;
+      break;
     default: error("Internal error: unknown type in mult=%d in lookup: %d", mult, type); // #nocov
     }
-   break;
+    break;
   default: error("Internal error: unknown mult in lookup: %d", mult); // #nocov
   }
   pass1 = clock() - start;
@@ -151,13 +150,13 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
         INTEGER(vv)[idx[j-1]++] = i+1;
       }
     }
-   break;
+    break;
   case EQUAL:
     for (i=0; i<xrows; i++) {
       INTEGER(VECTOR_ELT(lookup, from[i]-1))[idx[from[i]-1]++] = i+1;
       INTEGER(VECTOR_ELT(lookup, to[i]-1))[idx[to[i]-1]++] = i+1;
     }
-   break;
+    break;
   default: error("Internal error: unknown type lookup should have been caught earlier: %d", type); // #nocov
   }
   Free(idx);
@@ -173,7 +172,7 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
           INTEGER(tt)[0] = INTEGER(vv)[0];
         }
       }
-     break;
+      break;
 
     case LAST :
       for (i=0; i<uxrows; i++) {
@@ -190,7 +189,7 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
       case START: case END: case EQUAL:
         for (i=0; i<uxrows; i++)
           SET_VECTOR_ELT(type_lookup, i, VECTOR_ELT(lookup, i));
-       break;
+        break;
 
       case ANY :
         for (i=0; i<uxrows; i++) {
@@ -200,7 +199,7 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
           for (j=count[i]-type_count[i]; j<count[i]; j++)
             INTEGER(tt)[k++] = INTEGER(vv)[j];
         }
-       break;
+        break;
 
       case WITHIN :
         // for (i=0; i<uxrows; i++) {
@@ -209,7 +208,7 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
         //     for (j=0; j<type_count[i]; j++)
         //         INTEGER(tt)[j] = INTEGER(vv)[j];
         // }
-       break; // #nocov
+        break; // #nocov
       default: error("Internal error: unknown type in mult=%d in lookup should have been caught earlier: %d", mult, type); // #nocov
       }
      break;
@@ -259,7 +258,7 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
     case START: case END:
       for (i=0; i<rows; i++)
         totlen += (from[i] > 0 && type_count[from[i]-1]) ? type_count[from[i]-1] : 1;
-     break;
+      break;
 
     case EQUAL:
       for (i=0; i<rows; i++) {
@@ -282,7 +281,7 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
         if (len == totlen)
           ++totlen;
       }
-     break;
+      break;
 
     case ANY:
       for (i=0; i<rows; i++) {
@@ -296,7 +295,7 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
         if (len == totlen)
           ++totlen;
       }
-     break;
+      break;
 
     case WITHIN:
       for (i=0; i<rows; i++) {
@@ -320,7 +319,7 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
         if (len == totlen)
           ++totlen;
       }
-     break;
+      break;
     default: error("Internal error: unknown type in mult=ALL in overlaps: %d", mult, type); // #nocov
     }
   } else totlen = rows;
@@ -360,7 +359,7 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
           ++thislen;
         }
       }
-     break;
+      break;
 
     case EQUAL :
       for (i=0; i<rows; i++) {
@@ -396,7 +395,7 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
            ++thislen;
          }
       }
-     break;
+      break;
 
     case ANY :
       for (i=0; i<rows; i++) {
@@ -426,7 +425,7 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
           ++thislen;
         }
       }
-     break;
+      break;
 
     case WITHIN :
       for (i=0; i<rows; i++) {
@@ -461,10 +460,10 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
            ++thislen;
          }
       }
-     break;
+      break;
     default: error("Internal error: unknown type in mult=%d in overlaps: %d", mult, type); // #nocov
     }
-   break;
+    break;
 
   case FIRST:
     switch (type) {
@@ -483,7 +482,7 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
           ++thislen;
         }
       }
-     break;
+      break;
 
     case EQUAL :
       for (i=0; i<rows; i++) {
@@ -515,7 +514,7 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
            ++thislen;
          }
       }
-     break;
+      break;
 
     case ANY:
       for (i=0; i<rows; i++) {
@@ -536,7 +535,7 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
           ++thislen;
         }
       }
-     break;
+      break;
 
     case WITHIN:
       for (i=0; i<rows; i++) {
@@ -568,10 +567,10 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
           ++thislen;
         }
       }
-     break;
+      break;
     default: error("Internal error: unknown type in mult=%d in overlaps: %d", mult, type); // #nocov
     }
-   break;
+    break;
 
   case LAST:
     switch (type) {
@@ -630,7 +629,7 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
            ++thislen;
          }
       }
-     break;
+      break;
 
       // OLD logic for 'any,last' which had to check for maximum for each 'i'. Better logic below.
       // for 'first' we need to just get the minimum of first non-zero-length element, but not the same case for 'last'.
@@ -685,7 +684,7 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
           ++thislen;
         }
       }
-     break;
+      break;
 
     case WITHIN:
       for (i=0; i<rows; i++) {
@@ -717,10 +716,10 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
            ++thislen;
          }
       }
-     break;
+      break;
     default: error("Internal error: unknown type in mult=%d in overlaps: %d", mult, type); // #nocov
     }
-   break;
+    break;
   default: error("Internal error: unknown mult in overlaps: %d", mult); // #nocov
   }
   end2 = clock() - start;

--- a/src/ijoin.c
+++ b/src/ijoin.c
@@ -34,15 +34,15 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
   count = (int *)INTEGER(VECTOR_ELT(ux, uxcols-2));
   type_count = (int *)INTEGER(VECTOR_ELT(ux, uxcols-1));
   switch (mult) {
-  case FIRST:
+  case FIRST: {
     switch(type) {
-    case EQUAL:
+    case EQUAL: {
       for (i=0; i<xrows; i++) {
         count[from[i]-1]++; count[to[i]-1]++;
         type_count[from[i]-1]++; type_count[to[i]-1]++;
       }
-      break;
-    case START: case END: case ANY: case WITHIN:
+    } break;
+    case START: case END: case ANY: case WITHIN: {
       for (i=0; i<xrows; i++) {
         for (j=from[i]; j<=to[i]; j++) {
           count[j-1]++;
@@ -52,27 +52,28 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
         for (i=0; i<uxrows; i++)                      // TODO: this allocation can be avoided if we take care of FIRST/LAST accordingly in 'overlaps'
           if (count[i]) type_count[i] = 1;
       }
-      break;
+    }  break;
+    default: error("Internal error: unknown type in mult=%d in lookup: %d", mult, type); // #nocov
     }
-    break;
+  } break;
 
-  case LAST :
+  case LAST : {
     switch (type) {
-    case ANY:
+    case ANY: {
       for (i=0; i<xrows; i++) {
         for (j=from[i]; j<=to[i]; j++) {
           count[j-1]++;
           if (from[i]==j && !type_count[j-1]) type_count[j-1]++;
         }
       }
-      break;
-    case EQUAL:
+    } break;
+    case EQUAL: {
       for (i=0; i<xrows; i++) {
         count[from[i]-1]++; count[to[i]-1]++;
         type_count[from[i]-1]++; type_count[to[i]-1]++;
       }
-      break;
-    case START: case END: case WITHIN:
+    } break;
+    case START: case END: case WITHIN: {
       for (i=0; i<xrows; i++) {
         for (j=from[i]; j<=to[i]; j++) {
           count[j-1]++;
@@ -82,26 +83,27 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
         for (i=0; i<uxrows; i++)              // TODO: this allocation can be avoided if we take care of FIRST/LAST accordingly in 'overlaps'
           if (count[i]) type_count[i] = 1;
       }
-      break;
+    } break;
+    default: error("Internal error: unknown type in mult=%d in lookup: %d", mult, type); // #nocov
     }
-    break;
+  } break;
 
-  case ALL :
+  case ALL : {
     switch (type) {
-    case START: case END:
+    case START: case END: {
       for (i=0; i<xrows; i++) {
         for (j=from[i]; j<=to[i]; j++) {
           count[j-1]++; type_count[j-1]++;       // alternatively, we could simply do with type_count=count ?
         }
       }
-      break;
-    case EQUAL:
+    } break;
+    case EQUAL: {
       for (i=0; i<xrows; i++) {
         count[from[i]-1]++; count[to[i]-1]++;
         type_count[from[i]-1]++; type_count[to[i]-1]++;
       }
-      break;
-    case ANY :
+    } break;
+    case ANY : {
       for (i=0; i<xrows; i++) {
         k = from[i];
         for (j=from[i]; j<=to[i]; j++) {
@@ -109,16 +111,18 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
           if (k==j) type_count[j-1]++;
         }
       }
-      break;
-    case WITHIN :
+    } break;
+    case WITHIN : {
       for (i=0; i<xrows; i++) {
         for (j=from[i]; j<=to[i]; j++) {
           count[j-1]++;
         }
       }
-      break;
+    } break;
+    default: error("Internal error: unknown type in mult=%d in lookup: %d", mult, type); // #nocov
     }
-    break;
+  } break;
+  default: error("Internal error: unknown mult in lookup: %d", mult); // #nocov
   }
   pass1 = clock() - start;
   if (LOGICAL(verbose)[0])
@@ -140,26 +144,27 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
   start = clock();
   idx = Calloc(uxrows, R_len_t); // resets bits, =0
   switch (type) {
-  case ANY: case START: case END: case WITHIN:
+  case ANY: case START: case END: case WITHIN: {
     for (i=0; i<xrows; i++) {
       for (j=from[i]; j<=to[i]; j++) {
         vv = VECTOR_ELT(lookup, j-1);  // cache misses - memory efficiency? but 'lookups' are tiny - takes 0.036s on A.thaliana GFF for entire process)
         INTEGER(vv)[idx[j-1]++] = i+1;
       }
     }
-    break;
-  case EQUAL:
+  } break;
+  case EQUAL: {
     for (i=0; i<xrows; i++) {
       INTEGER(VECTOR_ELT(lookup, from[i]-1))[idx[from[i]-1]++] = i+1;
       INTEGER(VECTOR_ELT(lookup, to[i]-1))[idx[to[i]-1]++] = i+1;
     }
-    break;
+  } break;
+  default: error("Internal error: unknown type lookup should have been caught earlier: %d", type); // #nocov
   }
   Free(idx);
   // generate type_lookup
   if (type != WITHIN) {
     switch (mult) {
-    case FIRST :
+    case FIRST : {
       for (i=0; i<uxrows; i++) {
         if (!count[i]) continue;
         vv = VECTOR_ELT(lookup, i);
@@ -168,9 +173,9 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
           INTEGER(tt)[0] = INTEGER(vv)[0];
         }
       }
-      break;
+    } break;
 
-    case LAST :
+    case LAST : {
       for (i=0; i<uxrows; i++) {
         if (!count[i]) continue;
         vv = VECTOR_ELT(lookup, i);
@@ -179,15 +184,15 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
           INTEGER(tt)[0] = INTEGER(vv)[count[i]-1];
         }
       }
-
-    case ALL :
+    }
+    case ALL : {
       switch (type) {
-      case START: case END: case EQUAL:
+      case START: case END: case EQUAL: {
         for (i=0; i<uxrows; i++)
           SET_VECTOR_ELT(type_lookup, i, VECTOR_ELT(lookup, i));
-        break;
+      } break;
 
-      case ANY :
+      case ANY : {
         for (i=0; i<uxrows; i++) {
           vv = VECTOR_ELT(lookup, i);
           tt = VECTOR_ELT(type_lookup, i);
@@ -195,18 +200,20 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
           for (j=count[i]-type_count[i]; j<count[i]; j++)
             INTEGER(tt)[k++] = INTEGER(vv)[j];
         }
-        break;
+      } break;
 
-      case WITHIN :
+      case WITHIN : {
         // for (i=0; i<uxrows; i++) {
         //     vv = VECTOR_ELT(lookup, i);
         //     tt = VECTOR_ELT(type_lookup, i);
         //     for (j=0; j<type_count[i]; j++)
         //         INTEGER(tt)[j] = INTEGER(vv)[j];
         // }
-        break;
+      } break; // #nocov
+      default: error("Internal error: unknown type in mult=%d in lookup should have been caught earlier: %d", mult, type); // #nocov
       }
-      break;
+    } break;
+    default: error("Internal error: unknown mult in lookup: %d", mult); // #nocov
     }
   }
   pass3 = clock() - start;
@@ -249,12 +256,12 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
   if (mult == ALL) {
     totlen=0;
     switch (type) {
-    case START: case END:
+    case START: case END: {
       for (i=0; i<rows; i++)
         totlen += (from[i] > 0 && type_count[from[i]-1]) ? type_count[from[i]-1] : 1;
-      break;
+    } break;
 
-    case EQUAL:
+    case EQUAL: {
       for (i=0; i<rows; i++) {
         len = totlen; wlen=0, j=0, m=0;
         k = (from[i]>0) ? from[i] : 1;
@@ -275,9 +282,9 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
         if (len == totlen)
           ++totlen;
       }
-      break;
+    } break;
 
-    case ANY:
+    case ANY: {
       for (i=0; i<rows; i++) {
         len = totlen;
         // k = (from[i] > 0) ? from[i] : 1;
@@ -289,9 +296,9 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
         if (len == totlen)
           ++totlen;
       }
-      break;
+    } break;
 
-    case WITHIN:
+    case WITHIN: {
       for (i=0; i<rows; i++) {
         len = totlen; j=0; m=0;
         k = from[i];
@@ -313,7 +320,8 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
         if (len == totlen)
           ++totlen;
       }
-      break;
+    } break;
+    default: error("Internal error: unknown type in mult=ALL in overlaps: %d", mult, type); // #nocov
     }
   } else totlen = rows;
   end1 = clock() - start;
@@ -332,9 +340,9 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
   //   - enhance performance for special cases, and
   //   - easy to fix any bugs in the future
   switch (mult) {
-  case ALL:
+  case ALL: {
     switch (type) {
-    case START : case END :
+    case START : case END : {
       for (i=0; i<rows; i++) {
         len = thislen;
         if (from[i] > 0) {
@@ -352,9 +360,9 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
           ++thislen;
         }
       }
-      break;
+    } break;
 
-    case EQUAL :
+    case EQUAL : {
       for (i=0; i<rows; i++) {
         len = thislen;
         if (from[i] > 0 && to[i] > 0) {
@@ -388,9 +396,9 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
            ++thislen;
          }
       }
-      break;
+    } break;
 
-    case ANY :
+    case ANY : {
       for (i=0; i<rows; i++) {
         len = thislen;
         // k = (from[i]>0) ? from[i] : 1;
@@ -418,9 +426,9 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
           ++thislen;
         }
       }
-      break;
+    } break;
 
-    case WITHIN :
+    case WITHIN : {
       for (i=0; i<rows; i++) {
         len = thislen;
         k=from[i];
@@ -453,13 +461,14 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
            ++thislen;
          }
       }
-      break;
+    } break;
+    default: error("Internal error: unknown type in mult=%d in overlaps: %d", mult, type); // #nocov
     }
-    break;
+  } break;
 
-  case FIRST:
+  case FIRST: {
     switch (type) {
-      case START: case END:
+    case START: case END: {
       for (i=0; i<rows; i++) {
         len = thislen;
         INTEGER(f1__)[thislen] = i+1;
@@ -474,9 +483,9 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
           ++thislen;
         }
       }
-      break;
+    } break;
 
-    case EQUAL :
+    case EQUAL : {
       for (i=0; i<rows; i++) {
         len = thislen;
         INTEGER(f1__)[thislen] = i+1;
@@ -506,9 +515,9 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
            ++thislen;
          }
       }
-      break;
+    } break;
 
-    case ANY:
+    case ANY: {
       for (i=0; i<rows; i++) {
         len = thislen;
         INTEGER(f1__)[thislen] = i+1;
@@ -527,9 +536,9 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
           ++thislen;
         }
       }
-      break;
+    } break;
 
-    case WITHIN:
+    case WITHIN: {
       for (i=0; i<rows; i++) {
         len = thislen;
         INTEGER(f1__)[thislen] = i+1;
@@ -559,13 +568,14 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
           ++thislen;
         }
       }
-      break;
+    } break;
+    default: error("Internal error: unknown type in mult=%d in overlaps: %d", mult, type); // #nocov
     }
-    break;
+  } break;
 
-  case LAST:
+  case LAST: {
     switch (type) {
-    case START: case END:
+    case START: case END: {
       for (i=0; i<rows; i++) {
         len = thislen;
         INTEGER(f1__)[thislen] = i+1;
@@ -580,9 +590,9 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
           ++thislen;
         }
       }
-      break;
+    }  break;
 
-    case EQUAL :
+    case EQUAL : {
       // Debugging reference for future-me
       // R -d lldb
       // run -f file.R
@@ -620,7 +630,7 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
            ++thislen;
          }
       }
-      break;
+    } break;
 
       // OLD logic for 'any,last' which had to check for maximum for each 'i'. Better logic below.
       // for 'first' we need to just get the minimum of first non-zero-length element, but not the same case for 'last'.
@@ -644,7 +654,7 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
       // }
       // break;
 
-    case ANY:
+    case ANY: {
       for (i=0; i<rows; i++) {
         len = thislen;
         INTEGER(f1__)[thislen] = i+1;
@@ -675,9 +685,9 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
           ++thislen;
         }
       }
-      break;
+    } break;
 
-    case WITHIN:
+    case WITHIN: {
       for (i=0; i<rows; i++) {
         len = thislen;
         INTEGER(f1__)[thislen] = i+1;
@@ -707,9 +717,11 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
            ++thislen;
          }
       }
-      break;
+    } break;
+    default: error("Internal error: unknown type in mult=%d in overlaps: %d", mult, type); // #nocov
     }
-    break;
+  } break;
+  default: error("Internal error: unknown mult in overlaps: %d", mult); // #nocov
   }
   end2 = clock() - start;
   if (LOGICAL(verbose)[0])

--- a/src/nafill.c
+++ b/src/nafill.c
@@ -209,7 +209,7 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP inplace, SEXP cols, SEXP verbo
   if (!strcmp(CHAR(STRING_ELT(type, 0)), "const")) itype = 0;
   else if (!strcmp(CHAR(STRING_ELT(type, 0)), "locf")) itype = 1;
   else if (!strcmp(CHAR(STRING_ELT(type, 0)), "nocb")) itype = 2;
-  else error("Internal error: invalid type argument in nafillR function, should have been caught before. please report to data.table issue tracker."); // # nocov
+  else error("Internal error: invalid type argument in nafillR function, should have been caught before. Please report to data.table issue tracker."); // # nocov
 
   if (itype==0 && length(fill)!=1)
     error("fill must be a vector of length 1");
@@ -235,6 +235,7 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP inplace, SEXP cols, SEXP verbo
     case INTSXP : {
       nafillInteger(ix[i], inx[i], itype, ifill, &vans[i], bverbose);
     } break;
+    default: error("Internal error: invalid type argument in nafillR function, should have been caught before. Please report to data.table issue tracker."); // # nocov
     }
   }
   if (bverbose) toc = omp_get_wtime();


### PR DESCRIPTION
Inspired by: https://github.com/Rdatatable/data.table/pull/3692#commitcomment-34330836

Ran:

```
for (f in list.files('src', pattern = '\\.c', full.names = TRUE)) {
  l = readLines(f)
  nswitch = sum(grepl('switch\\s*\\(', l))
  ndefault = sum(grepl('default\\s*:', l))
  if (nswitch != ndefault)
    cat(sprintf('%s switches: %d, defaults: %d\n', basename(f), nswitch, ndefault))
}
```

And found the files here with `default`-less switches. Added internal errors for them+`nocov`'d, except in the one case where it was actually reasonable to reach there. Had to make a small edit to `writeNA` to make it even easier to do so (even without that `fill=expression(1)` would get there).

Mostly, the `default`-less switches are `switch(enum)` so it should be impossible in the current code to reach. These errors guard against editing the `enum`s' valid values in the future & neglecting to cover all the bases in testing new functionality.