### PR TITLE
ans_t messages helper

### DIFF
--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -9,3 +9,5 @@ fifelse = function(test, yes, no, na=NA) .Call(CfifelseR, test, yes, no, na)
 
 colnamesInt = function(x, cols, check_dups=FALSE) .Call(CcolnamesInt, x, cols, check_dups)
 coerceFill = function(x) .Call(CcoerceFillR, x)
+
+testMsg = function(status=0L, nx=2L, nk=2L) .Call(CtestMsgR, as.integer(status)[1L], as.integer(nx)[1L], as.integer(nk)[1L])

--- a/inst/tests/nafill.Rraw
+++ b/inst/tests/nafill.Rraw
@@ -1,9 +1,5 @@
 require(methods)
 if (exists("test.data.table", .GlobalEnv, inherits=FALSE)) {
-  if (!identical(suppressWarnings(packageDescription("data.table")), NA)) {
-    remove.packages("data.table")
-    stop("This is dev mode but data.table was installed. Uninstalled it. Please q() this R session and try cc() again. The installed namespace causes problems in dev mode for the S4 tests.\n")
-  }
   if ((tt<-compiler::enableJIT(-1))>0)
     cat("This is dev mode and JIT is enabled (level ", tt, ") so there will be a brief pause around the first test.\n", sep="")
 } else {

--- a/inst/tests/types.Rraw
+++ b/inst/tests/types.Rraw
@@ -1,0 +1,41 @@
+require(methods)
+if (exists("test.data.table", .GlobalEnv, inherits=FALSE)) {
+  if ((tt<-compiler::enableJIT(-1))>0)
+    cat("This is dev mode and JIT is enabled (level ", tt, ") so there will be a brief pause around the first test.\n", sep="")
+} else {
+  require(data.table)
+  test = data.table:::test
+  testMsg = data.table:::testMsg
+}
+
+# test returned statuses only
+test(1.01, testMsg(0, 1, 1), list(0L))
+test(1.02, testMsg(100, 1, 1), list(0L))
+test(1.03, testMsg(-100, 1, 1), list(0L))
+test(1.04, testMsg(0, 2, 2), as.list(rep(0L, 4)))
+test(1.05, testMsg(0, 2, 3), as.list(rep(0L, 6)))
+test(1.06, testMsg(1, 1, 1), list(1L))
+test(1.07, suppressWarnings(testMsg(2, 1, 1)), list(2L))
+test(1.08, suppressWarnings(testMsg(12, 1, 1)), list(2L)) # test that warn status is returned for msg and warn
+# test non-verbose messages
+out = c("testMsgR: 1:\ntestRaiseMsg: stdout 1 message\ntestRaiseMsg: stdout 2 message","testMsgR: 2:\ntestRaiseMsg: stdout 1 message\ntestRaiseMsg: stdout 2 message")
+msg = c("testMsgR: 1:\ntestRaiseMsg: stderr 1 message\ntestRaiseMsg: stderr 2 message","testMsgR: 2:\ntestRaiseMsg: stderr 1 message\ntestRaiseMsg: stderr 2 message")
+wrn = c("testMsgR: 1:\ntestRaiseMsg: stderr 1 warning\ntestRaiseMsg: stderr 2 warning","testMsgR: 2:\ntestRaiseMsg: stderr 1 warning\ntestRaiseMsg: stderr 2 warning")
+err = "testMsgR: 1:\ntestRaiseMsg: stderr 1 error\ntestRaiseMsg: stderr 2 error"
+test(2.01, testMsg(0, 2, 1), as.list(rep(0L, 2L)), notOutput="testMsgR")
+##test(2.02, testMsg(1, 2, 1), as.list(rep(1L, 2L)), message=msg) ## REprint does not raise message exception! #3874
+test(2.03, testMsg(2, 2, 1), as.list(rep(2L, 2L)), warning=wrn)
+##test(2.04, testMsg(12, 2, 1), as.list(rep(2L, 2L)), message=msg, warning=wrn)
+test(2.05, testMsg(3, 2, 1), error=err)
+test(2.06, testMsg(23, 2, 1), warning=wrn[1L], error=err)
+##test(2.07, testMsg(123, 2, 1), message=msg[1L], warning=wrn[1L], error=err)
+# test all messages
+op = options(datatable.verbose=TRUE)
+test(3.01, testMsg(0, 2, 1), as.list(rep(0L, 2L)), output=out)
+##test(3.02, testMsg(1, 2, 1), as.list(rep(1L, 2L)), output=out, message=msg)
+test(3.03, testMsg(2, 2, 1), as.list(rep(2L, 2L)), output=out, warning=wrn)
+##test(3.04, testMsg(12, 2, 1), as.list(rep(2L, 2L)), output=out, message=msg, warning=wrn)
+test(3.05, testMsg(3, 2, 1), output=out[1L], error=err)
+test(3.06, testMsg(23, 2, 1), output=out[1L], warning=wrn[1L], error=err)
+##test(3.07, testMsg(123, 2, 1), output=out[1L], message=msg[1L], warning=wrn[1L], error=err)
+options(op)

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -229,3 +229,5 @@ SEXP coerceUtf8IfNeeded(SEXP x);
 
 // types.c
 char *end(char *start);
+void ansMsg(ans_t *ans, int n, bool verbose, const char *func);
+SEXP testMsgR(SEXP status, SEXP x, SEXP k);

--- a/src/frollR.c
+++ b/src/frollR.c
@@ -180,11 +180,13 @@ SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEX
     ialgo = 0;                                                  // fast = 0
   else if (!strcmp(CHAR(STRING_ELT(algo, 0)), "exact"))
     ialgo = 1;                                                  // exact = 1
-  else error("Internal error: invalid algo argument in rolling function, should have been caught before. please report to data.table issue tracker."); // # nocov
+  else
+    error("Internal error: invalid algo argument in rolling function, should have been caught before. please report to data.table issue tracker."); // # nocov
 
   int* iik = NULL;
   if (!badaptive) {
-    if (!isInteger(ik)) error("Internal error: badaptive=%d but ik is not integer", badaptive);    // # nocov
+    if (!isInteger(ik))
+      error("Internal error: badaptive=%d but ik is not integer", badaptive); // # nocov
     iik = INTEGER(ik);                                          // pointer to non-adaptive window width, still can be vector when doing multiple windows
   } else {
     // ik is still R_NilValue from initialization. But that's ok as it's only needed below when !badaptive.
@@ -218,19 +220,7 @@ SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEX
     }
   }
 
