### PR TITLE
Fixed LTO warnings

### DIFF
--- a/cc.R
+++ b/cc.R
@@ -61,9 +61,9 @@ cc = function(test=TRUE, clean=FALSE, debug=FALSE, omp=!debug, cc_dir=Sys.getenv
   if (clean) system("rm *.o *.so")
   OMP = if (omp) "" else "no-"
   if (debug) {
-    ret = system(sprintf("MAKEFLAGS='-j CC=%s PKG_CFLAGS=-f%sopenmp CFLAGS=-std=c99\\ -O0\\ -ggdb\\ -pedantic' R CMD SHLIB -d -o data.table.so *.c", CC, OMP))
+    ret = system(sprintf("MAKEFLAGS='-j CC=%s PKG_CFLAGS=-f%sopenmp CFLAGS=-std=c99\\ -O0\\ -ggdb\\ -pedantic\\ -flto' R CMD SHLIB -d -o data.table.so *.c", CC, OMP))
   } else {
-    ret = system(sprintf("MAKEFLAGS='-j CC=%s CFLAGS=-f%sopenmp\\ -std=c99\\ -O3\\ -pipe\\ -Wall\\ -pedantic' R CMD SHLIB -o data.table.so *.c", CC, OMP))
+    ret = system(sprintf("MAKEFLAGS='-j CC=%s CFLAGS=-f%sopenmp\\ -std=c99\\ -O3\\ -pipe\\ -Wall\\ -pedantic\\ -flto' R CMD SHLIB -o data.table.so *.c", CC, OMP))
     # TODO add -Wextra too?
   }
   if (ret) return()

--- a/src/fwrite.c
+++ b/src/fwrite.c
@@ -35,12 +35,12 @@ static int8_t doQuote=INT8_MIN;        // whether to surround fields with double
 static bool qmethodEscape=false;       // when quoting fields, how to escape double quotes in the field contents (default false means to add another double quote)
 static bool squashDateTime=false;      // 0=ISO(yyyy-mm-dd) 1=squash(yyyymmdd)
 
-extern const char *getString(void *, int);
-extern const int getStringLen(void *, int);
+extern const char *getString(void *, int64_t);
+extern const int getStringLen(void *, int64_t);
 extern const int getMaxStringLen(void *, int64_t);
 extern const int getMaxCategLen(void *);
 extern const int getMaxListItemLen(void *, int64_t);
-extern const char *getCategString(void *, int);
+extern const char *getCategString(void *, int64_t);
 extern double wallclock(void);
 
 inline void write_chars(const char *x, char **pch)


### PR DESCRIPTION
LTO CRAN 'additional check'.
```
* installing *source* package ‘data.table’ ...
** package ‘data.table’ successfully unpacked and MD5 sums checked
** using staged installation
** libs
make[2]: Entering directory '/data/gannet/ripley/R/packages/tests-LTO/data.table/src'
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c assign.c -o assign.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c between.c -o between.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c bmerge.c -o bmerge.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c chmatch.c -o chmatch.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c dogroups.c -o dogroups.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c fastmean.c -o fastmean.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c fcast.c -o fcast.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c fmelt.c -o fmelt.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c forder.c -o forder.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c frank.c -o frank.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c fread.c -o fread.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c freadR.c -o freadR.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c froll.c -o froll.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c frollR.c -o frollR.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c frolladaptive.c -o frolladaptive.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c fsort.c -o fsort.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c fwrite.c -o fwrite.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c fwriteR.c -o fwriteR.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c gsumm.c -o gsumm.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c ijoin.c -o ijoin.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c init.c -o init.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c inrange.c -o inrange.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c nqrecreateindices.c -o nqrecreateindices.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c openmp-utils.c -o openmp-utils.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c quickselect.c -o quickselect.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c rbindlist.c -o rbindlist.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c reorder.c -o reorder.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c shift.c -o shift.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c subset.c -o subset.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c transpose.c -o transpose.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c uniqlist.c -o uniqlist.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c vecseq.c -o vecseq.o
gcc -I"/data/gannet/ripley/R/LTO9/include" -DNDEBUG   -I/usr/local/include  -fopenmp -fpic  -g -O2 -Wall -pedantic -mtune=native -flto -c wrappers.c -o wrappers.o
gcc -shared -g -O2 -Wall -pedantic -mtune=native -flto -fpic -L/usr/local/lib64 -o data.table.so assign.o between.o bmerge.o chmatch.o dogroups.o fastmean.o fcast.o fmelt.o forder.o frank.o fread.o freadR.o froll.o frollR.o frolladaptive.o fsort.o fwrite.o fwriteR.o gsumm.o ijoin.o init.o inrange.o nqrecreateindices.o openmp-utils.o quickselect.o rbindlist.o reorder.o shift.o subset.o transpose.o uniqlist.o vecseq.o wrappers.o -fopenmp
fwrite.c:36:20: warning: type of ‘getCategString’ does not match original declaration [-Wlto-type-mismatch]
   36 | extern const char *getCategString(void *, int);
      |                    ^
fwriteR.c:23:13: note: type mismatch in parameter 2
   23 | const char *getCategString(SEXP col, int64_t row) {
      |             ^
fwriteR.c:23:13: note: type ‘int64_t’ should match type ‘int’
fwriteR.c:23:13: note: ‘getCategString’ was previously declared here
fwriteR.c:23:13: note: code may be misoptimized unless ‘-fno-strict-aliasing’ is used
fwrite.c:35:20: warning: type of ‘getString’ does not match original declaration [-Wlto-type-mismatch]
   35 | extern const char *getString(void *, int);
      |                    ^
fwriteR.c:18:13: note: type mismatch in parameter 2
   18 | const char *getString(SEXP *col, int64_t row) {   // TODO: inline for use in fwrite.c
      |             ^
fwriteR.c:18:13: note: type ‘int64_t’ should match type ‘int’
fwriteR.c:18:13: note: ‘getString’ was previously declared here
fwriteR.c:18:13: note: code may be misoptimized unless ‘-fno-strict-aliasing’ is used
mv data.table.so datatable.so
if [ "" != "Windows_NT" ] && [ `uname -s` = 'Darwin' ]; then install_name_tool -id datatable.so datatable.so; fi
make[2]: Leaving directory '/data/gannet/ripley/R/packages/tests-LTO/data.table/src'
installing to /data/gannet/ripley/R/packages/tests-LTO/Libs/data.table-lib/00LOCK-data.table/00new/data.table/libs
** R
** inst
** byte-compile and prepare package for lazy loading
** help
*** installing help indices
** building package indices
** installing vignettes
** testing if installed package can be loaded from temporary location
** checking absolute paths in shared objects and dynamic libraries
** testing if installed package can be loaded from final location
** testing if installed package keeps a record of temporary installation path
* DONE (data.table)
Time 1:54.27, 43.94 + 2.22
```