### PR TITLE
memtest fwrite does not use verbose

### DIFF
--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -316,7 +316,7 @@ test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,no
   }
   if (memtest) {
     mem = as.list(c(inittime=inittime, filename=basename(filename), timestamp=timestamp, test=num, ps_mem(), gc_mem())) # nocov
-    fwrite(mem, "memtest.csv", append=TRUE)                                                                             # nocov
+    fwrite(mem, "memtest.csv", append=TRUE, verbose=FALSE)                                                                             # nocov
   }
   fail = FALSE
   if (.test.data.table) {


### PR DESCRIPTION
vanilla build which runs "memtest" was unnecesserily polluting main.Rout with fwrite verbose messages