### PR TITLE
fwrite gzip on Solaris 10: more tracing

### DIFF
--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -353,8 +353,10 @@ test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,no
     }
   }
   if (fail && exists("out",inherits=FALSE)) {
+    # nocov start
     cat("Output captured before unexpected warning/error/message:\n")
     cat(out,sep="\n")
+    # nocov end
   }
   if (!fail && !length(error) && (length(output) || length(notOutput))) {
     if (out[length(out)] == "NULL") out = out[-length(out)]

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -352,6 +352,10 @@ test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,no
       }
     }
   }
+  if (fail && exists("out",inherits=FALSE)) {
+    cat("Output captured before unexpected warning/error/message:\n")
+    cat(out,sep="\n")
+  }
   if (!fail && !length(error) && (length(output) || length(notOutput))) {
     if (out[length(out)] == "NULL") out = out[-length(out)]
     out = paste(out, collapse="\n")


### PR DESCRIPTION
More follow-up to #3964 
I have emailed this tar.gz to Prof Ripley to run on Solaris and send back the output.

* error message includes both library version and zlib.h version; a mismatch is expected but it isn't supposed to matter if the first digit is the same which is expected.
* more tracing of inputs and constants in verbose mode, based on reading zlib's source code to see why it is returned Z_STREAM_ERROR.  I attempted to trace zlib's internal state too (which causes Z_STREAM_ERROR in several places in zlib's source) but that appears to be hidden from application usage and won't compile. 
* when `test()` fails with an unexpected error (as is the case on Solaris currently) and it was passed an `output=` to check, the captured output is now displayed for the log. Currently that output is not being displayed in the CRAN output for this test 1658.421. This may help other tests in general too.

Currently Solaris is the only error on CRAN with the following output:
```
     Running test id 1658.4
     Running test id 1658.41
     Running test id 1658.421 Test 1658.421 produced 1 errors but expected 0
     Expected:
     Observed: zlib v1.2.11 deflate() returned error -2 with z_stream.msg ''. Please include the full output above in your data.table bug report.
     Running test id 1658.422
     Running test id 1658.423
     Running test id 1658.43 Test 1658.43 ran without errors but failed check that x equals y:
     > x = fread(f1)
     Empty data.table (0 rows and 2 cols): a,b
     [Key= Types=log,log Classes=log,log]
     > y = DT
     a b [Key= Types=int,int Classes=int,int]
     1: 1 1
     2: 1 1
     ---
     199: 2 4
     200: 2 4
     Different number of rows
     Error in fwrite(DT, file = f3 <- tempfile(), compress = "gzip") :
     zlib v1.2.11 deflate() returned error -2 with z_stream.msg ''. Please retry fwrite() with verbose=TRUE and include the full output with your data.table bug report.
     Calls: test.data.table -> sys.source -> eval -> eval -> fwrite
     Execution halted
```