-  for (R_len_t i=0; i<nx; i++) {                                // raise errors and warnings, as of now messages are not being produced
-    for (R_len_t j=0; j<nk; j++) {
-      if (verbose && (dans[i*nk+j].message[0][0] != '\0'))
-        Rprintf("%s: %d:\n%s", __func__, i*nk+j+1, dans[i*nk+j].message[0]);
-      if (dans[i*nk+j].message[1][0] != '\0')
-        REprintf("%s: %d:\n%s", __func__, i*nk+j+1, dans[i*nk+j].message[1]); // # nocov because no messages yet // change REprintf according to comments in #3483 when ready
-      if (dans[i*nk+j].message[2][0] != '\0')
-        warning("%s: %d:\n%s", __func__, i*nk+j+1, dans[i*nk+j].message[2]);
-      if (dans[i*nk+j].status == 3) {
-        error("%s: %d: %s", __func__, i*nk+j+1, dans[i*nk+j].message[3]); // # nocov because only caused by malloc
-      }
-    }
-  }
+  ansMsg(dans, nx*nk, verbose, __func__);                       // raise errors and warnings, as of now messages are not being produced
 
   if (verbose)
     Rprintf("%s: processing of %d column(s) and %d window(s) took %.3fs\n", __func__, nx, nk, omp_get_wtime()-tic);

