### PR TITLE
add recommendation to importFrom data.table special symbols

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -15,6 +15,10 @@ dim.data.table = function(x)
 setPackageName("data.table",.global)
 .global$print = ""
 
+# NB: if adding to/editing this list, be sure to do the following:
+#   (1) add to man/special-symbols.Rd
+#   (2) export() in NAMESPACE
+#   (3) add to vignettes/datatable-importing.Rmd#globals section
 .SD = .N = .I = .GRP = .BY = .EACHI = NULL
 # These are exported to prevent NOTEs from R CMD check, and checkUsage via compiler.
 # But also exporting them makes it clear (to users and other packages) that data.table uses these as symbols.

--- a/man/special-symbols.Rd
+++ b/man/special-symbols.Rd
@@ -6,9 +6,10 @@
 \alias{.GRP}
 \alias{.BY}
 \alias{.N}
+\alias{.EACHI}
 \title{ Special symbols }
 \description{
-    \code{.SD}, \code{.BY}, \code{.N}, \code{.I} and \code{.GRP} are \emph{read only} symbols for use in \code{j}. \code{.N} can be used in \code{i} as well. See the vignettes and examples here and in \code{\link{data.table}}.
+    \code{.SD}, \code{.BY}, \code{.N}, \code{.I}, \code{.GRP}, and \code{.EACHI} are \emph{read-only} symbols for use in \code{j}. \code{.N} can be used in \code{i} as well. See the vignettes and examples here and in \code{\link{data.table}}.
 }
 \details{
     The bindings of these variables are locked and attempting to assign to them will generate an error. If you wish to manipulate \code{.SD} before returning it, take a \code{copy(.SD)} first (see FAQ 4.5). Using \code{:=} in the \code{j} of \code{.SD} is reserved for future use as a (tortuously) flexible way to update \code{DT} by reference by group (even when groups are not contiguous in an ad hoc by).
@@ -21,6 +22,7 @@
         \item{\code{.N} is an integer, length 1, containing the number of rows in the group. This may be useful when the column names are not known in advance and for convenience generally. When grouping by \code{i}, \code{.N} is the number of rows in \code{x} matched to, for each row of \code{i}, regardless of whether \code{nomatch} is \code{NA} or \code{NULL}. It is renamed to \code{N} (no dot) in the result (otherwise a column called \code{".N"} could conflict with the \code{.N} variable, see FAQ 4.6 for more details and example), unless it is explicitly named; e.g., \code{DT[,list(total=.N),by=a]}.}
         \item{\code{.I} is an integer vector equal to \code{seq_len(nrow(x))}. While grouping, it holds for each item in the group, its row location in \code{x}. This is useful to subset in \code{j}; e.g. \code{DT[, .I[which.max(somecol)], by=grp]}.}
         \item{\code{.GRP} is an integer, length 1, containing a simple group counter. 1 for the 1st group, 2 for the 2nd, etc.}
+        \item{\code{.EACHI} is \code{NULL} but triggers a by-join; see \code{\link{data.table}}'s \code{by} argument for more details. }
     }
 }
 \seealso{

--- a/man/special-symbols.Rd
+++ b/man/special-symbols.Rd
@@ -9,12 +9,13 @@
 \alias{.EACHI}
 \title{ Special symbols }
 \description{
-    \code{.SD}, \code{.BY}, \code{.N}, \code{.I}, \code{.GRP}, and \code{.EACHI} are \emph{read-only} symbols for use in \code{j}. \code{.N} can be used in \code{i} as well. See the vignettes and examples here and in \code{\link{data.table}}.
+    \code{.SD}, \code{.BY}, \code{.N}, \code{.I}, and \code{.GRP} are \emph{read-only} symbols for use in \code{j}. \code{.N} can be used in \code{i} as well. See the vignettes and examples here and in \code{\link{data.table}}.
+    \code{.EACHI} is a symbol passed to \code{by}; i.e. \code{by=.EACHI}.
 }
 \details{
     The bindings of these variables are locked and attempting to assign to them will generate an error. If you wish to manipulate \code{.SD} before returning it, take a \code{copy(.SD)} first (see FAQ 4.5). Using \code{:=} in the \code{j} of \code{.SD} is reserved for future use as a (tortuously) flexible way to update \code{DT} by reference by group (even when groups are not contiguous in an ad hoc by).
 
-    These symbols are used in \code{j} and defined as follows.
+    These symbols used in \code{j} are defined as follows.
 
     \itemize{
         \item{\code{.SD} is a \code{data.table} containing the \bold{S}ubset of \code{x}'s \bold{D}ata for each group, excluding any columns used in \code{by} (or \code{keyby}).}
@@ -22,8 +23,9 @@
         \item{\code{.N} is an integer, length 1, containing the number of rows in the group. This may be useful when the column names are not known in advance and for convenience generally. When grouping by \code{i}, \code{.N} is the number of rows in \code{x} matched to, for each row of \code{i}, regardless of whether \code{nomatch} is \code{NA} or \code{NULL}. It is renamed to \code{N} (no dot) in the result (otherwise a column called \code{".N"} could conflict with the \code{.N} variable, see FAQ 4.6 for more details and example), unless it is explicitly named; e.g., \code{DT[,list(total=.N),by=a]}.}
         \item{\code{.I} is an integer vector equal to \code{seq_len(nrow(x))}. While grouping, it holds for each item in the group, its row location in \code{x}. This is useful to subset in \code{j}; e.g. \code{DT[, .I[which.max(somecol)], by=grp]}.}
         \item{\code{.GRP} is an integer, length 1, containing a simple group counter. 1 for the 1st group, 2 for the 2nd, etc.}
-        \item{\code{.EACHI} is \code{NULL} but triggers a by-join; see \code{\link{data.table}}'s \code{by} argument for more details. }
     }
+
+    \code{.EACHI} is defined as \code{NULL} but its value is not used. Its usage is \code{by=.EACHI} (or \code{keyby=.EACHI}) which invokes grouping-by-each-row-of-i; see \code{\link{data.table}}'s \code{by} argument for more details.
 }
 \seealso{
     \code{\link{data.table}}, \code{\link{:=}}, \code{\link{set}}, \code{\link{datatable-optimize}}

--- a/vignettes/datatable-importing.Rmd
+++ b/vignettes/datatable-importing.Rmd
@@ -37,7 +37,7 @@ The next thing is to define what content of `data.table` your package is using. 
 
 You may also want to use just a subset of `data.table` functions; for example, some packages may simply make use of `data.table`'s high-performance CSV reader and writer, for which you can add `importFrom(data.table, fread, fwrite)` in your `NAMESPACE` file. It is also possible to import all functions from a package _excluding_ particular ones using `import(data.table, except=c(fread, fwrite))`.
 
-Be sure to read also the note about non-standard evaluation in `data.table` [below](#globals)
+Be sure to read also the note about non-standard evaluation in `data.table` in [the section on "undefined globals"](#globals)
 
 ## Usage
 
@@ -118,17 +118,13 @@ aggr = function (x) {
 }
 ```
 
-The case for `:=` is slightly different, because `:=` is interpreted as a function in the above code; so instead of registering `:=` as `NULL`, you must register it as a function, e.g.:
-
-```
-`:=` = function(...) NULL
-```
-
-The case for `data.table`'s special symbols (`.SD`, `.BY`, `.N`, `.I`, `.GRP`, and `.EACHI`; see `?.N`) is slightly different. We recommend you import whichever of these values you use from `data.table`'s namespace to protect against any issues arising from the unlikely scenario that we change the exported value of these in the future, e.g. if you want to use both `.N` and `.I`, a minimal `NAMESPACE` would have:
+The case for `data.table`'s special symbols (`.SD`, `.BY`, `.N`, `.I`, `.GRP`, and `.EACHI`; see `?.N`) and assignment operator (`:=`) is slightly different. You should import whichever of these values you use from `data.table`'s namespace to protect against any issues arising from the unlikely scenario that we change the exported value of these in the future, e.g. if you want to use `.N`, `.I`, and `:=`, a minimal `NAMESPACE` would have:
 
 ```r
-importFrom(data.table, .N, .I)
+importFrom(data.table, .N, .I, ':=')
 ```
+
+Much simpler is to just use `import(data.table)` which will greedily allow usage in your package's code of any object exported from `data.table`.
 
 If you don't mind having `id` and `grp` registered as variables globally in your package namespace you can use `?globalVariables`. Be aware that these notes do not have any impact on the code or its functionality; if you are not going to publish your package, you may simply choose to ignore them.
 

--- a/vignettes/datatable-importing.Rmd
+++ b/vignettes/datatable-importing.Rmd
@@ -33,9 +33,11 @@ The first place to define a dependency in a package is the `DESCRIPTION` file. M
 
 ## `NAMESPACE` file {NAMESPACE}
 
-The next thing is to define what content of `data.table` your package is using. This needs to be done in the `NAMESPACE` file. Most commonly, package authors will want to use `import(data.table)` which will import all (exported, i.e., listed in `data.table`'s own `NAMESPACE` file) functions from `data.table`.
+The next thing is to define what content of `data.table` your package is using. This needs to be done in the `NAMESPACE` file. Most commonly, package authors will want to use `import(data.table)` which will import all exported (i.e., listed in `data.table`'s own `NAMESPACE` file) functions from `data.table`.
 
 You may also want to use just a subset of `data.table` functions; for example, some packages may simply make use of `data.table`'s high-performance CSV reader and writer, for which you can add `importFrom(data.table, fread, fwrite)` in your `NAMESPACE` file. It is also possible to import all functions from a package _excluding_ particular ones using `import(data.table, except=c(fread, fwrite))`.
+
+Be sure to read also the note about non-standard evaluation in `data.table` [below](#globals)
 
 ## Usage
 
@@ -84,7 +86,7 @@ test_that("aggregate dt", { expect_true(nrow(aggr(gen())) < 100) })
 
 If `data.table` is in Suggests (but not Imports) then you need to declare `.datatable.aware=TRUE` in one of the R/* files to avoid "object not found" errors when testing via `testthat::test_package` or `testthat::test_check`.
 
-## Dealing with "undefined global functions or variables"
+## Dealing with "undefined global functions or variables" {#globals}
 
 `data.table`'s use of R's deferred evaluation (especially on the left-hand side of `:=`) is not well-recognised by `R CMD check`. This results in `NOTE`s like the following during package check:
 
@@ -120,6 +122,12 @@ The case for `:=` is slightly different, because `:=` is interpreted as a functi
 
 ```
 `:=` = function(...) NULL
+```
+
+The case for `data.table`'s special symbols (`.SD`, `.BY`, `.N`, `.I`, `.GRP`, and `.EACHI`; see `?.N`) is slightly different. We recommend you import whichever of these values you use from `data.table`'s namespace to protect against any issues arising from the unlikely scenario that we change the exported value of these in the future, e.g. if you want to use both `.N` and `.I`, a minimal `NAMESPACE` would have:
+
+```r
+importFrom(data.table, .N, .I)
 ```
 
 If you don't mind having `id` and `grp` registered as variables globally in your package namespace you can use `?globalVariables`. Be aware that these notes do not have any impact on the code or its functionality; if you are not going to publish your package, you may simply choose to ignore them.


### PR DESCRIPTION
As suggested by Hadley here:

https://github.com/r-lib/roxygen2/issues/461#issuecomment-534077447

It's a good idea for exactly the reason that there may be some change down the line where we set e.g. `.N != NULL` and this would facilitate cascading this to downstreams.