### PR TITLE
Pass rchk

### DIFF
--- a/CRAN_Release.cmd
+++ b/CRAN_Release.cmd
@@ -143,7 +143,7 @@ remove.packages("xml2")    # we checked the URLs; don't need to do it again (man
 require(data.table)
 test.data.table()
 test.data.table(script="other.Rraw")
-test.data.table(script="froll.Rraw")
+test.data.table(script="*.Rraw")
 test.data.table(verbose=TRUE)   # since main.R no longer tests verbose mode
 gctorture2(step=50)
 system.time(test.data.table())  # apx 4hrs
@@ -170,7 +170,7 @@ cd ~/GitHub/data.table
 R310 CMD INSTALL ./data.table_1.12.3.tar.gz
 R310
 require(data.table)
-test.data.table()
+test.data.table(script="*.Rraw")
 
 
 ############################################
@@ -228,8 +228,8 @@ options(repos = "http://cloud.r-project.org")
 install.packages(c("bit64","xts","nanotime","R.utils","yaml")) # minimum packages needed to not skip any tests in test.data.table()
 # install.packages(c("curl","knitr"))                          # for `R CMD check` when not strict. Too slow to install when strict
 require(data.table)
-test.data.table()      # 7 mins (vs 1min normally) under UBSAN, ASAN and --strict-barrier
-test.data.table(script="froll.Rraw")  # without the fix in PR#3515, the --disable-long-double lumped into this build does now work and correctly reproduces the noLD problem
+test.data.table(script="*.Rraw") # 7 mins (vs 1min normally) under UBSAN, ASAN and --strict-barrier
+                                 # without the fix in PR#3515, the --disable-long-double lumped into this build does now work and correctly reproduces the noLD problem
 # If any problems, edit ~/.R/Makevars and activate "CFLAGS=-O0 -g" to trace. Rerun 'Rdevel-strict CMD INSTALL' and rerun tests.
 for (i in 1:10) if (!test.data.table()) break  # try several runs maybe even 100; e.g a few tests generate data with a non-fixed random seed
 # gctorture(TRUE)      # very slow, many days

--- a/CRAN_Release.cmd
+++ b/CRAN_Release.cmd
@@ -143,6 +143,7 @@ remove.packages("xml2")    # we checked the URLs; don't need to do it again (man
 require(data.table)
 test.data.table()
 test.data.table(script="other.Rraw")
