### PR TITLE
named arguments for non-vectors used as column name prefix again

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -50,10 +50,11 @@ data.table = function(..., keep.rownames=FALSE, check.names=FALSE, key=NULL, str
   # NOTE: It may be faster in some circumstances for users to create a data.table by creating a list l
   #       first, and then setattr(l,"class",c("data.table","data.frame")) and forgo checking.
   x = list(...)   # list() doesn't copy named inputs as from R >= 3.1.0 (a very welcome change)
-  names(x) = name_dots(...)
+  nd = name_dots(...)
+  names(x) = nd$vnames
   if (length(x)==0L) return( null.data.table() )
   if (length(x)==1L && (is.null(x[[1L]]) || (is.list(x[[1L]]) && length(x[[1L]])==0L))) return( null.data.table() ) #5377
-  ans = as.data.table.list(x, keep.rownames=keep.rownames, check.names=check.names)  # see comments inside as.data.table.list re copies
+  ans = as.data.table.list(x, keep.rownames=keep.rownames, check.names=check.names, .named=nd$.named)  # see comments inside as.data.table.list re copies
   if (!is.null(key)) {
     if (!is.character(key)) stop("key argument of data.table() must be character")
     if (length(key)==1L) {

--- a/R/setkey.R
+++ b/R/setkey.R
@@ -339,7 +339,8 @@ CJ = function(..., sorted = TRUE, unique = FALSE)
     if (is.null(vnames <- names(l))) vnames = paste0("V", seq_len(length(l)))
     else if (any(tt <- vnames=="")) vnames[tt] = paste0("V", which(tt))
   } else {
-    vnames = name_dots(...)
+    vnames = name_dots(...)$vnames
+    if (any(tt <- vnames=="")) vnames[tt] = paste0("V", which(tt))
   }
   dups = FALSE # fix for #1513
   for (i in seq_along(l)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -74,12 +74,15 @@ name_dots = function(...) {
   } else {
     vnames[is.na(vnames)] = ""
   }
-  for (i in which(vnames=="")) {
-    if ((tmp <- deparse(dot_sub[[i]])[1L]) == make.names(tmp))
-      vnames[i] = tmp
+  notnamed = vnames==""
+  if (any(notnamed)) {
+    syms = sapply(dot_sub, is.symbol)  # save the deparse() in most cases of plain symbol
+    for (i in which(notnamed)) {
+      tmp = if (syms[i]) as.character(dot_sub[[i]]) else deparse(dot_sub[[i]])[1L]
+      if (tmp == make.names(tmp)) vnames[i]=tmp
+    }
   }
-  if (length(w<-which(vnames==""))) vnames[w] = paste0("V", w)
-  vnames
+  list(vnames=vnames, .named=!notnamed)
 }
 
 # convert a vector like c(1, 4, 3, 2) into a string like [1, 4, 3, 2]

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -15102,11 +15102,11 @@ test(2056, as.data.table(a), ans)
 DF = structure(list(a=1:3, b=data.frame(foo=4:6, bar=7:9)), row.names=1:3, class="data.frame")
 DT = as.data.table(DF)
 test(2057.1, ncol(DT), 3L)
-test(2057.2, DT[2], data.table(a=2L, foo=5L, bar=8L))
+test(2057.2, DT[2], data.table(a=2L, b.foo=5L, b.bar=8L))
 DF = structure(list(a=list(c("a","b"), c("a","b"), c("a","b")), b=data.frame(foo=1:3, bar=4:6)), row.names=1:3, class="data.frame")
 #  A list being first is needed to mimic the jsonlite case. With this passing, test.R works from https://github.com/Rdatatable/data.table/issues/3369#issuecomment-462662752
 DT = as.data.table(DF)
-test(2057.3, DT, data.table(a=list(c("a","b"), c("a","b"), c("a","b")), foo=1:3, bar=4:6))
+test(2057.3, DT, data.table(a=list(c("a","b"), c("a","b"), c("a","b")), b.foo=1:3, b.bar=4:6))
 
 # one and two+ row cases of data.table, as.data.table and cbind involving list columns, given
 # the change to tests 1613.571-3 in PR#3471 in v1.12.4
@@ -15140,6 +15140,11 @@ test(2058.08, sapply(ans, class), c(V1="integer", V2="list"))                   
 test(2058.09, data.table( data.table(1:2), list(c("a","b"),"a") ),        ans)  # yes
 test(2058.10, as.data.table(list(data.table(1:2), list(c("a","b"),"a"))), ans)  # yes
 test(2058.11, cbind(data.table(1:2), list(c("a","b"),"a")),               ans)  # yes
+test(2058.12, cbind(first=data.table(A=1:3), second=data.table(A=4, B=5:7)),
+              data.table(first.A=1:3, second.A=4, second.B=5:7))                # no
+test(2058.13, cbind(data.table(A=1:3), second=data.table(A=4, B=5:7)),
+              data.table(A=1:3, second.A=4, second.B=5:7))                      # no
+test(2058.14, cbind(data.table(A=1,B=2),3), data.table(A=1,B=2,V2=3))           # no
 
 # rbindlist improved error message, #3638
 DT = data.table(a=1)


### PR DESCRIPTION
Resolves `recorder` and `rbi` in #3581 