### PR TITLE
add support for logical-as-numeric in frollmean

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -256,6 +256,8 @@
 
 14. The warning message when using `keyby=` together with `:=` is clearer, [#2763](https://github.com/Rdatatable/data.table/issues/2763). Thanks to @eliocamp.
 
+15. `frollmean` coerces `logical` input to `numeric` instead of failing to mimic the behavior of `integer` input.
+
 
 ### Changes in [v1.12.2](https://github.com/Rdatatable/data.table/milestone/14?closed=1)  (07 Apr 2019)
 

--- a/src/frollR.c
+++ b/src/frollR.c
@@ -14,7 +14,7 @@ SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEX
     x = PROTECT(allocVector(VECSXP, 1)); protecti++;
     if (isReal(obj)) {
       SET_VECTOR_ELT(x, 0, obj);
-    } else if (isInteger(obj)) {
+    } else if (isInteger(obj) || isLogical(obj)) {
       SET_VECTOR_ELT(x, 0, coerceVector(obj, REALSXP));
     } else {
       error("x must be of type numeric");


### PR DESCRIPTION
Jan I'm a bit unfamiliar with how the `froll` tests are structured, it looks like we should shoehorn some in around `9999.010`?