### PR TITLE
manual update, fixes to pass `--run-dontrun`

### DIFF
--- a/man/coalesce.Rd
+++ b/man/coalesce.Rd
@@ -25,20 +25,6 @@ z = c(11L, NA, 1L, 14L, NA, NA)
 coalesce(x, y, z)
 coalesce(list(x,y,z))   # same
 coalesce(x, list(y,z))  # same
-
-\dontrun{
-# default 4 threads on a laptop with 16GB RAM and 8 logical CPU
-N = 100e6
-x = replicate(5, {x=sample(N); x[sample(N, N/2)]=NA; x}, simplify=FALSE)  # 2GB
-system.time(y1 <- do.call(dplyr::coalesce, x))
-system.time(y2 <- do.call(hutils::coalesce, x))
-system.time(y3 <- do.call(data.table::coalesce, x))
-identical(y1,y2) && identical(y1,y3)
-#   user  system elapsed (seconds)
-#  4.935   1.876   6.810  # dplyr v0.8.1
-#  3.122   0.831   3.956  # hutils v1.5.0
-#  0.915   0.099   0.379  # data.table v1.12.4
-}
 }
 \keyword{ data }
 

--- a/man/data.table.Rd
+++ b/man/data.table.Rd
@@ -434,11 +434,8 @@ if (interactive()) {
 
   # get the latest devel version
   update.dev.pkg()
-  # compiled devel binary for Windows available -- no Rtools needed
-  update.dev.pkg(repo="https://Rdatatable.github.io/data.table")
   # read more at:
   # https://github.com/Rdatatable/data.table/wiki/Installation
 }
 }}
 \keyword{ data }
-

--- a/man/fread.Rd
+++ b/man/fread.Rd
@@ -248,7 +248,7 @@ table(sapply(DT,class))
 fread("http://www.stats.ox.ac.uk/pub/datasets/csb/ch11b.dat")
 
 # Decompresses .gz and .bz2 automatically :
-fread("http://stat-computing.org/dataexpo/2009/2008.csv.bz2")
+fread("http://stat-computing.org/dataexpo/2009/1987.csv.bz2")
 
 }
 

--- a/man/fread.Rd
+++ b/man/fread.Rd
@@ -229,36 +229,22 @@ cat("File size (MB):", round(file.info("test.csv")$size/1024^2),"\n")
 # 50 MB (1e6 rows x 6 columns)
 
 system.time(DF1 <-read.csv("test.csv",stringsAsFactors=FALSE))
-# 60 sec (first time in fresh R session)
+# 5.4 sec (first time in fresh R session)
 
 system.time(DF1 <- read.csv("test.csv",stringsAsFactors=FALSE))
-# 30 sec (immediate repeat is faster, varies)
+# 3.9 sec (immediate repeat is faster, varies)
 
 system.time(DF2 <- read.table("test.csv",header=TRUE,sep=",",quote="",
     stringsAsFactors=FALSE,comment.char="",nrows=n,
     colClasses=c("integer","integer","numeric",
                  "character","numeric","integer")))
-# 10 sec (consistently). All known tricks and known nrows, see references.
+# 1.2 sec (consistently). All known tricks and known nrows, see references.
 
-require(data.table)
-if(all(sapply(c("sqldf", "ff"), requireNamespace, quietly = TRUE))) {
-  require(sqldf)
-  require(ff)
+system.time(DT <- fread("test.csv"))
+# 0.1 sec (faster and friendlier)
 
-  system.time(DT <- fread("test.csv"))
-  #  3 sec (faster and friendlier)
-
-  system.time(SQLDF <- read.csv.sql("test.csv",dbname=NULL))
-  # 20 sec (friendly too, good defaults)
-
-  system.time(FFDF <- read.csv.ffdf(file="test.csv",nrows=n))
-  # 20 sec (friendly too, good defaults)
-
-  identical(DF1,DF2)
-  all.equal(as.data.table(DF1), DT)
-  identical(DF1,within(SQLDF,{b<-as.integer(b);c<-as.numeric(c)}))
-  identical(DF1,within(as.data.frame(FFDF),d<-as.character(d)))
-}
+identical(DF1, DF2)
+all.equal(as.data.table(DF1), DT)
 
 # Scaling up ...
 l = vector("list",10)
@@ -266,16 +252,16 @@ for (i in 1:10) l[[i]] = DT
 DTbig = rbindlist(l)
 tables()
 write.table(DTbig,"testbig.csv",sep=",",row.names=FALSE,quote=FALSE)
-# 500MB (10 million rows x 6 columns)
+# 500MB csv (10 million rows x 6 columns)
 
 system.time(DF <- read.table("testbig.csv",header=TRUE,sep=",",
     quote="",stringsAsFactors=FALSE,comment.char="",nrows=1e7,
     colClasses=c("integer","integer","numeric",
                  "character","numeric","integer")))