--- a/src/init.c
+++ b/src/init.c
@@ -175,6 +175,7 @@ R_CallMethodDef callMethods[] = {
 {"C_unlock", (DL_FUNC) &unlock, -1},
 {"C_islocked", (DL_FUNC) &islockedR, -1},
 {"CfrollapplyR", (DL_FUNC) &frollapplyR, -1},
+{"CtestMsgR", (DL_FUNC) &testMsgR, -1},
 {NULL, NULL, 0}
 };
 

--- a/src/nafill.c
+++ b/src/nafill.c
@@ -171,17 +171,7 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP inplace, SEXP cols, SEXP verbo
     }
   }
 
-  for (R_len_t i=0; i<nx; i++) {
-    if (bverbose && (vans[i].message[0][0] != '\0'))
-      Rprintf("%s: %d: %s", __func__, i+1, vans[i].message[0]);
-    if (vans[i].message[1][0] != '\0')
-      REprintf("%s: %d: %s", __func__, i+1, vans[i].message[1]); // # nocov
-    if (vans[i].message[2][0] != '\0')
-      warning("%s: %d: %s", __func__, i+1, vans[i].message[2]); // # nocov
-    if (vans[i].status == 3)  {
-      error("%s: %d: %s", __func__, i+1, vans[i].message[3]); // # nocov because only caused by malloc
-    }
-  }
+  ansMsg(vans, nx, bverbose, __func__);
 
   if (bverbose)
     Rprintf("%s: parallel processing of %d column(s) took %.3fs\n", __func__, nx, toc-tic);

--- a/src/types.c
+++ b/src/types.c
@@ -1,6 +1,82 @@
 #include <Rdefines.h>
+#include "data.table.h"
 
-// find end of a string, used to append verbose message or warnings
+/*
+ * find end of a string, used to append verbose messages or warnings
+ */
 char *end(char *start) {
   return strchr(start, 0);
+}
+
+/*
+ * function to print verbose messages, stderr messages, warnings and errors stored in ans_t struct
+ */
+void ansMsg(ans_t *ans, int n, bool verbose, const char *func) {
+  for (int i=0; i<n; i++) {
+    if (verbose && (ans[i].message[0][0] != '\0'))
+      Rprintf("%s: %d:\n%s", func, i+1, ans[i].message[0]);
+    if (ans[i].message[1][0] != '\0')
+      REprintf("%s: %d:\n%s", func, i+1, ans[i].message[1]);
+    if (ans[i].message[2][0] != '\0')
+      warning("%s: %d:\n%s", func, i+1, ans[i].message[2]);
+    if (ans[i].status == 3)
+      error("%s: %d:\n%s:", func, i+1, ans[i].message[3]);
+  }
+}
+
+/*
+ * R interface to test ansMsg function
+ * see inst/tests/types.Rraw
+ */
+void testRaiseMsg(ans_t *ans, int istatus, bool verbose) {
+  if (verbose) {
+    snprintf(end(ans->message[0]), 500, "%s: stdout 1 message\n", __func__);
+    snprintf(end(ans->message[0]), 500, "%s: stdout 2 message\n", __func__);
+  }
+  if (istatus == 1 || istatus == 12 || istatus == 13 || istatus == 123) {
+    snprintf(end(ans->message[1]), 500, "%s: stderr 1 message\n", __func__);
+    snprintf(end(ans->message[1]), 500, "%s: stderr 2 message\n", __func__);
+    ans->status = 1;
+  }
+  if (istatus == 2 || istatus == 12 || istatus == 23 || istatus == 123) {
+    snprintf(end(ans->message[2]), 500, "%s: stderr 1 warning\n", __func__);
+    snprintf(end(ans->message[2]), 500, "%s: stderr 2 warning\n", __func__);
+    ans->status = 2;
+  }
+  if (istatus == 3 || istatus == 13 || istatus == 23 || istatus == 123) {
+    snprintf(end(ans->message[3]), 500, "%s: stderr 1 error\n", __func__);
+    snprintf(end(ans->message[3]), 500, "%s: stderr 2 error\n", __func__); // printed too because errors appended and raised from ansMsg later on
+    ans->status = 3;
+  }
+  ans->int_v[0] = ans->status;
+}
+SEXP testMsgR(SEXP status, SEXP x, SEXP k) {
+  if (!isInteger(status) || !isInteger(x) || !isInteger(k))
+    error("status, nx, nk must be integer");
+  int protecti = 0;
+  const bool verbose = GetVerbose();
+  int istatus = INTEGER(status)[0], nx = INTEGER(x)[0], nk = INTEGER(k)[0];
+
+  // TODO below chunk into allocansList helper, not for 1.12.4
+  SEXP ans = PROTECT(allocVector(VECSXP, nk * nx)); protecti++;
+  ans_t *vans = (ans_t *)R_alloc(nx*nk, sizeof(ans_t));
+  if (verbose)
+    Rprintf("%s: allocating memory for results %dx%d\n", __func__, nx, nk);
+  for (R_len_t i=0; i<nx; i++) {
+    for (R_len_t j=0; j<nk; j++) {
+      SET_VECTOR_ELT(ans, i*nk+j, allocVector(INTSXP, 1));
+      vans[i*nk+j] = ((ans_t) { .int_v=INTEGER(VECTOR_ELT(ans, i*nk+j)), .status=0, .message={"\0","\0","\0","\0"} });
+    }
+  }
+
+  #pragma omp parallel for if (nx*nk>1) schedule(auto) collapse(2) num_threads(getDTthreads())
+  for (R_len_t i=0; i<nx; i++) {
+    for (R_len_t j=0; j<nk; j++) {
+      testRaiseMsg(&vans[i*nk+j], istatus, verbose);
+    }
+  }
+
+  ansMsg(vans, nx*nk, verbose, __func__);
+  UNPROTECT(protecti);
+  return ans;
 }

