### PR TITLE
Shut off warnPartialMatchArgs for certain R versions

### DIFF
--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -60,11 +60,27 @@ test.data.table = function(verbose=FALSE, pkg="pkg", silent=FALSE, with.other.pa
   # sample method changed in R 3.6 to remove bias; see #3431 for links and notes
   # This can be removed (and over 120 tests updated) if and when the oldest R version we test and support is moved to R 3.6
 
-  oldverbose = options(datatable.verbose=verbose)
-  oldenc = options(encoding="UTF-8")[[1L]]  # just for tests 708-712 on Windows
   # TO DO: reinstate solution for C locale of CRAN's Mac (R-Forge's Mac is ok)
   # oldlocale = Sys.getlocale("LC_CTYPE")
   # Sys.setlocale("LC_CTYPE", "")   # just for CRAN's Mac to get it off C locale (post to r-devel on 16 Jul 2012)
+
+  # Control options in case user set them. The user's values are restored after the sys.source() below.
+  if (is.null(options()$warnPartialMatchArgs))   options(warnPartialMatchArgs=FALSE)   # R 3.1.0 had a NULL default for these 3. Set to FALSE
+  if (is.null(options()$warnPartialMatchAttr))   options(warnPartialMatchAttr=FALSE)   # now otherwise options(oldOptions) fails later.
+  if (is.null(options()$warnPartialMatchDollar)) options(warnPartialMatchDollar=FALSE)
+  oldOptions = options(
+    datatable.verbose = verbose,
+    encoding = "UTF-8",  # just for tests 708-712 on Windows
+    datatable.optimize = Inf,
+    datatable.alloccol = 1024L,
+    datatable.print.class = FALSE,  # this is TRUE in cc.R and we like TRUE. But output= tests need to be updated (they assume FALSE currently)
+    datatable.rbindlist.check = NULL,
+    datatable.integer64 = "integer64",
+    warnPartialMatchArgs = base::getRversion()>="3.6.0", # ensure we don't rely on partial argument matching in internal code, #3664; >=3.6.0 for #3865
+    warnPartialMatchAttr = TRUE,
+    warnPartialMatchDollar = TRUE,
+    width = max(getOption('width'), 80L) # some tests (e.g. 1066, 1293) rely on capturing output that will be garbled with small width
+  )
 
   cat("getDTthreads(verbose=TRUE):\n")         # for tracing on CRAN; output to log before anything is attempted
   getDTthreads(verbose=TRUE)                   # includes the returned value in the verbose output (rather than dangling '[1] 4'); e.g. "data.table is using 4 threads"
@@ -98,8 +114,8 @@ test.data.table = function(verbose=FALSE, pkg="pkg", silent=FALSE, with.other.pa
   } else {
     sys.source(fn, envir=env)
   }
-  options(oldverbose)
-  options(oldenc)
+  options(oldOptions)
+
   # Sys.setlocale("LC_CTYPE", oldlocale)
   ans = env$nfail==0
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -91,35 +91,6 @@ for (s in sugg) {
   if (!loaded) cat("\n**** Suggested package",s,"is not installed. Tests using it will be skipped.\n\n")
 }
 
-# Control options in case user set them. The user's values are restored at the end of this file.
-# R 3.1.0 had a NULL default for these 3. Set to FALSE now for R 3.1.0, otherwise the options(oldOptions) fails at the end of this file.
-if (is.null(options()$warnPartialMatchArgs))   options(warnPartialMatchArgs=FALSE)
-if (is.null(options()$warnPartialMatchAttr))   options(warnPartialMatchAttr=FALSE)
-if (is.null(options()$warnPartialMatchDollar)) options(warnPartialMatchDollar=FALSE)
-# R 3.5.{0,1,2,3} use seq(along=x) in base::order, which should be seq(along.with=x);
-#   detect this specific issue and skip the PartialMatchArgs check if so; see #3865
-old = options(warnPartialMatchArgs=TRUE, warn=0L)
-skip_partial_match_args = inherits(tryCatch(base::order(1:10), warning = identity), 'warning')
-options(old)
-if (skip_partial_match_args)
-  cat('\n**** This version of R (',  R.version$major, '.', R.version$minor, ') ',
-      'uses partial argument matching in base::order, so skipping to set options(warnPartialMatchArgs=TRUE) ',
-      'during this test run. This is a known issue in R 3.5.0, 3.5.1, 3.5.2, and 3.5.3; please report ',
-      'if you receive this message in a different R version.', sep='')
-oldOptions = options(
-  datatable.optimize = Inf,
-  datatable.verbose = FALSE,
-  datatable.alloccol = 1024L,
-  datatable.print.class = FALSE,  # this is TRUE in cc.R and we like TRUE. But output= tests need to be updated (they assume FALSE currently)
-  datatable.rbindlist.check = NULL,
-  datatable.integer64 = "integer64",
-  warnPartialMatchArgs = !skip_partial_match_args,    # ensure we don't rely on partial argument matching in internal code, #3664
-  warnPartialMatchAttr = TRUE,
-  warnPartialMatchDollar = TRUE
-)
-# some tests (e.g. 1066, 1293) rely on capturing output that will be garbled with small width
-if (getOption('width') < 80L) options(width = 80L)
-
 ##########################
 
 test(1.1, tables(env=new.env()), null.data.table(), output = "No objects of class")
@@ -16079,4 +16050,3 @@ test(2109, DT[ , list(count=.N), by={list(State, ExitCode)}], DT[ , count := 1L]
 #  Add new tests above this line  #
 ###################################
 
-options(oldOptions)  # set at top of this file

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -96,6 +96,15 @@ for (s in sugg) {
 if (is.null(options()$warnPartialMatchArgs))   options(warnPartialMatchArgs=FALSE)
 if (is.null(options()$warnPartialMatchAttr))   options(warnPartialMatchAttr=FALSE)
 if (is.null(options()$warnPartialMatchDollar)) options(warnPartialMatchDollar=FALSE)
+# R 3.5.{0,1,2,3} use seq(along=x) in base::order, which should be seq(along.with=x);
+#   detect this specific issue and skip the PartialMatchArgs check if so; see #3865
+old = options(warnPartialMatchArgs=TRUE, warn=0L)
+skip_partial_match_args = inherits(tryCatch(base::order(1:10), warning = identity), 'warning')
+if (skip_partial_match_args)
+  cat('\n**** This version of R (',  R.version$major, '.', R.version$minor, ') ',
+      'uses partial argument matching in base::order, so skipping to set options(warnPartialMatchArgs=TRUE) ',
+      'during this test run. This is a known issue in R 3.5.0, 3.5.1, 3.5.2, and 3.5.3; please report ',
+      'if you receive this message in a different R version.', sep='')
 oldOptions = options(
   datatable.optimize = Inf,
   datatable.verbose = FALSE,
@@ -103,7 +112,7 @@ oldOptions = options(
   datatable.print.class = FALSE,  # this is TRUE in cc.R and we like TRUE. But output= tests need to be updated (they assume FALSE currently)
   datatable.rbindlist.check = NULL,
   datatable.integer64 = "integer64",
-  warnPartialMatchArgs = TRUE,    # ensure we don't rely on partial argument matching in internal code, #3664
+  warnPartialMatchArgs = !skip_partial_match_args,    # ensure we don't rely on partial argument matching in internal code, #3664
   warnPartialMatchAttr = TRUE,
   warnPartialMatchDollar = TRUE
 )

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -100,6 +100,7 @@ if (is.null(options()$warnPartialMatchDollar)) options(warnPartialMatchDollar=FA
 #   detect this specific issue and skip the PartialMatchArgs check if so; see #3865
 old = options(warnPartialMatchArgs=TRUE, warn=0L)
 skip_partial_match_args = inherits(tryCatch(base::order(1:10), warning = identity), 'warning')
+options(old)
 if (skip_partial_match_args)
   cat('\n**** This version of R (',  R.version$major, '.', R.version$minor, ') ',
       'uses partial argument matching in base::order, so skipping to set options(warnPartialMatchArgs=TRUE) ',


### PR DESCRIPTION
Closes #3865 

Confirmed the fix and the message on `rocker/r-ver:3.5.3`.

@jangorecki it strikes me that these `warn.*` options are not being turned on for the other test suites (`froll`, `nafill`, etc). Should we move this option setting to the `data.table:::test` level? Or just manually do this on a per-file basis?