### PR TITLE
free() memory in nafill & frollR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ some:
 
 .PHONY: clean
 clean:
-	rm -f data.table_1.12.3.tar.gz
+	rm -f data.table_1.12.3.tar.gz && rm -f src/*.o
 
 .PHONY: build
 build:

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ some:
 
 .PHONY: clean
 clean:
-	rm -f data.table_1.12.3.tar.gz && rm -f src/*.o
+	rm -f data.table_1.12.3.tar.gz && rm -f src/*.{o,so}
 
 .PHONY: build
 build:

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -121,7 +121,7 @@ replace_dot_alias = function(e) {
   }
 }
 
-"[.data.table" = function (x, i, j, by=NULL, keyby, with=TRUE, nomatch=getOption("datatable.nomatch", NA), mult="all", roll=FALSE, rollends=if (roll=="nearest") c(TRUE,TRUE) else if (roll>=0) c(FALSE,TRUE) else c(TRUE,FALSE), which=FALSE, .SDcols, verbose=getOption("datatable.verbose"), allow.cartesian=getOption("datatable.allow.cartesian"), drop=NULL, on=NULL)
+"[.data.table" = function (x, i, j, by, keyby, with=TRUE, nomatch=getOption("datatable.nomatch", NA), mult="all", roll=FALSE, rollends=if (roll=="nearest") c(TRUE,TRUE) else if (roll>=0) c(FALSE,TRUE) else c(TRUE,FALSE), which=FALSE, .SDcols, verbose=getOption("datatable.verbose"), allow.cartesian=getOption("datatable.allow.cartesian"), drop=NULL, on=NULL)
 {
   # ..selfcount <<- ..selfcount+1  # in dev, we check no self calls, each of which doubles overhead, or could
   # test explicitly if the caller is [.data.table (even stronger test. TO DO.)
@@ -143,16 +143,16 @@ replace_dot_alias = function(e) {
     on.exit(options(oldverbose))
   }
   .global$print=""
-  missingby = is.null(by) && missing(keyby)  # for tests 359 & 590 where passing by=NULL results in data.table not vector
+  missingby = missing(by) && missing(keyby)  # for tests 359 & 590 where passing by=NULL results in data.table not vector
   if (!missing(keyby)) {
-    if (!is.null(by)) stop("Provide either by= or keyby= but not both")
+    if (!missing(by)) stop("Provide either by= or keyby= but not both")
     if (missing(j)) { warning("Ignoring keyby= because j= is not supplied"); keyby=NULL; }
     by=bysub=substitute(keyby)
     keyby=TRUE
     # Assign to 'by' so that by is no longer missing and we can proceed as if there were one by
   } else {
-    if (!is.null(by) && missing(j)) { warning("Ignoring by= because j= is not supplied"); by=NULL; }
-    by=bysub= if (is.null(by)) NULL else substitute(by)
+    if (!missing(by) && missing(j)) { warning("Ignoring by= because j= is not supplied"); by=NULL; }
+    by=bysub= if (missing(by)) NULL else substitute(by)
     keyby=FALSE
   }
   bynull = !missingby && is.null(by) #3530
@@ -2220,12 +2220,12 @@ split.data.table = function(x, f, drop = FALSE, by, sorted = FALSE, keep.by = TR
   if (!missing(f)) {
     if (!length(f) && nrow(x))
       stop("group length is 0 but data nrow > 0")
-    if (!is.null(by))
+    if (!missing(by))
       stop("passing 'f' argument together with 'by' is not allowed, use 'by' when split by column in data.table and 'f' when split by external factor")
     # same as split.data.frame - handling all exceptions, factor orders etc, in a single stream of processing was a nightmare in factor and drop consistency
     return(lapply(split(x = seq_len(nrow(x)), f = f, drop = drop, ...), function(ind) x[ind]))
   }
-  if (is.null(by)) stop("Either 'by' or 'f' argument must be supplied")
+  if (missing(by)) stop("Either 'by' or 'f' argument must be supplied")
   # check reserved column names during processing
   if (".ll.tech.split" %chin% names(x)) stop("Column '.ll.tech.split' is reserved for split.data.table processing")
   if (".nm.tech.split" %chin% by) stop("Column '.nm.tech.split' is reserved for split.data.table processing")

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -121,7 +121,7 @@ replace_dot_alias = function(e) {
   }
 }
 
-"[.data.table" = function (x, i, j, by, keyby, with=TRUE, nomatch=getOption("datatable.nomatch", NA), mult="all", roll=FALSE, rollends=if (roll=="nearest") c(TRUE,TRUE) else if (roll>=0) c(FALSE,TRUE) else c(TRUE,FALSE), which=FALSE, .SDcols, verbose=getOption("datatable.verbose"), allow.cartesian=getOption("datatable.allow.cartesian"), drop=NULL, on=NULL)
+"[.data.table" = function (x, i, j, by=NULL, keyby, with=TRUE, nomatch=getOption("datatable.nomatch", NA), mult="all", roll=FALSE, rollends=if (roll=="nearest") c(TRUE,TRUE) else if (roll>=0) c(FALSE,TRUE) else c(TRUE,FALSE), which=FALSE, .SDcols, verbose=getOption("datatable.verbose"), allow.cartesian=getOption("datatable.allow.cartesian"), drop=NULL, on=NULL)
 {
   # ..selfcount <<- ..selfcount+1  # in dev, we check no self calls, each of which doubles overhead, or could
   # test explicitly if the caller is [.data.table (even stronger test. TO DO.)
@@ -143,16 +143,16 @@ replace_dot_alias = function(e) {
     on.exit(options(oldverbose))
   }
   .global$print=""
-  missingby = missing(by) && missing(keyby)  # for tests 359 & 590 where passing by=NULL results in data.table not vector
+  missingby = is.null(by) && missing(keyby)  # for tests 359 & 590 where passing by=NULL results in data.table not vector
   if (!missing(keyby)) {
-    if (!missing(by)) stop("Provide either by= or keyby= but not both")
+    if (!is.null(by)) stop("Provide either by= or keyby= but not both")
     if (missing(j)) { warning("Ignoring keyby= because j= is not supplied"); keyby=NULL; }
     by=bysub=substitute(keyby)
     keyby=TRUE
     # Assign to 'by' so that by is no longer missing and we can proceed as if there were one by
   } else {
-    if (!missing(by) && missing(j)) { warning("Ignoring by= because j= is not supplied"); by=NULL; }
-    by=bysub= if (missing(by)) NULL else substitute(by)
+    if (!is.null(by) && missing(j)) { warning("Ignoring by= because j= is not supplied"); by=NULL; }
+    by=bysub= if (is.null(by)) NULL else substitute(by)
     keyby=FALSE
   }
   bynull = !missingby && is.null(by) #3530
@@ -2220,12 +2220,12 @@ split.data.table = function(x, f, drop = FALSE, by, sorted = FALSE, keep.by = TR
   if (!missing(f)) {
     if (!length(f) && nrow(x))
       stop("group length is 0 but data nrow > 0")
-    if (!missing(by))
+    if (!is.null(by))
       stop("passing 'f' argument together with 'by' is not allowed, use 'by' when split by column in data.table and 'f' when split by external factor")
     # same as split.data.frame - handling all exceptions, factor orders etc, in a single stream of processing was a nightmare in factor and drop consistency
     return(lapply(split(x = seq_len(nrow(x)), f = f, drop = drop, ...), function(ind) x[ind]))
   }
-  if (missing(by)) stop("Either 'by' or 'f' argument must be supplied")
+  if (is.null(by)) stop("Either 'by' or 'f' argument must be supplied")
   # check reserved column names during processing
   if (".ll.tech.split" %chin% names(x)) stop("Column '.ll.tech.split' is reserved for split.data.table processing")
   if (".nm.tech.split" %chin% by) stop("Column '.nm.tech.split' is reserved for split.data.table processing")

--- a/inst/tests/froll.Rraw
+++ b/inst/tests/froll.Rraw
@@ -1041,7 +1041,7 @@ f = function(x) {
   # double type will be returned only for first iteration where we check type
   if (n==x[n]) 1 else NA # NA logical turns into garbage without coercion to double
 }
-test(6010.106, head(frollapply(1:5, 3, f), 3L), c(NA_real_,NA_real_,1), output=c("frollapplyR: allocating memory.*","frollapply: took.*","frollapplyR: processing.*took.*")) # testing only head 3 because rest is garbage
+#test(6010.106, head(frollapply(1:5, 3, f), 3L), c(NA_real_,NA_real_,1), output=c("frollapplyR: allocating memory.*","frollapply: took.*","frollapplyR: processing.*took.*")) # only head 3 is valid, rest is undefined as REAL is applied on logical type, can return garbage or fail with REAL error
 options(datatable.verbose=FALSE)
 #### test coverage
 test(6010.501, frollapply(1:3, "b", sum), error="n must be integer")

--- a/inst/tests/nafill.Rraw
+++ b/inst/tests/nafill.Rraw
@@ -64,6 +64,7 @@ test(1.45, nafill(l, "nocb"), list(c(1:2,4L,4:5), structure(c(1,2,4,4,5), class=
 test(1.46, nafill(l, fill=0), list(c(1:2,0L,4:5), structure(c(1,2,0,4,5), class="Date"), c(0L,2L,0L,4L,0L), structure(c(0,2,0,4,0), class="Date")))
 test(1.47, nafill(l, fill=as.Date(0, origin="1970-01-01")), list(c(1:2,0L,4:5), structure(c(1,2,0,4,5), class="Date"), c(0L,2L,0L,4L,0L), structure(c(0,2,0,4,0), class="Date")))
 test(1.48, nafill(l, fill=as.Date("2019-06-05")), list(c(1:2,18052L,4:5), structure(c(1,2,18052,4,5), class="Date"), c(18052L,2L,18052L,4L,18052L), structure(c(18052,2,18052,4,18052), class="Date")))
+test(1.49, nafill(numeric()), numeric())
 if (test_bit64) {
   l = list(a=as.integer64(c(1:2,NA,4:5)), b=as.integer64(c(NA,2L,NA,4L,NA)))
   test(1.61, lapply(nafill(l, "locf"), as.character), lapply(list(c(1:2,2L,4:5), c(NA,2L,2L,4L,4L)), as.character))
@@ -158,6 +159,9 @@ dt = data.table(a=c(1L, 2L, NA_integer_), b=c(1, 2, NA_real_))
 test(5.01, nafill(dt, "locf", verbose=TRUE), output="nafillInteger: took.*nafillDouble: took.*nafillR.*took")
 test(5.02, setnafill(dt, "locf", verbose=TRUE), output="nafillInteger: took.*nafillDouble: took.*nafillR.*took")
 test(5.03, nafill(dt, "locf", verbose=NA), error="verbose must be TRUE or FALSE")
+if (test_bit64) {
+  test(5.04, nafill(as.integer64(c(NA,2,NA,3)), "locf", verbose=TRUE), as.integer64(c(NA,2,2,3)), output="nafillInteger64: took.*nafillR.*took")
+}
 
 # coerceFill
 if (test_bit64) {

--- a/man/froll.Rd
+++ b/man/froll.Rd
@@ -203,7 +203,7 @@ f = function(x) {             ## FUN is not type-stable
   # double type will be returned only for first iteration where we check type
   if (n==x[n]) 1 else NA # NA logical turns into garbage without coercion to double
 }
-frollapply(1:5, 3, f)
+try(frollapply(1:5, 3, f))
 }
 \seealso{
   \code{\link{shift}}, \code{\link{data.table}}

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -226,3 +226,5 @@ SEXP unlock(SEXP x);
 bool islocked(SEXP x);
 SEXP islockedR(SEXP x);
 
+// types.c
+char *end(char *start);

--- a/src/froll.c
+++ b/src/froll.c
@@ -1,9 +1,8 @@
-#include "froll.h"
-
-// helper used to append verbose message or warnings
-static char *end(char *start) {
-  return strchr(start, 0);
-}
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <Rdefines.h>
+#include "data.table.h"
 
 /* fast rolling mean - router
  * early stopping for window bigger than input
@@ -353,7 +352,7 @@ void frollapply(double *x, int64_t nx, double *w, int k, ans_t *ans, int align, 
   if (teval0 == REALSXP) {
     for (int64_t i=k; i<nx; i++) {
       memcpy(w, x+(i-k+1), k*sizeof(double));
-      ans->dbl_v[i] = REAL(eval(call, rho))[0];
+      ans->dbl_v[i] = REAL(eval(call, rho))[0]; // this may fail with for a not type-stable fun
     }
   } else {
     for (int64_t i=k; i<nx; i++) {

--- a/src/froll.h
+++ b/src/froll.h
@@ -1,4 +1,0 @@
-#include <stdio.h>
-#include <stdint.h>
-#include <stdbool.h>
-#include "frollR.h"

--- a/src/frollR.c
+++ b/src/frollR.c
@@ -230,7 +230,6 @@ SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEX
         char err_msg[ANST_MSG_SIZE]; // # nocov
         int k=0; // # nocov
         while (dans[i*nk+j].message[3][k++] != '\0') err_msg[k] = dans[i*nk+j].message[3][k]; // # nocov
-        //strcopy(err_msg, dans[i*nk+j].message[3]); // # nocov
         free(dans); // # nocov
         error("%s: %d: %s", __func__, i*nk+j+1, err_msg); // # nocov because only caused by malloc
       }

--- a/src/frollR.c
+++ b/src/frollR.c
@@ -227,7 +227,10 @@ SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEX
       if (dans[i*nk+j].message[2][0] != '\0')
         warning("%s: %d:\n%s", __func__, i*nk+j+1, dans[i*nk+j].message[2]);
       if (dans[i*nk+j].status == 3) {
-        char err_msg[4096] = dans[i*nk+j].message[3]; // # nocov
+        char err_msg[ANST_MSG_SIZE]; // # nocov
+        int k=0; // # nocov
+        while (dans[i*nk+j].message[3][k++] != '\0') err_msg[k] = dans[i*nk+j].message[3][k]; // # nocov
+        //strcopy(err_msg, dans[i*nk+j].message[3]); // # nocov
         free(dans); // # nocov
         error("%s: %d: %s", __func__, i*nk+j+1, err_msg); // # nocov because only caused by malloc
       }

--- a/src/frollR.c
+++ b/src/frollR.c
@@ -235,6 +235,7 @@ SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEX
     Rprintf("%s: processing of %d column(s) and %d window(s) took %.3fs\n", __func__, nx, nk, omp_get_wtime()-tic);
 
   UNPROTECT(protecti);
+  free(dans);
   return isVectorAtomic(obj) && length(ans) == 1 ? VECTOR_ELT(ans, 0) : ans;
 }
 

--- a/src/frollR.c
+++ b/src/frollR.c
@@ -226,8 +226,11 @@ SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEX
         REprintf("%s: %d:\n%s", __func__, i*nk+j+1, dans[i*nk+j].message[1]); // # nocov because no messages yet // change REprintf according to comments in #3483 when ready
       if (dans[i*nk+j].message[2][0] != '\0')
         warning("%s: %d:\n%s", __func__, i*nk+j+1, dans[i*nk+j].message[2]);
-      if (dans[i*nk+j].status == 3)
-        error("%s: %d: %s", __func__, i*nk+j+1, dans[i*nk+j].message[3]); // # nocov because only caused by malloc
+      if (dans[i*nk+j].status == 3) {
+        char err_msg = dans[i*nk+j].message[3]; // # nocov
+        free(dans); // # nocov
+        error("%s: %d: %s", __func__, i*nk+j+1, err_msg); // # nocov because only caused by malloc
+      }
     }
   }
 

--- a/src/frollR.c
+++ b/src/frollR.c
@@ -1,4 +1,5 @@
-#include "frollR.h"
+#include <Rdefines.h>
+#include "data.table.h"
 
 SEXP coerceToRealListR(SEXP obj) {
   // accept atomic/list of integer/logical/real returns list of real
@@ -95,10 +96,11 @@ SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEX
     }
   }
   int* ikl[nk];                                                 // pointers to adaptive window width
-  if (badaptive)
+  if (badaptive) {
     for (int j=0; j<nk; j++) ikl[j] = INTEGER(VECTOR_ELT(kl, j));
+  }
 
-  if (!isLogical(narm) || length(narm)!=1 || LOGICAL(narm)[0]==NA_LOGICAL)
+  if (!IS_TRUE_OR_FALSE(narm))
     error("na.rm must be TRUE or FALSE");
 
   if (!isLogical(hasna) || length(hasna)!=1)
@@ -226,13 +228,12 @@ SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEX
         REprintf("%s: %d:\n%s", __func__, i*nk+j+1, dans[i*nk+j].message[1]); // # nocov because no messages yet // change REprintf according to comments in #3483 when ready
       if (dans[i*nk+j].message[2][0] != '\0')
         warning("%s: %d:\n%s", __func__, i*nk+j+1, dans[i*nk+j].message[2]);
-      if (dans[i*nk+j].status == 3) {
-        char err_msg[ANST_MSG_SIZE]; // # nocov
-        int k=0; // # nocov
-        while (dans[i*nk+j].message[3][k++] != '\0') err_msg[k] = dans[i*nk+j].message[3][k]; // # nocov
-        free(dans); // # nocov
+      if (dans[i*nk+j].status == 3) { // # nocov start
+        char err_msg[ANS_MSG_SIZE];
+        strncpy(err_msg, dans[i*nk+j].message[3], ANS_MSG_SIZE);
+        free(dans);
         error("%s: %d: %s", __func__, i*nk+j+1, err_msg); // # nocov because only caused by malloc
-      }
+      } // # nocov end
     }
   }
 

--- a/src/frollR.c
+++ b/src/frollR.c
@@ -227,7 +227,7 @@ SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEX
       if (dans[i*nk+j].message[2][0] != '\0')
         warning("%s: %d:\n%s", __func__, i*nk+j+1, dans[i*nk+j].message[2]);
       if (dans[i*nk+j].status == 3) {
-        char err_msg = dans[i*nk+j].message[3]; // # nocov
+        char err_msg[4096] = dans[i*nk+j].message[3]; // # nocov
         free(dans); // # nocov
         error("%s: %d: %s", __func__, i*nk+j+1, err_msg); // # nocov because only caused by malloc
       }

--- a/src/frollR.c
+++ b/src/frollR.c
@@ -122,13 +122,11 @@ SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEX
     error("using adaptive TRUE and align argument different than 'right' is not implemented");
 
   SEXP ans = PROTECT(allocVector(VECSXP, nk * nx)); protecti++; // allocate list to keep results
-  ans_t *dans = malloc(sizeof(ans_t)*nx*nk);                    // answer columns as array of ans_t struct
-  if (!dans)
-    error("%s: Unable to allocate memory answer", __func__); // # nocov
-  double* dx[nx];                                               // pointers to source columns
-  uint_fast64_t inx[nx];                                        // to not recalculate `length(x[[i]])` we store it in extra array
   if (verbose)
     Rprintf("%s: allocating memory for results %dx%d\n", __func__, nx, nk);
+  ans_t *dans = (ans_t *)R_alloc(nx*nk, sizeof(ans_t));         // answer columns as array of ans_t struct
+  double* dx[nx];                                               // pointers to source columns
+  uint_fast64_t inx[nx];                                        // to not recalculate `length(x[[i]])` we store it in extra array
   for (R_len_t i=0; i<nx; i++) {
     inx[i] = xlength(VECTOR_ELT(x, i));                         // for list input each vector can have different length
     for (R_len_t j=0; j<nk; j++) {
@@ -228,12 +226,9 @@ SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEX
         REprintf("%s: %d:\n%s", __func__, i*nk+j+1, dans[i*nk+j].message[1]); // # nocov because no messages yet // change REprintf according to comments in #3483 when ready
       if (dans[i*nk+j].message[2][0] != '\0')
         warning("%s: %d:\n%s", __func__, i*nk+j+1, dans[i*nk+j].message[2]);
-      if (dans[i*nk+j].status == 3) { // # nocov start
-        char err_msg[ANS_MSG_SIZE];
-        strncpy(err_msg, dans[i*nk+j].message[3], ANS_MSG_SIZE);
-        free(dans);
-        error("%s: %d: %s", __func__, i*nk+j+1, err_msg); // # nocov because only caused by malloc
-      } // # nocov end
+      if (dans[i*nk+j].status == 3) {
+        error("%s: %d: %s", __func__, i*nk+j+1, dans[i*nk+j].message[3]); // # nocov because only caused by malloc
+      }
     }
   }
 
@@ -241,7 +236,6 @@ SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEX
     Rprintf("%s: processing of %d column(s) and %d window(s) took %.3fs\n", __func__, nx, nk, omp_get_wtime()-tic);
 
   UNPROTECT(protecti);
-  free(dans);
   return isVectorAtomic(obj) && length(ans) == 1 ? VECTOR_ELT(ans, 0) : ans;
 }
 
@@ -307,13 +301,11 @@ SEXP frollapplyR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP align, SEXP rho) {
   }
 
   SEXP ans = PROTECT(allocVector(VECSXP, nk * nx)); protecti++;
-  ans_t *dans = malloc(sizeof(ans_t)*nx*nk);
-  if (!dans)
-    error("%s: Unable to allocate memory answer", __func__); // # nocov
-  double* dx[nx];
-  uint_fast64_t inx[nx];
   if (verbose)
     Rprintf("%s: allocating memory for results %dx%d\n", __func__, nx, nk);
+  ans_t *dans = (ans_t *)R_alloc(nx*nk, sizeof(ans_t));
+  double* dx[nx];
+  uint_fast64_t inx[nx];
   for (R_len_t i=0; i<nx; i++) {
     inx[i] = xlength(VECTOR_ELT(x, i));
     for (R_len_t j=0; j<nk; j++) {

--- a/src/frollR.h
+++ b/src/frollR.h
@@ -1,2 +1,0 @@
-#include "data.table.h"
-#include <Rdefines.h>

--- a/src/frolladaptive.c
+++ b/src/frolladaptive.c
@@ -1,9 +1,8 @@
-#include "froll.h"
-
-// helper used to append verbose message or warnings
-static char *end(char *start) {
-  return strchr(start, 0);
-}
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <Rdefines.h>
+#include "data.table.h"
 
 /* fast adaptive rolling mean - router
  * algo = 0: fadaptiverollmeanFast

--- a/src/nafill.c
+++ b/src/nafill.c
@@ -162,8 +162,10 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP inplace, SEXP cols, SEXP verbo
     if (vans[i].message[2][0] != '\0')
       warning("%s: %d: %s", __func__, i+1, vans[i].message[2]);
     if (vans[i].status == 3) {
-      char err_msg[4096] = vans[i].message[3]; // # nocov
-      free(vans); // # nocov
+      char err_msg[ANST_MSG_SIZE];
+      int k=0;
+      while (vans[i].message[3][k++] != '\0') err_msg[k] = vans[i].message[3][k];
+      free(vans);
       error("%s: %d: %s", __func__, i+1, err_msg); // # nocov end
     }
   }

--- a/src/nafill.c
+++ b/src/nafill.c
@@ -2,7 +2,8 @@
 
 void nafillDouble(double *x, uint_fast64_t nx, unsigned int type, double fill, ans_t *ans, bool verbose) {
   double tic=0.0;
-  if (verbose) tic = omp_get_wtime();
+  if (verbose)
+    tic = omp_get_wtime();
   if (type==0) { // const
     for (uint_fast64_t i=0; i<nx; i++) {
       ans->dbl_v[i] = ISNA(x[i]) ? fill : x[i];
@@ -18,11 +19,13 @@ void nafillDouble(double *x, uint_fast64_t nx, unsigned int type, double fill, a
       ans->dbl_v[i] = ISNA(x[i]) ? ans->dbl_v[i+1] : x[i];
     }
   }
-  if (verbose) snprintf(ans->message[0], 500, "%s: took %.3fs\n", __func__, omp_get_wtime()-tic);
+  if (verbose)
+    snprintf(ans->message[0], 500, "%s: took %.3fs\n", __func__, omp_get_wtime()-tic);
 }
 void nafillInteger(int32_t *x, uint_fast64_t nx, unsigned int type, int32_t fill, ans_t *ans, bool verbose) {
   double tic=0.0;
-  if (verbose) tic = omp_get_wtime();
+  if (verbose)
+    tic = omp_get_wtime();
   if (type==0) { // const
     for (uint_fast64_t i=0; i<nx; i++) {
       ans->int_v[i] = x[i]==NA_INTEGER ? fill : x[i];
@@ -38,11 +41,13 @@ void nafillInteger(int32_t *x, uint_fast64_t nx, unsigned int type, int32_t fill
       ans->int_v[i] = x[i]==NA_INTEGER ? ans->int_v[i+1] : x[i];
     }
   }
-  if (verbose) snprintf(ans->message[0], 500, "%s: took %.3fs\n", __func__, omp_get_wtime()-tic);
+  if (verbose)
+    snprintf(ans->message[0], 500, "%s: took %.3fs\n", __func__, omp_get_wtime()-tic);
 }
 void nafillInteger64(int64_t *x, uint_fast64_t nx, unsigned int type, int64_t fill, ans_t *ans, bool verbose) {
   double tic=0.0;
-  if (verbose) tic = omp_get_wtime();
+  if (verbose)
+    tic = omp_get_wtime();
   if (type==0) { // const
     for (uint_fast64_t i=0; i<nx; i++) {
       ans->int64_v[i] = x[i]==NA_INTEGER64 ? fill : x[i];
@@ -58,22 +63,26 @@ void nafillInteger64(int64_t *x, uint_fast64_t nx, unsigned int type, int64_t fi
       ans->int64_v[i] = x[i]==NA_INTEGER64 ? ans->int64_v[i+1] : x[i];
     }
   }
-  if (verbose) snprintf(ans->message[0], 500, "%s: took %.3fs\n", __func__, omp_get_wtime()-tic);
+  if (verbose)
+    snprintf(ans->message[0], 500, "%s: took %.3fs\n", __func__, omp_get_wtime()-tic);
 }
 
 SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP inplace, SEXP cols, SEXP verbose) {
   int protecti=0;
-  if (!isLogical(verbose) || length(verbose)!=1 || LOGICAL(verbose)[0]==NA_LOGICAL)
+  if (!IS_TRUE_OR_FALSE(verbose))
     error("verbose must be TRUE or FALSE");
   bool bverbose = LOGICAL(verbose)[0];
 
-  if (!xlength(obj)) return(obj);
+  if (!xlength(obj))
+    return(obj);
 
   bool binplace = LOGICAL(inplace)[0];
   SEXP x = R_NilValue;
   if (isVectorAtomic(obj)) {
-    if (binplace) error("'x' argument is atomic vector, in-place update is supported only for list/data.table");
-    else if (!isReal(obj) && !isInteger(obj)) error("'x' argument must be numeric type, or list/data.table of numeric types");
+    if (binplace)
+      error("'x' argument is atomic vector, in-place update is supported only for list/data.table");
+    else if (!isReal(obj) && !isInteger(obj))
+      error("'x' argument must be numeric type, or list/data.table of numeric types");
     x = PROTECT(allocVector(VECSXP, 1)); protecti++; // wrap into list
     SET_VECTOR_ELT(x, 0, obj);
   } else {
@@ -82,7 +91,8 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP inplace, SEXP cols, SEXP verbo
     int *icols = INTEGER(ricols);
     for (int i=0; i<length(ricols); i++) {
       SEXP this_col = VECTOR_ELT(obj, icols[i]-1);
-      if (!isReal(this_col) && !isInteger(this_col)) error("'x' argument must be numeric type, or list/data.table of numeric types");
+      if (!isReal(this_col) && !isInteger(this_col))
+        error("'x' argument must be numeric type, or list/data.table of numeric types");
       SET_VECTOR_ELT(x, i, this_col);
     }
   }
@@ -94,7 +104,8 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP inplace, SEXP cols, SEXP verbo
   uint_fast64_t inx[nx];
   SEXP ans = R_NilValue;
   ans_t *vans = malloc(sizeof(ans_t)*nx);
-  if (!vans) error("%s: Unable to allocate memory answer", __func__); // # nocov
+  if (!vans)
+    error("%s: Unable to allocate memory answer", __func__); // # nocov
   for (R_len_t i=0; i<nx; i++) {
     inx[i] = xlength(VECTOR_ELT(x, i));
     dx[i] = REAL(VECTOR_ELT(x, i));
@@ -114,10 +125,14 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP inplace, SEXP cols, SEXP verbo
   }
 
   unsigned int itype;
-  if (!strcmp(CHAR(STRING_ELT(type, 0)), "const")) itype = 0;
-  else if (!strcmp(CHAR(STRING_ELT(type, 0)), "locf")) itype = 1;
-  else if (!strcmp(CHAR(STRING_ELT(type, 0)), "nocb")) itype = 2;
-  else error("Internal error: invalid type argument in nafillR function, should have been caught before. Please report to data.table issue tracker."); // # nocov
+  if (!strcmp(CHAR(STRING_ELT(type, 0)), "const"))
+    itype = 0;
+  else if (!strcmp(CHAR(STRING_ELT(type, 0)), "locf"))
+    itype = 1;
+  else if (!strcmp(CHAR(STRING_ELT(type, 0)), "nocb"))
+    itype = 2;
+  else
+    error("Internal error: invalid type argument in nafillR function, should have been caught before. Please report to data.table issue tracker."); // # nocov
 
   if (itype==0 && length(fill)!=1)
     error("fill must be a vector of length 1");
@@ -125,10 +140,12 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP inplace, SEXP cols, SEXP verbo
   double dfill=NA_REAL;
   int32_t ifill=NA_INTEGER;
   int64_t i64fill=NA_INTEGER64;
-  if (itype==0) coerceFill(fill, &dfill, &ifill, &i64fill);
+  if (itype==0)
+    coerceFill(fill, &dfill, &ifill, &i64fill);
 
   double tic=0.0, toc=0.0;
-  if (bverbose) tic = omp_get_wtime();
+  if (bverbose)
+    tic = omp_get_wtime();
   #pragma omp parallel for if (nx>1) num_threads(getDTthreads())
   for (R_len_t i=0; i<nx; i++) {
     SEXP this_x = VECTOR_ELT(x, i);
@@ -146,31 +163,33 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP inplace, SEXP cols, SEXP verbo
     default: error("Internal error: invalid type argument in nafillR function, should have been caught before. Please report to data.table issue tracker."); // # nocov
     }
   }
-  if (bverbose) toc = omp_get_wtime();
+  if (bverbose)
+    toc = omp_get_wtime();
 
   if (!binplace) {
     for (R_len_t i=0; i<nx; i++) {
-      if (!isNull(ATTRIB(VECTOR_ELT(x, i)))) copyMostAttrib(VECTOR_ELT(x, i), VECTOR_ELT(ans, i));
+      if (!isNull(ATTRIB(VECTOR_ELT(x, i))))
+        copyMostAttrib(VECTOR_ELT(x, i), VECTOR_ELT(ans, i));
     }
   }
 
   for (R_len_t i=0; i<nx; i++) {
     if (bverbose && (vans[i].message[0][0] != '\0'))
       Rprintf("%s: %d: %s", __func__, i+1, vans[i].message[0]);
-    if (vans[i].message[1][0] != '\0')
-      REprintf("%s: %d: %s", __func__, i+1, vans[i].message[1]); // # nocov start
+    if (vans[i].message[1][0] != '\0') // # nocov start
+      REprintf("%s: %d: %s", __func__, i+1, vans[i].message[1]);
     if (vans[i].message[2][0] != '\0')
       warning("%s: %d: %s", __func__, i+1, vans[i].message[2]);
-    if (vans[i].status == 3) {
-      char err_msg[ANST_MSG_SIZE];
-      int k=0;
-      while (vans[i].message[3][k++] != '\0') err_msg[k] = vans[i].message[3][k];
+    if (vans[i].status == 3)  { // # nocov start
+      char err_msg[ANS_MSG_SIZE];
+      strncpy(err_msg, vans[i].message[3], ANS_MSG_SIZE);
       free(vans);
-      error("%s: %d: %s", __func__, i+1, err_msg); // # nocov end
-    }
+      error("%s: %d: %s", __func__, i+1, err_msg); // # nocov because only caused by malloc
+    } // # nocov end
   }
 
-  if (bverbose) Rprintf("%s: parallel processing of %d column(s) took %.3fs\n", __func__, nx, toc-tic);
+  if (bverbose)
+    Rprintf("%s: parallel processing of %d column(s) took %.3fs\n", __func__, nx, toc-tic);
 
   UNPROTECT(protecti);
   free(vans);

--- a/src/nafill.c
+++ b/src/nafill.c
@@ -155,10 +155,17 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP inplace, SEXP cols, SEXP verbo
   }
 
   for (R_len_t i=0; i<nx; i++) {
-    if (bverbose && (vans[i].message[0][0] != '\0')) Rprintf("%s: %d: %s", __func__, i+1, vans[i].message[0]);
-    if (vans[i].message[1][0] != '\0') REprintf("%s: %d: %s", __func__, i+1, vans[i].message[1]); // # nocov start
-    if (vans[i].message[2][0] != '\0') warning("%s: %d: %s", __func__, i+1, vans[i].message[2]);
-    if (vans[i].status == 3) error("%s: %d: %s", __func__, i+1, vans[i].message[3]); // # nocov end
+    if (bverbose && (vans[i].message[0][0] != '\0'))
+      Rprintf("%s: %d: %s", __func__, i+1, vans[i].message[0]);
+    if (vans[i].message[1][0] != '\0')
+      REprintf("%s: %d: %s", __func__, i+1, vans[i].message[1]); // # nocov start
+    if (vans[i].message[2][0] != '\0')
+      warning("%s: %d: %s", __func__, i+1, vans[i].message[2]);
+    if (vans[i].status == 3) {
+      char err_msg = vans[i].message[3]; // # nocov
+      free(vans); // # nocov
+      error("%s: %d: %s", __func__, i+1, err_msg); // # nocov end
+    }
   }
 
   if (bverbose) Rprintf("%s: parallel processing of %d column(s) took %.3fs\n", __func__, nx, toc-tic);

--- a/src/nafill.c
+++ b/src/nafill.c
@@ -164,6 +164,7 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP inplace, SEXP cols, SEXP verbo
   if (bverbose) Rprintf("%s: parallel processing of %d column(s) took %.3fs\n", __func__, nx, toc-tic);
 
   UNPROTECT(protecti);
+  free(vans);
   if (binplace) {
     return obj;
   } else {

--- a/src/nafill.c
+++ b/src/nafill.c
@@ -176,10 +176,10 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP inplace, SEXP cols, SEXP verbo
   for (R_len_t i=0; i<nx; i++) {
     if (bverbose && (vans[i].message[0][0] != '\0'))
       Rprintf("%s: %d: %s", __func__, i+1, vans[i].message[0]);
-    if (vans[i].message[1][0] != '\0') // # nocov start
-      REprintf("%s: %d: %s", __func__, i+1, vans[i].message[1]);
+    if (vans[i].message[1][0] != '\0')
+      REprintf("%s: %d: %s", __func__, i+1, vans[i].message[1]); // # nocov
     if (vans[i].message[2][0] != '\0')
-      warning("%s: %d: %s", __func__, i+1, vans[i].message[2]);
+      warning("%s: %d: %s", __func__, i+1, vans[i].message[2]); // # nocov
     if (vans[i].status == 3)  { // # nocov start
       char err_msg[ANS_MSG_SIZE];
       strncpy(err_msg, vans[i].message[3], ANS_MSG_SIZE);

--- a/src/nafill.c
+++ b/src/nafill.c
@@ -103,9 +103,7 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP inplace, SEXP cols, SEXP verbo
   int64_t* i64x[nx];
   uint_fast64_t inx[nx];
   SEXP ans = R_NilValue;
-  ans_t *vans = malloc(sizeof(ans_t)*nx);
-  if (!vans)
-    error("%s: Unable to allocate memory answer", __func__); // # nocov
+  ans_t *vans = (ans_t *)R_alloc(nx, sizeof(ans_t));
   for (R_len_t i=0; i<nx; i++) {
     inx[i] = xlength(VECTOR_ELT(x, i));
     dx[i] = REAL(VECTOR_ELT(x, i));
@@ -180,19 +178,15 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP inplace, SEXP cols, SEXP verbo
       REprintf("%s: %d: %s", __func__, i+1, vans[i].message[1]); // # nocov
     if (vans[i].message[2][0] != '\0')
       warning("%s: %d: %s", __func__, i+1, vans[i].message[2]); // # nocov
-    if (vans[i].status == 3)  { // # nocov start
-      char err_msg[ANS_MSG_SIZE];
-      strncpy(err_msg, vans[i].message[3], ANS_MSG_SIZE);
-      free(vans);
-      error("%s: %d: %s", __func__, i+1, err_msg); // # nocov because only caused by malloc
-    } // # nocov end
+    if (vans[i].status == 3)  {
+      error("%s: %d: %s", __func__, i+1, vans[i].message[3]); // # nocov because only caused by malloc
+    }
   }
 
   if (bverbose)
     Rprintf("%s: parallel processing of %d column(s) took %.3fs\n", __func__, nx, toc-tic);
 
   UNPROTECT(protecti);
-  free(vans);
   if (binplace) {
     return obj;
   } else {

--- a/src/nafill.c
+++ b/src/nafill.c
@@ -162,7 +162,7 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP inplace, SEXP cols, SEXP verbo
     if (vans[i].message[2][0] != '\0')
       warning("%s: %d: %s", __func__, i+1, vans[i].message[2]);
     if (vans[i].status == 3) {
-      char err_msg = vans[i].message[3]; // # nocov
+      char err_msg[4096] = vans[i].message[3]; // # nocov
       free(vans); // # nocov
       error("%s: %d: %s", __func__, i+1, err_msg); // # nocov end
     }

--- a/src/types.c
+++ b/src/types.c
@@ -1,0 +1,6 @@
+#include <Rdefines.h>
+
+// find end of a string, used to append verbose message or warnings
+char *end(char *start) {
+  return strchr(start, 0);
+}

--- a/src/types.h
+++ b/src/types.h
@@ -1,10 +1,12 @@
 #include<stdint.h>
 
+#define ANST_MSG_SIZE 4096
+
 typedef struct ans_t {
-  int32_t *int_v;             // used in nafill
-  double *dbl_v;              // used in froll, nafill
-  int64_t *int64_v;           // not used yet
-  uint8_t status;             // 0:ok, 1:message, 2:warning, 3:error; unix return signal: {0,1,2}=0, {3}=1
-  char message[4][4096];      // STDOUT: output, STDERR: message, warning, error
+  int32_t *int_v;                 // used in nafill
+  double *dbl_v;                  // used in froll, nafill
+  int64_t *int64_v;               // not used yet
+  uint8_t status;                 // 0:ok, 1:message, 2:warning, 3:error; unix return signal: {0,1,2}=0, {3}=1
+  char message[4][ANST_MSG_SIZE]; // STDOUT: output, STDERR: message, warning, error
 // implicit n_message limit discussed here: https://github.com/Rdatatable/data.table/issues/3423#issuecomment-487722586
 } ans_t;

--- a/src/types.h
+++ b/src/types.h
@@ -5,12 +5,11 @@
  * catch verbose stdout messages, stderr messages, warnings and errors
  * safe to use inside parallel regions, of course allocated outside
  */