--- a/src/types.c
+++ b/src/types.c
@@ -52,7 +52,7 @@ void testRaiseMsg(ans_t *ans, int istatus, bool verbose) {
 }
 SEXP testMsgR(SEXP status, SEXP x, SEXP k) {
   if (!isInteger(status) || !isInteger(x) || !isInteger(k))
-    error("status, nx, nk must be integer");
+    error("internal error: status, nx, nk must be integer"); // # nocov
   int protecti = 0;
   const bool verbose = GetVerbose();
   int istatus = INTEGER(status)[0], nx = INTEGER(x)[0], nk = INTEGER(k)[0];

--- a/src/types.h
+++ b/src/types.h
@@ -1,15 +1,16 @@
 #include<stdint.h>
 
 /*
- * a struct to carry out results of a computation
+ * a struct to carry out results of embarrassingly parallel computation
  * catch verbose stdout messages, stderr messages, warnings and errors
  * safe to use inside parallel regions, of course allocated outside
  */
+#define ANS_MSG_SIZE 4096
 typedef struct ans_t {
   int32_t *int_v;        // used in nafill
   double *dbl_v;         // used in froll, nafill
   int64_t *int64_v;      // not used yet
   uint8_t status;        // 0:ok, 1:message, 2:warning, 3:error; unix return signal: {0,1,2}=0, {3}=1
-  char message[4][4096]; // STDOUT: output, STDERR: message, warning, error
+  char message[4][ANS_MSG_SIZE]; // STDOUT: output, STDERR: message, warning, error
 // implicit n_message limit discussed here: https://github.com/Rdatatable/data.table/issues/3423#issuecomment-487722586
 } ans_t;

--- a/tests/types.R
+++ b/tests/types.R
@@ -1,0 +1,2 @@
+require(data.table)
+test.data.table(script="types.Rraw")


### PR DESCRIPTION
Simplifies logic of frollfunR and nafillR by using helper function ansMsg that prints verbose output, messages, warnings and errors. C `testRaiseMsg`, `testMsgR` and R `testMsg` functions has been added only for testing/code coverage purpose.
Few tests are disabled for now due to #3874.

This PR also provides a working template for parallelizing "embarrassingly parallel" problems by using `ans_t` struct that carry out results of a computations to be performed in parallel providing a place to catch exceptions which are deferred and raised from non-parallel region. It is currently being used in frollfunR and nafillR.