### PR TITLE
Homepage additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ DT[Petal.Width > 1.0, mean(Petal.Length), by = Species]
 
 `data.table` is widely used by the R community. As of July 2019, it was used by over 680 CRAN and Bioconductor packages and was the [9th most starred](http://www.r-pkg.org/starred) R package on GitHub. If you need help, the `data.table` community is active StackOverflow, with nearly [9,000 questions](http://stackoverflow.com/questions/tagged/data.table).
 
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/fZpA_cU0SPg" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
 ### Stay up-to-date
 
 - click the **Watch** button at the top and right of GitHub project page

--- a/README.md
+++ b/README.md
@@ -92,8 +92,6 @@ DT[Petal.Width > 1.0, mean(Petal.Length), by = Species]
 
 `data.table` is widely used by the R community. As of July 2019, it was used by over 680 CRAN and Bioconductor packages and was the [9th most starred](http://www.r-pkg.org/starred) R package on GitHub. If you need help, the `data.table` community is active StackOverflow, with nearly [9,000 questions](http://stackoverflow.com/questions/tagged/data.table).
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/fZpA_cU0SPg" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
 ### Stay up-to-date
 
 - click the **Watch** button at the top and right of GitHub project page

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -9,7 +9,7 @@ development:
 
 navbar:
   structure:
-    left:  [home, introduction, reference, articles, news, benchmarks]
+    left:  [home, introduction, vignettes, news, benchmarks, presentations, articles]
     right: [github]
   components:
     home:
@@ -18,10 +18,7 @@ navbar:
     introduction:
       text: Introduction
       href: articles/datatable-intro.html
-    reference:
-      text: Manual
-      href: reference/index.html
-    articles:
+    vignettes:
       text: Vignettes
       menu:
       - text: "Introduction to data.table"
@@ -42,12 +39,20 @@ navbar:
         href: articles/datatable-importing.html
       - text: "Benchmarking data.table"
         href: articles/datatable-benchmarking.html
+      - text: Reference manual
+        href: reference/index.html
     news:
       text: Changelog
       href: news/index.html
     benchmarks:
       text: Benchmarks
       href: https://h2oai.github.io/db-benchmark
+    presentations:
+      text: Presentations
+      href: https://github.com/Rdatatable/data.table/wiki/Presentations
+    articles:
+      text: Articles
+      href: https://github.com/Rdatatable/data.table/wiki/Articles
     github:
       icon: fab fa-github fa-lg
       href: https://github.com/Rdatatable/data.table


### PR DESCRIPTION
Added Presentation and Articles as menu items at the top.
Moved manual to the bottom of vignettes menu. So as to point to the vignettes first before the (potentially off-putting) reference manual.