### PR TITLE
between tzone to pass CoSMoS

### DIFF
--- a/R/between.R
+++ b/R/between.R
@@ -21,8 +21,10 @@ between = function(x, lower, upper, incbounds=TRUE, NAbounds=TRUE) {
       tt = attr(x,"tzone",exact=TRUE)
       if (is.null(tt)) "" else tt
     })
+    # lower/upper should be more tightly linked than x/lower, so error
+    #   if the former don't match but only inform if they latter don't
     if (tzs[2L]!=tzs[3L]) {
-      stop("'between' lower= and upper= are both POSIXct but have different tzone attributes: ", brackify(tzs[2:3],quote=TRUE), ". Please align their tzone.")
+      stop("'between' lower= and upper= are both POSIXct but have different tzone attributes: ", brackify(tzs[2:3],quote=TRUE), ". Please align their time zones.")
       # otherwise the check in between.c that lower<=upper can (correctly) fail for this reason
     }
     if (tzs[1L]!=tzs[2L]) {

--- a/R/between.R
+++ b/R/between.R
@@ -17,12 +17,17 @@ between = function(x, lower, upper, incbounds=TRUE, NAbounds=TRUE) {
   }
   # POSIX check timezone match
   if (is.px(x) && is.px(lower) && is.px(upper)) {
-    tz_match = function(x, y, z) { # NULL match "", else all identical
-      ((is.null(x) || !nzchar(x)) && (is.null(y) || !nzchar(y)) && (is.null(z) || !nzchar(z))) ||
-        (identical(x, y) && identical(x, z))
+    tzs = sapply(list(x,lower,upper), function(x) {
+      tt = attr(x,"tzone",exact=TRUE)
+      if (is.null(tt)) "" else tt
+    })
+    if (tzs[2L]!=tzs[3L]) {
+      stop("'between' lower= and upper= are both POSIXct but have different tzone attributes: ", brackify(tzs[2:3],quote=TRUE), ". Please align their tzone.")
+      # otherwise the check in between.c that lower<=upper can (correctly) fail for this reason
     }
-    if (!tz_match(attr(x, "tzone", exact=TRUE), attr(lower, "tzone", exact=TRUE), attr(upper, "tzone", exact=TRUE))) {
-      stop("'between' function arguments have mismatched timezone attribute, align all arguments to same timezone")
+    if (tzs[1L]!=tzs[2L]) {
+      message("'between' arguments are all POSIXct but have mismatched tzone attributes: ", brackify(tzs,quote=TRUE),". The UTC times will be compared.")
+      # the underlying numeric is always UTC anyway in POSIXct so no coerce is needed; just compare as-is. As done by CoSMoS::example(analyzeTS), #3581
     }
   }
   if (is.i64(x)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -84,8 +84,9 @@ name_dots = function(...) {
 
 # convert a vector like c(1, 4, 3, 2) into a string like [1, 4, 3, 2]
 #   (common aggregation method for error messages)
-brackify = function(x) {
+brackify = function(x, quote=FALSE) {
   # arbitrary cutoff
+  if (quote && is.character(x)) x = paste0("'",head(x,11),"'")
   if (length(x) > 10L) x = c(x[1:10], '...')
   sprintf('[%s]', paste(x, collapse = ', '))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -85,9 +85,11 @@ name_dots = function(...) {
 # convert a vector like c(1, 4, 3, 2) into a string like [1, 4, 3, 2]
 #   (common aggregation method for error messages)
 brackify = function(x, quote=FALSE) {
-  # arbitrary cutoff
-  if (quote && is.character(x)) x = paste0("'",head(x,11),"'")
-  if (length(x) > 10L) x = c(x[1:10], '...')
+  # arbitrary
+  CUTOFF = 10L
+  # keep one more than needed to trigger dots if needed
+  if (quote && is.character(x)) x = paste0("'",head(x,CUTOFF+1L),"'")
+  if (length(x) > CUTOFF) x = c(x[1:CUTOFF], '...')
   sprintf('[%s]', paste(x, collapse = ', '))
 }
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -14729,20 +14729,26 @@ test(2038.15, between(x, dn, up), error="coercion to POSIX failed")
 x = as.POSIXct("2016-09-18 07:00:00", tz="UTC") + 0:10*60*15
 dn = as.POSIXct('2016-09-18 08:00:00')
 up = '2016-09-18 09:00:00'
-test(2038.16, between(x, dn, up), error="mismatched timezone attribute")
+test(2038.16, between(x, dn, up),
+     error="'between' lower= and upper= are both POSIXct but have different tzone attributes: ['', 'UTC']. Please align their tzone.")
+up = as.POSIXct('2016-09-18 09:00:00')
+if (attr(dn,"tzone",exact=TRUE)!="UTC") {  # normally the case on laptops (local time zone) but may be UTC on CRAN test machine for example
+  test(2038.17, length(between(x, dn, up)), 11L,  # true/false may depend on the local time zone so just test length
+     message="'between' arguments are all POSIXct but have mismatched tzone attributes: ['UTC', '', '']. The UTC times will be compared.")
+}
 
 # `between` support `.` in RHS #2315
 X = data.table(a = 1:5, b = 6:10, c = c(5:1))
-test(2038.17, X[c %between% list(a, b)], X[c %between% .(a, b)])
+test(2038.20, X[c %between% list(a, b)], X[c %between% .(a, b)])
 
 # between num to int coercion #3517
 old = options("datatable.verbose"=TRUE)
-test(2038.18, between(1:5, 2, 4), output="between parallel processing of integer")
-test(2038.19, between(1:5, 2L, 4), output="between parallel processing of integer")
-test(2038.20, between(1:5, 2, 4L), output="between parallel processing of integer")
+test(2038.31, between(1:5, 2, 4), output="between parallel processing of integer")
+test(2038.32, between(1:5, 2L, 4), output="between parallel processing of integer")
+test(2038.33, between(1:5, 2, 4L), output="between parallel processing of integer")
 # revdep regression #3565
-test(2038.21, between(1:10, -Inf, Inf),            rep(TRUE,10), output="between parallel processing of double with closed bounds")
-test(2038.22, between(as.double(1:10), -Inf, Inf), rep(TRUE,10), output="between parallel processing of double with closed bounds")
+test(2038.34, between(1:10, -Inf, Inf),            rep(TRUE,10), output="between parallel processing of double with closed bounds")
+test(2038.35, between(as.double(1:10), -Inf, Inf), rep(TRUE,10), output="between parallel processing of double with closed bounds")
 options(old)
 
 # between int64 support

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -14730,7 +14730,7 @@ x = as.POSIXct("2016-09-18 07:00:00", tz="UTC") + 0:10*60*15
 dn = as.POSIXct('2016-09-18 08:00:00')
 up = '2016-09-18 09:00:00'
 test(2038.16, between(x, dn, up),
-     error="'between' lower= and upper= are both POSIXct but have different tzone attributes: ['', 'UTC']. Please align their tzone.")
+     error="'between' lower= and upper= are both POSIXct but have different tzone attributes: ['', 'UTC']. Please align their time zones.")
 up = as.POSIXct('2016-09-18 09:00:00')
 if (attr(dn,"tzone",exact=TRUE)!="UTC") {  # normally the case on laptops (local time zone) but may be UTC on CRAN test machine for example
   test(2038.17, length(between(x, dn, up)), 11L,  # true/false may depend on the local time zone so just test length

--- a/revdep.R
+++ b/revdep.R
@@ -1,6 +1,6 @@
 # Run by package maintainer via these entries in ~/.bash_aliases :
 #   alias revdepr='cd ~/build/revdeplib/ && R_LIBS_SITE=none R_LIBS=~/build/revdeplib/ _R_CHECK_FORCE_SUGGESTS_=false R_PROFILE_USER=~/GitHub/data.table/revdep.R R'
-#   alias revdepsh='cd ~/build/revdeplib/ && export R_LIBS_SITE=none && export R_LIBS=~/build/revdeplib/ && export _R_CHECK_FORCE_SUGGESTS_=false'
+#   alias revdepsh='cd ~/build/revdeplib/ && export TZ=UTC && export R_LIBS_SITE=none && export R_LIBS=~/build/revdeplib/ && export _R_CHECK_FORCE_SUGGESTS_=false'
 # revdep = reverse first-order dependency; i.e. the CRAN and Bioconductor packages which directly use data.table (765 at the time of writing)
 
 # Check that env variables have been set correctly:


### PR DESCRIPTION
To resolve `CoSMoS` in #3581 
```
require(CoSMoS)
example(analyzeTS)
```
WIP because although CoSMoS now gets past its `between()` call with the new message, comparing as UTC means nothing passes the subset and a later line then fails, as follows :
```
> ## Load data included in the package
> ## (to find out more about the data use ?precip)
> data('precip')
> ## Don't show: 
> ## test for one month to make it fast
> precip <- precip[between(date, as.POSIXct('1990-1-01', format('%Y-%m-%d'), tz = 'America/Regina'), as.POSIXct('1990-1-5', format('%Y-%m-%d'), tz = 'America/Regina'))]
'between' arguments are all POSIXct but have mismatched tzone attributes: ['', 'America/Regina', 'America/Regina']. The UTC times will be compared.
> a <- analyzeTS(precip)
Error in cor(x, y, use = "p") : 'x' is empty
Calls: analyzeTS ... seasonalACF -> lapply -> FUN -> sapply -> lapply -> FUN -> cor
Execution halted
```

Resolved. Need to run revdeps with TZ=UTC as CRAN does.