### PR TITLE
coalesce(NULL,foo) returns NULL

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -15291,6 +15291,7 @@ z_addr = address(z1)
 setcoalesce(z1, z2, z3)
 test(2060.603, address(z1), z_addr)
 test(2060.604, z1, `[<-`(z1, na_idx, c(4-2i, 5-1i, NA)))
+test(2060.605, coalesce(NULL, "foo"), NULL) # as seen in mlr using BBmisc::coalesce from example(getHyperPars), #3581
 
 # #3650 -- ensure max nrow check on CJ is applied after unique
 l = replicate(ceiling(log10(.Machine$integer.max)), rep(1L, 10L), simplify = FALSE)

--- a/man/coalesce.Rd
+++ b/man/coalesce.Rd
@@ -17,6 +17,7 @@ Factor type is supported only when the factor levels of each item are equal.
 }
 \value{
 Atomic vector of the same type and length as the first vector, having \code{NA} values replaced by corresponding non-\code{NA} values from the other vectors.
+If the first item is \code{NULL}, the result is \code{NULL}.
 }
 \seealso{
   \code{\link{fifelse}}

--- a/src/coalesce.c
+++ b/src/coalesce.c
@@ -8,7 +8,7 @@ SEXP coalesce(SEXP x, SEXP inplaceArg) {
   const bool inplace = LOGICAL(inplaceArg)[0];
   const bool verbose = GetVerbose();
   int nprotect = 0;
-  if (length(x)==0) return R_NilValue;
+  if (length(x)==0 || isNull(VECTOR_ELT(x,0))) return R_NilValue;  // coalesce(NULL, "foo") return NULL even though character type mismatches type NULL
   SEXP first;  // the first vector (it might be the first argument, or it might be the first column of a data.table|frame
   int off = 1; // when x has been pointed to the list of replacement candidates, is the first candidate in position 0 or 1 in the list
   if (TYPEOF(VECTOR_ELT(x,0)) == VECSXP) {


### PR DESCRIPTION
Part resolves `mlr` for #3581 
This was only revealed because `data.table::coalesce` masks `BBmisc::coalesce` in this case (`dplyr::coalesce` in others).  In other words, by exporting coalesce we are inflicting the new function on packages like mlr.  There was a suggestion (#3754) that we should rename `coalesce` as `fcoalesce`, so that was a good idea (reopened). We can still optimize `coalesce` to `fcoalesce` within `DT[...]`.