### PR TITLE
Closes #3760 -- prevent setDT for data.frame w matrix columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -333,6 +333,8 @@
 
 19. Subsetting does a better job of catching a malformed `data.table` with error rather than segfault. A column may not be NULL, nor may a column be an object which has columns (such as a `data.frame` or `matrix`). Thanks to a comment and reproducible example in [#3369](https://github.com/Rdatatable/data.table/issues/3369) from Drew Abbot which demonstrated the issue which arose from parsing JSON. The next release will enable `as.data.table` to unpack columns which are `data.frame` to support this use case.
 
+20. `setDT` fails for `data.frame` with matrix columns, [#3760](https://github.com/Rdatatable/data.table/issues/3760). Such objects cannot be converted to `data.table` by reference -- `as.data.table`, which will convert each matrix column to a new `data.table` column, is appropriate for this case.
+
 #### NOTES
 
 1. When upgrading to 1.12.0 some Windows users might have seen `CdllVersion not found` in some circumstances. We found a way to catch that so the [helpful message](https://twitter.com/MattDowle/status/1084528873549705217) now occurs for those upgrading from versions prior to 1.12.0 too, as well as those upgrading from 1.12.0 to a later version. See item 1 in notes section of 1.12.0 below for more background.

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2655,8 +2655,14 @@ setDT = function(x, keep.rownames=FALSE, key=NULL, check.names=FALSE) {
     cname = as.character(name)
     envir = home(cname, parent.frame())
     if (bindingIsLocked(cname, envir)) {
-      stop("Can not convert '", cname, "' to data.table by reference because binding is locked. It is very likely that '", cname, "' resides within a package (or an environment) that is locked to prevent modifying its variable bindings. Try copying the object to your current environment, ex: var <- copy(var) and then using setDT again.")
+      stop("Cannot convert '", cname, "' to data.table by reference because binding is locked. It is very likely that '", cname, "' resides within a package (or an environment) that is locked to prevent modifying its variable bindings. Try copying the object to your current environment, ex: var <- copy(var) and then using setDT again.")
     }
+  }
+  # #3760 check validity of x as a data.table
+  coldim = lapply(x, dim)
+  if (!is.null(unlist(coldim))) {
+    idx = which(!vapply_1b(coldim, is.null))
+    stop("Use as.data.table for this object -- because some columns have dimensions, it cannot be converted to data.table by reference. Column indices: ", brackify(idx))
   }
   if (is.data.table(x)) {
     # fix for #1078 and #1128, see .resetclass() for explanation.

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -15671,6 +15671,11 @@ if (test_bit64) {
   test(2077.06, int64_int32_match(d[, sum(i32, na.rm=TRUE), g], d[, sum(i64, na.rm=TRUE), g]))
 }
 
+# #3760 validate data.table before setDT
+DF = data.frame(a=1:5)
+DF$m = matrix(6:15, ncol=2L)
+test(2078, setDT(DF), error='Use as.data.table for this object')
+
 
 ###################################
 #  Add new tests above this line  #


### PR DESCRIPTION
#3760 

Not sure this is an ideal solution, but it works & indeed `as.data.table` is the appropriate function for such objects.