### PR TITLE
use _R_CHECK_TESTS_NLINES=0 in CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,6 +25,8 @@ environment:
 # Default GCC_PATH appears to be gcc-4.6.3 which is now unsupported as from Rtools.exe v3.4.
     _R_CHECK_NO_STOP_ON_TEST_ERROR_: true
 # continue tests even if some script failed
+    _R_CHECK_TESTS_NLINES_: 0
+# Block truncation of any error messages in R CMD check
 
   matrix:
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,8 @@ variables:
   CRAN_MIRROR: "https://cloud.r-project.org"
   _R_CHECK_FORCE_SUGGESTS_: "false"
   _R_CHECK_NO_STOP_ON_TEST_ERROR_: "true"
+  # Block truncation of any error messages in R CMD check
+  _R_CHECK_TESTS_NLINES_: 0
 
 stages:
   - dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,5 +50,7 @@ env:
     - PKG_CFLAGS="-O3 -Wall -pedantic"
     - _R_CHECK_NO_STOP_ON_TEST_ERROR_=true
     - _R_CHECK_CRAN_INCOMING_REMOTE_=false
+    # Block truncation of any error messages in R CMD check
+    - _R_CHECK_TESTS_NLINES_=0
     # drat using @jangorecki token
     - secure: "CxDW++rsQApQWos+h1z/F76odysyD6AtXJrDwlCHlgqXeKJNRATR4wZDDR18SK+85jUqjoqOvpyrq+5kKuyg6AnA/zduaX2uYE5mcntEUiyzlG/jJUKbcJqt22nyAvFXP3VS60T2u4H6IIhVmr7dArdxLkv8W+pJvf2Tg6kx8Ws="


### PR DESCRIPTION
Came across this today:

https://yihui.name/en/2017/12/last-13-lines-of-output/

Can make reaction to test fails much quicker if we can see the full output...

Could also just choose something larger like 50, not sure if this will blow up the logs needlessly in successful cases. In any case 13 is often not enough.