### PR TITLE
update GLCI to use more recent win r-devel, which is 4.0 already, clo…

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -207,7 +207,7 @@ test-dev-win: # R-devel on windows
     TEST_DATA_TABLE_MEMTEST: "FALSE" # disabled as described in #3147
   allow_failure: false
   script:
-    - Rscript -e "source('.ci/ci.R'); cu<-contrib.url(getOption('repos'), ver=Sys.getenv('R_BIN_VERSION')); print(cu); print(rownames(available.packages(cu))); install.packages(dcf.dependencies('DESCRIPTION', which='all'), quiet=TRUE, contriburl=cu)"
+    - Rscript -e "source('.ci/ci.R'); cu<-contrib.url(getOption('repos'), 'binary', ver=Sys.getenv('R_BIN_VERSION')); print(cu); print(rownames(available.packages(cu))); install.packages(dcf.dependencies('DESCRIPTION', which='all'), quiet=TRUE, contriburl=cu)"
     - *copy-src
     - rm -r bus
     - *move-src

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,7 +27,7 @@ mirror-packages: # download all recursive dependencies of data.table suggests an
     - bus/$CI_BUILD_NAME/cran
   variables:
     R_BIN_VERSION: "3.6"
-    R_DEVEL_BIN_VERSION: "3.7"
+    R_DEVEL_BIN_VERSION: "4.0"
   script:
     - echo 'source(".ci/ci.R")' >> .Rprofile
     - mkdir -p bus/$CI_BUILD_NAME/cran/src/contrib
@@ -202,7 +202,7 @@ test-rel-win: # windows test and build binaries
 test-dev-win: # R-devel on windows
   <<: *test-win
   variables:
-    R_BIN_VERSION: "3.7"
+    R_BIN_VERSION: "4.0"
     R_DIR: "R-devel"
     TEST_DATA_TABLE_MEMTEST: "FALSE" # disabled as described in #3147
   allow_failure: false
@@ -254,7 +254,7 @@ integration: # merging all artifacts to produce single R repository and summarie
   #- test-rel-osx
   variables:
     R_BIN_VERSION: "3.6"
-    R_DEVEL_BIN_VERSION: "3.7"
+    R_DEVEL_BIN_VERSION: "4.0"
   script:
     # pkgdown installs pkgs from "." so run at start to have clean root dir
     - apt-get update -qq && apt-get install -y libxml2-dev

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -207,7 +207,7 @@ test-dev-win: # R-devel on windows
     TEST_DATA_TABLE_MEMTEST: "FALSE" # disabled as described in #3147
   allow_failure: false
   script:
-    - Rscript -e "source('.ci/ci.R'); cu<-contrib.url(getOption('repos'), 'binary', ver=Sys.getenv('R_BIN_VERSION')); print(cu); print(rownames(available.packages(cu))); install.packages(dcf.dependencies('DESCRIPTION', which='all'), quiet=TRUE, contriburl=cu)"
+    - Rscript -e "source('.ci/ci.R'); install.packages(dcf.dependencies('DESCRIPTION', which='all'), quiet=TRUE, contriburl=contrib.url(getOption('repos'), 'binary', ver=Sys.getenv('R_BIN_VERSION')))"
     - *copy-src
     - rm -r bus
     - *move-src

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -207,7 +207,7 @@ test-dev-win: # R-devel on windows
     TEST_DATA_TABLE_MEMTEST: "FALSE" # disabled as described in #3147
   allow_failure: false
   script:
-    - Rscript -e "source('.ci/ci.R'); install.packages(dcf.dependencies('DESCRIPTION', which='all'), quiet=TRUE, contriburl=contrib.url(getOption('repos'), ver=Sys.getenv('R_BIN_VERSION')))"
+    - Rscript -e "source('.ci/ci.R'); cu<-contrib.url(getOption('repos'), ver=Sys.getenv('R_BIN_VERSION')); print(cu); print(rownames(available.packages(cu))); install.packages(dcf.dependencies('DESCRIPTION', which='all'), quiet=TRUE, contriburl=cu)"
     - *copy-src
     - rm -r bus
     - *move-src

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -207,7 +207,7 @@ test-dev-win: # R-devel on windows
     TEST_DATA_TABLE_MEMTEST: "FALSE" # disabled as described in #3147
   allow_failure: false
   script:
-    - Rscript -e "source('.ci/ci.R'); install.packages(dcf.dependencies('DESCRIPTION', which='all'), quiet=TRUE)"
+    - Rscript -e "source('.ci/ci.R'); install.packages(dcf.dependencies('DESCRIPTION', which='all'), quiet=TRUE, contriburl=contrib.url(getOption('repos'), ver=Sys.getenv('R_BIN_VERSION'))"
     - *copy-src
     - rm -r bus
     - *move-src

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -207,7 +207,7 @@ test-dev-win: # R-devel on windows
     TEST_DATA_TABLE_MEMTEST: "FALSE" # disabled as described in #3147
   allow_failure: false
   script:
-    - Rscript -e "source('.ci/ci.R'); install.packages(dcf.dependencies('DESCRIPTION', which='all'), quiet=TRUE, contriburl=contrib.url(getOption('repos'), ver=Sys.getenv('R_BIN_VERSION'))"
+    - Rscript -e "source('.ci/ci.R'); install.packages(dcf.dependencies('DESCRIPTION', which='all'), quiet=TRUE, contriburl=contrib.url(getOption('repos'), ver=Sys.getenv('R_BIN_VERSION')))"
     - *copy-src
     - rm -r bus
     - *move-src

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,7 +27,7 @@ mirror-packages: # download all recursive dependencies of data.table suggests an
     - bus/$CI_BUILD_NAME/cran
   variables:
     R_BIN_VERSION: "3.6"
-    R_DEVEL_BIN_VERSION: "4.0"
+    R_DEVEL_BIN_VERSION: "3.7" ## CRAN does not yet use 4.0 for R-devel
   script:
     - echo 'source(".ci/ci.R")' >> .Rprofile
     - mkdir -p bus/$CI_BUILD_NAME/cran/src/contrib
@@ -202,7 +202,7 @@ test-rel-win: # windows test and build binaries
 test-dev-win: # R-devel on windows
   <<: *test-win
   variables:
-    R_BIN_VERSION: "4.0"
+    R_BIN_VERSION: "3.7"
     R_DIR: "R-devel"
     TEST_DATA_TABLE_MEMTEST: "FALSE" # disabled as described in #3147
   allow_failure: false
@@ -254,7 +254,7 @@ integration: # merging all artifacts to produce single R repository and summarie
   #- test-rel-osx
   variables:
     R_BIN_VERSION: "3.6"
-    R_DEVEL_BIN_VERSION: "4.0"
+    R_DEVEL_BIN_VERSION: "3.7"
   script:
     # pkgdown installs pkgs from "." so run at start to have clean root dir
     - apt-get update -qq && apt-get install -y libxml2-dev


### PR DESCRIPTION
closes #3969
on our windows CI runner R-devel got upgraded to r77294 (2019-10-15).
"R-devel" directory now stores the new 4.0 rather than 3.7 version, thus any pipelines running now, before merging this PR might get in trouble.
This PR is already running GLCI here: https://gitlab.com/jangorecki/data.table/pipelines/89602324 once completed should be safe to merge.