### PR TITLE
trace fwrite-zlib on solaris

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 2. Compilation failed on CRAN's MacOS due to an older version of `zlib.h/zconf.h` which did not have `z_const` defined, [#3939](https://github.com/Rdatatable/data.table/issues/3939). Other open-source projects unrelated to R have experienced this problem on MacOS too. We have followed the common practice of removing `z_const` to support the older `zlib` versions, and data.table's release procedures have gained a `grep` to ensure `z_const` isn't used again by accident in future. The library `zlib` is used for `fwrite`'s new feature of multithreaded compression on-the-fly; see item 3 of 1.12.4 below.
 
+3. An error, again in `fwrite`'s compression, but only observed so far on Solaris 32bit has been fixed, [#3931](https://github.com/Rdatatable/data.table/issues/3931): `Error -2: one or more threads failed to allocate buffers or there was a compression error.` In case it happens again, this area has been made more robust and the error more detailed.
+
 ## NOTES
 
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -9639,8 +9639,8 @@ test(1658.40, fwrite(matrix(1:4, nrow=2, ncol=2, dimnames = list(c("ra","rb"),c(
 # fwrite compress
 test(1658.41, fwrite(data.table(a=c(1:3), b=c(1:3)), compress="gzip"), output='a,b\n1,1\n2,2\n3,3')  # compress ignored on console
 DT = data.table(a=rep(1:2,each=100), b=rep(1:4,each=25))
-fwrite(DT, file=f1<-tempfile(fileext=".gz"))
-fwrite(DT, file=f2<-tempfile())
+fwrite(DT, file=f1<-tempfile(fileext=".gz"), verbose=TRUE)  # verbose temporary to trace #3931 on Solaris
+fwrite(DT, file=f2<-tempfile(), verbose=TRUE)
 test(1658.42, file.info(f1)$size < file.info(f2)$size)  # 74 < 804  (file.size() isn't available in R 3.1.0)
 if (test_R.utils) test(1658.43, fread(f1), DT)  # use fread to decompress gz (works cross-platform)
 fwrite(DT, file=f3<-tempfile(), compress="gzip")   # compress to filename not ending .gz

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -9639,8 +9639,8 @@ test(1658.40, fwrite(matrix(1:4, nrow=2, ncol=2, dimnames = list(c("ra","rb"),c(
 # fwrite compress
 test(1658.41, fwrite(data.table(a=c(1:3), b=c(1:3)), compress="gzip"), output='a,b\n1,1\n2,2\n3,3')  # compress ignored on console
 DT = data.table(a=rep(1:2,each=100), b=rep(1:4,each=25))
-fwrite(DT, file=f1<-tempfile(fileext=".gz"), verbose=TRUE)  # verbose temporary to trace #3931 on Solaris
-fwrite(DT, file=f2<-tempfile(), verbose=TRUE)
+fwrite(DT, file=f1<-tempfile(fileext=".gz"))
+fwrite(DT, file=f2<-tempfile())
 test(1658.42, file.info(f1)$size < file.info(f2)$size)  # 74 < 804  (file.size() isn't available in R 3.1.0)
 if (test_R.utils) test(1658.43, fread(f1), DT)  # use fread to decompress gz (works cross-platform)
 fwrite(DT, file=f3<-tempfile(), compress="gzip")   # compress to filename not ending .gz

--- a/src/fwrite.c
+++ b/src/fwrite.c
@@ -794,16 +794,20 @@ void fwriteMain(fwriteMainArgs args)
   errno=0;
   char *buffPool = malloc(nth*(size_t)buffSize);
   if (!buffPool) {
+    // # nocov start
     STOP("Unable to allocate %d MB * %d thread buffers; '%d: %s'. Please read ?fwrite for nThread, buffMB and verbose options.",
-         (size_t)buffSize/(1024^2), nth, errno, strerror(errno));   // # nocov
+         (size_t)buffSize/(1024^2), nth, errno, strerror(errno));
+    // # nocov end
   }
   char *zbuffPool = NULL;
   if (args.is_gzip) {
     zbuffPool = malloc(nth*(size_t)zbuffSize);
     if (!zbuffPool) {
-      free(buffPool);                                               // # nocov
+      // # nocov start
+      free(buffPool);
       STOP("Unable to allocate %d MB * %d thread compressed buffers; '%d: %s'. Please read ?fwrite for nThread, buffMB and verbose options.",
-         (size_t)zbuffSize/(1024^2), nth, errno, strerror(errno));  // # nocov
+         (size_t)zbuffSize/(1024^2), nth, errno, strerror(errno));
+      // # nocov end
     }
   }
 
@@ -954,12 +958,12 @@ void fwriteMain(fwriteMainArgs args)
   // '&& !failed' is to not report the error as just 'closing file' but the next line for more detail
   // from the original error.
   if (failed) {
-    // nocov start
+    // # nocov start
     if (failed_compress)
       STOP("Error %d: compression error. Please retry with verbose=TRUE and search online for this error message.\n", failed_compress);
     if (failed_write)
       STOP("%s: '%s'", strerror(failed_write), args.filename);
-    // nocov end
+    // # nocov end
   }
 }
 

--- a/src/fwrite.c
+++ b/src/fwrite.c
@@ -817,10 +817,6 @@ void fwriteMain(fwriteMainArgs args)
 
   #pragma omp parallel num_threads(nth)
   {
-    #pragma omp single
-    {
-      nth = omp_get_num_threads();  // update nth with the actual nth (might be less than requested)
-    }
     int me = omp_get_thread_num();
     int my_failed_compress = 0;
     char *ch, *myBuff;


### PR DESCRIPTION
Closes #3931 

Moved the malloc up before the parallel region.  So that it can have its own more detailed error message and to avoid any concern about malloc thread safety on solaris 10.
Changed `failed` to bool and only write true, so it can be naked in the usual way.
Compress and write error codes separated explicitly.  Probably overkill but to leave no doubt in case both positive and negative error codes are possible on Solaris, and to avoid needing to ask Prof Ripley to test a 2nd time.
The thread which fails and reaches ordered section first writes its error code thread-safely.

- [x] sent to Prof Ripley to run on Solaris.  Hopefully it will pass. If not, this should provide more detail on the error.
- [x] remove temporary verbose just after test 1658.41