### PR TITLE
coerceClass

### DIFF
--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -8,4 +8,5 @@ setcoalesce = function(...) .Call(Ccoalesce, list(...), TRUE)
 fifelse = function(test, yes, no) .Call(CfifelseR,test, yes, no)
 
 colnamesInt = function(x, cols, check_dups=FALSE) .Call(CcolnamesInt, x, cols, check_dups)
-coerceFill = function(x) .Call(CcoerceFillR, x)
+coerceClass = function(x, out) .Call(CcoerceClassR, x, out)
+coerceFill = function(x) coerceClass(x, list(0L, 0, structure(0, class="integer64"))) # temporarily till new tests in place

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -9,4 +9,3 @@ fifelse = function(test, yes, no) .Call(CfifelseR,test, yes, no)
 
 colnamesInt = function(x, cols, check_dups=FALSE) .Call(CcolnamesInt, x, cols, check_dups)
 coerceClass = function(x, out) .Call(CcoerceClassR, x, out)
-coerceFill = function(x) coerceClass(x, list(0L, 0, structure(0, class="integer64"))) # temporarily till new tests in place

--- a/inst/tests/nafill.Rraw
+++ b/inst/tests/nafill.Rraw
@@ -161,8 +161,8 @@ test(5.03, nafill(dt, "locf", verbose=NA), error="verbose must be TRUE or FALSE"
 
 # coerceFill
 if (test_bit64) {
-  test(6.01, coerceFill(1:2), error="fill argument must be length 1")
-  test(6.02, coerceFill("a"), error="fill argument must be numeric")
+  #test(6.01, coerceFill(1:2), error="fill argument must be length 1") # since coerceClass in utils.c it handle vector input
+  #test(6.02, coerceFill("a"), error="fill argument must be numeric") # since coerceClass in utils.c unsupported input is redirected to R's coerceVector
   test(6.11, identical(coerceFill(NA), list(NA_integer_, NA_real_, as.integer64(NA))))
   test(6.21, identical(coerceFill(3L), list(3L, 3, as.integer64(3))))
   test(6.22, identical(coerceFill(0L), list(0L, 0, as.integer64(0))))

--- a/inst/tests/nafill.Rraw
+++ b/inst/tests/nafill.Rraw
@@ -10,8 +10,6 @@ if (exists("test.data.table", .GlobalEnv, inherits=FALSE)) {
   require(data.table)
   test = data.table:::test
   INT = data.table:::INT
-  colnamesInt = data.table:::colnamesInt
-  coerceFill = data.table:::coerceFill
 }
 
 sugg = c(
@@ -125,56 +123,8 @@ test(3.05, setnafill(list(letters[1:5]), fill=0), error="must be numeric type, o
 test(3.06, nafill(x, fill=1:2), error="fill must be a vector of length 1")
 test(3.07, nafill(x, fill="asd"), error="fill argument must be numeric")
 
-# colnamesInt helper
-dt = data.table(a=1, b=2, d=3)
-test(4.01, colnamesInt(dt, "a"), 1L)
-test(4.02, colnamesInt(dt, 1L), 1L)
-test(4.03, colnamesInt(dt, 1), 1L)
-test(4.04, colnamesInt(dt, c("a","d")), c(1L, 3L))
-test(4.05, colnamesInt(dt, c(1L, 3L)), c(1L, 3L))
-test(4.06, colnamesInt(dt, c(1, 3)), c(1L, 3L))
-test(4.07, colnamesInt(dt, c("a", "e")), error="specify non existing column*.*e")
-test(4.08, colnamesInt(dt, c(1L, 4L)), error="specify non existing column*.*4")
-test(4.09, colnamesInt(dt, c(1, 4)), error="specify non existing column*.*4")
-test(4.10, colnamesInt(dt, c("a", NA)), error="specify non existing column*.*NA")
-test(4.11, colnamesInt(dt, c(1L, NA)), error="specify non existing column")
-test(4.12, colnamesInt(dt, c(1, NA)), error="specify non existing column")
-test(4.13, colnamesInt(dt, c("a","d","a"), check_dups=TRUE), error="specify duplicated column")
-test(4.14, colnamesInt(dt, c(1L, 3L, 1L), check_dups=TRUE), error="specify duplicated column")
-test(4.15, colnamesInt(dt, c(1, 3, 1), check_dups=TRUE), error="specify duplicated column")
-test(4.16, colnamesInt(dt, list("a")), error="must be character or numeric")
-test(4.17, colnamesInt(dt, NA), error="must be character or numeric")
-test(4.18, colnamesInt(dt, character()), integer())
-test(4.19, colnamesInt(dt, numeric()), integer())
-test(4.20, colnamesInt(dt, integer()), integer())
-test(4.21, colnamesInt(dt, NULL), seq_along(dt))
-test(4.22, colnamesInt("asd", 1), error="must be data.table compatible")
-test(4.23, colnamesInt(dt, 1, check_dups="a"), error="check_dups")
-names(dt) <- NULL
-test(4.24, colnamesInt(dt, "a"), error="has no names")
-
 # verbose
 dt = data.table(a=c(1L, 2L, NA_integer_), b=c(1, 2, NA_real_))
 test(5.01, nafill(dt, "locf", verbose=TRUE), output="nafillInteger: took.*nafillDouble: took.*nafillR.*took")
 test(5.02, setnafill(dt, "locf", verbose=TRUE), output="nafillInteger: took.*nafillDouble: took.*nafillR.*took")
 test(5.03, nafill(dt, "locf", verbose=NA), error="verbose must be TRUE or FALSE")
-
-# coerceFill
-if (test_bit64) {
-  #test(6.01, coerceFill(1:2), error="fill argument must be length 1") # since coerceClass in utils.c it handle vector input
-  #test(6.02, coerceFill("a"), error="fill argument must be numeric") # since coerceClass in utils.c unsupported input is redirected to R's coerceVector
-  test(6.11, identical(coerceFill(NA), list(NA_integer_, NA_real_, as.integer64(NA))))
-  test(6.21, identical(coerceFill(3L), list(3L, 3, as.integer64(3))))
-  test(6.22, identical(coerceFill(0L), list(0L, 0, as.integer64(0))))
-  test(6.23, identical(coerceFill(NA_integer_), list(NA_integer_, NA_real_, as.integer64(NA))))
-  test(6.31, identical(coerceFill(as.integer64(3)), list(3L, 3, as.integer64(3))))
-  test(6.32, identical(coerceFill(as.integer64(3000000003)), list(NA_integer_, 3000000003, as.integer64("3000000003"))))
-  test(6.33, identical(coerceFill(as.integer64(0)), list(0L, 0, as.integer64(0))))
-  test(6.34, identical(coerceFill(as.integer64(NA)), list(NA_integer_, NA_real_, as.integer64(NA))))
-  test(6.41, identical(coerceFill(3), list(3L, 3, as.integer64(3))))
-  test(6.42, identical(coerceFill(0), list(0L, 0, as.integer64(0))))
-  test(6.43, identical(coerceFill(NA_real_), list(NA_integer_, NA_real_, as.integer64(NA))))
-  test(6.44, identical(coerceFill(NaN), list(NA_integer_, NaN, as.integer64(NA))))
-  test(6.45, identical(coerceFill(Inf), list(NA_integer_, Inf, as.integer64(NA))))
-  test(6.46, identical(coerceFill(-Inf), list(NA_integer_, -Inf, as.integer64(NA))))
-}

--- a/inst/tests/utils.Rraw
+++ b/inst/tests/utils.Rraw
@@ -11,7 +11,6 @@ if (exists("test.data.table", .GlobalEnv, inherits=FALSE)) {
   test = data.table:::test
   colnamesInt = data.table:::colnamesInt
   coerceClass = data.table:::coerceClass
-  coerceFill = data.table:::coerceFill
 }
 
 sugg = c(
@@ -22,49 +21,6 @@ for (s in sugg) {
   assign(paste0("test_",s), loaded<-suppressWarnings(suppressMessages(require(s, character.only=TRUE))))
   if (!loaded) cat("\n**** Suggested package",s,"is not installed. Tests using it will be skipped.\n\n")
 }
-
-# coerceClass verbose
-op = options(datatable.verbose=TRUE)
-test(1.01, coerceClass("0", list(integer(0))), 0L, output="unknown to integer using coerceVector")
-test(1.02, coerceClass(0L, list(integer(0))), 0L, output="integer to integer using memcpy")
-test(1.03, coerceClass(structure(0, class="integer64"), list(integer(0))), 0L, output="long long to integer using loop")
-test(1.04, coerceClass(0, list(integer(0))), 0L, output="double to integer using loop")
-test(1.05, coerceClass("0", list(double(0))), 0, output="unknown to double using coerceVector")
-test(1.06, coerceClass("0", list(structure(double(0), class="integer64"))), structure(0, class="integer64"), output="unknown to long long using coerceVector")
-test(1.07, coerceClass(0L, list(double(0))), 0, output="integer to double using loop")
-test(1.08, coerceClass(0L, list(structure(double(0), class="integer64"))), structure(0, class="integer64"), output="integer to long long using loop")
-test(1.09, coerceClass(0, list(double(0))), 0, output="double to double using memcpy")
-test(1.10, coerceClass(0, list(structure(double(0), class="integer64"))), structure(0, class="integer64"), output="double to long long using loop")
-test(1.11, coerceClass(structure(0, class="integer64"), list(double(0))), 0, output="long long to double using loop")
-test(1.12, coerceClass(structure(0, class="integer64"), list(structure(double(0), class="integer64"))), structure(0, class="integer64"), output="long long to long long using memcpy")
-test(1.13, coerceClass("0", list(complex(0))), 0+0i, output="unknown to unknown using coerceVector")
-options(op)
-# coerceClass atomic out
-test(1.21, coerceClass(0L, integer(0)), 0L)
-test(1.22, coerceClass(0L, double(0)), 0)
-test(1.23, coerceClass(0, integer(0)), 0L)
-test(1.24, coerceClass(0, double(0)), 0)
-# coerceClass list out
-test(1.31, coerceClass(0L, list(integer(0), double(0))), list(0L, 0))
-test(1.32, coerceClass(0L, list(double(0), double(0))), list(0, 0))
-test(1.33, coerceClass(0, list(integer(0), integer(0))), list(0L, 0L))
-test(1.34, coerceClass(0, list(double(0), integer(0))), list(0, 0L))
-# coerceClass vector x
-test(1.41, coerceClass(1:3, integer(0)), 1:3)
-test(1.42, coerceClass(1:3, double(0)), c(1,2,3))
-test(1.43, coerceClass(c(1,2,3), integer(0)), 1:3)
-test(1.44, coerceClass(c(1,2,3), double(0)), c(1,2,3))
-
-# int32 range
-
-# int64 range
-
-#matrix
-#array
-#nanotime
-#int64-nanotime
-#nanotime-int64
-#factor
 
 # colnamesInt helper
 dt = data.table(a=1, b=2, d=3)
@@ -94,22 +50,58 @@ test(4.23, colnamesInt(dt, 1, check_dups="a"), error="check_dups")
 names(dt) <- NULL
 test(4.24, colnamesInt(dt, "a"), error="has no names")
 
-# coerceFill
+# coerceClass verbose
+op = options(datatable.verbose=TRUE)
+test(5.01, coerceClass("0", list(integer(0))), 0L, output="unknown to integer using coerceVector")
+test(5.02, coerceClass(0L, list(integer(0))), 0L, output="integer to integer using memcpy")
+test(5.03, coerceClass(structure(0, class="integer64"), list(integer(0))), 0L, output="long long to integer using loop")
+test(5.04, coerceClass(0, list(integer(0))), 0L, output="double to integer using loop")
+test(5.05, coerceClass("0", list(double(0))), 0, output="unknown to double using coerceVector")
+test(5.06, coerceClass("0", list(structure(double(0), class="integer64"))), structure(0, class="integer64"), output="unknown to long long using coerceVector")
+test(5.07, coerceClass(0L, list(double(0))), 0, output="integer to double using loop")
+test(5.08, coerceClass(0L, list(structure(double(0), class="integer64"))), structure(0, class="integer64"), output="integer to long long using loop")
+test(5.09, coerceClass(0, list(double(0))), 0, output="double to double using memcpy")
+test(5.10, coerceClass(0, list(structure(double(0), class="integer64"))), structure(0, class="integer64"), output="double to long long using loop")
+test(5.11, coerceClass(structure(0, class="integer64"), list(double(0))), 0, output="long long to double using loop")
+test(5.12, coerceClass(structure(0, class="integer64"), list(structure(double(0), class="integer64"))), structure(0, class="integer64"), output="long long to long long using memcpy")
+test(5.13, coerceClass("0", list(complex(0))), 0+0i, output="unknown to unknown using coerceVector")
+options(op)
+# coerceClass atomic out
+test(5.21, coerceClass(0L, integer(0)), 0L)
+test(5.22, coerceClass(0L, double(0)), 0)
+test(5.23, coerceClass(0, integer(0)), 0L)
+test(5.24, coerceClass(0, double(0)), 0)
+# coerceClass list out
+test(5.31, coerceClass(0L, list(integer(0), double(0))), list(0L, 0))
+test(5.32, coerceClass(0L, list(double(0), double(0))), list(0, 0))
+test(5.33, coerceClass(0, list(integer(0), integer(0))), list(0L, 0L))
+test(5.34, coerceClass(0, list(double(0), integer(0))), list(0, 0L))
+# coerceClass vector x
+test(5.41, coerceClass(1:3, integer(0)), 1:3)
+test(5.42, coerceClass(1:3, double(0)), c(1,2,3))
+test(5.43, coerceClass(c(1,2,3), integer(0)), 1:3)
+test(5.44, coerceClass(c(1,2,3), double(0)), c(1,2,3))
+
+# int32 range
+# int64 range
+# matrix, array, nanotime, int64-nanotime, nanotime-int64, factor
+
 if (test_bit64) {
-  #test(6.01, coerceFill(1:2), error="fill argument must be length 1") # since coerceClass in utils.c it handle vector input
-  #test(6.02, coerceFill("a"), error="fill argument must be numeric") # since coerceClass in utils.c unsupported input is redirected to R's coerceVector
-  test(6.11, identical(coerceFill(NA), list(NA_integer_, NA_real_, as.integer64(NA))))
-  test(6.21, identical(coerceFill(3L), list(3L, 3, as.integer64(3))))
-  test(6.22, identical(coerceFill(0L), list(0L, 0, as.integer64(0))))
-  test(6.23, identical(coerceFill(NA_integer_), list(NA_integer_, NA_real_, as.integer64(NA))))
-  test(6.31, identical(coerceFill(as.integer64(3)), list(3L, 3, as.integer64(3))))
-  test(6.32, identical(coerceFill(as.integer64(3000000003)), list(NA_integer_, 3000000003, as.integer64("3000000003"))))
-  test(6.33, identical(coerceFill(as.integer64(0)), list(0L, 0, as.integer64(0))))
-  test(6.34, identical(coerceFill(as.integer64(NA)), list(NA_integer_, NA_real_, as.integer64(NA))))
-  test(6.41, identical(coerceFill(3), list(3L, 3, as.integer64(3))))
-  test(6.42, identical(coerceFill(0), list(0L, 0, as.integer64(0))))
-  test(6.43, identical(coerceFill(NA_real_), list(NA_integer_, NA_real_, as.integer64(NA))))
-  test(6.44, identical(coerceFill(NaN), list(NA_integer_, NaN, as.integer64(NA))))
-  test(6.45, identical(coerceFill(Inf), list(NA_integer_, Inf, as.integer64(NA))))
-  test(6.46, identical(coerceFill(-Inf), list(NA_integer_, -Inf, as.integer64(NA))))
+  out = list(0L, 0, as.integer64(0))
+  test(6.01, identical(coerceClass(1:2, out), list(1:2, c(1,2), as.integer64(1:2))))
+  test(6.02, coerceClass(0+0i, out), list(0L, 0, as.integer64(0)))
+  test(6.11, identical(coerceClass(NA, out), list(NA_integer_, NA_real_, as.integer64(NA))))
+  test(6.21, identical(coerceClass(3L, out), list(3L, 3, as.integer64(3))))
+  test(6.22, identical(coerceClass(0L, out), list(0L, 0, as.integer64(0))))
+  test(6.23, identical(coerceClass(NA_integer_, out), list(NA_integer_, NA_real_, as.integer64(NA))))
+  test(6.31, identical(coerceClass(as.integer64(3), out), list(3L, 3, as.integer64(3))))
+  test(6.32, identical(coerceClass(as.integer64(3000000003), out), list(NA_integer_, 3000000003, as.integer64("3000000003"))))
+  test(6.33, identical(coerceClass(as.integer64(0), out), list(0L, 0, as.integer64(0))))
+  test(6.34, identical(coerceClass(as.integer64(NA), out), list(NA_integer_, NA_real_, as.integer64(NA))))
+  test(6.41, identical(coerceClass(3, out), list(3L, 3, as.integer64(3))))
+  test(6.42, identical(coerceClass(0, out), list(0L, 0, as.integer64(0))))
+  test(6.43, identical(coerceClass(NA_real_, out), list(NA_integer_, NA_real_, as.integer64(NA))))
+  test(6.44, identical(coerceClass(NaN, out), list(NA_integer_, NaN, as.integer64(NA))))
+  test(6.45, identical(coerceClass(Inf, out), list(NA_integer_, Inf, as.integer64(NA))))
+  test(6.46, identical(coerceClass(-Inf, out), list(NA_integer_, -Inf, as.integer64(NA))))
 }

--- a/inst/tests/utils.Rraw
+++ b/inst/tests/utils.Rraw
@@ -52,36 +52,29 @@ test(4.24, colnamesInt(dt, "a"), error="has no names")
 
 # coerceClass verbose
 op = options(datatable.verbose=TRUE)
-test(5.01, coerceClass("0", list(integer(0))), list(0L), output="unknown to integer using coerceVector")
-test(5.02, coerceClass(0L, list(integer(0))), list(0L), output="integer to integer using memcpy")
-test(5.03, coerceClass(structure(0, class="integer64"), list(integer(0))), list(0L), output="long long to integer using loop")
-test(5.04, coerceClass(0, list(integer(0))), list(0L), output="double to integer using loop")
-test(5.05, coerceClass("0", list(double(0))), list(0), output="unknown to double using coerceVector")
-test(5.06, coerceClass("0", list(structure(double(0), class="integer64"))), list(structure(0, class="integer64")), output="unknown to long long using coerceVector")
-test(5.07, coerceClass(0L, list(double(0))), list(0), output="integer to double using loop")
-test(5.08, coerceClass(0L, list(structure(double(0), class="integer64"))), list(structure(0, class="integer64")), output="integer to long long using loop")
-test(5.09, coerceClass(0, list(double(0))), list(0), output="double to double using memcpy")
-test(5.10, coerceClass(0, list(structure(double(0), class="integer64"))), list(structure(0, class="integer64")), output="double to long long using loop")
-test(5.11, coerceClass(structure(0, class="integer64"), list(double(0))), list(0), output="long long to double using loop")
-test(5.12, coerceClass(structure(0, class="integer64"), list(structure(double(0), class="integer64"))), list(structure(0, class="integer64")), output="long long to long long using memcpy")
-test(5.13, coerceClass("0", list(complex(0))), list(0+0i), output="unknown to unknown using coerceVector")
+test(5.01, coerceClass(c("0",NA_character_), integer(0)), c(0L,NA_integer_), output="unknown to integer using coerceVector")
+test(5.02, coerceClass(c(0L,NA_integer_), integer(0)), c(0L,NA_integer_), output="integer to integer using memcpy")
+if (test_bit64) test(5.03, coerceClass(as.integer64(c(0,NA_real_)), integer(0)), c(0L,NA_integer_), output="long long to integer using loop")
+test(5.04, coerceClass(c(0,NA_real_), integer(0)), c(0L,NA_integer_), output="double to integer using loop")
+test(5.05, coerceClass(c("0",NA_character_), double(0)), c(0,NA_real_), output="unknown to double using coerceVector")
+if (test_bit64) test(5.06, coerceClass(c(0+0i,NA_complex_), as.integer64(numeric(0))), as.integer64(c("0","9218868437227407266")), output="unknown to long long using coerceVector") # complex-int64 NAs not handled - as expected
+test(5.07, coerceClass(c(0L,NA_integer_), double(0)), c(0,NA_real_), output="integer to double using loop")
+if (test_bit64) test(5.08, coerceClass(c(0L,NA_integer_), as.integer64(numeric(0))), as.integer64(c(0,NA_real_)), output="integer to long long using loop")
+test(5.09, coerceClass(c(0,NA_real_), double(0)), c(0,NA_real_), output="double to double using memcpy")
+if (test_bit64) test(5.10, coerceClass(c(0,NA_real_), as.integer64(numeric(0))), as.integer64(c(0,NA_real_)), output="double to long long using loop")
+if (test_bit64) test(5.11, coerceClass(as.integer64(c(0,NA_real_)), double(0)), c(0,NA_real_), output="long long to double using loop")
+if (test_bit64) test(5.12, coerceClass(as.integer64(c(0,NA_real_)), as.integer64(numeric(0))), as.integer64(c(0,NA_real_)), output="long long to long long using memcpy")
+#if (test_bit64) test(5.13, coerceClass(c("0",NA_character_), as.integer64(numeric(0))), as.integer64(c(0,NA_real_)), output="string to long long using loop") # TODO
+test(5.14, coerceClass(c(0L,NA_integer_), character(0)), c("0",NA_character_), output="unknown to string using coerceVector")
+#if (test_bit64) test(5.15, coerceClass(as.integer64(c(0,NA_real_)), character(0)), c("0",NA_character_), output="long long to string using loop") # TODO
+test(5.16, coerceClass(c("0",NA_character_), complex(0)), c(0+0i, NA_complex_), output="unknown to unknown using coerceVector")
 options(op)
 # coerceClass atomic out
-test(5.21, coerceClass(0L, integer(0)), 0L)
-test(5.22, coerceClass(0L, double(0)), 0)
-test(5.23, coerceClass(0, integer(0)), 0L)
-test(5.24, coerceClass(0, double(0)), 0)
+test(5.41, coerceClass(0L, integer(0)), 0L)
+test(5.42, coerceClass(0L, double(0)), 0)
+test(5.43, coerceClass(0, integer(0)), 0L)
+test(5.44, coerceClass(0, double(0)), 0)
 # coerceClass list out
-test(5.31, coerceClass(0L, list(integer(0), double(0))), list(0L, 0))
-test(5.32, coerceClass(0L, list(double(0), double(0))), list(0, 0))
-test(5.33, coerceClass(0, list(integer(0), integer(0))), list(0L, 0L))
-test(5.34, coerceClass(0, list(double(0), integer(0))), list(0, 0L))
-# coerceClass vector x
-test(5.41, coerceClass(1:3, integer(0)), 1:3)
-test(5.42, coerceClass(1:3, double(0)), c(1,2,3))
-test(5.43, coerceClass(c(1,2,3), integer(0)), 1:3)
-test(5.44, coerceClass(c(1,2,3), double(0)), c(1,2,3))
-# coerceClass vector x list out
 test(5.51, coerceClass(1:3, list(integer(0), double(0))), list(1:3, c(1,2,3)))
 test(5.52, coerceClass(1:3, list(double(0), double(0))), list(c(1,2,3), c(1,2,3)))
 test(5.53, coerceClass(c(1,2,3), list(integer(0), integer(0))), list(1:3, 1:3))
@@ -91,11 +84,16 @@ test(5.61, coerceClass(list(1:3), double(0)), error="argument must be atomic typ
 test(5.62, coerceClass(1:3, list()), error="argument must be atomic type or a non-empty list")
 
 # int32 range
+int_min = 0L-.Machine$integer.max
+int_max = .Machine$integer.max
+# matrix, array, data.frame
 # int64 range
-# matrix, array
 # nanotime, int64-nanotime, nanotime-int64
+# logical
+#test(5.02, coerceClass(c(FALSE,NA), integer(0)), c(0L,NA_integer_), output="integer to integer using memcpy")
+#test(5.02, coerceClass(c(FALSE,NA), double(0)), c(0,NA_real_), output="integer to double using loop")
+#test(5.02, coerceClass(c(0,NA_real_), logical(0)), c(FALSE,NA), output="double to integer using loop") # TODO
 # factor
-# character
 # list
 
 if (test_bit64) {

--- a/inst/tests/utils.Rraw
+++ b/inst/tests/utils.Rraw
@@ -86,6 +86,9 @@ test(5.51, coerceClass(1:3, list(integer(0), double(0))), list(1:3, c(1,2,3)))
 test(5.52, coerceClass(1:3, list(double(0), double(0))), list(c(1,2,3), c(1,2,3)))
 test(5.53, coerceClass(c(1,2,3), list(integer(0), integer(0))), list(1:3, 1:3))
 test(5.54, coerceClass(c(1,2,3), list(double(0), integer(0))), list(c(1,2,3), 1:3))
+# error
+test(5.61, coerceClass(list(1:3), double(0)), error="argument must be atomic type")
+test(5.62, coerceClass(1:3, list()), error="argument must be atomic type or a non-empty list")
 
 # int32 range
 # int64 range

--- a/inst/tests/utils.Rraw
+++ b/inst/tests/utils.Rraw
@@ -52,19 +52,19 @@ test(4.24, colnamesInt(dt, "a"), error="has no names")
 
 # coerceClass verbose
 op = options(datatable.verbose=TRUE)
-test(5.01, coerceClass("0", list(integer(0))), 0L, output="unknown to integer using coerceVector")
-test(5.02, coerceClass(0L, list(integer(0))), 0L, output="integer to integer using memcpy")
-test(5.03, coerceClass(structure(0, class="integer64"), list(integer(0))), 0L, output="long long to integer using loop")
-test(5.04, coerceClass(0, list(integer(0))), 0L, output="double to integer using loop")
-test(5.05, coerceClass("0", list(double(0))), 0, output="unknown to double using coerceVector")
-test(5.06, coerceClass("0", list(structure(double(0), class="integer64"))), structure(0, class="integer64"), output="unknown to long long using coerceVector")
-test(5.07, coerceClass(0L, list(double(0))), 0, output="integer to double using loop")
-test(5.08, coerceClass(0L, list(structure(double(0), class="integer64"))), structure(0, class="integer64"), output="integer to long long using loop")
-test(5.09, coerceClass(0, list(double(0))), 0, output="double to double using memcpy")
-test(5.10, coerceClass(0, list(structure(double(0), class="integer64"))), structure(0, class="integer64"), output="double to long long using loop")
-test(5.11, coerceClass(structure(0, class="integer64"), list(double(0))), 0, output="long long to double using loop")
-test(5.12, coerceClass(structure(0, class="integer64"), list(structure(double(0), class="integer64"))), structure(0, class="integer64"), output="long long to long long using memcpy")
-test(5.13, coerceClass("0", list(complex(0))), 0+0i, output="unknown to unknown using coerceVector")
+test(5.01, coerceClass("0", list(integer(0))), list(0L), output="unknown to integer using coerceVector")
+test(5.02, coerceClass(0L, list(integer(0))), list(0L), output="integer to integer using memcpy")
+test(5.03, coerceClass(structure(0, class="integer64"), list(integer(0))), list(0L), output="long long to integer using loop")
+test(5.04, coerceClass(0, list(integer(0))), list(0L), output="double to integer using loop")
+test(5.05, coerceClass("0", list(double(0))), list(0), output="unknown to double using coerceVector")
+test(5.06, coerceClass("0", list(structure(double(0), class="integer64"))), list(structure(0, class="integer64")), output="unknown to long long using coerceVector")
+test(5.07, coerceClass(0L, list(double(0))), list(0), output="integer to double using loop")
+test(5.08, coerceClass(0L, list(structure(double(0), class="integer64"))), list(structure(0, class="integer64")), output="integer to long long using loop")
+test(5.09, coerceClass(0, list(double(0))), list(0), output="double to double using memcpy")
+test(5.10, coerceClass(0, list(structure(double(0), class="integer64"))), list(structure(0, class="integer64")), output="double to long long using loop")
+test(5.11, coerceClass(structure(0, class="integer64"), list(double(0))), list(0), output="long long to double using loop")
+test(5.12, coerceClass(structure(0, class="integer64"), list(structure(double(0), class="integer64"))), list(structure(0, class="integer64")), output="long long to long long using memcpy")
+test(5.13, coerceClass("0", list(complex(0))), list(0+0i), output="unknown to unknown using coerceVector")
 options(op)
 # coerceClass atomic out
 test(5.21, coerceClass(0L, integer(0)), 0L)
@@ -81,13 +81,22 @@ test(5.41, coerceClass(1:3, integer(0)), 1:3)
 test(5.42, coerceClass(1:3, double(0)), c(1,2,3))
 test(5.43, coerceClass(c(1,2,3), integer(0)), 1:3)
 test(5.44, coerceClass(c(1,2,3), double(0)), c(1,2,3))
+# coerceClass vector x list out
+test(5.51, coerceClass(1:3, list(integer(0), double(0))), list(1:3, c(1,2,3)))
+test(5.52, coerceClass(1:3, list(double(0), double(0))), list(c(1,2,3), c(1,2,3)))
+test(5.53, coerceClass(c(1,2,3), list(integer(0), integer(0))), list(1:3, 1:3))
+test(5.54, coerceClass(c(1,2,3), list(double(0), integer(0))), list(c(1,2,3), 1:3))
 
 # int32 range
 # int64 range
-# matrix, array, nanotime, int64-nanotime, nanotime-int64, factor
+# matrix, array
+# nanotime, int64-nanotime, nanotime-int64
+# factor
+# character
+# list
 
 if (test_bit64) {
-  out = list(0L, 0, as.integer64(0))
+  out = list(0L, 0, as.integer64(0)) # test ported from old coerceFill, used in nafill
   test(6.01, identical(coerceClass(1:2, out), list(1:2, c(1,2), as.integer64(1:2))))
   test(6.02, coerceClass(0+0i, out), list(0L, 0, as.integer64(0)))
   test(6.11, identical(coerceClass(NA, out), list(NA_integer_, NA_real_, as.integer64(NA))))

--- a/inst/tests/utils.Rraw
+++ b/inst/tests/utils.Rraw
@@ -1,0 +1,115 @@
+require(methods)
+if (exists("test.data.table", .GlobalEnv, inherits=FALSE)) {
+  if (!identical(suppressWarnings(packageDescription("data.table")), NA)) {
+    remove.packages("data.table")
+    stop("This is dev mode but data.table was installed. Uninstalled it. Please q() this R session and try cc() again. The installed namespace causes problems in dev mode for the S4 tests.\n")
+  }
+  if ((tt<-compiler::enableJIT(-1))>0)
+    cat("This is dev mode and JIT is enabled (level ", tt, ") so there will be a brief pause around the first test.\n", sep="")
+} else {
+  require(data.table)
+  test = data.table:::test
+  colnamesInt = data.table:::colnamesInt
+  coerceClass = data.table:::coerceClass
+  coerceFill = data.table:::coerceFill
+}
+
+sugg = c(
+  "bit64",
+  "nanotime"
+)
+for (s in sugg) {
+  assign(paste0("test_",s), loaded<-suppressWarnings(suppressMessages(require(s, character.only=TRUE))))
+  if (!loaded) cat("\n**** Suggested package",s,"is not installed. Tests using it will be skipped.\n\n")
+}
+
+# coerceClass verbose
+op = options(datatable.verbose=TRUE)
+test(1.01, coerceClass("0", list(integer(0))), 0L, output="unknown to integer using coerceVector")
+test(1.02, coerceClass(0L, list(integer(0))), 0L, output="integer to integer using memcpy")
+test(1.03, coerceClass(structure(0, class="integer64"), list(integer(0))), 0L, output="long long to integer using loop")
+test(1.04, coerceClass(0, list(integer(0))), 0L, output="double to integer using loop")
+test(1.05, coerceClass("0", list(double(0))), 0, output="unknown to double using coerceVector")
+test(1.06, coerceClass("0", list(structure(double(0), class="integer64"))), structure(0, class="integer64"), output="unknown to long long using coerceVector")
+test(1.07, coerceClass(0L, list(double(0))), 0, output="integer to double using loop")
+test(1.08, coerceClass(0L, list(structure(double(0), class="integer64"))), structure(0, class="integer64"), output="integer to long long using loop")
+test(1.09, coerceClass(0, list(double(0))), 0, output="double to double using memcpy")
+test(1.10, coerceClass(0, list(structure(double(0), class="integer64"))), structure(0, class="integer64"), output="double to long long using loop")
+test(1.11, coerceClass(structure(0, class="integer64"), list(double(0))), 0, output="long long to double using loop")
+test(1.12, coerceClass(structure(0, class="integer64"), list(structure(double(0), class="integer64"))), structure(0, class="integer64"), output="long long to long long using memcpy")
+test(1.13, coerceClass("0", list(complex(0))), 0+0i, output="unknown to unknown using coerceVector")
+options(op)
+# coerceClass atomic out
+test(1.21, coerceClass(0L, integer(0)), 0L)
+test(1.22, coerceClass(0L, double(0)), 0)
+test(1.23, coerceClass(0, integer(0)), 0L)
+test(1.24, coerceClass(0, double(0)), 0)
+# coerceClass list out
+test(1.31, coerceClass(0L, list(integer(0), double(0))), list(0L, 0))
+test(1.32, coerceClass(0L, list(double(0), double(0))), list(0, 0))
+test(1.33, coerceClass(0, list(integer(0), integer(0))), list(0L, 0L))
+test(1.34, coerceClass(0, list(double(0), integer(0))), list(0, 0L))
+# coerceClass vector x
+test(1.41, coerceClass(1:3, integer(0)), 1:3)
+test(1.42, coerceClass(1:3, double(0)), c(1,2,3))
+test(1.43, coerceClass(c(1,2,3), integer(0)), 1:3)
+test(1.44, coerceClass(c(1,2,3), double(0)), c(1,2,3))
+
+# int32 range
+
+# int64 range
+
+#matrix
+#array
+#nanotime
+#int64-nanotime
+#nanotime-int64
+#factor
+
+# colnamesInt helper
+dt = data.table(a=1, b=2, d=3)
+test(4.01, colnamesInt(dt, "a"), 1L)
+test(4.02, colnamesInt(dt, 1L), 1L)
+test(4.03, colnamesInt(dt, 1), 1L)
+test(4.04, colnamesInt(dt, c("a","d")), c(1L, 3L))
+test(4.05, colnamesInt(dt, c(1L, 3L)), c(1L, 3L))
+test(4.06, colnamesInt(dt, c(1, 3)), c(1L, 3L))
+test(4.07, colnamesInt(dt, c("a", "e")), error="specify non existing column*.*e")
+test(4.08, colnamesInt(dt, c(1L, 4L)), error="specify non existing column*.*4")
+test(4.09, colnamesInt(dt, c(1, 4)), error="specify non existing column*.*4")
+test(4.10, colnamesInt(dt, c("a", NA)), error="specify non existing column*.*NA")
+test(4.11, colnamesInt(dt, c(1L, NA)), error="specify non existing column")
+test(4.12, colnamesInt(dt, c(1, NA)), error="specify non existing column")
+test(4.13, colnamesInt(dt, c("a","d","a"), check_dups=TRUE), error="specify duplicated column")
+test(4.14, colnamesInt(dt, c(1L, 3L, 1L), check_dups=TRUE), error="specify duplicated column")
+test(4.15, colnamesInt(dt, c(1, 3, 1), check_dups=TRUE), error="specify duplicated column")
+test(4.16, colnamesInt(dt, list("a")), error="must be character or numeric")
+test(4.17, colnamesInt(dt, NA), error="must be character or numeric")
+test(4.18, colnamesInt(dt, character()), integer())
+test(4.19, colnamesInt(dt, numeric()), integer())
+test(4.20, colnamesInt(dt, integer()), integer())
+test(4.21, colnamesInt(dt, NULL), seq_along(dt))
+test(4.22, colnamesInt("asd", 1), error="must be data.table compatible")
+test(4.23, colnamesInt(dt, 1, check_dups="a"), error="check_dups")
+names(dt) <- NULL
+test(4.24, colnamesInt(dt, "a"), error="has no names")
+
+# coerceFill
+if (test_bit64) {
+  #test(6.01, coerceFill(1:2), error="fill argument must be length 1") # since coerceClass in utils.c it handle vector input
+  #test(6.02, coerceFill("a"), error="fill argument must be numeric") # since coerceClass in utils.c unsupported input is redirected to R's coerceVector
+  test(6.11, identical(coerceFill(NA), list(NA_integer_, NA_real_, as.integer64(NA))))
+  test(6.21, identical(coerceFill(3L), list(3L, 3, as.integer64(3))))
+  test(6.22, identical(coerceFill(0L), list(0L, 0, as.integer64(0))))
+  test(6.23, identical(coerceFill(NA_integer_), list(NA_integer_, NA_real_, as.integer64(NA))))
+  test(6.31, identical(coerceFill(as.integer64(3)), list(3L, 3, as.integer64(3))))
+  test(6.32, identical(coerceFill(as.integer64(3000000003)), list(NA_integer_, 3000000003, as.integer64("3000000003"))))
+  test(6.33, identical(coerceFill(as.integer64(0)), list(0L, 0, as.integer64(0))))
+  test(6.34, identical(coerceFill(as.integer64(NA)), list(NA_integer_, NA_real_, as.integer64(NA))))
+  test(6.41, identical(coerceFill(3), list(3L, 3, as.integer64(3))))
+  test(6.42, identical(coerceFill(0), list(0L, 0, as.integer64(0))))
+  test(6.43, identical(coerceFill(NA_real_), list(NA_integer_, NA_real_, as.integer64(NA))))
+  test(6.44, identical(coerceFill(NaN), list(NA_integer_, NaN, as.integer64(NA))))
+  test(6.45, identical(coerceFill(Inf), list(NA_integer_, Inf, as.integer64(NA))))
+  test(6.46, identical(coerceFill(-Inf), list(NA_integer_, -Inf, as.integer64(NA))))
+}

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -211,5 +211,5 @@ SEXP coalesce(SEXP x, SEXP inplace);
 bool isRealReallyInt(SEXP x);
 SEXP isReallyReal(SEXP x);
 SEXP colnamesInt(SEXP x, SEXP cols, SEXP check_dups);
-void coerceFill(SEXP fill, double *dfill, int32_t *ifill, int64_t *i64fill);
-SEXP coerceFillR(SEXP fill);
+SEXP coerceClass(SEXP x, SEXP out);
+SEXP coerceClassR(SEXP x, SEXP out);

--- a/src/init.c
+++ b/src/init.c
@@ -165,7 +165,7 @@ R_CallMethodDef callMethods[] = {
 {"CdllVersion", (DL_FUNC) &dllVersion, -1},
 {"CnafillR", (DL_FUNC) &nafillR, -1},
 {"CcolnamesInt", (DL_FUNC) &colnamesInt, -1},
-{"CcoerceFillR", (DL_FUNC) &coerceFillR, -1},
+{"CcoerceClassR", (DL_FUNC) &coerceClassR, -1},
 {"CinitLastUpdated", (DL_FUNC) &initLastUpdated, -1},
 {"Ccj", (DL_FUNC) &cj, -1},
 {"Ccoalesce", (DL_FUNC) &coalesce, -1},

--- a/src/utils.c
+++ b/src/utils.c
@@ -87,6 +87,10 @@ SEXP colnamesInt(SEXP x, SEXP cols, SEXP check_dups) {
   return ricols;
 }
 
+/* coerceClass
+ * coerce 'x' into same class as 'out', content of 'out' is ignored but attributes are copied
+ * handle coercion between integer, numeric, integer64, all others are redirected to R's coerceVector
+ */
 SEXP coerceClass(SEXP x, SEXP out) {
   int protecti = 0;
   const bool verbose = GetVerbose();
@@ -222,12 +226,15 @@ SEXP coerceClass(SEXP x, SEXP out) {
   UNPROTECT(protecti);
   return ans;
 }
+/* coerceClassR
+ * vectorized coerceClass: taking list into 'out' and returning list of coerced objects, so 'x' can be coerced to different classes at once
+ */
 SEXP coerceClassR(SEXP x, SEXP out) {
   if (!isVectorAtomic(x))
     error("'x' argument must be atomic type");
   int protecti = 0;
+  SEXP _out = out;
   if (isVectorAtomic(out)) {
-    SEXP _out = out;
     out = PROTECT(allocVector(VECSXP, 1)); protecti++;
     SET_VECTOR_ELT(out, 0, _out);
   }
@@ -240,5 +247,5 @@ SEXP coerceClassR(SEXP x, SEXP out) {
     SET_VECTOR_ELT(ans, i, coerceClass(x, VECTOR_ELT(out, i)));
   }
   UNPROTECT(protecti);
-  return n==1 ? VECTOR_ELT(ans, 0) : ans;
+  return isVectorAtomic(_out) && n==1 ? VECTOR_ELT(ans, 0) : ans;
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -225,13 +225,15 @@ SEXP coerceClass(SEXP x, SEXP out) {
 SEXP coerceClassR(SEXP x, SEXP out) {
   if (!isVectorAtomic(x))
     error("'x' argument must be atomic type");
+  int protecti = 0;
   if (isVectorAtomic(out)) {
-    // wrap into list logic
+    SEXP _out = out;
+    out = PROTECT(allocVector(VECSXP, 1)); protecti++;
+    SET_VECTOR_ELT(out, 0, _out);
   }
   if (!isNewList(out) || !length(out))
     error("'out' argument must be atomic type or a non-empty list");
 
-  int protecti=0;
   R_len_t n = LENGTH(out);
   SEXP ans = PROTECT(allocVector(VECSXP, n)); protecti++;
   for (int i=0; i<n; i++) {

--- a/tests/utils.R
+++ b/tests/utils.R
@@ -1,0 +1,2 @@
+require(data.table)
+test.data.table(script="utils.Rraw")


### PR DESCRIPTION
closes #3913

Internally used in `nafill` function `coerceFill` has been heavily modified, and renamed to `coerceClass`. Main purpose of the function is to handle coercion between types/classes with care on int64.
Comparing to previous `coerceFill` version, new `coerceClass`:
- handle coerce of vector, not only scalar
- handle coercion from any class to any class
- int64 coercion is taken care for integer and double only
- coercion between int / double / int64 is handled in the function, otherwise R's `coerceVector` is used - as a result, consider char to int64 (`coerceClass("1", list(integer(0), bit64::as.integer64(0)))`). This is going to be addressed in this PR, placeholders are in place. Also there might be some missing warnings like (NA introduced by coercion, Int overflow), which are currently not checked/issued in our int / double / int64 handling.

utils.c tests moved into own test script

----

motivation:
- extend `nafill` for types other than integer, numeric and int64
- to be re-used as efficient way to handle conversions like
```r
data.table(a=1:2, b=bit64::as.integer64(1:2))[2L, c("a","b") := NA][]
#       a                   b
#   <int>               <i64>
#1:     1                   1
#2:    NA 9218868437227407266
data.table(a=1:2, b=bit64::as.integer64(1:2))[2L, c("a","b") := coerceClass(NA, .SD)][]
#   <int> <i64>
#1:     1     1
#2:    NA  <NA>
```
in `assign`, `rbindlist` and potentially other places where we need to take care of int64 NAs handling or other classes like #3654

----

As of current moment I don't understand coverage issue, it reports few closing brackets `}` that are not being covered. Maybe a matter of waiting for update.