### PR TITLE
purge integer-as-real usages in R/

### DIFF
--- a/CRAN_Release.cmd
+++ b/CRAN_Release.cmd
@@ -66,6 +66,10 @@ grep -P "\t" ./src/*.c
 grep -n "[^A-Za-z0-9]T[^A-Za-z0-9]" ./inst/tests/tests.Rraw
 grep -n "[^A-Za-z0-9]F[^A-Za-z0-9]" ./inst/tests/tests.Rraw
 
+# All integers in R should be forced as longs with L -- this catches most common usages
+#   - tolerance=0 usages in setops.R are valid numeric 0, as are anything in strings
+grep -Er grep -Enr "^[^#]*(?:\[|==|>|<|>=|<=|,|\(|\+)\s*[-]?[0-9]+[^0-9L:.e]" R | grep -Ev "stop|warning|tolerance"
+
 # No system.time in main tests.Rraw. Timings should be in benchmark.Rraw
 grep -n "system[.]time" ./inst/tests/tests.Rraw
 

--- a/CRAN_Release.cmd
+++ b/CRAN_Release.cmd
@@ -66,9 +66,11 @@ grep -P "\t" ./src/*.c
 grep -n "[^A-Za-z0-9]T[^A-Za-z0-9]" ./inst/tests/tests.Rraw
 grep -n "[^A-Za-z0-9]F[^A-Za-z0-9]" ./inst/tests/tests.Rraw
 
-# All integers in R should be forced as longs with L -- this catches most common usages
-#   - tolerance=0 usages in setops.R are valid numeric 0, as are anything in strings
-grep -Er grep -Enr "^[^#]*(?:\[|==|>|<|>=|<=|,|\(|\+)\s*[-]?[0-9]+[^0-9L:.e]" R | grep -Ev "stop|warning|tolerance"
+# All integers internally should have L suffix to avoid lots of one-item coercions
+# Where 0 numeric is intended we should perhaps use 0.0 for clarity and make the grep easier
+# 1) tolerance=0 usages in setops.R are valid numeric 0, as are anything in strings
+# 2) leave the rollends default using roll>=0 though; comments in PR #3803
+grep -Enr "^[^#]*(?:\[|==|>|<|>=|<=|,|\(|\+)\s*[-]?[0-9]+[^0-9L:.e]" R | grep -Ev "stop|warning|tolerance"
 
 # No system.time in main tests.Rraw. Timings should be in benchmark.Rraw
 grep -n "system[.]time" ./inst/tests/tests.Rraw

--- a/R/bmerge.R
+++ b/R/bmerge.R
@@ -134,11 +134,11 @@ bmerge = function(i, x, icols, xcols, roll, rollends, nomatch, mult, ops, verbos
       }
     }
     ## these variables are only needed for non-equi joins. Set them to default.
-    nqgrp = integer(0)
+    nqgrp = integer(0L)
     nqmaxgrp = 1L
   } else {
     # non-equi operators present.. investigate groups..
-    nqgrp = integer(0)
+    nqgrp = integer(0L)
     nqmaxgrp = 1L
     if (verbose) cat("Non-equi join operators detected ... \n")
     if (roll != FALSE) stop("roll is not implemented for non-equi joins yet.")

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -140,7 +140,7 @@ replace_order = function(isub, verbose, env) {
   return(isub)
 }
 
-"[.data.table" = function (x, i, j, by, keyby, with=TRUE, nomatch=getOption("datatable.nomatch", NA), mult="all", roll=FALSE, rollends=if (roll=="nearest") c(TRUE,TRUE) else if (roll>=0) c(FALSE,TRUE) else c(TRUE,FALSE), which=FALSE, .SDcols, verbose=getOption("datatable.verbose"), allow.cartesian=getOption("datatable.allow.cartesian"), drop=NULL, on=NULL)
+"[.data.table" = function (x, i, j, by, keyby, with=TRUE, nomatch=getOption("datatable.nomatch", NA), mult="all", roll=FALSE, rollends=if (roll=="nearest") c(TRUE,TRUE) else if (roll>=0L) c(FALSE,TRUE) else c(TRUE,FALSE), which=FALSE, .SDcols, verbose=getOption("datatable.verbose"), allow.cartesian=getOption("datatable.allow.cartesian"), drop=NULL, on=NULL)
 {
   # ..selfcount <<- ..selfcount+1  # in dev, we check no self calls, each of which doubles overhead, or could
   # test explicitly if the caller is [.data.table (even stronger test. TO DO.)
@@ -353,7 +353,7 @@ replace_order = function(isub, verbose, env) {
     # optimize here so that we can switch it off if needed
     check_eval_env = environment()
     check_eval_env$eval_forder = FALSE
-    if (getOption("datatable.optimize") >= 1) {
+    if (getOption("datatable.optimize") >= 1L) {
       isub = replace_order(isub, verbose, check_eval_env)
     }
     if (check_eval_env$eval_forder) {
@@ -543,13 +543,13 @@ replace_order = function(isub, verbose, env) {
           ## restore original order. This is a very expensive operation.
           ## benchmarks have shown that starting with 1e6 irows, a tweak can significantly reduce time
           ## (see #2366)
-          if (verbose) {last.started.at=proc.time()[3];cat("Reordering", length(irows), "rows after bmerge done in ... ");flush.console()}
+          if (verbose) {last.started.at=proc.time()[3L];cat("Reordering", length(irows), "rows after bmerge done in ... ");flush.console()}
           if(length(irows) < 1e6){
             irows = fsort(irows, internal=TRUE) ## internally, fsort on integer falls back to forderv
             } else {
               irows = as.integer(fsort(as.numeric(irows))) ## nocov; parallelized for numeric, but overhead of type conversion
             }
-          if (verbose) {cat(round(proc.time()[3]-last.started.at,3),"secs\n");flush.console()}
+          if (verbose) {cat(round(proc.time()[3L]-last.started.at,3L),"secs\n");flush.console()}
         }
         ## make sure, all columns are taken from x and not from i.
         ## This is done by simply telling data.table to continue as if there was a simple subset
@@ -595,9 +595,9 @@ replace_order = function(isub, verbose, env) {
     if (notjoin) {
       if (byjoin || !is.integer(irows) || is.na(nomatch)) stop("Internal error: notjoin but byjoin or !integer or nomatch==NA") # nocov
       irows = irows[irows!=0L]
-      if (verbose) {last.started.at=proc.time()[3];cat("Inverting irows for notjoin done in ... ");flush.console()}
+      if (verbose) {last.started.at=proc.time()[3L];cat("Inverting irows for notjoin done in ... ");flush.console()}
       i = irows = if (length(irows)) seq_len(nrow(x))[-irows] else NULL  # NULL meaning all rows i.e. seq_len(nrow(x))
-      if (verbose) cat(round(proc.time()[3]-last.started.at, 3), "sec\n")
+      if (verbose) cat(round(proc.time()[3L]-last.started.at, 3L), "sec\n")
       leftcols = integer()  # proceed as if row subset from now on, length(leftcols) is switched on later
       rightcols = integer()
       # Doing this once here, helps speed later when repeatedly subsetting each column. R's [irows] would do this for each
@@ -1462,7 +1462,7 @@ replace_order = function(isub, verbose, env) {
   lockBinding(".iSD",SDenv)
 
   GForce = FALSE
-  if ( getOption("datatable.optimize")>=1 && (is.call(jsub) || (is.name(jsub) && as.character(jsub)[[1L]] %chin% c(".SD",".N"))) ) {  # Ability to turn off if problems or to benchmark the benefit
+  if ( getOption("datatable.optimize")>=1L && (is.call(jsub) || (is.name(jsub) && as.character(jsub)[[1L]] %chin% c(".SD",".N"))) ) {  # Ability to turn off if problems or to benchmark the benefit
     # Optimization to reduce overhead of calling lapply over and over for each group
     oldjsub = jsub
     funi = 1L # Fix for #985
@@ -1618,12 +1618,12 @@ replace_order = function(isub, verbose, env) {
     dotN = function(x) is.name(x) && x==".N" # For #5760. TODO: Rprof() showed dotN() may be the culprit if iterated (#1470)?; avoid the == which converts each x to character?
     # FR #971, GForce kicks in on all subsets, no joins yet. Although joins could work with
     # nomatch=0L even now.. but not switching it on yet, will deal it separately.
-    if (getOption("datatable.optimize")>=2 && !is.data.table(i) && !byjoin && length(f__) && !length(lhs)) {
+    if (getOption("datatable.optimize")>=2L && !is.data.table(i) && !byjoin && length(f__) && !length(lhs)) {
       if (!length(ansvars) && !use.I) {
         GForce = FALSE
         if ( (is.name(jsub) && jsub == ".N") || (is.call(jsub) && length(jsub)==2L && length(as.character(jsub[[1L]])) && as.character(jsub[[1L]])[1L] == "list" && length(as.character(jsub[[2L]])) && as.character(jsub[[2L]])[1L] == ".N") ) {
           GForce = TRUE
-          if (verbose) cat("GForce optimized j to '",deparse(jsub,width.cutoff=200L),"'\n",sep="")
+          if (verbose) cat("GForce optimized j to '",deparse(jsub, width.cutoff=200L, nlines=1L),"'\n",sep="")
         }
       } else {
         # Apply GForce
@@ -1658,7 +1658,7 @@ replace_order = function(isub, verbose, env) {
             jsub[[1L]] = as.name(paste0("g", jsub[[1L]]))
             if (length(jsub)==3L) jsub[[3L]] = eval(jsub[[3L]], parent.frame())   # tests 1187.3 & 1187.5
           }
-          if (verbose) cat("GForce optimized j to '",deparse(jsub,width.cutoff=200L),"'\n",sep="")
+          if (verbose) cat("GForce optimized j to '",deparse(jsub, width.cutoff=200L, nlines=1L),"'\n",sep="")
         } else if (verbose) cat("GForce is on, left j unchanged\n");
       }
     }
@@ -1685,7 +1685,7 @@ replace_order = function(isub, verbose, env) {
       }
       if (verbose) {
         if (!identical(oldjsub, jsub))
-          cat("Old mean optimization changed j from '",deparse(oldjsub),"' to '",deparse(jsub,width.cutoff=200),"'\n",sep="")
+          cat("Old mean optimization changed j from '",deparse(oldjsub),"' to '",deparse(jsub, width.cutoff=200L, nlines=1L),"'\n",sep="")
         else
           cat("Old mean optimization is on, left j unchanged.\n")
       }
@@ -1697,8 +1697,8 @@ replace_order = function(isub, verbose, env) {
       # when fastmean can do trim.
     }
   } else if (verbose) {
-    if (getOption("datatable.optimize")<1) cat("All optimizations are turned off\n")
-    else cat("Optimization is on but left j unchanged (single plain symbol): '",deparse(jsub,width.cutoff=200),"'\n",sep="")
+    if (getOption("datatable.optimize")<1L) cat("All optimizations are turned off\n")
+    else cat("Optimization is on but left j unchanged (single plain symbol): '",deparse(jsub, width.cutoff=200L, nlines=1L),"'\n",sep="")
   }
   if (byjoin) {
     groups = i
@@ -1877,7 +1877,7 @@ as.matrix.data.table = function(x, rownames=NULL, rownames.value=NULL, ...) {
   if (!is.null(rownames)) {
     # extract that column and drop it.
     rownames.value = x[[rownames]]
-    dm = dim(x) - c(0, 1)
+    dm = dim(x) - 0:1
     cn = names(x)[-rownames]
     X = x[, .SD, .SDcols = cn]
   } else {
@@ -2670,7 +2670,7 @@ setDT = function(x, keep.rownames=FALSE, key=NULL, check.names=FALSE) {
     setattr(x, 'class', .resetclass(x, 'data.table'))
     if (!missing(key)) setkeyv(x, key) # fix for #1169
     if (check.names) setattr(x, "names", make.names(names(x), unique=TRUE))
-    if (selfrefok(x) > 0) return(invisible(x)) else alloc.col(x)
+    if (selfrefok(x) > 0L) return(invisible(x)) else alloc.col(x)
   } else if (is.data.frame(x)) {
     rn = if (!identical(keep.rownames, FALSE)) rownames(x) else NULL
     setattr(x, "row.names", .set_row_names(nrow(x)))
@@ -2841,7 +2841,7 @@ isReallyReal = function(x) {
   ## Determine, whether the nature of isub in general supports fast binary search
   remainingIsub = isub
   i = list()
-  on = character(0)
+  on = character(0L)
   nonEqui = FALSE
   while(length(remainingIsub)){
     if(is.call(remainingIsub)){
@@ -3006,14 +3006,14 @@ isReallyReal = function(x) {
   operators = character(length(on))
   ## loop over the elements and extract operators and column names.
   for(i in seq_along(pieces)){
-    thisCols      = character(0)
-    thisOperators = character(0)
-    j = 1
+    thisCols      = character(0L)
+    thisOperators = character(0L)
+    j = 1L
     while(j <= length(pieces[[i]])){
       if(pieces[[i]][j] == "`"){
         ## start of a variable name with backtick.
-        thisCols = c(thisCols, pieces[[i]][j+1])
-        j = j+3 # +1 is the column name, +2 is delimiting "`", +3 is next relevant entry.`
+        thisCols = c(thisCols, pieces[[i]][j+1L])
+        j = j+3L # +1 is the column name, +2 is delimiting "`", +3 is next relevant entry.`
       } else {
         ## no backtick
         ## search for operators
@@ -3021,42 +3021,42 @@ isReallyReal = function(x) {
                            unlist(regmatches(pieces[[i]][j], gregexpr(pat, pieces[[i]][j])),
                                   use.names = FALSE))
         ## search for column names
-        thisCols = c(thisCols, trimws(strsplit(pieces[[i]][j], pat)[[1]]))
+        thisCols = c(thisCols, trimws(strsplit(pieces[[i]][j], pat)[[1L]]))
         ## there can be empty string column names because of trimws, remove them
         thisCols = thisCols[thisCols != ""]
-        j = j+1
+        j = j+1L
       }
     }
-    if (length(thisOperators) == 0) {
+    if (length(thisOperators) == 0L) {
       ## if no operator is given, it must be ==
       operators[i] = "=="
-    } else if (length(thisOperators) == 1) {
+    } else if (length(thisOperators) == 1L) {
       operators[i] = thisOperators
     } else {
       ## multiple operators found in one 'on' part. Something is wrong.
       stop("Found more than one operator in one 'on' statement: ", on[i], ". Please specify a single operator.")
     }
-    if (length(thisCols) == 2){
+    if (length(thisCols) == 2L){
       ## two column names found, first is xCol, second is iCol for sure
-      xCols[i] = thisCols[1]
-      iCols[i] = thisCols[2]
-    } else if (length(thisCols) == 1){
+      xCols[i] = thisCols[1L]
+      iCols[i] = thisCols[2L]
+    } else if (length(thisCols) == 1L){
       ## a single column name found. Can mean different things
       if(xCols[i] != ""){
         ## xCol is given by names(on). thisCols must be iCol
-        iCols[i] = thisCols[1]
+        iCols[i] = thisCols[1L]
       } else if (isnull_inames){
         ## i has no names. It will be given the names V1, V2, ... automatically.
         ## The single column name is the x column. It will match to the ith column in i.
-        xCols[i] = thisCols[1]
+        xCols[i] = thisCols[1L]
         iCols[i] = paste0("V", i)
       } else {
         ## i has names and one single column name is given by on.
         ## This means that xCol and iCol have the same name.
-        xCols[i] = thisCols[1]
-        iCols[i] = thisCols[1]
+        xCols[i] = thisCols[1L]
+        iCols[i] = thisCols[1L]
       }
-    } else if (length(thisCols) == 0){
+    } else if (length(thisCols) == 0L){
       stop("'on' contains no column name: ", on[i], ". Each 'on' clause must contain one or two column names.")
     } else {
       stop("'on' contains more than 2 column names: ", on[i], ". Each 'on' clause must contain one or two column names.")

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -140,7 +140,7 @@ replace_order = function(isub, verbose, env) {
   return(isub)
 }
 
-"[.data.table" = function (x, i, j, by, keyby, with=TRUE, nomatch=getOption("datatable.nomatch", NA), mult="all", roll=FALSE, rollends=if (roll=="nearest") c(TRUE,TRUE) else if (roll>=0L) c(FALSE,TRUE) else c(TRUE,FALSE), which=FALSE, .SDcols, verbose=getOption("datatable.verbose"), allow.cartesian=getOption("datatable.allow.cartesian"), drop=NULL, on=NULL)
+"[.data.table" = function (x, i, j, by, keyby, with=TRUE, nomatch=getOption("datatable.nomatch", NA), mult="all", roll=FALSE, rollends=if (roll=="nearest") c(TRUE,TRUE) else if (roll>=0) c(FALSE,TRUE) else c(TRUE,FALSE), which=FALSE, .SDcols, verbose=getOption("datatable.verbose"), allow.cartesian=getOption("datatable.allow.cartesian"), drop=NULL, on=NULL)
 {
   # ..selfcount <<- ..selfcount+1  # in dev, we check no self calls, each of which doubles overhead, or could
   # test explicitly if the caller is [.data.table (even stronger test. TO DO.)

--- a/R/foverlaps.R
+++ b/R/foverlaps.R
@@ -112,12 +112,12 @@ foverlaps = function(x, y, by.x=if (!is.null(key(x))) key(x) else key(y), by.y=k
     if (type %chin% c("within", "any")) {
       mcall[[3L]] = substitute(
         # datetimes before 1970-01-01 are represented as -ve numerics, #3349
-        if (isposix) unclass(val)*(1 + sign(unclass(val))*dt_eps())
+        if (isposix) unclass(val)*(1L + sign(unclass(val))*dt_eps())
         else if (isdouble) {
           # fix for #1006 - 0.0 occurs in both start and end
           # better fix for 0.0, and other -ves. can't use 'incr'
           # hopefully this doesn't open another can of worms
-          (val+dt_eps())*(1 + sign(val)*dt_eps())
+          (val+dt_eps())*(1L + sign(val)*dt_eps())
         }
         else val+1L, # +1L is for integer/IDate/Date class, for examples
         list(val = mcall[[3L]]))

--- a/R/fread.R
+++ b/R/fread.R
@@ -25,7 +25,7 @@ yaml=FALSE, autostart=NA, tmpdir=tempdir())
              isTRUEorFALSE(verbose), isTRUEorFALSE(check.names), isTRUEorFALSE(logical01), isTRUEorFALSE(keepLeadingZeros), isTRUEorFALSE(yaml) )
   stopifnot( isTRUEorFALSE(stringsAsFactors) || (is.double(stringsAsFactors) && length(stringsAsFactors)==1L && 0.0<=stringsAsFactors && stringsAsFactors<=1.0))
   stopifnot( is.numeric(nrows), length(nrows)==1L )
-  if (is.na(nrows) || nrows<0) nrows=Inf   # accept -1 to mean Inf, as read.table does
+  if (is.na(nrows) || nrows<0L) nrows=Inf   # accept -1 to mean Inf, as read.table does
   if (identical(header,"auto")) header=NA
   stopifnot(is.logical(header) && length(header)==1L)  # TRUE, FALSE or NA
   stopifnot(is.numeric(nThread) && length(nThread)==1L)

--- a/R/fwrite.R
+++ b/R/fwrite.R
@@ -47,7 +47,7 @@ fwrite = function(x, file="", append=FALSE, quote="auto",
     isTRUEorFALSE(bom),
     length(na) == 1L, #1725, handles NULL or character(0) input
     is.character(file) && length(file)==1L && !is.na(file),
-    length(buffMB)==1L && !is.na(buffMB) && 1L<=buffMB && buffMB<=1024,
+    length(buffMB)==1L && !is.na(buffMB) && 1L<=buffMB && buffMB<=1024L,
     length(nThread)==1L && !is.na(nThread) && nThread>=1L
     )
 

--- a/R/onAttach.R
+++ b/R/onAttach.R
@@ -20,7 +20,7 @@
   if (!isTRUE(getOption("datatable.quiet"))) {   # new option in v1.12.4, #3489
     packageStartupMessage("data.table ", v, if(dev)paste0(" IN DEVELOPMENT built ",d,g),
                           " using ", getDTthreads(verbose=FALSE), " threads (see ?getDTthreads).  Latest news: r-datatable.com")
-    if (dev && (Sys.Date() - as.Date(d))>28)
+    if (dev && (Sys.Date() - as.Date(d))>28L)
       packageStartupMessage("**********\nThis development version of data.table was built more than 4 weeks ago. Please update: data.table::update.dev.pkg()\n**********")
     if (!.Call(ChasOpenMP))
       packageStartupMessage("**********\nThis installation of data.table has not detected OpenMP support. It should still work but in single-threaded mode.",

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -33,7 +33,7 @@
   prefix = if (!missing(pkgname)) "data.table::" else ""  # R provides the arguments when it calls .onLoad, I don't in dev/test
   if (!length(grep("data.table", ss[[2L]], fixed = TRUE))) {
     ss = ss[c(1L, NA, 2L:length(ss))]
-    ss[[2L]] = parse(text=paste0("if (!identical(class(..1),'data.frame')) for (x in list(...)) { if (inherits(x,'data.table')) return(",prefix,"data.table(...)) }"))[[1]]
+    ss[[2L]] = parse(text=paste0("if (!identical(class(..1),'data.frame')) for (x in list(...)) { if (inherits(x,'data.table')) return(",prefix,"data.table(...)) }"))[[1L]]
     body(tt)=ss
     (unlockBinding)("cbind.data.frame",baseenv())
     assign("cbind.data.frame",tt,envir=asNamespace("base"),inherits=FALSE)

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -57,7 +57,7 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
     }
     return(invisible(x))
   }
-  if ((topn*2+1)<nrow(x) && (nrow(x)>nrows || !topnmiss)) {
+  if ((topn*2L+1L)<nrow(x) && (nrow(x)>nrows || !topnmiss)) {
     toprint = rbindlist(list(head(x, topn), tail(x, topn)), use.names=FALSE)  # no need to match names because head and tail of same x, and #3306
     rn = c(seq_len(topn), seq.int(to=nrow(x), length.out=topn))
     printdots = TRUE

--- a/R/setkey.R
+++ b/R/setkey.R
@@ -329,7 +329,7 @@ setorderv = function(x, cols = colnames(x), order=1L, na.last=FALSE)
       setattr(x, 'row.names', rownames(x)[o])
     }
     k = key(x)
-    if (!identical(head(cols, length(k)), k) || any(head(order, length(k)) < 0))
+    if (!identical(head(cols, length(k)), k) || any(head(order, length(k)) < 0L))
       setattr(x, 'sorted', NULL) # if 'forderv' is not 0-length & key is not a same-ordered subset of cols, it means order has changed. So, set key to NULL, else retain key.
     setattr(x, 'index', NULL)  # remove secondary keys too. These could be reordered and retained, but simpler and faster to remove
   }

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -75,7 +75,7 @@ test.data.table = function(verbose=FALSE, pkg="pkg", silent=FALSE, with.other.pa
   assign("foreign", foreign, envir=env)
   assign("nfail", 0L, envir=env)
   assign("ntest", 0L, envir=env)
-  assign("prevtest", -1, envir=env)
+  assign("prevtest", -1L, envir=env)
   assign("whichfail", NULL, envir=env)
   assign("started.at", proc.time(), envir=env)
   assign("lasttime", proc.time()[3L], envir=env)  # used by test() to attribute time inbetween tests to the next test
@@ -118,7 +118,7 @@ test.data.table = function(verbose=FALSE, pkg="pkg", silent=FALSE, with.other.pa
                 ", locale='", Sys.getlocale(), "'",
                 ", l10n_info()='", paste0(names(l10n_info()), "=", l10n_info(), collapse="; "), "'",
                 ", getDTthreads()='", paste0(gsub("[ ][ ]+","==",gsub("^[ ]+","",capture.output(invisible(getDTthreads(verbose=TRUE))))), collapse="; "), "'")
-  DT = head(timings[-1L][order(-time)],10)   # exclude id 1 as in dev that includes JIT
+  DT = head(timings[-1L][order(-time)], 10L)   # exclude id 1 as in dev that includes JIT
   if ((x<-sum(timings[["nTest"]])) != ntest) {
     warning("Timings count mismatch:",x,"vs",ntest)  # nocov
   }
@@ -151,8 +151,8 @@ test.data.table = function(verbose=FALSE, pkg="pkg", silent=FALSE, with.other.pa
   #if (memtest<-get("memtest", envir=env)) memtest.plot(get("inittime", envir=env))
 
   # nocov start
-  if (nfail > 0) {
-    if (nfail>1) {s1="s";s2="s: "} else {s1="";s2=" "}
+  if (nfail > 0L) {
+    if (nfail > 1L) {s1="s";s2="s: "} else {s1="";s2=" "}
     cat("\r")
     stop(nfail," error",s1," out of ",ntest," in ",timetaken(started.at)," on ",date(),". [",plat,"].",
          " Search ",names(fn)," for test number",s2,paste(whichfail,collapse=", "),".")
@@ -194,7 +194,7 @@ ps_mem = function() {
   ans = tryCatch(as.numeric(system(cmd, intern=TRUE, ignore.stderr=TRUE)), warning=function(w) NA_real_, error=function(e) NA_real_)
   stopifnot(length(ans)==1L) # extra check if other OSes would not handle 'tail -1' properly for some reason
   # returns RSS memory occupied by current R process in MB rounded to 1 decimal places (as in gc), ps already returns KB
-  c("PS_rss"=round(ans / 1024, 1))
+  c("PS_rss"=round(ans / 1024, 1L))
   # nocov end
 }
 
@@ -237,7 +237,7 @@ test = function(num,x,y=TRUE,error=NULL,warning=NULL,output=NULL,message=NULL) {
     foreign = get("foreign", parent.frame())
     time = nTest = NULL  # to avoid 'no visible binding' note
     on.exit( {
-       now = proc.time()[3]
+       now = proc.time()[3L]
        took = now-lasttime  # so that prep time between tests is attributed to the following test
        assign("lasttime", now, parent.frame(), inherits=TRUE)
        timings[ as.integer(num), `:=`(time=time+took, nTest=nTest+1L), verbose=FALSE ]

--- a/man/data.table.Rd
+++ b/man/data.table.Rd
@@ -25,7 +25,7 @@ data.table(\dots, keep.rownames=FALSE, check.names=FALSE, key=NULL, stringsAsFac
   mult = "all",
   roll = FALSE,
   rollends = if (roll=="nearest") c(TRUE,TRUE)
-             else if (roll>=0) c(FALSE,TRUE)
+             else if (roll>=0L) c(FALSE,TRUE)
              else c(TRUE,FALSE),
   which = FALSE,
   .SDcols,

--- a/man/data.table.Rd
+++ b/man/data.table.Rd
@@ -25,7 +25,7 @@ data.table(\dots, keep.rownames=FALSE, check.names=FALSE, key=NULL, stringsAsFac
   mult = "all",
   roll = FALSE,
   rollends = if (roll=="nearest") c(TRUE,TRUE)
-             else if (roll>=0L) c(FALSE,TRUE)
+             else if (roll>=0) c(FALSE,TRUE)
              else c(TRUE,FALSE),
   which = FALSE,
   .SDcols,


### PR DESCRIPTION
Follow-up to #2573 -- some `1` usages crept back in.

This time added to `CRAN_Release.cmd` to help "automate" the upkeep on this in the future