### PR TITLE
document internal test function

### DIFF
--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -1,9 +1,9 @@
-test.data.table = function(verbose=FALSE, pkg="pkg", silent=FALSE, with.other.packages=FALSE, benchmark=FALSE, script="tests.Rraw") {
+test.data.table = function(verbose=FALSE, pkg=".", silent=FALSE, script="tests.Rraw") {
   if (exists("test.data.table", .GlobalEnv,inherits=FALSE)) {
     # package developer
     # nocov start
     if ("package:data.table" %chin% search()) stop("data.table package is loaded. Unload or start a fresh R session.")
-    rootdir = if (pkg %chin% dir()) file.path(getwd(), pkg) else Sys.getenv("PROJ_PATH")
+    rootdir = if (pkg!="." && pkg %chin% dir()) file.path(getwd(), pkg) else Sys.getenv("PROJ_PATH")
     subdir = file.path("inst","tests")
     # nocov end
   } else {
@@ -21,17 +21,6 @@ test.data.table = function(verbose=FALSE, pkg="pkg", silent=FALSE, with.other.pa
     return(invisible())
     # nocov end
   }
-
-  # nocov start
-  if (isTRUE(benchmark)) {
-    warning("'benchmark' argument is deprecated, use script='benchmark.Rraw' instead")
-    script = "benchmark.Rraw"
-  }
-  if (isTRUE(with.other.packages)) {
-    warning("'with.other.packages' argument is deprecated, use script='other.Rraw' instead")
-    script = "other.Rraw"
-  }
-  # nocov end
 
   if (!is.null(script)) {
     stopifnot(is.character(script), length(script)==1L, !is.na(script), nzchar(script))
@@ -233,7 +222,7 @@ gc_mem = function() {
   # nocov end
 }
 
-test = function(num,x,y=TRUE,error=NULL,warning=NULL,output=NULL,notOutput=NULL,message=NULL) {
+test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,notOutput=NULL) {
   # Usage:
   # i) tests that x equals y when both x and y are supplied, the most common usage
   # ii) tests that x is TRUE when y isn't supplied

--- a/man/test.Rd
+++ b/man/test.Rd
@@ -20,7 +20,7 @@ test(num, x, y = TRUE,
 \item{notOutput}{ Or if you are testing that a feature does not print particular console output. }
 }
 \note{
-   \code{NA_real_} and \code{NaN} treated as equal, use \code{identical} if distinction is needed. See examples below.
+   \code{NA_real_} and \code{NaN} are treated as equal, use \code{identical} if distinction is needed. See examples below.
 }
 \value{
 Logical \code{TRUE} when test passes, \code{FALSE} when test fails. Invisibly.

--- a/man/test.Rd
+++ b/man/test.Rd
@@ -1,0 +1,39 @@
+\name{test}
+\alias{test}
+\title{ Test assertions for equality, exceptions and console output }
+\description{
+  An internal function used to tests equality, errors, warnings, messages, console output.
+}
+\usage{
+test(num, x, y = TRUE,
+     error = NULL, warning = NULL, message = NULL,
+     output = NULL, notOutput = NULL)
+}
+\arguments{
+\item{num}{ A unique identifier for a test, helpful in identifying the source of failure when testing is not working. Currently, we use a manually-incremented system with tests formatted as \code{n.m}, where essentially \code{n} indexes an issue and \code{m} indexes aspects of that issue. For the most part, your new PR should only have one value of \code{n} (scroll to the end of \code{inst/tests/tests.Rraw} to see the next available ID) and then index the tests within your PR by increasing \code{m}. Note -- \code{n.m} is interpreted as a number, so \code{123.4} and \code{123.40} are actually the same -- please \code{0}-pad as appropriate. Test identifiers should be provided in increasing order. }
+\item{x}{ An input object to be evaluated. }
+\item{y}{ Pre-defined output against which you are testing \code{x}, by default \code{TRUE}. }
+\item{error}{ When you are testing behaviour of code that you expect to fail with an error, supply the expected error message to this argument. It is interpreted as a regular expression, so you can be abbreviated, but try to include the key portion of the error so as not to accidentally include a different error message. }
+\item{warning}{ Same as \code{error}, in the case that you expect your code to issue a warning. Note that since the code evaluates successfully, you should still supply \code{y}. }
+\item{message}{ Same as \code{warning} but expects \code{message} exception. }
+\item{output}{ If you are testing the printing/console output behaviour of some feature. Again, regex-compatible. }
+\item{notOutput}{ Or if you are testing that a feature does not print particular console output. }
+}
+\details{
+   The atomic testing function used in \code{data.table} test scripts that are run by \code{\link{test.data.table}}.
+}
+\value{
+Logical \code{TRUE} when test passes, \code{FALSE} when test fails. Invisibly.
+}
+\seealso{ \code{\link{test.data.table}} }
+\examples{
+test = data.table:::test
+test(1, x = sum(1:5), y = 15L)
+test(2, log(-1), NaN, warning="NaNs")
+test(3, sum("a"), error="invalid.*character")
+# test failure example
+stopifnot(
+  test(4, TRUE, FALSE) == FALSE
+)
+}
+\keyword{ data }

--- a/man/test.Rd
+++ b/man/test.Rd
@@ -2,7 +2,7 @@
 \alias{test}
 \title{ Test assertions for equality, exceptions and console output }
 \description{
-  An internal function used to tests equality, errors, warnings, messages, console output.
+  An internal testing function used in \code{data.table} test scripts that are run by \code{\link{test.data.table}}.
 }
 \usage{
 test(num, x, y = TRUE,
@@ -19,8 +19,8 @@ test(num, x, y = TRUE,
 \item{output}{ If you are testing the printing/console output behaviour of some feature. Again, regex-compatible. }
 \item{notOutput}{ Or if you are testing that a feature does not print particular console output. }
 }
-\details{
-   The atomic testing function used in \code{data.table} test scripts that are run by \code{\link{test.data.table}}.
+\note{
+   \code{NA_real_} and \code{NaN} treated as equal, use \code{identical} if distinction is needed. See examples below.
 }
 \value{
 Logical \code{TRUE} when test passes, \code{FALSE} when test fails. Invisibly.
@@ -35,5 +35,9 @@ test(3, sum("a"), error="invalid.*character")
 stopifnot(
   test(4, TRUE, FALSE) == FALSE
 )
+# NA_real_ vs NaN
+test(5.01, NA_real_, NaN)
+test(5.03, all.equal(NaN, NA_real_))
+test(5.02, identical(NaN, NA_real_), FALSE)
 }
 \keyword{ data }

--- a/man/test.Rd
+++ b/man/test.Rd
@@ -10,17 +10,23 @@ test(num, x, y = TRUE,
      output = NULL, notOutput = NULL)
 }
 \arguments{
-\item{num}{ A unique identifier for a test, helpful in identifying the source of failure when testing is not working. Currently, we use a manually-incremented system with tests formatted as \code{n.m}, where essentially \code{n} indexes an issue and \code{m} indexes aspects of that issue. For the most part, your new PR should only have one value of \code{n} (scroll to the end of \code{inst/tests/tests.Rraw} to see the next available ID) and then index the tests within your PR by increasing \code{m}. Note -- \code{n.m} is interpreted as a number, so \code{123.4} and \code{123.40} are actually the same -- please \code{0}-pad as appropriate. Test identifiers should be provided in increasing order. }
-\item{x}{ An input object to be evaluated. }
-\item{y}{ Pre-defined output against which you are testing \code{x}, by default \code{TRUE}. }
+\item{num}{ A unique identifier for a test, helpful in identifying the source of failure when testing is not working. Currently, we use a manually-incremented system with tests formatted as \code{n.m}, where essentially \code{n} indexes an issue and \code{m} indexes aspects of that issue. For the most part, your new PR should only have one value of \code{n} (scroll to the end of \code{inst/tests/tests.Rraw} to see the next available ID) and then index the tests within your PR by increasing \code{m}. Note -- \code{n.m} is interpreted as a number, so \code{123.4} and \code{123.40} are actually the same -- please \code{0}-pad as appropriate. Test identifiers are checked to be in increasing order at runtime to prevent duplicates being possible. }
+\item{x}{ An input expression to be evaluated. }
+\item{y}{ Pre-defined value to compare to \code{x}, by default \code{TRUE}. }
 \item{error}{ When you are testing behaviour of code that you expect to fail with an error, supply the expected error message to this argument. It is interpreted as a regular expression, so you can be abbreviated, but try to include the key portion of the error so as not to accidentally include a different error message. }
 \item{warning}{ Same as \code{error}, in the case that you expect your code to issue a warning. Note that since the code evaluates successfully, you should still supply \code{y}. }
 \item{message}{ Same as \code{warning} but expects \code{message} exception. }
-\item{output}{ If you are testing the printing/console output behaviour of some feature. Again, regex-compatible. }
-\item{notOutput}{ Or if you are testing that a feature does not print particular console output. }
+\item{output}{ If you are testing the printing/console output behaviour; e.g. with \code{verbose=TRUE} or \code{options(datatable.verbose=TRUE)}. Again, regex-compatible and case sensitive. }
+\item{notOutput}{ Or if you are testing that a feature does \emph{not} print particular console output. Case insensitive (unlike output) so that the test does not incorrectly pass just because the string is not found due to case. }
 }
 \note{
    \code{NA_real_} and \code{NaN} are treated as equal, use \code{identical} if distinction is needed. See examples below.
+
+   If \code{warning=} is not supplied then you are automatically asserting no warning is expected; the test will fail if any warning does occur. Similarly for \code{message=}.
+
+   Multiple warnings are supported; supply a vector of strings to \code{warning=}. If \code{x} does not produce the correct number of warnings in the correct order, the test will fail.
+
+   Strings passed to \code{notOutput=} should be minimal; e.g. pick out single words from the output that you desire to check does not occur. The reason being so that the test does not incorrectly pass just because the output has slightly changed. For example \code{notOutput="revised"} is better than \code{notOutput="revised flag to true"}. \code{notOutput=} is automatically case insensitive for this reason.
 }
 \value{
 Logical \code{TRUE} when test passes, \code{FALSE} when test fails. Invisibly.

--- a/man/test.data.table.Rd
+++ b/man/test.data.table.Rd
@@ -5,16 +5,12 @@
   Runs a set of tests to check data.table is working correctly.
 }
 \usage{
-test.data.table(verbose=FALSE, pkg="pkg", silent=FALSE,
-                with.other.packages=FALSE, benchmark=FALSE,
-                script="tests.Rraw")
+test.data.table(verbose=FALSE, pkg=".", silent=FALSE, script="tests.Rraw")
 }
 \arguments{
 \item{verbose}{ If \code{TRUE} sets datatable.verbose to \code{TRUE} for the duration of the tests. }
-\item{pkg}{Root directory name under which all package content (ex: DESCRIPTION, src/, R/, inst/ etc..) resides.}
-\item{silent}{Logical, default \code{FALSE}, when \code{TRUE} it will not raise error on in case of test fails.}
-\item{with.other.packages}{ Deprecated. Run compatibility tests with other packages. Use \code{script='other.Rraw'} instead. }
-\item{benchmark}{ Deprecated. Run the benchmark script. Use \code{script='benchmark.Rraw'} instead. }
+\item{pkg}{ Root directory name under which all package content (ex: DESCRIPTION, src/, R/, inst/ etc..) resides. Used only in \emph{dev-mode}. }
+\item{silent}{ Logical, default \code{FALSE}, when \code{TRUE} it will not raise error on in case of test fails. }
 \item{script}{ Run arbitrary R test script. }
 }
 \details{
@@ -23,5 +19,5 @@ test.data.table(verbose=FALSE, pkg="pkg", silent=FALSE,
 \value{
 When \code{silent} equals to \code{TRUE} it will return \code{TRUE} if all tests were successful. \code{FALSE} otherwise. If \code{silent} equals to \code{FALSE} it will return \code{TRUE} if all tests were successful. Error otherwise.
 }
-\seealso{ \code{\link{data.table}} }
+\seealso{ \code{\link{data.table}}, \code{\link{test}} }
 \keyword{ data }


### PR DESCRIPTION
- moves documentation of a `test` function from https://github.com/Rdatatable/data.table/wiki/Contributing into `man/test.Rd` (the proper place for function documentation)
- change order of `test`'s `message` arg to be just after the `warning`, to stack exceptions together
- removes deprecated arguments in `test.data.table` (`with.other.packages`, `benchmark`)
- change a default value of "dev-mode" argument `pkg="pkg"` to a nicer default `pkg="."` - maybe we could remove that argument at all?
- closes #2960 by documenting behaviour