### PR TITLE
compress *.Rraw in release only, not git.

### DIFF
--- a/.dev/CRAN_Release.cmd
+++ b/.dev/CRAN_Release.cmd
@@ -443,8 +443,14 @@ Bump version to even release number in 3 places :
   2) NEWS (without 'on CRAN date' text as that's not yet known)
   3) dllVersion() at the end of init.c
 DO NOT push to GitHub. Prevents even a slim possibility of user getting premature version. Even release numbers must have been obtained from CRAN and only CRAN. There were too many support problems in the past before this procedure was brought in.
+du -k inst/tests                # 1.5MB before
+bzip2 inst/tests/*.Rraw         # compress *.Rraw just for release to CRAN; do not commit compressed *.Rraw to git
+du -k inst/tests                # 0.75MB after
 R CMD build .
-R CMD check --as-cran data.table_1.12.4.tar.gz
+R CMD check data.table_1.12.4.tar.gz --as-cran
+#
+bunzip2 inst/tests/*.Rraw.bz2  # decompress *.Rraw again so as not to commit compressed *.Rraw to git
+#
 Resubmit to winbuilder (R-release, R-devel and R-oldrelease)
 Submit to CRAN. Message template :
 ------------------------------------------------------------

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -1,4 +1,5 @@
-test.data.table = function(verbose=FALSE, pkg=".", silent=FALSE, script="tests.Rraw") {
+test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=FALSE) {
+  stopifnot(isTRUEorFALSE(verbose), isTRUEorFALSE(silent))
   if (exists("test.data.table", .GlobalEnv,inherits=FALSE)) {
     # package developer
     # nocov start
@@ -13,31 +14,38 @@ test.data.table = function(verbose=FALSE, pkg=".", silent=FALSE, script="tests.R
   }
   fulldir = file.path(rootdir, subdir)
 
+  stopifnot(is.character(script), length(script)==1L, !is.na(script), nzchar(script))
+  if (!grepl(".Rraw$", script))
+    stop("script must end with '.Rraw'. If a file ending '.Rraw.bz2' exists, that will be found and used.") # nocov
+
   if (identical(script,"*.Rraw")) {
     # nocov start
-    scripts = dir(fulldir, "*.Rraw")
-    scripts = scripts[!scripts %in% c("benchmark.Rraw","other.Rraw")]
+    scripts = dir(fulldir, "*.Rraw.*")
+    scripts = scripts[!grepl("bench|other", scripts)]
+    scripts = gsub("[.]bz2$","",scripts)
     for (fn in scripts) {test.data.table(verbose=verbose, pkg=pkg, silent=silent, script=fn); cat("\n");}
     return(invisible())
     # nocov end
   }
 
-  if (!is.null(script)) {
-    stopifnot(is.character(script), length(script)==1L, !is.na(script), nzchar(script))
-    if (!identical(basename(script), script)) {
-      # nocov start
-      subdir = dirname(script)
-      fulldir = normalizePath(subdir, mustWork=FALSE)
-      fn = basename(script)
-      # nocov end
-    } else {
-      fn = script
-    }
+  if (!identical(basename(script), script)) {
+    # nocov start
+    subdir = dirname(script)
+    fulldir = normalizePath(subdir, mustWork=FALSE)
+    fn = basename(script)
+    # nocov end
   } else {
-    stop("'script' argument should not be NULL") # nocov
+    fn = script
+  }
+
+  if (!file.exists(file.path(fulldir, fn))) {
+    fn2 = paste0(fn,".bz2")
+    if (!file.exists(file.path(fulldir, fn2)))
+      stop("Neither ",fn," or ",fn2," exist in ",fulldir) # nocov
+    fn = fn2
+    # sys.source() below accepts .bz2 directly
   }
   fn = setNames(file.path(fulldir, fn), file.path(subdir, fn))
-  if (!file.exists(fn)) stop(fn," does not exist") # nocov
 
   # From R 3.6.0 onwards, we can check that && and || are using only length-1 logicals (in the test suite)
   # rather than relying on x && y being equivalent to x[[1L]] && y[[1L]]  silently.

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -39,11 +39,14 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
   }
 
   if (!file.exists(file.path(fulldir, fn))) {
+    # see end of CRAN_Release.cmd where *.Rraw are compressed just for CRAN release; #3937
+    # nocov start
     fn2 = paste0(fn,".bz2")
     if (!file.exists(file.path(fulldir, fn2)))
-      stop("Neither ",fn," or ",fn2," exist in ",fulldir) # nocov
+      stop("Neither ",fn," or ",fn2," exist in ",fulldir)
     fn = fn2
-    # sys.source() below accepts .bz2 directly
+    # nocov end
+    # sys.source() below accepts .bz2 directly.
   }
   fn = setNames(file.path(fulldir, fn), file.path(subdir, fn))
 

--- a/man/test.data.table.Rd
+++ b/man/test.data.table.Rd
@@ -5,13 +5,13 @@
   Runs a set of tests to check data.table is working correctly.
 }
 \usage{
-test.data.table(verbose=FALSE, pkg=".", silent=FALSE, script="tests.Rraw")
+test.data.table(script="tests.Rraw", verbose=FALSE, pkg=".", silent=FALSE)
 }
 \arguments{
+\item{script}{ Run arbitrary R test script. }
 \item{verbose}{ If \code{TRUE} sets datatable.verbose to \code{TRUE} for the duration of the tests. }
 \item{pkg}{ Root directory name under which all package content (ex: DESCRIPTION, src/, R/, inst/ etc..) resides. Used only in \emph{dev-mode}. }
 \item{silent}{ Logical, default \code{FALSE}, when \code{TRUE} it will not raise error on in case of test fails. }
-\item{script}{ Run arbitrary R test script. }
 }
 \details{
    Runs a series of tests. These can be used to see features and examples of usage, too. Running test.data.table will tell you the full location of the test file(s) to open.


### PR DESCRIPTION
Follow up to #3933
Just adds the notes to CRAN_Release.cmd, plus some refinements to test.data.table() find the file with the `.Rraw.bz2` extension.  But other than that, `base::sys.source()` already accepts compressed input directly.

The saves another 0.75MB,  to add to the saving in #3933 of 0.27MB brings the overall installed size of `/inst/tests` down from 1.7MB to 0.7MB.  Plenty to avoid the 5.1MB breach of 5.0MB. We should be at around 4.0MB now even with a `-g` bloated `.so`.