### PR TITLE
minor documentation fixes (change \dots to ...)

### DIFF
--- a/man/assign.Rd
+++ b/man/assign.Rd
@@ -10,13 +10,13 @@
 }
 \usage{
 # 1. LHS := RHS form
-# DT[i, LHS := RHS, by = \dots]
-# DT[i, c("LHS1", "LHS2") := list(RHS1, RHS2), by = \dots]
+# DT[i, LHS := RHS, by = ...]
+# DT[i, c("LHS1", "LHS2") := list(RHS1, RHS2), by = ...]
 
 # 2. Functional form
 # DT[i, `:=`(LHS1 = RHS1,
 #            LHS2 = RHS2,
-#            \dots), by = \dots]
+#            ...), by = ...]
 
 set(x, i = NULL, j, value)
 }

--- a/man/rbindlist.Rd
+++ b/man/rbindlist.Rd
@@ -8,7 +8,7 @@
 }
 \usage{
 rbindlist(l, use.names="check", fill=FALSE, idcol=NULL)
-# rbind(\dots, use.names=TRUE, fill=FALSE, idcol=NULL)
+# rbind(..., use.names=TRUE, fill=FALSE, idcol=NULL)
 }
 \arguments{
   \item{l}{ A list containing \code{data.table}, \code{data.frame} or \code{list} objects. \code{\dots} is the same but you pass the objects by name separately. }


### PR DESCRIPTION
Just cleaning up remaining `\dots` artifacts in documentation.
As mentioned in https://github.com/Rdatatable/data.table/pull/3091#issuecomment-426681344 the `\dots` macros is not parsed when inside a comment inside R code.