### PR TITLE
Avoid `frollapply()` stack overflows and protect limits

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,8 @@ Authors@R: c(
   person("Roy","Storey",           role="ctb"),
   person("Manish","Saraswat",      role="ctb"),
   person("Morgan","Jacob",         role="ctb"),
-  person("Michael","Schubmehl",    role="ctb"))
+  person("Michael","Schubmehl",    role="ctb"),
+  person("Davis","Vaughan",        role="ctb"))
 Depends: R (>= 3.1.0)
 Imports: methods
 Suggests: bit64, curl, R.utils, knitr, xts, nanotime, zoo, yaml

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 ## BUG FIXES
 
+1. `frollapply` could segfault and exceed R's C protect limits, [#3993](https://github.com/Rdatatable/data.table/issues/3993). Thanks to @DavisVaughan for reporting and fixing.
+
 ## NOTES
 
 

--- a/inst/tests/froll.Rraw
+++ b/inst/tests/froll.Rraw
@@ -1027,6 +1027,12 @@ test(6010.005, frollmean(d, 3:4), frollapply(d, 3:4, mean))
 d = rbind(d, list(NA,NA))
 ans = list(c(NA,NA,1.5,2,1.5,2,2.5), c(NA,NA,NA,2,1,1.5,2), c(NA,NA,1.25,1.5,1.75,1.5,2), c(NA,NA,NA,1.5,1,1.25,1.5))
 test(6010.006, frollapply(d, 3:4, function(x, ...) if (sum(x, ...)>5) min(x, ...) else max(x, ...), na.rm=TRUE), ans)
+# segfault and protect limits #3993 - disabled by default due to high memory usage
+if (FALSE) {
+  test(6010.007, frollapply(1, rep(1L, 1e5), identity), as.list(rep(1, 1e5)))
+  test(6010.008, frollapply(1, rep(1L, 1e6), identity), as.list(rep(1, 1e6)))
+  test(6010.009, frollapply(as.list(rep(1, 1e6)), 1, identity), as.list(rep(1, 1e6)))
+}
 #### corner cases from examples
 test(6010.101, frollapply(1:5, 3, function(x) head(x, 2)), error="frollapply: results from provided FUN are not length 1")
 f = function(x) {

--- a/src/frollR.c
+++ b/src/frollR.c
@@ -307,21 +307,22 @@ SEXP frollapplyR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP align, SEXP rho) {
     dx[i] = REAL(VECTOR_ELT(x, i));
   }
 
-  double *dw[nk];
-  SEXP pw[nk], pc[nk];
-  // in the following loop we handle vectorized k argument
-  // for each k we need to allocate own width window object: pw
+  double* dw;
+  SEXP pw, pc;
+
+  // in the outer loop we handle vectorized k argument
+  // for each k we need to allocate a width window object: pw
   // we also need to construct distinct R call pointing to that window
   for (R_len_t j=0; j<nk; j++) {
-    pw[j] = PROTECT(allocVector(REALSXP, ik[j])); protecti++;
-    dw[j] = REAL(pw[j]);
-    pc[j] = PROTECT(LCONS(fun, LCONS(pw[j], LCONS(R_DotsSymbol, R_NilValue)))); protecti++;
-  }
+    pw = PROTECT(allocVector(REALSXP, ik[j]));
+    dw = REAL(pw);
+    pc = PROTECT(LCONS(fun, LCONS(pw, LCONS(R_DotsSymbol, R_NilValue))));
 
-  for (R_len_t i=0; i<nx; i++) {
-    for (R_len_t j=0; j<nk; j++) {
-      frollapply(dx[i], inx[i], dw[j], ik[j], &dans[i*nk+j], ialign, dfill, pc[j], rho, verbose);
+    for (R_len_t i=0; i<nx; i++) {
+      frollapply(dx[i], inx[i], dw, ik[j], &dans[i*nk+j], ialign, dfill, pc, rho, verbose);
     }
+
+    UNPROTECT(2);
   }
 
   if (verbose)

--- a/src/frollR.c
+++ b/src/frollR.c
@@ -296,8 +296,8 @@ SEXP frollapplyR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP align, SEXP rho) {
   if (verbose)
     Rprintf("%s: allocating memory for results %dx%d\n", __func__, nx, nk);
   ans_t *dans = (ans_t *)R_alloc(nx*nk, sizeof(ans_t));
-  double* dx[nx];
-  uint64_t inx[nx];
+  double** dx = (double**)R_alloc(nx, sizeof(double*));
+  uint64_t* inx = (uint64_t*)R_alloc(nx, sizeof(uint64_t));
   for (R_len_t i=0; i<nx; i++) {
     inx[i] = xlength(VECTOR_ELT(x, i));
     for (R_len_t j=0; j<nk; j++) {


### PR DESCRIPTION
Closes #3993 

The following three examples from #3993 now run without issue, no segfaults!

``` r
library(data.table)

xx <- frollapply(1, rep(1L, 1e5), identity)

yy <- frollapply(1, rep(1L, 1e6), identity)

zz <- frollapply(as.list(rep(1, 1e6)), 1, identity)
```

If someone else wants to take over adding tests (if you want them), please go ahead. I'm not familiar with how you all test the package.

