### PR TITLE
use typeof in print(class=TRUE)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -224,6 +224,8 @@
     # [1] "A" "b" "c"
     ```
 
+29. The `class` argument to `data.table`'s `print` method now includes the `typeof` the column as well, [#2998](https://github.com/Rdatatable/data.table/issues/2998). `typeof` is quite important in R since it reveals the fundamental storage type of a given object, which is immutable without making copies, whereas the `class` of an object is closer to a decoration -- `setattr` can change the `class` without copies. As such, objects in R with the same `typeof` but different class are easier to combine than when `typeof` differs.
+
 ## BUG FIXES
 
 1. `first`, `last`, `head` and `tail` by group no longer error in some cases, [#2030](https://github.com/Rdatatable/data.table/issues/2030) [#3462](https://github.com/Rdatatable/data.table/issues/3462). Thanks to @franknarf1 for reporting.
@@ -1118,4 +1120,3 @@ When `j` is a symbol (as in the quanteda and xgboost examples above) it will con
 
 
 # data.table v1.9.8 (Nov 2016) back to v1.2 (Aug 2008) has been moved to [NEWS.0.md](https://github.com/Rdatatable/data.table/blob/master/NEWS.0.md)
-

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -76,14 +76,21 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
     colnames(toprint)=rep("", ncol(toprint))
   if (isTRUE(class) && col.names != "none") {
     #Matching table for most common types & their abbreviations
-    class_abb = c(list = "<list>", integer = "<int>", numeric = "<num>",
-      character = "<char>", Date = "<Date>", complex = "<cplx>",
-      factor = "<fctr>", POSIXct = "<POSc>", logical = "<lgcl>",
-      IDate = "<IDat>", integer64 = "<i64>", raw = "<raw>",
-      expression = "<expr>", ordered = "<ord>")
-    classes = vapply(x, function(col) class(col)[1L], "", USE.NAMES=FALSE)
+    class_abb = c(
+      list = "list", integer = "int", numeric = "num", double = "dbl",
+      character = "char", Date = "Date", complex = "cplx",
+      factor = "fctr", POSIXct = "POSc", logical = "lgcl",
+      IDate = "IDat", integer64 = "i64", raw = "raw",
+      expression = "expr", ordered = "ord"
+    )
+    classes = vapply_1c(x, function(col) class(col)[1L], use.names=FALSE)
+    types = vapply_1c(x, typeof, use.names=FALSE)
     abbs = unname(class_abb[classes])
-    if ( length(idx <- which(is.na(abbs))) ) abbs[idx] = paste0("<", classes[idx], ">")
+    if ( length(idx <- which(is.na(abbs))) ) abbs[idx] = classes[idx]
+    # \U2286: subset equality symbol to indicate subclasses
+    if ( any(idx <- types != classes & classes != 'numeric') )
+      abbs[idx] = paste0(abbs[idx], '\U2286', unname(class_abb[types[idx]]))
+    abbs = paste0('<', abbs, '>')
     toprint = rbind(abbs, toprint)
     rownames(toprint)[1L] = ""
   }

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -8206,24 +8206,24 @@ DT1  = data.table(lcol = list(list(1:3), list(1:3), list(1:3)),
                   icol, ncol = as.numeric(icol), ccol = c("a", "b", "c"),
                   xcol = as.complex(icol), ocol = factor(icol, ordered = TRUE),
                   fcol = factor(icol))
-test(1610.1, capture.output(print(DT1, class=TRUE)),
-     c("     lcol  icol  ncol   ccol   xcol  ocol   fcol",
-       "   <list> <int> <num> <char> <cplx> <ord> <fctr>",
-       "1: <list>     1     1      a   1+0i     1      1",
-       "2: <list>     2     2      b   2+0i     2      2",
-       "3: <list>     3     3      c   3+0i     3      3"))
+test(1610.1, print(DT1, class=TRUE),
+     output = c("     lcol  icol  ncol   ccol   xcol      ocol       fcol",
+                "   <list> <int> <num> <char> <cplx> <ord\U2286int> <fctr\U2286int>",
+                "1: <list>     1     1      a   1+0i         1          1",
+                "2: <list>     2     2      b   2+0i         2          2",
+                "3: <list>     3     3      c   3+0i         3          3"))
 DT2 = data.table(
   Dcol = as.Date('2016-01-01') + 0:2,
   Pcol = as.POSIXct('2016-01-01 01:00:00', tz = 'UTC') + 86400L*(0:2),
   gcol = TRUE, Icol = as.IDate(16801) + 0:2,
   ucol = `class<-`(1:3, 'asdf')
 )
-test(1610.2, capture.output(print(DT2, class=TRUE)),
-     c("         Dcol                Pcol   gcol       Icol   ucol",
-       "       <Date>              <POSc> <lgcl>     <IDat> <asdf>",
-       "1: 2016-01-01 2016-01-01 01:00:00   TRUE 2016-01-01      1",
-       "2: 2016-01-02 2016-01-02 01:00:00   TRUE 2016-01-02      2",
-       "3: 2016-01-03 2016-01-03 01:00:00   TRUE 2016-01-03      3"))
+test(1610.2, print(DT2, class=TRUE),
+     output = c("         Dcol                Pcol   gcol       Icol       ucol",
+                "   <Date\U2286dbl>          <POSc\U2286dbl> <lgcl> <IDat\U2286int> <asdf\U2286int>",
+                "1: 2016-01-01 2016-01-01 01:00:00   TRUE 2016-01-01          1",
+                "2: 2016-01-02 2016-01-02 01:00:00   TRUE 2016-01-02          2",
+                "3: 2016-01-03 2016-01-03 01:00:00   TRUE 2016-01-03          3"))
 
 # fix for #833
 l1 = list(a=seq_len(5), matrix(seq_len(25),ncol = 5, nrow = 5))

--- a/man/print.data.table.Rd
+++ b/man/print.data.table.Rd
@@ -21,7 +21,7 @@
   \item{x}{ A \code{data.table}. }
   \item{topn}{ The number of rows to be printed from the beginning and end of tables with more than \code{nrows} rows. }
   \item{nrows}{ The number of rows which will be printed before truncation is enforced. }
-  \item{class}{ If \code{TRUE}, the resulting output will include above each column its storage class (or a self-evident abbreviation thereof). }
+  \item{class}{ If \code{TRUE}, the resulting output will include above each column its (first) class (or a self-evident abbreviation thereof); when the storage class (via \code{\link{typeof}}) differs (e.g. \code{Date} is stored as \code{double}), this will also be printed after a subset equality symbol. }
   \item{row.names}{ If \code{TRUE}, row indices will be printed alongside \code{x}. }
   \item{col.names}{ One of three flavours for controlling the display of column names in output. \code{"auto"} includes column names above the data, as well as below the table if \code{nrow(x) > 20}. \code{"top"} excludes this lower register when applicable, and \code{"none"} suppresses column names altogether (as well as column classes if \code{class = TRUE}. }
   \item{print.keys}{ If \code{TRUE}, any \code{\link{key}} and/or \code{\link[=indices]{index}} currently assigned to \code{x} will be printed prior to the preview of the data. }


### PR DESCRIPTION
Closes #2998

I have a feeling `⊆` won't show up on windows. Open to suggestions for a better separator of `class(x)[1L]` and `typeof(x)`. `⊆` looks clear to me but maybe I've just been staring at it too long. Other things I considered: `#`, `->`, `/`, `~`, `-`.

Given this and breaking-ish nature ("front-end"-only change), marking for 1.13.0.