-#define ANS_MSG_SIZE 4096
 typedef struct ans_t {
-  int32_t *int_v;                 // used in nafill
-  double *dbl_v;                  // used in froll, nafill
-  int64_t *int64_v;               // not used yet
-  uint8_t status;                 // 0:ok, 1:message, 2:warning, 3:error; unix return signal: {0,1,2}=0, {3}=1
-  char message[4][ANS_MSG_SIZE]; // STDOUT: output, STDERR: message, warning, error
+  int32_t *int_v;        // used in nafill
+  double *dbl_v;         // used in froll, nafill
+  int64_t *int64_v;      // not used yet
+  uint8_t status;        // 0:ok, 1:message, 2:warning, 3:error; unix return signal: {0,1,2}=0, {3}=1
+  char message[4][4096]; // STDOUT: output, STDERR: message, warning, error
 // implicit n_message limit discussed here: https://github.com/Rdatatable/data.table/issues/3423#issuecomment-487722586
 } ans_t;

--- a/src/types.h
+++ b/src/types.h
@@ -1,12 +1,16 @@
 #include<stdint.h>
 
-#define ANST_MSG_SIZE 4096
-
+/*
+ * a struct to carry out results of a computation
+ * catch verbose stdout messages, stderr messages, warnings and errors
+ * safe to use inside parallel regions, of course allocated outside
+ */
+#define ANS_MSG_SIZE 4096
 typedef struct ans_t {
   int32_t *int_v;                 // used in nafill
   double *dbl_v;                  // used in froll, nafill
   int64_t *int64_v;               // not used yet
   uint8_t status;                 // 0:ok, 1:message, 2:warning, 3:error; unix return signal: {0,1,2}=0, {3}=1
-  char message[4][ANST_MSG_SIZE]; // STDOUT: output, STDERR: message, warning, error
+  char message[4][ANS_MSG_SIZE]; // STDOUT: output, STDERR: message, warning, error
 // implicit n_message limit discussed here: https://github.com/Rdatatable/data.table/issues/3423#issuecomment-487722586
 } ans_t;

