### PR TITLE
more configure tweaks

### DIFF
--- a/configure
+++ b/configure
@@ -2,39 +2,53 @@
 # Let's keep this simple. If pkg-config is available, use it. Otherwise print
 # the helpful message to aid user if compilation does fail. Note 25 of R-exts:
 # "[pkg-config] is available on the machines used to produce the CRAN binary packages"
-# This script should pass `checkbashisms` for portability; e.g. CRAN's Solaris 10
+# This script should pass `checkbashisms` for portability; e.g. CRAN's Solaris 10,
+# and R-exts note 24 now suggests 'checkbashisms' as we proposed.
 
+msg=0
 pkg-config --version >/dev/null 2>&1
 if [ $? -ne 0 ]; then
-  echo "*** pkg-config is not installed. It is used to check that zlib is installed. Compilation"
-  echo "*** will now be attempted and if it works you can ignore this message. If compilation fails"
-  echo "*** and you cannot install pkg-config, try: locate zlib.h zconf.h. If they are not found"
-  echo "*** then try installing zlib1g-dev (Debian/Ubuntu), zlib-devel (Fedora) or zlib (OSX)"
-  exit 0  # now that the advice has been printed, exit with success and continue
+  echo "*** pkg-config is not installed."
+  msg=1
+else
+  pkg-config --exists zlib
+  if [ $? -ne 0 ]; then
+    echo "*** pkg-config is installed but 'pkg-config --exists zlib' did not return 0."
+    msg=1
+  else
+    lib=`pkg-config --libs zlib`
+    expr "$lib" : ".*-lz$" >/dev/null
+    if [ $? -ne 0 ]; then
+      expr "$lib" : ".*-lz " >/dev/null
+      # would use \b in one expr but MacOS does not support \b
+      if [ $? -ne 0 ]; then
+        echo "*** pkg-config is installed and 'pkg-config --exists zlib' succeeds but"
+        echo "*** 'pkg-config --libs zlib' returns '${lib}' which does not include the standard -lz."
+        msg=1
+      fi
+    fi
+  fi
 fi
 
-pkg-config --exists zlib
-if [ $? -ne 0 ]; then
-  echo "pkg-config did not detect zlib is installed. Please install it:"
-  echo "* deb: zlib1g-dev (Debian, Ubuntu, ...)"
-  echo "* rpm: zlib-devel (Fedora, EPEL, ...)"
-  echo "* brew: zlib (OSX)"
-  exit 1  # nothing more to do; zlib is required currently
+if [ $msg -ne 0 ]; then
+  echo "*** Compilation will now be attempted and if it works you can ignore this message. However,"
+  echo "*** if compilation fails, try 'locate zlib.h zconf.h' and ensure the zlib development library"
+  echo "*** is installed :"
+  echo "***   deb: zlib1g-dev (Debian, Ubuntu, ...)"
+  echo "***   rpm: zlib-devel (Fedora, EPEL, ...)"
+  echo "***   brew: zlib (OSX)"
+  echo "*** Note that zlib is required to compile R itself so you may find the advice in the R-admin"
+  echo "*** guide helpful regarding zlib. On Debian/Ubuntu, zlib1g-dev is a dependency of r-base as"
+  echo "*** shown by 'apt-cache showsrc r-base | grep ^Build-Depends | grep zlib', and therefore"
+  echo "*** 'sudo apt-get build-dep r-base' should be sufficient too."
+  echo "*** To silence this message, please ensure that :"
+  echo "***   1) 'pkg-config --exists zlib' succeeds (i.e. \$? -eq 0)"
+  echo "***   2) 'pkg-config --libs zlib' includes '-lz'"
+  echo "*** Compilation will now be attempted ..."
+  exit 0
 fi
 
 version=`pkg-config --modversion zlib`
 echo "zlib ${version} is available ok"
-
-lib=`pkg-config --libs zlib`
-expr "$lib" : ".*-lz$" >/dev/null
-if [ $? -ne 0 ]; then
-  expr "$lib" : ".*-lz " >/dev/null
-  # would use \b in one expr but MacOS does not support \b
-  if [ $? -ne 0 ]; then
-    echo "zlib is linked using ${lib} which does not include the standard -lz. Please report to data.table issue tracker on GitHub."
-    exit 1
-  fi
-fi
-
 exit 0
 

--- a/configure
+++ b/configure
@@ -43,7 +43,7 @@ if [ $msg -ne 0 ]; then
   echo "*** 'sudo apt-get build-dep r-base' should be sufficient too."
   echo "*** To silence this message, please ensure that :"
   echo "***   1) 'pkg-config --exists zlib' succeeds (i.e. \$? -eq 0)"
-  echo "***   2) 'pkg-config --libs zlib' includes '-lz'"
+  echo "***   2) 'pkg-config --libs zlib' contains -lz"
   echo "*** Compilation will now be attempted ..."
   exit 0
 fi


### PR DESCRIPTION
More follow up to #3964 
This time not Solaris but something odd on CRAN's macOS.

---

From Kurt : 

For the prev submission, Prof Ripley found the following:

```
This version does not install for me on macOS:

pkg-config did not detect zlib is installed. Please install it:
* deb: zlib1g-dev (Debian, Ubuntu, ...)
* rpm: zlib-devel (Fedora, EPEL, ...)
* brew: zlib (OSX)
ERROR: configuration failed for package ‘data.table’

macOS does not have pkg-config, nor does it supply .pc files for its
system software (SU has packaged some, but not zlib nor for current
macOS).  And a pkg-config-only test is not portable for other platforms.
```

Can you pls fix accordingly?

Best
-k

---

From Matt : 

Thanks, Kurt and Prof Ripley.

I don't assume that pkg-config is installed, but it appears then that it is installed on that macOS box (as R-exts note 25 says) but, oddly, pkg-config is claiming zlib is not installed when we know it is (since current CRAN error with recent 1.12.4 on macOS is runtime error long after compilation, which stands to reason since zlib is required by R itself). This all works fine on Travis macOS so it is not macOS per se.

However, I can see a fix I can make for this situation; i.e., pkg-config being installed but not returning an accurate result. I'll fix and resubmit.

I'm hoping this means the previous attempt works now on Solaris then? I can see Rrof Ripley added 'checkbashisms' to R-exts note 24 as I suggested (so he received that email), but I didn't hear back from him after that 2nd Solaris attempt.  (I didn't receive the reply you've quoted from him about macOS.)

Best, Matt