+test.data.table(script="froll.Rraw")
 test.data.table(verbose=TRUE)   # since main.R no longer tests verbose mode
 gctorture2(step=50)
 system.time(test.data.table())  # apx 4hrs

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -14,10 +14,12 @@ test.data.table = function(verbose=FALSE, pkg="pkg", silent=FALSE, with.other.pa
   fulldir = file.path(rootdir, subdir)
 
   if (identical(script,"*.Rraw")) {
+    # nocov start
     scripts = dir(fulldir, "*.Rraw")
     scripts = scripts[!scripts %in% c("benchmark.Rraw","other.Rraw")]
     for (fn in scripts) {test.data.table(verbose=verbose, pkg=pkg, silent=silent, script=fn); cat("\n");}
     return(invisible())
+    # nocov end
   }
 
   # nocov start

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -13,6 +13,13 @@ test.data.table = function(verbose=FALSE, pkg="pkg", silent=FALSE, with.other.pa
   }
   fulldir = file.path(rootdir, subdir)
 
+  if (identical(script,"*.Rraw")) {
+    scripts = dir(fulldir, "*.Rraw")
+    scripts = scripts[!scripts %in% c("benchmark.Rraw","other.Rraw")]
+    for (fn in scripts) {test.data.table(verbose=verbose, pkg=pkg, silent=silent, script=fn); cat("\n");}
+    return(invisible())
+  }
+
   # nocov start
   if (isTRUE(benchmark)) {
     warning("'benchmark' argument is deprecated, use script='benchmark.Rraw' instead")

--- a/src/dogroups.c
+++ b/src/dogroups.c
@@ -6,8 +6,8 @@
 SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEXP xjiscols, SEXP grporder, SEXP order, SEXP starts, SEXP lens, SEXP jexp, SEXP env, SEXP lhs, SEXP newnames, SEXP on, SEXP verbose)
 {
   R_len_t rownum, ngrp, nrowgroups, njval=0, ngrpcols, ansloc=0, maxn, estn=-1, thisansloc, grpn, thislen, igrp, origIlen=0, origSDnrow=0;
-  int protecti=0;
-  SEXP names, names2, xknames, bynames, dtnames, ans=NULL, jval, thiscol, BY, N, I, GRP, iSD, xSD, rownames, s, RHS, listwrap, target, source, tmp;
+  int nprotect=0;
+  SEXP ans=NULL, jval, thiscol, BY, N, I, GRP, iSD, xSD, rownames, s, RHS, target, source, tmp;
   Rboolean wasvector, firstalloc=FALSE, NullWarnDone=FALSE;
   clock_t tstart=0, tblock[10]={0}; int nblock[10]={0};
 
@@ -22,11 +22,11 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
   ngrpcols = length(grpcols);
   nrowgroups = length(VECTOR_ELT(groups,0));
   // fix for longstanding FR/bug, #495. E.g., DT[, c(sum(v1), lapply(.SD, mean)), by=grp, .SDcols=v2:v3] resulted in error.. the idea is, 1) we create .SDall, which is normally == .SD. But if extra vars are detected in jexp other than .SD, then .SD becomes a shallow copy of .SDall with only .SDcols in .SD. Since internally, we don't make a copy, changing .SDall will reflect in .SD. Hopefully this'll workout :-).
-  SEXP SDall = PROTECT(findVar(install(".SDall"), env)); protecti++;  // PROTECT for rchk
-  SEXP SD = PROTECT(findVar(install(".SD"), env)); protecti++;
+  SEXP SDall = PROTECT(findVar(install(".SDall"), env)); nprotect++;  // PROTECT for rchk
+  SEXP SD = PROTECT(findVar(install(".SD"), env)); nprotect++;
 
-  defineVar(sym_BY, BY = PROTECT(allocVector(VECSXP, ngrpcols)), env); protecti++;  // PROTECT for rchk
-  bynames = PROTECT(allocVector(STRSXP, ngrpcols));  protecti++;   // TO DO: do we really need bynames, can we assign names afterwards in one step?
+  defineVar(sym_BY, BY = PROTECT(allocVector(VECSXP, ngrpcols)), env); nprotect++;  // PROTECT for rchk
+  SEXP bynames = PROTECT(allocVector(STRSXP, ngrpcols));  nprotect++;   // TO DO: do we really need bynames, can we assign names afterwards in one step?
   for (int i=0; i<ngrpcols; ++i) {
     int j = INTEGER(grpcols)[i]-1;
     SET_VECTOR_ELT(BY, i, allocVector(TYPEOF(VECTOR_ELT(groups, j)),
@@ -43,19 +43,19 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
   if (isNull(jiscols) && (length(bynames)!=length(groups) || length(bynames)!=length(grpcols))) error("!length(bynames)[%d]==length(groups)[%d]==length(grpcols)[%d]",length(bynames),length(groups),length(grpcols));
   // TO DO: check this check above.
 
-  N =   PROTECT(findVar(install(".N"), env));   protecti++; // PROTECT for rchk
-  GRP = PROTECT(findVar(install(".GRP"), env)); protecti++;
-  iSD = PROTECT(findVar(install(".iSD"), env)); protecti++; // 1-row and possibly no cols (if no i variables are used via JIS)
-  xSD = PROTECT(findVar(install(".xSD"), env)); protecti++;
+  N =   PROTECT(findVar(install(".N"), env));   nprotect++; // PROTECT for rchk
+  GRP = PROTECT(findVar(install(".GRP"), env)); nprotect++;
+  iSD = PROTECT(findVar(install(".iSD"), env)); nprotect++; // 1-row and possibly no cols (if no i variables are used via JIS)
+  xSD = PROTECT(findVar(install(".xSD"), env)); nprotect++;
   R_len_t maxGrpSize = 0;
   const int *ilens = INTEGER(lens), n=LENGTH(lens);
   for (R_len_t i=0; i<n; ++i) {
     if (ilens[i] > maxGrpSize) maxGrpSize = ilens[i];
   }
-  defineVar(install(".I"), I = PROTECT(allocVector(INTSXP, maxGrpSize)), env); protecti++;
+  defineVar(install(".I"), I = PROTECT(allocVector(INTSXP, maxGrpSize)), env); nprotect++;
   R_LockBinding(install(".I"), env);
 
-  dtnames = PROTECT(getAttrib(dt, R_NamesSymbol)); protecti++; // added here to fix #4990 - `:=` did not issue recycling warning during "by"
+  SEXP dtnames = PROTECT(getAttrib(dt, R_NamesSymbol)); nprotect++; // added here to fix #4990 - `:=` did not issue recycling warning during "by"
   // fetch rownames of .SD.  rownames[1] is set to -thislen for each group, in case .SD is passed to
   // non data.table aware package that uses rownames
   for (s = ATTRIB(SD); s != R_NilValue && TAG(s)!=R_RowNamesSymbol; s = CDR(s));  // getAttrib0 basically but that's hidden in attrib.c
@@ -65,7 +65,7 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
 
   // fetch names of .SD and prepare symbols. In case they are copied-on-write by user assigning to those variables
   // using <- in j (which is valid, useful and tested), they are repointed to the .SD cols for each group.
-  names = PROTECT(getAttrib(SDall, R_NamesSymbol)); protecti++;
+  SEXP names = PROTECT(getAttrib(SDall, R_NamesSymbol)); nprotect++;
   if (length(names) != length(SDall)) error("length(names)!=length(SD)");
   SEXP *nameSyms = (SEXP *)R_alloc(length(names), sizeof(SEXP));
   for(int i=0; i<length(SDall); ++i) {
@@ -79,7 +79,7 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
   origIlen = length(I);  // test 762 has length(I)==1 but nrow(SD)==0
   if (length(SDall)) origSDnrow = length(VECTOR_ELT(SDall, 0));
 
-  xknames = getAttrib(xSD, R_NamesSymbol);
+  SEXP xknames = PROTECT(getAttrib(xSD, R_NamesSymbol)); nprotect++;
   if (length(xknames) != length(xSD)) error("length(xknames)!=length(xSD)");
   SEXP *xknameSyms = (SEXP *)R_alloc(length(xknames), sizeof(SEXP));
   for(int i=0; i<length(xSD); ++i) {
@@ -91,8 +91,7 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
   if (length(iSD)!=length(jiscols)) error("length(iSD)[%d] != length(jiscols)[%d]",length(iSD),length(jiscols));
   if (length(xSD)!=length(xjiscols)) error("length(xSD)[%d] != length(xjiscols)[%d]",length(xSD),length(xjiscols));
 
-  PROTECT(listwrap = allocVector(VECSXP, 1));
-  protecti++;
+  SEXP listwrap = PROTECT(allocVector(VECSXP, 1)); nprotect++;
   Rboolean jexpIsSymbolOtherThanSD = (isSymbol(jexp) && strcmp(CHAR(PRINTNAME(jexp)),".SD")!=0);  // test 559
 
   ansloc = 0;
@@ -355,7 +354,7 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
           // Common case 3 : head or tail of .SD perhaps
         if (estn<maxn) estn=maxn;  // if the result for the first group is larger than the table itself(!) Unusual case where a join is being done in j via .SD and the 1-row table is an edge case of bigger picture.
         PROTECT(ans = allocVector(VECSXP, ngrpcols + njval));
-        protecti++;
+        nprotect++;
         firstalloc=TRUE;
         for(int j=0; j<ngrpcols; ++j) {
           thiscol = VECTOR_ELT(groups, INTEGER(grpcols)[j]-1);
@@ -376,17 +375,18 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
           SET_VECTOR_ELT(ans, ngrpcols+j, allocVector(TYPEOF(thiscol), estn));
           copyMostAttrib(thiscol, VECTOR_ELT(ans,ngrpcols+j));  // not names, otherwise test 276 would fail
         }
-        names = getAttrib(jval, R_NamesSymbol);
-        if (!isNull(names)) {
+        SEXP jvalnames = PROTECT(getAttrib(jval, R_NamesSymbol));
+        if (!isNull(jvalnames)) {
           if (LOGICAL(verbose)[0]) Rprintf("The result of j is a named list. It's very inefficient to create the same names over and over again for each group. When j=list(...), any names are detected, removed and put back after grouping has completed, for efficiency. Using j=transform(), for example, prevents that speedup (consider changing to :=). This message may be upgraded to warning in future.\n");  // e.g. test 104 has j=transform().
           // names of result come from the first group and the names of remaining groups are ignored (all that matters for them is that the number of columns (and their types) match the first group.
-          names2 = PROTECT(allocVector(STRSXP,ngrpcols+njval));
-          protecti++;
+          SEXP names2 = PROTECT(allocVector(STRSXP,ngrpcols+njval));
           //  for (j=0; j<ngrpcols; j++) SET_STRING_ELT(names2, j, STRING_ELT(bynames,j));  // These get set back up in R
-          for (int j=0; j<njval; ++j) SET_STRING_ELT(names2, ngrpcols+j, STRING_ELT(names,j));
+          for (int j=0; j<njval; ++j) SET_STRING_ELT(names2, ngrpcols+j, STRING_ELT(jvalnames,j));
           setAttrib(ans, R_NamesSymbol, names2);
+          UNPROTECT(1); // names2
           // setAttrib(SD, R_NamesSymbol, R_NilValue); // so that lapply(.SD,mean) is unnamed from 2nd group on
         }
+        UNPROTECT(1); // jvalnames
       } else {
         estn = ((double)ngrp/i)*1.1*(ansloc+maxn);
         if (LOGICAL(verbose)[0]) Rprintf("dogroups: growing from %d to %d rows\n", length(VECTOR_ELT(ans,0)), estn);
@@ -462,7 +462,7 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
     }
     ansloc += maxn;
     if (firstalloc) {
-      protecti++;          //  remember the first jval. If we UNPROTECTed now, we'd unprotect
+      nprotect++;          //  remember the first jval. If we UNPROTECTed now, we'd unprotect
       firstalloc = FALSE;  //  ans. The first jval is needed to create the right size and type of ans.
       // TO DO: could avoid this last 'if' by adding a dummy PROTECT after first alloc for this UNPROTECT(1) to do.
     }
@@ -486,7 +486,7 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
                           1.0*tblock[w]/CLOCKS_PER_SEC, nblock[w]);
     Rprintf("  eval(j) took %.3fs for %d calls\n", 1.0*tblock[2]/CLOCKS_PER_SEC, nblock[2]);
   }
-  UNPROTECT(protecti);
+  UNPROTECT(nprotect);
   return(ans);
 }
 

--- a/src/fcast.c
+++ b/src/fcast.c
@@ -19,17 +19,15 @@ SEXP fcast(SEXP lhs, SEXP val, SEXP nrowArg, SEXP ncolArg, SEXP idxArg, SEXP fil
   for (int i=0; i<nval; ++i) {
     SEXP thiscol = VECTOR_ELT(val, i);
     SEXP thisfill = fill;
-    bool count=false;
+    int nprotect = 0;
     if (isNull(fill)) {
       isfill = false;
       if (LOGICAL(is_agg)[0]) {
-        thisfill = PROTECT(allocNAVector(TYPEOF(thiscol), 1));
-        count = true;
+        thisfill = PROTECT(allocNAVector(TYPEOF(thiscol), 1)); nprotect++;
       } else thisfill = VECTOR_ELT(fill_d, i);
     }
     if (isfill && TYPEOF(fill) != TYPEOF(thiscol)) {
-      thisfill = PROTECT(coerceVector(fill, TYPEOF(thiscol)));
-      count = true;
+      thisfill = PROTECT(coerceVector(fill, TYPEOF(thiscol))); nprotect++;
     }
     switch (TYPEOF(thiscol)) {
     case INTSXP:
@@ -81,7 +79,7 @@ SEXP fcast(SEXP lhs, SEXP val, SEXP nrowArg, SEXP ncolArg, SEXP idxArg, SEXP fil
       break;
     default: error("Unsupported column type in fcast val: '%s'", type2char(TYPEOF(thiscol))); // #nocov
     }
-    if (count) UNPROTECT(1);
+    UNPROTECT(nprotect);
   }
   UNPROTECT(1);
   return(ans);

--- a/src/fmelt.c
+++ b/src/fmelt.c
@@ -91,19 +91,19 @@ SEXP concat(SEXP vec, SEXP idx) {
 
 // deal with measure.vars of type VECSXP
 SEXP measurelist(SEXP measure, SEXP dtnames) {
-  int i, n=length(measure), nprotect=0;
+  int i, n=length(measure), protecti=0;
   SEXP ans, tmp;
-  ans = PROTECT(allocVector(VECSXP, n)); nprotect++;
+  ans = PROTECT(allocVector(VECSXP, n)); protecti++;
   for (i=0; i<n; i++) {
     switch(TYPEOF(VECTOR_ELT(measure, i))) {
-      case STRSXP  : tmp = PROTECT(chmatch(VECTOR_ELT(measure, i), dtnames, 0)); nprotect++; break;
-      case REALSXP : tmp = PROTECT(coerceVector(VECTOR_ELT(measure, i), INTSXP)); nprotect++; break;
+      case STRSXP  : tmp = PROTECT(chmatch(VECTOR_ELT(measure, i), dtnames, 0)); protecti++; break;
+      case REALSXP : tmp = PROTECT(coerceVector(VECTOR_ELT(measure, i), INTSXP)); protecti++; break;
       case INTSXP  : tmp = VECTOR_ELT(measure, i); break;
       default : error("Unknown 'measure.vars' type %s at index %d of list", type2char(TYPEOF(VECTOR_ELT(measure, i))), i+1);
     }
     SET_VECTOR_ELT(ans, i, tmp);
   }
-  UNPROTECT(nprotect);
+  UNPROTECT(protecti);
   return(ans);
 }
 
@@ -125,17 +125,17 @@ static SEXP unlist_(SEXP xint) {
 }
 
 SEXP checkVars(SEXP DT, SEXP id, SEXP measure, Rboolean verbose) {
-  int i, ncol=LENGTH(DT), targetcols=0, nprotect=0, u=0, v=0;
+  int i, ncol=LENGTH(DT), targetcols=0, protecti=0, u=0, v=0;
   SEXP thiscol, idcols = R_NilValue, valuecols = R_NilValue, tmp, tmp2, booltmp, unqtmp, ans;
-  SEXP dtnames = PROTECT(getAttrib(DT, R_NamesSymbol)); nprotect++;
+  SEXP dtnames = PROTECT(getAttrib(DT, R_NamesSymbol)); protecti++;
 
   if (isNull(id) && isNull(measure)) {
     for (i=0; i<ncol; i++) {
       thiscol = VECTOR_ELT(DT, i);
       if ((isInteger(thiscol) || isNumeric(thiscol) || isLogical(thiscol)) && !isFactor(thiscol)) targetcols++;
     }
-    idcols = PROTECT(allocVector(INTSXP, ncol-targetcols)); nprotect++;
-    tmp = PROTECT(allocVector(INTSXP, targetcols)); nprotect++;
+    idcols = PROTECT(allocVector(INTSXP, ncol-targetcols)); protecti++;
+    tmp = PROTECT(allocVector(INTSXP, targetcols)); protecti++;
     for (i=0; i<ncol; i++) {
       thiscol = VECTOR_ELT(DT, i);
       if ((isInteger(thiscol) || isNumeric(thiscol) || isLogical(thiscol)) && !isFactor(thiscol)) {
@@ -143,32 +143,32 @@ SEXP checkVars(SEXP DT, SEXP id, SEXP measure, Rboolean verbose) {
       } else
         INTEGER(idcols)[v++] = i+1;
     }
-    valuecols = PROTECT(allocVector(VECSXP, 1)); nprotect++;
+    valuecols = PROTECT(allocVector(VECSXP, 1)); protecti++;
     SET_VECTOR_ELT(valuecols, 0, tmp);
     warning("id.vars and measure.vars are internally guessed when both are 'NULL'. All non-numeric/integer/logical type columns are considered id.vars, which in this case are columns [%s]. Consider providing at least one of 'id' or 'measure' vars in future.", CHAR(STRING_ELT(concat(dtnames, idcols), 0)));
   } else if (!isNull(id) && isNull(measure)) {
     switch(TYPEOF(id)) {
-      case STRSXP  : PROTECT(tmp = chmatch(id, dtnames, 0)); nprotect++; break;
-      case REALSXP : PROTECT(tmp = coerceVector(id, INTSXP)); nprotect++; break;
+      case STRSXP  : PROTECT(tmp = chmatch(id, dtnames, 0)); protecti++; break;
+      case REALSXP : PROTECT(tmp = coerceVector(id, INTSXP)); protecti++; break;
       case INTSXP  : tmp = id; break;
       default : error("Unknown 'id.vars' type %s, must be character or integer vector", type2char(TYPEOF(id)));
     }
-    booltmp = PROTECT(duplicated(tmp, FALSE)); nprotect++;
+    booltmp = PROTECT(duplicated(tmp, FALSE)); protecti++;
     for (i=0; i<length(tmp); i++) {
       if (INTEGER(tmp)[i] <= 0 || INTEGER(tmp)[i] > ncol)
         error("One or more values in 'id.vars' is invalid.");
       else if (!LOGICAL(booltmp)[i]) targetcols++;
       else continue;
     }
-    unqtmp = PROTECT(allocVector(INTSXP, targetcols)); nprotect++;
+    unqtmp = PROTECT(allocVector(INTSXP, targetcols)); protecti++;
     u = 0;
     for (i=0; i<length(booltmp); i++) {
       if (!LOGICAL(booltmp)[i]) {
         INTEGER(unqtmp)[u++] = INTEGER(tmp)[i];
       }
     }
-    tmp2 = PROTECT(set_diff(unqtmp, ncol)); nprotect++;
-    valuecols = PROTECT(allocVector(VECSXP, 1)); nprotect++;
+    tmp2 = PROTECT(set_diff(unqtmp, ncol)); protecti++;
+    valuecols = PROTECT(allocVector(VECSXP, 1)); protecti++;
     SET_VECTOR_ELT(valuecols, 0, tmp2);
     idcols = tmp;
     if (verbose) {
@@ -177,34 +177,34 @@ SEXP checkVars(SEXP DT, SEXP id, SEXP measure, Rboolean verbose) {
     }
   } else if (isNull(id) && !isNull(measure)) {
     switch(TYPEOF(measure)) {
-      case STRSXP  : tmp2 = PROTECT(chmatch(measure, dtnames, 0)); nprotect++; break;
-      case REALSXP : tmp2 = PROTECT(coerceVector(measure, INTSXP)); nprotect++; break;
+      case STRSXP  : tmp2 = PROTECT(chmatch(measure, dtnames, 0)); protecti++; break;
+      case REALSXP : tmp2 = PROTECT(coerceVector(measure, INTSXP)); protecti++; break;
       case INTSXP  : tmp2 = measure; break;
-      case VECSXP  : tmp2 = PROTECT(measurelist(measure, dtnames)); nprotect++; break;
+      case VECSXP  : tmp2 = PROTECT(measurelist(measure, dtnames)); protecti++; break;
       default : error("Unknown 'measure.vars' type %s, must be character or integer vector/list", type2char(TYPEOF(measure)));
     }
     tmp = tmp2;
     if (isNewList(measure)) {
-      tmp = PROTECT(unlist_(tmp2)); nprotect++;
+      tmp = PROTECT(unlist_(tmp2)); protecti++;
     }
-    booltmp = PROTECT(duplicated(tmp, FALSE)); nprotect++;
+    booltmp = PROTECT(duplicated(tmp, FALSE)); protecti++;
     for (i=0; i<length(tmp); i++) {
       if (INTEGER(tmp)[i] <= 0 || INTEGER(tmp)[i] > ncol)
         error("One or more values in 'measure.vars' is invalid.");
       else if (!LOGICAL(booltmp)[i]) targetcols++;
       else continue;
     }
-    unqtmp = PROTECT(allocVector(INTSXP, targetcols)); nprotect++;
+    unqtmp = PROTECT(allocVector(INTSXP, targetcols)); protecti++;
     u = 0;
     for (i=0; i<length(booltmp); i++) {
       if (!LOGICAL(booltmp)[i]) {
         INTEGER(unqtmp)[u++] = INTEGER(tmp)[i];
       }
     }
-    idcols = PROTECT(set_diff(unqtmp, ncol)); nprotect++;
+    idcols = PROTECT(set_diff(unqtmp, ncol)); protecti++;
     if (isNewList(measure)) valuecols = tmp2;
     else {
-      valuecols = PROTECT(allocVector(VECSXP, 1)); nprotect++;
+      valuecols = PROTECT(allocVector(VECSXP, 1)); protecti++;
       SET_VECTOR_ELT(valuecols, 0, tmp2);
     }
     if (verbose) {
@@ -213,8 +213,8 @@ SEXP checkVars(SEXP DT, SEXP id, SEXP measure, Rboolean verbose) {
     }
   } else if (!isNull(id) && !isNull(measure)) {
     switch(TYPEOF(id)) {
-      case STRSXP  : tmp = PROTECT(chmatch(id, dtnames, 0)); nprotect++; break;
-      case REALSXP : tmp = PROTECT(coerceVector(id, INTSXP)); nprotect++; break;
+      case STRSXP  : tmp = PROTECT(chmatch(id, dtnames, 0)); protecti++; break;
+      case REALSXP : tmp = PROTECT(coerceVector(id, INTSXP)); protecti++; break;
       case INTSXP  : tmp = id; break;
       default : error("Unknown 'id.vars' type %s, must be character or integer vector", type2char(TYPEOF(id)));
     }
@@ -222,17 +222,17 @@ SEXP checkVars(SEXP DT, SEXP id, SEXP measure, Rboolean verbose) {
       if (INTEGER(tmp)[i] <= 0 || INTEGER(tmp)[i] > ncol)
         error("One or more values in 'id.vars' is invalid.");
     }
-    idcols = PROTECT(tmp); nprotect++;
+    idcols = PROTECT(tmp); protecti++;
     switch(TYPEOF(measure)) {
-      case STRSXP  : tmp2 = PROTECT(chmatch(measure, dtnames, 0)); nprotect++; break;
-      case REALSXP : tmp2 = PROTECT(coerceVector(measure, INTSXP)); nprotect++; break;
+      case STRSXP  : tmp2 = PROTECT(chmatch(measure, dtnames, 0)); protecti++; break;
+      case REALSXP : tmp2 = PROTECT(coerceVector(measure, INTSXP)); protecti++; break;
       case INTSXP  : tmp2 = measure; break;
-      case VECSXP  : tmp2 = PROTECT(measurelist(measure, dtnames)); nprotect++; break;
+      case VECSXP  : tmp2 = PROTECT(measurelist(measure, dtnames)); protecti++; break;
       default : error("Unknown 'measure.vars' type %s, must be character or integer vector", type2char(TYPEOF(measure)));
     }
     tmp = tmp2;
     if (isNewList(measure)) {
-      tmp = PROTECT(unlist_(tmp2)); nprotect++;
+      tmp = PROTECT(unlist_(tmp2)); protecti++;
     }
     for (i=0; i<length(tmp); i++) {
       if (INTEGER(tmp)[i] <= 0 || INTEGER(tmp)[i] > ncol)
@@ -240,14 +240,14 @@ SEXP checkVars(SEXP DT, SEXP id, SEXP measure, Rboolean verbose) {
     }
     if (isNewList(measure)) valuecols = tmp2;
     else {
-      valuecols = PROTECT(allocVector(VECSXP, 1)); nprotect++;
+      valuecols = PROTECT(allocVector(VECSXP, 1)); protecti++;
       SET_VECTOR_ELT(valuecols, 0, tmp2);
     }
   }
-  ans = PROTECT(allocVector(VECSXP, 2)); nprotect++;
+  ans = PROTECT(allocVector(VECSXP, 2)); protecti++;
   SET_VECTOR_ELT(ans, 0, idcols);
   SET_VECTOR_ELT(ans, 1, valuecols);
-  UNPROTECT(nprotect);
+  UNPROTECT(protecti);
   return(ans);
 }
 
@@ -422,7 +422,7 @@ SEXP getvaluecols(SEXP DT, SEXP dtnames, Rboolean valfactor, Rboolean verbose, s
     int counter = 0;
     bool copyattr = false;
     for (int j=0; j<data->lmax; ++j) {
-      int thisnprotect = 0;
+      int thisprotecti = 0;
       SEXP thiscol = (j < data->leach[i]) ? VECTOR_ELT(DT, INTEGER(thisvaluecols)[j]-1)
                        : allocNAVector(data->maxtype[i], data->nrow);
       if (!copyattr && data->isidentical[i] && !data->isfactor[i]) {
@@ -430,7 +430,7 @@ SEXP getvaluecols(SEXP DT, SEXP dtnames, Rboolean valfactor, Rboolean verbose, s
         copyattr = true;
       }
       if (TYPEOF(thiscol) != TYPEOF(target) && (data->maxtype[i] == VECSXP || !isFactor(thiscol))) {
-        thiscol = PROTECT(coerceVector(thiscol, TYPEOF(target)));  thisnprotect++;
+        thiscol = PROTECT(coerceVector(thiscol, TYPEOF(target)));  thisprotecti++;
       }
       const int *ithisidx = NULL;
       int thislen = 0;
@@ -453,7 +453,7 @@ SEXP getvaluecols(SEXP DT, SEXP dtnames, Rboolean valfactor, Rboolean verbose, s
         if (data->isfactor[i]) {
           if (isFactor(thiscol)) {
             SET_VECTOR_ELT(flevels, j, getAttrib(thiscol, R_LevelsSymbol));
-            thiscol = PROTECT(asCharacterFactor(thiscol));  thisnprotect++;
+            thiscol = PROTECT(asCharacterFactor(thiscol));  thisprotecti++;
             isordered[j] = isOrdered(thiscol);
           } else SET_VECTOR_ELT(flevels, j, thiscol);
         }
@@ -490,7 +490,7 @@ SEXP getvaluecols(SEXP DT, SEXP dtnames, Rboolean valfactor, Rboolean verbose, s
         error("Unknown column type '%s' for column '%s'.", type2char(TYPEOF(thiscol)), CHAR(STRING_ELT(dtnames, INTEGER(thisvaluecols)[i]-1)));
       }
       if (data->narm) counter += thislen;
-      UNPROTECT(thisnprotect);  // inside inner loop (note that it's double loop) so as to limit use of protection stack
+      UNPROTECT(thisprotecti);  // inside inner loop (note that it's double loop) so as to limit use of protection stack
     }
     if (thisvalfactor && data->isfactor[i] && TYPEOF(target) != VECSXP) {
       //SEXP clevels = PROTECT(combineFactorLevels(flevels, &(data->isfactor[i]), isordered));
@@ -500,15 +500,15 @@ SEXP getvaluecols(SEXP DT, SEXP dtnames, Rboolean valfactor, Rboolean verbose, s
       SET_VECTOR_ELT(ansvals, i, combineFactorLevels(flevels, target, &(data->isfactor[i]), isordered));
     }
   }
-  UNPROTECT(2);  // flevels, ansvals. Not using two protection counters (nprotect and thisnprotect) to keep rchk happy.
+  UNPROTECT(2);  // flevels, ansvals. Not using two protection counters (protecti and thisprotecti) to keep rchk happy.
   return(ansvals);
 }
 
 SEXP getvarcols(SEXP DT, SEXP dtnames, Rboolean varfactor, Rboolean verbose, struct processData *data) {
   // reworked in PR#3455 to create character/factor directly for efficiency, and handle duplicates (#1754)
   // data->nrow * data->lmax == data->totlen
-  int nprotect=0;
-  SEXP ansvars=PROTECT(allocVector(VECSXP, 1)); nprotect++;
+  int protecti=0;
+  SEXP ansvars=PROTECT(allocVector(VECSXP, 1)); protecti++;
   SEXP target;
   if (data->lvalues==1 && length(VECTOR_ELT(data->valuecols, 0)) != data->lmax)
     error("Internal error: fmelt.c:getvarcols %d %d", length(VECTOR_ELT(data->valuecols, 0)), data->lmax);  // # nocov
@@ -539,19 +539,19 @@ SEXP getvarcols(SEXP DT, SEXP dtnames, Rboolean varfactor, Rboolean verbose, str
     if (data->lvalues == 1) {
       SEXP thisvaluecols = VECTOR_ELT(data->valuecols, 0);
       int len = length(thisvaluecols);
-      levels = PROTECT(allocVector(STRSXP, len)); nprotect++;
+      levels = PROTECT(allocVector(STRSXP, len)); protecti++;
       const int *vd = INTEGER(thisvaluecols);
       for (int j=0; j<len; ++j) SET_STRING_ELT(levels, j, STRING_ELT(dtnames, vd[j]-1));
-      SEXP m = PROTECT(chmatch(levels, levels, 0)); nprotect++;  // do we have any dups?
+      SEXP m = PROTECT(chmatch(levels, levels, 0)); protecti++;  // do we have any dups?
       int numRemove = 0;  // remove dups and any for which narm and all-NA
       int *md = INTEGER(m);
       for (int j=0; j<len; ++j) {
         if (md[j]!=j+1 /*dup*/ || (data->narm && length(VECTOR_ELT(data->naidx, j))==0)) { numRemove++; md[j]=0; }
       }
       if (numRemove) {
-        SEXP newlevels = PROTECT(allocVector(STRSXP, len-numRemove)); nprotect++;
+        SEXP newlevels = PROTECT(allocVector(STRSXP, len-numRemove)); protecti++;
         for (int i=0, loc=0; i<len; ++i) if (md[i]!=0) { SET_STRING_ELT(newlevels, loc++, STRING_ELT(levels, i)); }
-        m = PROTECT(chmatch(levels, newlevels, 0)); nprotect++;  // budge up the gaps
+        m = PROTECT(chmatch(levels, newlevels, 0)); protecti++;  // budge up the gaps
         md = INTEGER(m);
         levels = newlevels;
       }
@@ -561,7 +561,7 @@ SEXP getvarcols(SEXP DT, SEXP dtnames, Rboolean varfactor, Rboolean verbose, str
       }
     } else {
       int nlevel=0;
-      levels = PROTECT(allocVector(STRSXP, data->lmax)); nprotect++;
+      levels = PROTECT(allocVector(STRSXP, data->lmax)); protecti++;
       for (int j=0, ansloc=0; j<data->lmax; ++j) {
         const int thislen = data->narm ? length(VECTOR_ELT(data->naidx, j)) : data->nrow;
         if (thislen==0) continue;  // so as not to bump level
@@ -573,7 +573,7 @@ SEXP getvarcols(SEXP DT, SEXP dtnames, Rboolean varfactor, Rboolean verbose, str
       if (nlevel < data->lmax) {
         // data->narm is true and there are some all-NA items causing at least one 'if (thislen==0) continue' above
         // shrink the levels
-        SEXP newlevels = PROTECT(allocVector(STRSXP, nlevel)); nprotect++;
+        SEXP newlevels = PROTECT(allocVector(STRSXP, nlevel)); protecti++;
         for (int i=0; i<nlevel; ++i) SET_STRING_ELT(newlevels, i, STRING_ELT(levels, i));
         levels = newlevels;
       }
@@ -581,7 +581,7 @@ SEXP getvarcols(SEXP DT, SEXP dtnames, Rboolean varfactor, Rboolean verbose, str
     setAttrib(target, R_LevelsSymbol, levels);
     setAttrib(target, R_ClassSymbol, ScalarString(char_factor));
   }
-  UNPROTECT(nprotect);
+  UNPROTECT(protecti);
   return(ansvars);
 }
 
@@ -682,25 +682,25 @@ SEXP fmelt(SEXP DT, SEXP id, SEXP measure, SEXP varfactor, SEXP valfactor, SEXP 
     if (verbose) Rprintf("ncol(data) is 0. Nothing to melt. Returning original data.table.");
     return(DT);
   }
-  int nprotect=0;
-  dtnames = PROTECT(getAttrib(DT, R_NamesSymbol)); nprotect++;
+  int protecti=0;
+  dtnames = PROTECT(getAttrib(DT, R_NamesSymbol)); protecti++;
   if (isNull(dtnames)) error("names(data) is NULL. Please report to data.table-help");
   if (LOGICAL(narmArg)[0] == TRUE) narm = TRUE;
   if (LOGICAL(verboseArg)[0] == TRUE) verbose = TRUE;
   struct processData data;
-  data.RCHK = PROTECT(allocVector(VECSXP, 2)); nprotect++;
+  data.RCHK = PROTECT(allocVector(VECSXP, 2)); protecti++;
   preprocess(DT, id, measure, varnames, valnames, narm, verbose, &data);
   // edge case no measure.vars
   if (!data.lmax) {
-    SEXP tt = PROTECT(shallowwrapper(DT, data.idcols)); nprotect++;
-    ans = PROTECT(copyAsPlain(tt)); nprotect++;
+    SEXP tt = PROTECT(shallowwrapper(DT, data.idcols)); protecti++;
+    ans = PROTECT(copyAsPlain(tt)); protecti++;
   } else {
-    ansvals = PROTECT(getvaluecols(DT, dtnames, LOGICAL(valfactor)[0], verbose, &data)); nprotect++;
-    ansvars = PROTECT(getvarcols(DT, dtnames, LOGICAL(varfactor)[0], verbose, &data)); nprotect++;
-    ansids  = PROTECT(getidcols(DT, dtnames, verbose, &data)); nprotect++;
+    ansvals = PROTECT(getvaluecols(DT, dtnames, LOGICAL(valfactor)[0], verbose, &data)); protecti++;
+    ansvars = PROTECT(getvarcols(DT, dtnames, LOGICAL(varfactor)[0], verbose, &data)); protecti++;
+    ansids  = PROTECT(getidcols(DT, dtnames, verbose, &data)); protecti++;
 
     // populate 'ans'
-    ans = PROTECT(allocVector(VECSXP, data.lids+1+data.lvalues)); nprotect++; // 1 is for variable column
+    ans = PROTECT(allocVector(VECSXP, data.lids+1+data.lvalues)); protecti++; // 1 is for variable column
     for (int i=0; i<data.lids; i++) {
       SET_VECTOR_ELT(ans, i, VECTOR_ELT(ansids, i));
     }
@@ -709,7 +709,7 @@ SEXP fmelt(SEXP DT, SEXP id, SEXP measure, SEXP varfactor, SEXP valfactor, SEXP 
       SET_VECTOR_ELT(ans, data.lids+1+i, VECTOR_ELT(ansvals, i));
     }
     // fill in 'ansnames'
-    ansnames = PROTECT(allocVector(STRSXP, data.lids+1+data.lvalues)); nprotect++;
+    ansnames = PROTECT(allocVector(STRSXP, data.lids+1+data.lvalues)); protecti++;
     for (int i=0; i<data.lids; i++) {
       SET_STRING_ELT(ansnames, i, STRING_ELT(dtnames, INTEGER(data.idcols)[i]-1));
     }
@@ -719,6 +719,6 @@ SEXP fmelt(SEXP DT, SEXP id, SEXP measure, SEXP varfactor, SEXP valfactor, SEXP 
     }
     setAttrib(ans, R_NamesSymbol, ansnames);
   }
-  UNPROTECT(nprotect);
+  UNPROTECT(protecti);
   return(ans);
 }

--- a/src/transpose.c
+++ b/src/transpose.c
@@ -53,11 +53,9 @@ SEXP transpose(SEXP l, SEXP fill, SEXP ignoreArg, SEXP keepNamesArg) {
     SEXP li = VECTOR_ELT(l, i);
     const int len = length(li);
     if (ignore && len==0) continue;
-    bool coerce = false;
     if (TYPEOF(li) != maxtype) {
       li = PROTECT(isFactor(li) ? asCharacterFactor(li) : coerceVector(li, maxtype));
-      coerce = true;
-    }
+    } else PROTECT(li); // extra PROTECT just to help rchk by avoiding two counter variables
     switch (maxtype) {
     case LGLSXP : {
       const int *ili = LOGICAL(li);
@@ -89,7 +87,7 @@ SEXP transpose(SEXP l, SEXP fill, SEXP ignoreArg, SEXP keepNamesArg) {
     default :
       error("Unsupported column type '%s'", type2char(maxtype));
     }
-    if (coerce) UNPROTECT(1);
+    UNPROTECT(1); // inside the loop to save the protection stack
     k++;
   }
   UNPROTECT(nprotect);


### PR DESCRIPTION
Closes #3619 

`rchk` prefers a counter to be passed to UNPROTECT.
So : 
    ```UNPROTECT(nprotect);```
rather than : 
    ```if (coerced) UNPROTECT(1);```
That way it can statically track the protection stack via the counter variable.