-# 100-200 sec (varies)
+# 17.0 sec (varies)
 
 system.time(DT <- fread("testbig.csv"))
-# 30-40 sec
+#  0.8 sec
 
 all(mapply(all.equal, DF, DT))
 
@@ -290,20 +276,20 @@ download.file("http://stat-computing.org/dataexpo/2009/2008.csv.bz2",
 system("bunzip2 2008.csv.bz2")
 # 658MB (7,009,728 rows x 29 columns)
 
-colClasses = sapply(read.csv("2008.csv",nrows=100),class)
+colClasses = sapply(read.csv("2008.csv",nrows=100,stringsAsFactors=FALSE),class)
 # 4 character, 24 integer, 1 logical. Incorrect.
 
-colClasses = sapply(read.csv("2008.csv",nrows=200),class)
+colClasses = sapply(read.csv("2008.csv",nrows=200,stringsAsFactors=FALSE),class)
 # 5 character, 24 integer. Correct. Might have missed data only using 100 rows
 # since read.table assumes colClasses is correct.
 
 system.time(DF <- read.table("2008.csv", header=TRUE, sep=",",
     quote="",stringsAsFactors=FALSE,comment.char="",nrows=7009730,
     colClasses=colClasses))
-# 360 secs
+# 24.4 secs
 
 system.time(DT <- fread("2008.csv"))
-#  40 secs
+#  1.9 secs
 
 table(sapply(DT,class))
 # 5 character and 24 integer columns. Correct without needing to worry about colClasses

--- a/man/fread.Rd
+++ b/man/fread.Rd
@@ -141,8 +141,74 @@ On YAML, see \url{http://yaml.org/}; on csvy, see \url{http://csvy.org/}.
   \code{\link[utils:read.table]{read.csv}}, \code{\link[base:connections]{url}}, \code{\link[base:locales]{Sys.setlocale}}, \code{\link{setDTthreads}}, \code{\link{fwrite}}, \href{https://CRAN.R-project.org/package=bit64}{\code{bit64::integer64}}
 }
 \examples{
-\dontrun{
+# Reads text input directly :
+fread("A,B\n1,2\n3,4")
 
+# Reads pasted input directly :
+fread("A,B
+1,2
+3,4
+")
+
+# Finds the first data line automatically :
+fread("
+This is perhaps a banner line or two or ten.
+A,B
+1,2
+3,4
+")
+
+# Detects whether column names are present automatically :
+fread("
+1,2
+3,4
+")
+
+# Numerical precision :
+
+DT = fread("A\n1.010203040506070809010203040506\n")
+# TODO: add numerals=c("allow.loss", "warn.loss", "no.loss") from base::read.table, +"use.Rmpfr"
+typeof(DT$A)=="double"   # currently "allow.loss" with no option
+
+DT = fread("A\n1.46761e-313\n")   # read as 'numeric'
+DT[,sprintf("\%.15E",A)]   # beyond what double precision can store accurately to 15 digits
+# For greater accuracy use colClasses to read as character, then package Rmpfr.
+
+# colClasses
+data = "A,B,C,D\n1,3,5,7\n2,4,6,8\n"
+fread(data, colClasses=c(B="character",C="character",D="character"))  # as read.csv
+fread(data, colClasses=list(character=c("B","C","D")))    # saves typing
+fread(data, colClasses=list(character=2:4))     # same using column numbers
+
+# drop
+fread(data, colClasses=c("B"="NULL","C"="NULL"))   # as read.csv
+fread(data, colClasses=list(NULL=c("B","C")))      #
+fread(data, drop=c("B","C"))      # same but less typing, easier to read
+fread(data, drop=2:3)             # same using column numbers
+
+# select
+# (in read.csv you need to work out which to drop)
+fread(data, select=c("A","D"))    # less typing, easier to read
+fread(data, select=c(1,4))        # same using column numbers
+
+# select and types combined
+fread(data, select=c(A="numeric", D="character"))
+fread(data, select=list(numeric="A", character="D"))
+
+# skip blank lines
+fread("a,b\n1,a\n2,b\n\n\n3,c\n", blank.lines.skip=TRUE)
+# fill
+fread("a,b\n1,a\n2\n3,c\n", fill=TRUE)
+fread("a,b\n\n1,a\n2\n\n3,c\n\n", fill=TRUE)
+
+# fill with skip blank lines
+fread("a,b\n\n1,a\n2\n\n3,c\n\n", fill=TRUE, blank.lines.skip=TRUE)
+
+# check.names usage
+fread("a b,a b\n1,2\n")
+fread("a b,a b\n1,2\n", check.names=TRUE) # no duplicates + syntactically valid names
+
+\dontrun{
 # Demo speed-up
 n = 1e6
 DT = data.table( a=sample(1:1000,n,replace=TRUE),
@@ -251,73 +317,6 @@ fread("http://www.stats.ox.ac.uk/pub/datasets/csb/ch11b.dat")
 fread("http://stat-computing.org/dataexpo/2009/1987.csv.bz2")
 
 }
-
-# Reads text input directly :
-fread("A,B\n1,2\n3,4")
-
-# Reads pasted input directly :
-fread("A,B
-1,2
-3,4
-")
-
-# Finds the first data line automatically :
-fread("
-This is perhaps a banner line or two or ten.
-A,B
-1,2
-3,4
-")
-
-# Detects whether column names are present automatically :
-fread("
-1,2
-3,4
-")
-
-# Numerical precision :
-
-DT = fread("A\n1.010203040506070809010203040506\n")
-# TODO: add numerals=c("allow.loss", "warn.loss", "no.loss") from base::read.table, +"use.Rmpfr"
-typeof(DT$A)=="double"   # currently "allow.loss" with no option
-
-DT = fread("A\n1.46761e-313\n")   # read as 'numeric'
-DT[,sprintf("\%.15E",A)]   # beyond what double precision can store accurately to 15 digits
-# For greater accuracy use colClasses to read as character, then package Rmpfr.
-
-# colClasses
-data = "A,B,C,D\n1,3,5,7\n2,4,6,8\n"
-fread(data, colClasses=c(B="character",C="character",D="character"))  # as read.csv
-fread(data, colClasses=list(character=c("B","C","D")))    # saves typing
-fread(data, colClasses=list(character=2:4))     # same using column numbers
-
-# drop
-fread(data, colClasses=c("B"="NULL","C"="NULL"))   # as read.csv
-fread(data, colClasses=list(NULL=c("B","C")))      #
-fread(data, drop=c("B","C"))      # same but less typing, easier to read
-fread(data, drop=2:3)             # same using column numbers
-
-# select
-# (in read.csv you need to work out which to drop)
-fread(data, select=c("A","D"))    # less typing, easier to read
-fread(data, select=c(1,4))        # same using column numbers
-
-# select and types combined
-fread(data, select=c(A="numeric", D="character"))
-fread(data, select=list(numeric="A", character="D"))
-
-# skip blank lines
-fread("a,b\n1,a\n2,b\n\n\n3,c\n", blank.lines.skip=TRUE)
-# fill
-fread("a,b\n1,a\n2\n3,c\n", fill=TRUE)
-fread("a,b\n\n1,a\n2\n\n3,c\n\n", fill=TRUE)
-
-# fill with skip blank lines
-fread("a,b\n\n1,a\n2\n\n3,c\n\n", fill=TRUE, blank.lines.skip=TRUE)
-
-# check.names usage
-fread("a b,a b\n1,2\n")
-fread("a b,a b\n1,2\n", check.names=TRUE) # no duplicates + syntactically valid names
 }
 \keyword{ data }
 

--- a/man/special-symbols.Rd
+++ b/man/special-symbols.Rd
@@ -27,7 +27,6 @@
     \code{\link{data.table}}, \code{\link{:=}}, \code{\link{set}}, \code{\link{datatable-optimize}}
 }
 \examples{
-\dontrun{
 DT = data.table(x=rep(c("b","a","c"),each=3), v=c(1,1,1,2,2,1,1,2,2), y=c(1,3,6), a=1:9, b=9:1)
 DT
 X = data.table(x=c("c","b"), v=8:7, foo=c(4,2))
@@ -46,5 +45,5 @@ DT[, c(.(y=max(y)), lapply(.SD, min)),
         by=rleid(v), .SDcols=v:b]      # compute 'j' for each consecutive runs of 'v'
 DT[, grp := .GRP, by=x]                # add a group counter
 X[, DT[.BY, y, on="x"], by=x]          # join within each group
-}}
+}
 \keyword{ data }

--- a/man/test.data.table.Rd
+++ b/man/test.data.table.Rd
@@ -24,11 +24,4 @@ test.data.table(verbose=FALSE, pkg="pkg", silent=FALSE,
 When \code{silent} equals to \code{TRUE} it will return \code{TRUE} if all tests were successful. \code{FALSE} otherwise. If \code{silent} equals to \code{FALSE} it will return \code{TRUE} if all tests were successful. Error otherwise.
 }
 \seealso{ \code{\link{data.table}} }
-\examples{
-\dontrun{
-  library(data.table)
-  test.data.table()
-}
-}
 \keyword{ data }
-


### PR DESCRIPTION
I would generally avoid posting timings in examples, despite putting into `dontrun`. As we can see, timings changes heavily over time, a 10 folds in below examples. It then make sense to keep them in NEWS.md where entries are bounds to a point in time. Moreover timings are highly affected by configuration, like number of threads, disk speed. It is not very practice to flesh out all such details in examples.