### PR TITLE
Autoname-j 2

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -16377,6 +16377,8 @@ test(2121.2, DT[ , {{{b = b; .(a, b = b + 1)}}}], DT[ , .(a, b=b+1)])
 test(2121.3, DT[ , if (.N > 1L) .(b), by=a], DT[1:2])
 test(2121.4, DT[ , if (.N > 1L) .(b) else .(c=b), by=a], DT[ , .(a, c=b)],
      warning="Different branches of j expression produced different auto-named columns")
+test(2121.5, DT[, .(.N=.N), by=a], data.table(a=c(1,2), .N=2:1)) # user supplied names preside over autoname dropping leading dot
+
 
 ###################################
 #  Add new tests above this line  #


### PR DESCRIPTION
Follow up to #3802 to pass R 3.1.0
Closes #4048 without bumping

I found a simple way to backport the R 3.2.0 feature without using a switch on version number or feature test. This avoids the complexity of more code and nocov.
Also slightly simplified the logic in data.table.R regarding autonaming to avoid a little bit of overhead, but that wasn't needed to support R 3.1.0.