### PR TITLE
osx travis

### DIFF
--- a/.dev/CRAN_Release.cmd
+++ b/.dev/CRAN_Release.cmd
@@ -148,6 +148,7 @@ gctorture2(step=50)
 system.time(test.data.table(script="*.Rraw"))  # apx 8h = froll 3h + nafill 1m + main 5h
 
 # Upload to win-builder: release, dev & old-release
+# Turn on Travis OSX; it's off in dev until it's added to GLCI (#3326) as it adds 17min after 11min Linux.
 
 
 ###############################################

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ r:
 
 os:
   - linux
-  # - osx  # Takes 13m (+9m linux = 22m total); #3357; #3326; #3331. Off by default to speed up dev cycle. AppVeyor covers R-devel and completes in 10m concurrently.
+  - osx  # Takes 13m (+9m linux = 22m total); #3357; #3326; #3331. Off by default to speed up dev cycle. AppVeyor covers R-devel and completes in 10m concurrently.
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install llvm &&


### PR DESCRIPTION
To investigate #3939 
- [x] add to CRAN_Release.cmd procedures to turn back on OSX.  I had turned it off in #3326 because it was slowing down dev cycle.  Should be turned back on in release procedures.