### PR TITLE
added check= to between(), default FALSE

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -96,7 +96,7 @@
 
 7. New variable `.Last.updated` (similar to R's `.Last.value`) contains the number of rows affected by the most recent `:=` or `set()`, [#1885](https://github.com/Rdatatable/data.table/issues/1885). For details see `?.Last.updated`.
 
-8. `between()` and `%between%` are faster for `POSIXct`, [#3519](https://github.com/Rdatatable/data.table/issues/3519), and now support the `.()` alias, [#2315](https://github.com/Rdatatable/data.table/issues/2315). Thanks to @Henrik-P for the reports. There is now also support for `bit64`'s `integer64` class and more robust coercion of types, [#3517](https://github.com/Rdatatable/data.table/issues/3517).
+8. `between()` and `%between%` are faster for `POSIXct`, [#3519](https://github.com/Rdatatable/data.table/issues/3519), and now support the `.()` alias, [#2315](https://github.com/Rdatatable/data.table/issues/2315). Thanks to @Henrik-P for the reports. There is now also support for `bit64`'s `integer64` class and more robust coercion of types, [#3517](https://github.com/Rdatatable/data.table/issues/3517). `between()` gains `check=` which checks `any(lower>upper)`; off by default for speed in particular for type character.
 
 9. New convenience functions `%ilike%` and `%flike%` which map to new `like()` arguments `ignore.case` and `fixed` respectively, [#3333](https://github.com/Rdatatable/data.table/issues/3333). `%ilike%` is for case-insensitive pattern matching. `%flike%` is for more efficient matching of fixed strings. Thanks to @andreasLD for providing most of the core code.
 
@@ -1116,5 +1116,4 @@ When `j` is a symbol (as in the quanteda and xgboost examples above) it will con
 
 
 # data.table v1.9.8 (Nov 2016) back to v1.2 (Aug 2008) has been moved to [NEWS.0.md](https://github.com/Rdatatable/data.table/blob/master/NEWS.0.md)
-
 

--- a/R/between.R
+++ b/R/between.R
@@ -1,5 +1,5 @@
 # is x[i] in between lower[i] and upper[i] ?
-between = function(x, lower, upper, incbounds=TRUE, NAbounds=TRUE) {
+between = function(x, lower, upper, incbounds=TRUE, NAbounds=TRUE, check=FALSE) {
   if (is.logical(x)) stop("between has been x of type logical")
   if (is.logical(lower)) lower = as.integer(lower)   # typically NA (which is logical type)
   if (is.logical(upper)) upper = as.integer(upper)   # typically NA (which is logical type)
@@ -42,10 +42,11 @@ between = function(x, lower, upper, incbounds=TRUE, NAbounds=TRUE) {
     # faster parallelised version for int/double/character
     # Cbetween supports length(lower)==1 (recycled) and (from v1.12.0) length(lower)==length(x).
     # length(upper) can be 1 or length(x) independently of lower
-    .Call(Cbetween, x, lower, upper, incbounds, NAbounds)
+    .Call(Cbetween, x, lower, upper, incbounds, NAbounds, check)
   } else {
     if (isTRUE(getOption("datatable.verbose"))) cat("optimised between not available for this data type, fallback to slow R routine\n")
     if (isTRUE(NAbounds) && (anyNA(lower) || anyNA(upper))) stop("Not yet implemented NAbounds=TRUE for this non-numeric and non-character type")
+    if (check && any(lower>upper, na.rm=TRUE)) stop("Some lower>upper for this non-numeric and non-character type")
     if (incbounds) x>=lower & x<=upper
     else x>lower & x<upper
   }

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -15791,6 +15791,7 @@ if (test_bit64) {
 test(2082.07, between(letters[1:2], c("foo","bar"), c("bar")), c(FALSE,FALSE))
 test(2082.08, between(letters[1:2], c("foo","bar"), c("bar"), check=TRUE), error="Item 1 of lower ('foo') is greater than item 1 of upper ('bar')")
 test(2082.09, between(as.raw(1:5), as.raw(3), as.raw(2), check=TRUE), error="Some lower>upper for this non-numeric and non-character type")
+test(2082.10, between(1:3, 2, 4, check=NA), error="check must be TRUE or FALSE")
 
 # partial instantiation of integer64 column was creating NA_REAL, not INT64_MIN
 if (test_bit64) {

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -15778,11 +15778,19 @@ test(2081.01, between(as.raw(1:5), as.raw(2), as.raw(4)),                  c(FAL
 test(2081.02, between(as.raw(1:5), as.raw(2), as.raw(4), incbounds=FALSE), c(FALSE, FALSE, TRUE, FALSE, FALSE), output="fallback to slow R")
 options(old)
 test(2081.03, between(3i, NA, NA), error="Not yet implemented NAbounds=TRUE for this non-numeric and non-character type")
-# check that lower<=upper
-test(2082.01, between(1:3, INT(2,3,4), 2L), error="Item 2 of lower (3) is greater than item 1 of upper (2)")
-test(2082.02, between(as.double(1:3), c(2,3,4), 2), error="Item 2 of lower [(]3.*[)] is greater than item 1 of upper [(]2.*[)]")
-if (test_bit64) test(2082.03, between(as.integer64(1:3), as.integer64(2), as.integer64(1)), error="Item 1 of lower (2) is greater than item 1 of upper (1)")
-test(2082.04, between(letters[1:2], c("foo","bar"), c("bar")), error="Item 1 of lower ('foo') is greater than item 1 of upper ('bar')")
+
+# new check in 1.12.4 that lower<=upper when check=TRUE (FALSE by default), #3838
+test(2082.01, between(1:3, INT(2,3,4), 2L), ans<-c(FALSE, FALSE, FALSE))
+test(2082.02, between(1:3, INT(2,3,4), 2L, check=TRUE), error="Item 2 of lower (3) is greater than item 1 of upper (2)")
+test(2082.03, between(as.double(1:3), c(2,3,4), 2), ans)
+test(2082.04, between(as.double(1:3), c(2,3,4), 2, check=TRUE), error="Item 2 of lower [(]3.*[)] is greater than item 1 of upper [(]2.*[)]")
+if (test_bit64) {
+  test(2082.05, between(as.integer64(1:3), as.integer64(2), as.integer64(1)), ans)
+  test(2082.06, between(as.integer64(1:3), as.integer64(2), as.integer64(1), check=TRUE), error="Item 1 of lower (2) is greater than item 1 of upper (1)")
+}
+test(2082.07, between(letters[1:2], c("foo","bar"), c("bar")), c(FALSE,FALSE))
+test(2082.08, between(letters[1:2], c("foo","bar"), c("bar"), check=TRUE), error="Item 1 of lower ('foo') is greater than item 1 of upper ('bar')")
+test(2082.09, between(as.raw(1:5), as.raw(3), as.raw(2), check=TRUE), error="Some lower>upper for this non-numeric and non-character type")
 
 # partial instantiation of integer64 column was creating NA_REAL, not INT64_MIN
 if (test_bit64) {

--- a/man/between.Rd
+++ b/man/between.Rd
@@ -10,14 +10,13 @@ Intended for use in \code{i} in \code{[.data.table}.
 \code{between} is equivalent to \code{lower<=x & x<=upper} when
 \code{incbounds=TRUE}, or \code{lower<x & y<upper} when \code{FALSE}. With a caveat that
 \code{NA} in \code{lower} or \code{upper} are taken as unlimited bounds not \code{NA}.
-This can be changed by setting \code{NAbounds} to \code{NA}. Further, as a convenient
-safety feature for robustness, an error is issued if any \code{lower>upper}.
+This can be changed by setting \code{NAbounds} to \code{NA}.
 
 \code{inrange} checks whether each value in \code{x} is in between any of
 the intervals provided in \code{lower,upper}.
 }
 \usage{
-between(x, lower, upper, incbounds=TRUE, NAbounds=TRUE)
+between(x, lower, upper, incbounds=TRUE, NAbounds=TRUE, check=FALSE)
 x \%between\% y
 
 inrange(x, lower, upper, incbounds=TRUE)
@@ -35,6 +34,7 @@ interpreted as \code{lower} and \code{y[[2]]} as \code{upper}.}
 \code{FALSE} means exclusive bounds, i.e., (lower,upper).
 It is set to \code{TRUE} by default for infix notations.}
 \item{NAbounds}{ If \code{lower} (\code{upper}) contains an \code{NA} what should \code{lower<=x} (\code{x<=upper}) return? By default \code{TRUE} so that a missing bound is interpreted as unlimited. }
+\item{check}{ Produce error if \code{any(lower>upper)}? \code{FALSE} by default for efficiency, in particular type \code{character}. }
 }
 \details{
 

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -205,7 +205,7 @@ void nafillInteger(int32_t *x, uint_fast64_t nx, unsigned int type, int32_t fill
 SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP inplace, SEXP cols, SEXP verbose);
 
 // between.c
-SEXP between(SEXP x, SEXP lower, SEXP upper, SEXP incbounds, SEXP NAbounds);
+SEXP between(SEXP x, SEXP lower, SEXP upper, SEXP incbounds, SEXP NAbounds, SEXP check);
 
 // coalesce.c
 SEXP coalesce(SEXP x, SEXP inplace);


### PR DESCRIPTION
Closes #3838 
Went further than the request and changed it to be an option to turn it on, rather than turn it off.  It hasn't checked in previous versions so this is gentler. For efficiency too, especially type character.