### PR TITLE
assign iris from scratch in tests

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2135,7 +2135,7 @@ subset.data.table = function (x, subset, select, ...)
     key.cols = intersect(key.cols, names(x)[vars]) ## Only keep key.columns found in the select clause
   }
 
-  ans = x[r, vars, with=FALSE]
+  ans = x[r, vars, with = FALSE]
 
   if (nrow(ans) > 0L) {
     if (!missing(select) && length(key.cols)) {

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2135,7 +2135,7 @@ subset.data.table = function (x, subset, select, ...)
     key.cols = intersect(key.cols, names(x)[vars]) ## Only keep key.columns found in the select clause
   }
 
-  ans = x[r, ..vars]
+  ans = x[r, vars, with=FALSE]
 
   if (nrow(ans) > 0L) {
     if (!missing(select) && length(key.cols)) {

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2135,7 +2135,7 @@ subset.data.table = function (x, subset, select, ...)
     key.cols = intersect(key.cols, names(x)[vars]) ## Only keep key.columns found in the select clause
   }
 
-  ans = x[r, vars, with = FALSE]
+  ans = x[r, ..vars]
 
   if (nrow(ans) > 0L) {
     if (!missing(select) && length(key.cols)) {

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -1683,6 +1683,8 @@ test(583, DT[a<1], DT[0])
 test(584, DT[a<1], output="Empty data.table (0 rows and 2 cols): a,v")
 test(585, DT[a<1,list(v)], output="Empty data.table (0 rows and 1 cols): v")
 test(586.1, data.table(a=integer(),V1=integer()), output="Empty data.table (0 rows and 2 cols): a,V1")
+env = environment()
+data(iris, package='datasets', envir = env) # in case user has edited iris in their session
 test(586.2, print.data.table(iris[,FALSE]), output="Empty data.frame (150 rows and 0 cols)")   #3363
 
 # Test that .N is available in by on empty table, also in #1945


### PR DESCRIPTION
Originally planned to remove `with=FALSE` usage from `subset.data.table` (see commits) but Jan points out this is not a good idea.

In the process I found this fix for `tests.Rraw` though so may as well merge that.