### PR TITLE
Clean up & improve fastmean

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1800,7 +1800,7 @@ replace_order = function(isub, verbose, env) {
   if (length(expr)==2L)  # no parameters passed to mean, so defaults of trim=0 and na.rm=FALSE
     return(call(".External",quote(Cfastmean),expr[[2L]], FALSE))
     # return(call(".Internal",expr))  # slightly faster than .External, but R now blocks .Internal in coerce.c from apx Sep 2012
-  if (length(expr)==3L && identical("na",substring(names(expr)[3L], 1L, 2L)))   # one parameter passed to mean()
+  if (length(expr)==3L && identical("n", substring(names(expr)[3L], 1L, 1L)))   # one parameter passed to mean()
     return(call(".External",quote(Cfastmean),expr[[2L]], expr[[3L]]))  # faster than .Call
   assign("nomeanopt",TRUE,parent.frame())
   expr  # e.g. trim is not optimized, just na.rm

--- a/src/fastmean.c
+++ b/src/fastmean.c
@@ -51,7 +51,8 @@ SEXP fastmean(SEXP args)
     case INTSXP: {
       int *pi = INTEGER(x);
       for (i = 0; i<l; i++) {
-        if(pi[i] == NA_INTEGER) continue;
+        if (pi[i] == NA_INTEGER)
+          continue;
         s += pi[i];   // no under/overflow here, s is long double not integer
         n++;
       }
@@ -64,7 +65,8 @@ SEXP fastmean(SEXP args)
     case REALSXP: {
       double *pr = REAL(x);
       for (i = 0; i<l; i++) {
-        if(ISNAN(pr[i])) continue;  // TO DO: could drop this line and let NA propogate?
+        if (ISNAN(pr[i]))
+          continue;
         s += pr[i];
         n++;
       }
@@ -75,7 +77,7 @@ SEXP fastmean(SEXP args)
       s /= n;
       if(R_FINITE((double)s)) {
         for (i = 0; i<l; i++) {
-          if(ISNAN(pr[i])) continue;
+          if (ISNAN(pr[i])) continue;
           t += (pr[i] - s);
         }
         s += t/n;
@@ -92,7 +94,10 @@ SEXP fastmean(SEXP args)
     case INTSXP: {
       int *pi = INTEGER(x);
       for (i = 0; i<l; i++) {
-        if(pi[i] == NA_INTEGER) {UNPROTECT(1); return(ans);}
+        if (pi[i] == NA_INTEGER) {
+          UNPROTECT(1);
+          return(ans);
+        }
         s += pi[i];
       }
       REAL(ans)[0] = (double) (s/l);
@@ -101,7 +106,10 @@ SEXP fastmean(SEXP args)
     case REALSXP: {
       double *pr = REAL(x);
       for (i = 0; i<l; i++) {
-        if(ISNAN(pr[i])) {UNPROTECT(1); return(ans);}
+        if (ISNAN(pr[i])) {
+          UNPROTECT(1);
+          return(ans);
+        }
         s += pr[i];
       }
       s /= l;

--- a/src/fastmean.c
+++ b/src/fastmean.c
@@ -77,7 +77,8 @@ SEXP fastmean(SEXP args)
       s /= n;
       if(R_FINITE((double)s)) {
         for (i = 0; i<l; i++) {
-          if (ISNAN(pr[i])) continue;
+          if (ISNAN(pr[i]))
+            continue;
           t += (pr[i] - s);
         }
         s += t/n;


### PR DESCRIPTION
Closes #2799

Only noticed @jangorecki had self-assigned (and more importantly labeled for next release) after doing this part (switched to match `mean(x, n=TRUE)` and pulled out R API usage from `for` loops).

Remains is to activate this outside grouping context -- wasn't sure whether to (1) duplicate code in non-grouping case around here:

https://github.com/Rdatatable/data.table/blob/3d0dc92e811fb15d01292566c82c136502c50155/R/data.table.R#L1273

(2) move the `fastmean` code somewhere earlier so that it applies before the code splits grouping v non-grouping evaluation:

https://github.com/Rdatatable/data.table/blob/3d0dc92e811fb15d01292566c82c136502c50155/R/data.table.R#L1664-L1697

(3) write a function `do_fastmean` which can be called in both cases (necessitates creating a copy of `jsub`, though we also do that a few other places now, cost seems to be ok even for "large" `jsub`

I also noticed `CPLXSXP` code is commented out, maybe worth supporting complex now too as an addendum to #3690 