--- a/src/utils.c
+++ b/src/utils.c
@@ -105,15 +105,16 @@ void coerceFill(SEXP fill, double *dfill, int32_t *ifill, int64_t *i64fill) {
       } else {
         ifill[0] = llfill[0]>INT32_MAX ? NA_INTEGER : (int32_t)(llfill[0]);
         dfill[0] = (double)(llfill[0]);
-        i64fill[0] = (int64_t)(llfill[0]);
+        i64fill[0] = llfill[0]>INT64_MAX ? NA_INTEGER64 : (int64_t)(llfill[0]);
       }
     } else {
-      if (ISNA(REAL(fill)[0])) {
+      double rfill = REAL(fill)[0];
+      if (ISNA(rfill)) {
         ifill[0] = NA_INTEGER; dfill[0] = NA_REAL; i64fill[0] = NA_INTEGER64;
       } else {
-        ifill[0] = (int32_t)(REAL(fill)[0]);
-        dfill[0] = REAL(fill)[0];
-        i64fill[0] = (int64_t)(REAL(fill)[0]);
+        ifill[0] = rfill>INT32_MAX ? NA_INTEGER : (int32_t)(rfill);
+        dfill[0] = rfill;
+        i64fill[0] = rfill>INT64_MAX ? NA_INTEGER64 : (int64_t)(rfill);
       }
     }
   } else if (isLogical(fill) && LOGICAL(fill)[0]==NA_LOGICAL) {

--- a/src/utils.c
+++ b/src/utils.c
@@ -109,7 +109,7 @@ void coerceFill(SEXP fill, double *dfill, int32_t *ifill, int64_t *i64fill) {
       }
     } else {
       double rfill = REAL(fill)[0];
-      if (ISNA(rfill)) {
+      if (ISNAN(rfill)) {
         ifill[0] = NA_INTEGER; dfill[0] = NA_REAL; i64fill[0] = NA_INTEGER64;
       } else {
         ifill[0] = rfill>INT32_MAX ? NA_INTEGER : (int32_t)(rfill);

--- a/src/utils.c
+++ b/src/utils.c
@@ -110,7 +110,8 @@ void coerceFill(SEXP fill, double *dfill, int32_t *ifill, int64_t *i64fill) {
     } else {
       double rfill = REAL(fill)[0];
       if (ISNAN(rfill)) {
-        ifill[0] = NA_INTEGER; dfill[0] = NA_REAL; i64fill[0] = NA_INTEGER64;
+        // NA -> NA, NaN -> NaN
+        ifill[0] = NA_INTEGER; dfill[0] = rfill; i64fill[0] = NA_INTEGER64;
       } else {
         ifill[0] = rfill>INT32_MAX ? NA_INTEGER : (int32_t)(rfill);
         dfill[0] = rfill;


### PR DESCRIPTION
Closes #3866 and closes #3873 

Jan take a look to confirm I've `free`d in the right place.

Approach was just to `ctrl+f` for the last usage of each variable then `free` afterwards.

Have tested on `RDvalgrind` binary of `wch1/r-debug` image. Also ran on `RDsan` and `RDcsan` but there was some openMP issue.