### PR TITLE
fix NA filled by shift(nanotime, fill=NA)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 ## BUG FIXES
 
+1. `shift()` on a `nanotime` with the default `fill=NA` now fills a `nanotime` missing value correctly, [#3942](https://github.com/Rdatatable/data.table/pull/3942). Thanks to @mschubmehl for the PR.
+
 ## NOTES
 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 ## BUG FIXES
 
-1. `shift()` on a `nanotime` with the default `fill=NA` now fills a `nanotime` missing value correctly, [#3942](https://github.com/Rdatatable/data.table/pull/3942). Thanks to @mschubmehl for the PR.
+1. `shift()` on a `nanotime` with the default `fill=NA` now fills a `nanotime` missing value correctly, [#3945](https://github.com/Rdatatable/data.table/issues/3945). Thanks to @mschubmehl for reporting and fixing in PR [#3942](https://github.com/Rdatatable/data.table/pull/3942).
 
 ## NOTES
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -6472,6 +6472,11 @@ ans = list(as.integer(c(NA, 1:9)), as.integer(c(NA, NA, 1:8)))
 setattr(ans, 'names', nm)
 test(1463.39, shift(x, 1:2, give.names=TRUE), ans)
 
+if (test_nanotime) {
+  test(1463.40, shift(nanotime(1:4)         ), c(nanotime::nanotime(NA), nanotime::nanotime(1:3)));
+  test(1463.41, shift(nanotime(1:4), fill=0L), c(nanotime::nanotime(0L), nanotime::nanotime(1:3)));
+}
+
 # FR #686
 DT = data.table(a=rep(c("A", "B", "C", "A", "B"), c(2,2,3,1,2)), foo=1:10)
 # Seemingly superfluous 'foo' is needed to test fix for #1942

--- a/src/shift.c
+++ b/src/shift.c
@@ -5,7 +5,7 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
 
   size_t size;
   int protecti=0;
-  SEXP x, tmp=R_NilValue, elem, ans, thisfill, klass;
+  SEXP x, tmp=R_NilValue, elem, ans, thisfill;
   unsigned long long *dthisfill;
   enum {LAG, LEAD/*, SHIFT, CYCLIC*/} stype = LAG; // currently SHIFT maps to LAG and CYCLIC is unimplemented (see comments in #1708)
   if (!xlength(obj)) return(obj); // NULL, list()
@@ -61,8 +61,7 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
       break;
 
     case REALSXP :
-      klass = getAttrib(elem, R_ClassSymbol);
-      if (isString(klass) && STRING_ELT(klass, 0) == char_integer64) {
+      if (Rinherits(elem, char_integer64)) {
         thisfill = PROTECT(allocVector(REALSXP, 1)); protecti++;
         dthisfill = (unsigned long long *)REAL(thisfill);
         if (INTEGER(fill)[0] == NA_INTEGER)


### PR DESCRIPTION
Closes #3945 

Currently `shift(nanotime(1:4))` incorrectly fills a `numeric` `NA` rather than an `integer64` `NA` into the result vector. This is because we incorrectly check that the class is exactly `integer64`, rather than inherited from it, as we do in most other contexts. This PR fixes that, and adds test cases for shift called on nanotimes.