### PR TITLE
mingw I64 warnings

### DIFF
--- a/src/assign.c
+++ b/src/assign.c
@@ -1,6 +1,4 @@
 #include "data.table.h"
-#include <Rdefines.h>
-#include <Rmath.h>
 
 static void finalizer(SEXP p)
 {

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -1,10 +1,10 @@
+#include "dt_stdio.h"  // PRId64 and PRIu64
 #include <R.h>
 #define USE_RINTERNALS
 #include <Rinternals.h>
 // #include <signal.h> // the debugging machinery + breakpoint aidee
 // raise(SIGINT);
 #include <stdint.h>    // for uint64_t rather than unsigned long long
-#include <inttypes.h>  // for PRId64 and PRIu64
 #include <stdbool.h>
 #include "myomp.h"
 #include "types.h"

--- a/src/dt_stdio.h
+++ b/src/dt_stdio.h
@@ -1,0 +1,34 @@
+
+// It seems that latest min64-w64 compiler needs some help to avoid warnings; #4064
+// It appears that its inttypes.h defines PRId64 to be I64 on Windows but then warns that
+// I64 is not C99 too. Which is correct, but we know, and we don't want any warnings, and
+// we can't control settings on CRAN. So here we try and isolate ourselves from all scenarios.
+// There is a lot online about this, but these were a few that were most useful:
+// https://stackoverflow.com/questions/23718110/error-unknown-conversion-type-character-l-in-format-scanning-long-long
+// https://gitlab.freedesktop.org/nacho.garglez/cerbero/commit/4ec6bfdc1db1e4bc8d4278f53ad295af1efe89fb
+// https://github.com/GNOME/glib/commit/98a0ab929d8c59ee27e5f470f11d077bb6a56749#diff-969b60ad3d206fd45c208e266ccfed38
+// https://sourceforge.net/p/mingw-w64/wiki2/gnu%20printf/
+// Warning that __USE_MINGW_ANSI_STDIO could be deprecated:
+// https://mingw-w64-public.narkive.com/aQDJHqCv/how-to-printf-64-bit-integer-in-64-bit-compiler-in-strict-iso-mode-with-all-warnings-enabled
+// and then actual deprecation (with complaints) earlier in 2019 here:
+// https://osdn.net/projects/mingw/lists/archive/users/2019-January/000202.html
+// But I can't find _mingw.h. I can find mingw.h but not advice within it:
+// https://github.com/git/git/blob/master/compat/mingw.h#L448
+// The deprecation about I64 doesn't seem to take into account that lld throws the warning in MinGW:
+//   warning: unknown conversion type character 'l' in format [-Wformat=]
+// So let's see if the approach below works for now.
+// If we need to make changes in future, we can do it here in one place.
+
+#ifndef DT_STDIO_H
+#define DT_STDIO_H
+#if defined(__MINGW32__) || (defined __MINGW64__)
+  #define __USE_MINGW_ANSI_STDIO 1
+  #include <stdio.h>
+  #define PRId64 "lld"
+  #define PRIu64 "llu"
+#else
+  #include <stdio.h>
+  #include <inttypes.h>
+  // let inttypes.h decide: lld on Linux/C99; I64 on Windows Visual Studio for example
+#endif
+#endif

--- a/src/fread.h
+++ b/src/fread.h
@@ -1,9 +1,9 @@
 #ifndef dt_FREAD_H
 #define dt_FREAD_H
-#include <stdint.h>  // uint32_t
-#include <inttypes.h> // PRId64
-#include <stdlib.h>  // size_t
-#include <stdbool.h> // bool
+#include "dt_stdio.h"  // PRId64
+#include <stdint.h>    // uint32_t
+#include <stdlib.h>    // size_t
+#include <stdbool.h>   // bool
 #include "myomp.h"
 #ifdef DTPY
   #include "py_fread.h"

--- a/src/froll.c
+++ b/src/froll.c
@@ -45,7 +45,7 @@ void frollmean(unsigned int algo, double *x, uint64_t nx, ans_t *ans, int k, int
  */
 void frollmeanFast(double *x, uint64_t nx, ans_t *ans, int k, double fill, bool narm, int hasna, bool verbose) {
   if (verbose)
-    snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
+    snprintf(end(ans->message[0]), 500, "frollmeanFast: running for input length %"PRIu64", window %d, hasna %d, narm %d\n", (uint64_t)nx, k, hasna, (int)narm);
   long double w = 0.0;                                          // sliding window aggregate
   bool truehasna = hasna>0;                                     // flag to re-run with NA support if NAs detected
   if (!truehasna) {
@@ -134,7 +134,7 @@ void frollmeanFast(double *x, uint64_t nx, ans_t *ans, int k, double fill, bool 
  */
 void frollmeanExact(double *x, uint64_t nx, ans_t *ans, int k, double fill, bool narm, int hasna, bool verbose) {
   if (verbose)
-    snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
+    snprintf(end(ans->message[0]), 500, "frollmeanExact: running in parallel for input length %"PRIu64", window %d, hasna %d, narm %d\n", (uint64_t)nx, k, hasna, (int)narm);
   for (int i=0; i<k-1; i++) {                                   // fill partial window only
     ans->dbl_v[i] = fill;
   }
@@ -248,7 +248,7 @@ void frollsum(unsigned int algo, double *x, uint64_t nx, ans_t *ans, int k, int 
 }
 void frollsumFast(double *x, uint64_t nx, ans_t *ans, int k, double fill, bool narm, int hasna, bool verbose) {
   if (verbose)
-    snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
+    snprintf(end(ans->message[0]), 500, "frollsumFast: running for input length %"PRIu64", window %d, hasna %d, narm %d\n", (uint64_t)nx, k, hasna, (int)narm);
   long double w = 0.0;
   bool truehasna = hasna>0;
   if (!truehasna) {
@@ -332,7 +332,7 @@ void frollsumFast(double *x, uint64_t nx, ans_t *ans, int k, double fill, bool n
 }
 void frollsumExact(double *x, uint64_t nx, ans_t *ans, int k, double fill, bool narm, int hasna, bool verbose) {
   if (verbose)
-    snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
+    snprintf(end(ans->message[0]), 500, "frollsumExact: running in parallel for input length %"PRIu64", window %d, hasna %d, narm %d\n", (uint64_t)nx, k, hasna, (int)narm);
   for (int i=0; i<k-1; i++) {
     ans->dbl_v[i] = fill;
   }

--- a/src/froll.c
+++ b/src/froll.c
@@ -1,7 +1,3 @@
-#include <stdio.h>
-#include <stdint.h>
-#include <stdbool.h>
-#include <Rdefines.h>
 #include "data.table.h"
 
 /* fast rolling mean - router

--- a/src/frolladaptive.c
+++ b/src/frolladaptive.c
@@ -26,7 +26,7 @@ void fadaptiverollmean(unsigned int algo, double *x, uint64_t nx, ans_t *ans, in
  */
 void fadaptiverollmeanFast(double *x, uint64_t nx, ans_t *ans, int *k, double fill, bool narm, int hasna, bool verbose) {
   if (verbose)
-    snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
+    snprintf(end(ans->message[0]), 500, "fadaptiverollmeanFast: running for input length %"PRIu64", hasna %d, narm %d\n", (uint64_t)nx, hasna, (int) narm);
   bool truehasna = hasna>0;                                     // flag to re-run if NAs detected
   long double w = 0.0;
   double *cs = malloc(nx*sizeof(double));                       // cumsum vector, same as double cs[nx] but no segfault
@@ -111,7 +111,7 @@ void fadaptiverollmeanFast(double *x, uint64_t nx, ans_t *ans, int *k, double fi
  */
 void fadaptiverollmeanExact(double *x, uint64_t nx, ans_t *ans, int *k, double fill, bool narm, int hasna, bool verbose) {
   if (verbose)
-    snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
+    snprintf(end(ans->message[0]), 500, "fadaptiverollmeanExact: running in parallel for input length %"PRIu64", hasna %d, narm %d\n", (uint64_t)nx, hasna, (int) narm);
   bool truehasna = hasna>0;                                     // flag to re-run if NAs detected
   if (!truehasna || !narm) {                                    // narm=FALSE handled here as NAs properly propagated in exact algo
     #pragma omp parallel for num_threads(getDTthreads())
@@ -215,7 +215,7 @@ void fadaptiverollsum(unsigned int algo, double *x, uint64_t nx, ans_t *ans, int
 }
 void fadaptiverollsumFast(double *x, uint64_t nx, ans_t *ans, int *k, double fill, bool narm, int hasna, bool verbose) {
   if (verbose)
-    snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
+    snprintf(end(ans->message[0]), 500, "fadaptiverollsumFast: running for input length %"PRIu64", hasna %d, narm %d\n", (uint64_t)nx, hasna, (int) narm);
   bool truehasna = hasna>0;
   long double w = 0.0;
   double *cs = malloc(nx*sizeof(double));
@@ -295,7 +295,7 @@ void fadaptiverollsumFast(double *x, uint64_t nx, ans_t *ans, int *k, double fil
 }
 void fadaptiverollsumExact(double *x, uint64_t nx, ans_t *ans, int *k, double fill, bool narm, int hasna, bool verbose) {
   if (verbose)
-    snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
+    snprintf(end(ans->message[0]), 500, "fadaptiverollsumExact: running in parallel for input length %"PRIu64", hasna %d, narm %d\n", (uint64_t)nx, hasna, (int) narm);
   bool truehasna = hasna>0;
   if (!truehasna || !narm) {
     #pragma omp parallel for num_threads(getDTthreads())

--- a/src/frolladaptive.c
+++ b/src/frolladaptive.c
@@ -1,7 +1,3 @@
-#include <stdio.h>
-#include <stdint.h>
-#include <stdbool.h>
-#include <Rdefines.h>
 #include "data.table.h"
 
 /* fast adaptive rolling mean - router

--- a/src/fwrite.c
+++ b/src/fwrite.c
@@ -1,9 +1,9 @@
+#include "dt_stdio.h"
 #include <errno.h>
 #include <unistd.h>    // for access()
 #include <fcntl.h>
 #include <stdbool.h>   // true and false
 #include <stdint.h>    // INT32_MIN
-#include <inttypes.h>  // PRId64
 #include <math.h>      // isfinite, isnan
 #include <stdlib.h>    // abs
 #include <string.h>    // strlen, strerror


### PR DESCRIPTION
Closes #4062 again
Follow up to #4064 
Let's see if this passes rtools 3.5 as done on AppVeyor.

It doesn't pass win-builder R-devel rtools 4.0,  as on CRAN : 

>This notification has been generated automatically.
>Your package data.table_1.12.7.tar.gz has been built and checked for Windows.
>Please check the log files and (if working) the binary package at:
>https://win-builder.r-project.org/SLI5D0q5ZqdK
>The files will be removed after roughly 72 hours.
>Installation time in seconds: 142
>Check time in seconds: 1073
>Status: 1 WARNING
>R Under development (unstable) (2019-11-14 r77415)

See the notes and links I added to dt_stdio.h in this PR.
Maybe we should ask here: https://osdn.net/projects/mingw/lists/archive/users/

Oh wait ... these warnings are not in the same files they were before. These are froll.  Maybe it's something else not detected before and this PR is in the right direction after all.

That's really strange that it's only froll.c and frolladaptive.c.  There is plenty of PRId64 in other files and we don't see these warnings for those.  On CRAN we see this warning in many other files, but withis PR we just see in froll.  All I can see different in the froll cases is they all start with `%s` but I don't see the problem with that.

```
Found the following significant warnings:
  assign.c:882:107: warning: too many arguments for format [-Wformat-extra-args]
  assign.c:889:107: warning: too many arguments for format [-Wformat-extra-args]
  assign.c:895:107: warning: too many arguments for format [-Wformat-extra-args]
  forder.c:503:10: warning: too many arguments for format [-Wformat-extra-args]
  forder.c:607:16: warning: too many arguments for format [-Wformat-extra-args]
  fread.c:418:36: warning: too many arguments for format [-Wformat-extra-args]
  fread.c:423:34: warning: too many arguments for format [-Wformat-extra-args]
  fread.c:429:30: warning: too many arguments for format [-Wformat-extra-args]
  fread.c:2217:21: warning: too many arguments for format [-Wformat-extra-args]
  froll.c:52:41: warning: too many arguments for format [-Wformat-extra-args]
  froll.c:141:41: warning: too many arguments for format [-Wformat-extra-args]
  froll.c:255:41: warning: too many arguments for format [-Wformat-extra-args]
  froll.c:339:41: warning: too many arguments for format [-Wformat-extra-args]
  frolladaptive.c:33:41: warning: too many arguments for format [-Wformat-extra-args]
  frolladaptive.c:118:41: warning: too many arguments for format [-Wformat-extra-args]
  frolladaptive.c:222:41: warning: too many arguments for format [-Wformat-extra-args]
  frolladaptive.c:302:41: warning: too many arguments for format [-Wformat-extra-args]
```

```
* installing *source* package 'data.table' ...
** using staged installation

   **********************************************
   WARNING: this package has a configure script
         It probably needs manual configuration
   **********************************************


** libs

*** arch - i386
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c assign.c -o assign.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c between.c -o between.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c bmerge.c -o bmerge.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c chmatch.c -o chmatch.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c cj.c -o cj.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c coalesce.c -o coalesce.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c dogroups.c -o dogroups.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c fastmean.c -o fastmean.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c fcast.c -o fcast.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c fifelse.c -o fifelse.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c fmelt.c -o fmelt.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c forder.c -o forder.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c frank.c -o frank.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c fread.c -o fread.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c freadR.c -o freadR.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c froll.c -o froll.o
froll.c: In function 'frollmeanFast':
froll.c:52:41: warning: unknown conversion type character 'l' in format [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from data.table.h:1,
                 from froll.c:5:
dt_stdio.h:11:20: note: format string is defined here
   #define PRIu64 "llu"
                    ^
froll.c:52:41: warning: format '%d' expects argument of type 'int', but argument 5 has type 'long long unsigned int' [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                    ~~~~~~~~~~~~
froll.c:52:90: note: format string is defined here
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                                                                         ~^
                                                                                         %I64d
froll.c:52:41: warning: too many arguments for format [-Wformat-extra-args]
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
froll.c: In function 'frollmeanExact':
froll.c:141:41: warning: unknown conversion type character 'l' in format [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from data.table.h:1,
                 from froll.c:5:
dt_stdio.h:11:20: note: format string is defined here
   #define PRIu64 "llu"
                    ^
froll.c:141:41: warning: format '%d' expects argument of type 'int', but argument 5 has type 'long long unsigned int' [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                    ~~~~~~~~~~~~
froll.c:141:102: note: format string is defined here
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                                                                                     ~^
                                                                                                     %I64d
froll.c:141:41: warning: too many arguments for format [-Wformat-extra-args]
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
froll.c: In function 'frollsumFast':
froll.c:255:41: warning: unknown conversion type character 'l' in format [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from data.table.h:1,
                 from froll.c:5:
dt_stdio.h:11:20: note: format string is defined here
   #define PRIu64 "llu"
                    ^
froll.c:255:41: warning: format '%d' expects argument of type 'int', but argument 5 has type 'long long unsigned int' [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                    ~~~~~~~~~~~~
froll.c:255:90: note: format string is defined here
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                                                                         ~^
                                                                                         %I64d
froll.c:255:41: warning: too many arguments for format [-Wformat-extra-args]
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
froll.c: In function 'frollsumExact':
froll.c:339:41: warning: unknown conversion type character 'l' in format [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from data.table.h:1,
                 from froll.c:5:
dt_stdio.h:11:20: note: format string is defined here
   #define PRIu64 "llu"
                    ^
froll.c:339:41: warning: format '%d' expects argument of type 'int', but argument 5 has type 'long long unsigned int' [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                    ~~~~~~~~~~~~
froll.c:339:102: note: format string is defined here
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                                                                                     ~^
                                                                                                     %I64d
froll.c:339:41: warning: too many arguments for format [-Wformat-extra-args]
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c frollR.c -o frollR.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c frolladaptive.c -o frolladaptive.o
frolladaptive.c: In function 'fadaptiverollmeanFast':
frolladaptive.c:33:41: warning: unknown conversion type character 'l' in format [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from data.table.h:1,
                 from frolladaptive.c:5:
dt_stdio.h:11:20: note: format string is defined here
   #define PRIu64 "llu"
                    ^
frolladaptive.c:33:41: warning: format '%d' expects argument of type 'int', but argument 5 has type 'long long unsigned int' [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                         ~~~~~~~~~~~~
frolladaptive.c:33:89: note: format string is defined here
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                                                                        ~^
                                                                                        %I64d
frolladaptive.c:33:41: warning: too many arguments for format [-Wformat-extra-args]
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
frolladaptive.c: In function 'fadaptiverollmeanExact':
frolladaptive.c:118:41: warning: unknown conversion type character 'l' in format [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from data.table.h:1,
                 from frolladaptive.c:5:
dt_stdio.h:11:20: note: format string is defined here
   #define PRIu64 "llu"
                    ^
frolladaptive.c:118:41: warning: format '%d' expects argument of type 'int', but argument 5 has type 'long long unsigned int' [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                         ~~~~~~~~~~~~
frolladaptive.c:118:101: note: format string is defined here
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                                                                                    ~^
                                                                                                    %I64d
frolladaptive.c:118:41: warning: too many arguments for format [-Wformat-extra-args]
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
frolladaptive.c: In function 'fadaptiverollsumFast':
frolladaptive.c:222:41: warning: unknown conversion type character 'l' in format [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from data.table.h:1,
                 from frolladaptive.c:5:
dt_stdio.h:11:20: note: format string is defined here
   #define PRIu64 "llu"
                    ^
frolladaptive.c:222:41: warning: format '%d' expects argument of type 'int', but argument 5 has type 'long long unsigned int' [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                         ~~~~~~~~~~~~
frolladaptive.c:222:89: note: format string is defined here
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                                                                        ~^
                                                                                        %I64d
frolladaptive.c:222:41: warning: too many arguments for format [-Wformat-extra-args]
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
frolladaptive.c: In function 'fadaptiverollsumExact':
frolladaptive.c:302:41: warning: unknown conversion type character 'l' in format [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from data.table.h:1,
                 from frolladaptive.c:5:
dt_stdio.h:11:20: note: format string is defined here
   #define PRIu64 "llu"
                    ^
frolladaptive.c:302:41: warning: format '%d' expects argument of type 'int', but argument 5 has type 'long long unsigned int' [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                         ~~~~~~~~~~~~
frolladaptive.c:302:101: note: format string is defined here
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                                                                                    ~^
                                                                                                    %I64d
frolladaptive.c:302:41: warning: too many arguments for format [-Wformat-extra-args]
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c fsort.c -o fsort.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c fwrite.c -o fwrite.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c fwriteR.c -o fwriteR.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c gsumm.c -o gsumm.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c ijoin.c -o ijoin.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c init.c -o init.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c inrange.c -o inrange.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c nafill.c -o nafill.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c nqrecreateindices.c -o nqrecreateindices.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c openmp-utils.c -o openmp-utils.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c quickselect.c -o quickselect.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c rbindlist.c -o rbindlist.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c reorder.c -o reorder.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c shift.c -o shift.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c subset.c -o subset.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c transpose.c -o transpose.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c types.c -o types.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c uniqlist.c -o uniqlist.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c utils.c -o utils.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c vecseq.c -o vecseq.o
d:/Compiler/rtools40/mingw32/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c wrappers.c -o wrappers.o
d:/Compiler/rtools40/mingw32/bin/gcc -shared -s -static-libgcc -o data.table.dll tmp.def assign.o between.o bmerge.o chmatch.o cj.o coalesce.o dogroups.o fastmean.o fcast.o fifelse.o fmelt.o forder.o frank.o fread.o freadR.o froll.o frollR.o frolladaptive.o fsort.o fwrite.o fwriteR.o gsumm.o ijoin.o init.o inrange.o nafill.o nqrecreateindices.o openmp-utils.o quickselect.o rbindlist.o reorder.o shift.o subset.o transpose.o types.o uniqlist.o utils.o vecseq.o wrappers.o -fopenmp -lz -Ld:/Compiler/gcc-4.9.3/local330/lib/i386 -Ld:/Compiler/gcc-4.9.3/local330/lib -LD:/RCompile/recent/R4/bin/i386 -lR
mv data.table.dll datatable.dll
if [ "Windows_NT" != "Windows_NT" ] && [ `uname -s` = 'Darwin' ]; then install_name_tool -id datatable.dll datatable.dll; fi
installing to d:/RCompile/CRANguest/R-devel_gcc8/lib/00LOCK-data.table/00new/data.table/libs/i386

*** arch - x64
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c assign.c -o assign.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c between.c -o between.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c bmerge.c -o bmerge.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c chmatch.c -o chmatch.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c cj.c -o cj.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c coalesce.c -o coalesce.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c dogroups.c -o dogroups.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c fastmean.c -o fastmean.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c fcast.c -o fcast.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c fifelse.c -o fifelse.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c fmelt.c -o fmelt.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c forder.c -o forder.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c frank.c -o frank.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c fread.c -o fread.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c freadR.c -o freadR.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c froll.c -o froll.o
froll.c: In function 'frollmeanFast':
froll.c:52:41: warning: unknown conversion type character 'l' in format [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from data.table.h:1,
                 from froll.c:5:
dt_stdio.h:11:20: note: format string is defined here
   #define PRIu64 "llu"
                    ^
froll.c:52:41: warning: format '%d' expects argument of type 'int', but argument 5 has type 'long long unsigned int' [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                    ~~~~~~~~~~~~
froll.c:52:90: note: format string is defined here
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                                                                         ~^
                                                                                         %I64d
froll.c:52:41: warning: too many arguments for format [-Wformat-extra-args]
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
froll.c: In function 'frollmeanExact':
froll.c:141:41: warning: unknown conversion type character 'l' in format [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from data.table.h:1,
                 from froll.c:5:
dt_stdio.h:11:20: note: format string is defined here
   #define PRIu64 "llu"
                    ^
froll.c:141:41: warning: format '%d' expects argument of type 'int', but argument 5 has type 'long long unsigned int' [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                    ~~~~~~~~~~~~
froll.c:141:102: note: format string is defined here
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                                                                                     ~^
                                                                                                     %I64d
froll.c:141:41: warning: too many arguments for format [-Wformat-extra-args]
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
froll.c: In function 'frollsumFast':
froll.c:255:41: warning: unknown conversion type character 'l' in format [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from data.table.h:1,
                 from froll.c:5:
dt_stdio.h:11:20: note: format string is defined here
   #define PRIu64 "llu"
                    ^
froll.c:255:41: warning: format '%d' expects argument of type 'int', but argument 5 has type 'long long unsigned int' [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                    ~~~~~~~~~~~~
froll.c:255:90: note: format string is defined here
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                                                                         ~^
                                                                                         %I64d
froll.c:255:41: warning: too many arguments for format [-Wformat-extra-args]
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
froll.c: In function 'frollsumExact':
froll.c:339:41: warning: unknown conversion type character 'l' in format [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from data.table.h:1,
                 from froll.c:5:
dt_stdio.h:11:20: note: format string is defined here
   #define PRIu64 "llu"
                    ^
froll.c:339:41: warning: format '%d' expects argument of type 'int', but argument 5 has type 'long long unsigned int' [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                    ~~~~~~~~~~~~
froll.c:339:102: note: format string is defined here
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                                                                                     ~^
                                                                                                     %I64d
froll.c:339:41: warning: too many arguments for format [-Wformat-extra-args]
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", window %d, hasna %d, narm %d\n", __func__, (uint64_t)nx, k, hasna, (int)narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c frollR.c -o frollR.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c frolladaptive.c -o frolladaptive.o
frolladaptive.c: In function 'fadaptiverollmeanFast':
frolladaptive.c:33:41: warning: unknown conversion type character 'l' in format [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from data.table.h:1,
                 from frolladaptive.c:5:
dt_stdio.h:11:20: note: format string is defined here
   #define PRIu64 "llu"
                    ^
frolladaptive.c:33:41: warning: format '%d' expects argument of type 'int', but argument 5 has type 'long long unsigned int' [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                         ~~~~~~~~~~~~
frolladaptive.c:33:89: note: format string is defined here
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                                                                        ~^
                                                                                        %I64d
frolladaptive.c:33:41: warning: too many arguments for format [-Wformat-extra-args]
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
frolladaptive.c: In function 'fadaptiverollmeanExact':
frolladaptive.c:118:41: warning: unknown conversion type character 'l' in format [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from data.table.h:1,
                 from frolladaptive.c:5:
dt_stdio.h:11:20: note: format string is defined here
   #define PRIu64 "llu"
                    ^
frolladaptive.c:118:41: warning: format '%d' expects argument of type 'int', but argument 5 has type 'long long unsigned int' [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                         ~~~~~~~~~~~~
frolladaptive.c:118:101: note: format string is defined here
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                                                                                    ~^
                                                                                                    %I64d
frolladaptive.c:118:41: warning: too many arguments for format [-Wformat-extra-args]
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
frolladaptive.c: In function 'fadaptiverollsumFast':
frolladaptive.c:222:41: warning: unknown conversion type character 'l' in format [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from data.table.h:1,
                 from frolladaptive.c:5:
dt_stdio.h:11:20: note: format string is defined here
   #define PRIu64 "llu"
                    ^
frolladaptive.c:222:41: warning: format '%d' expects argument of type 'int', but argument 5 has type 'long long unsigned int' [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                         ~~~~~~~~~~~~
frolladaptive.c:222:89: note: format string is defined here
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                                                                        ~^
                                                                                        %I64d
frolladaptive.c:222:41: warning: too many arguments for format [-Wformat-extra-args]
     snprintf(end(ans->message[0]), 500, "%s: running for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
frolladaptive.c: In function 'fadaptiverollsumExact':
frolladaptive.c:302:41: warning: unknown conversion type character 'l' in format [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from data.table.h:1,
                 from frolladaptive.c:5:
dt_stdio.h:11:20: note: format string is defined here
   #define PRIu64 "llu"
                    ^
frolladaptive.c:302:41: warning: format '%d' expects argument of type 'int', but argument 5 has type 'long long unsigned int' [-Wformat=]
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                         ~~~~~~~~~~~~
frolladaptive.c:302:101: note: format string is defined here
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                                                                                    ~^
                                                                                                    %I64d
frolladaptive.c:302:41: warning: too many arguments for format [-Wformat-extra-args]
     snprintf(end(ans->message[0]), 500, "%s: running in parallel for input length %"PRIu64", hasna %d, narm %d\n", __func__, (uint64_t)nx, hasna, (int) narm);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c fsort.c -o fsort.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c fwrite.c -o fwrite.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c fwriteR.c -o fwriteR.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c gsumm.c -o gsumm.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c ijoin.c -o ijoin.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c init.c -o init.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c inrange.c -o inrange.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c nafill.c -o nafill.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c nqrecreateindices.c -o nqrecreateindices.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c openmp-utils.c -o openmp-utils.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c quickselect.c -o quickselect.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c rbindlist.c -o rbindlist.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c reorder.c -o reorder.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c shift.c -o shift.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c subset.c -o subset.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c transpose.c -o transpose.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c types.c -o types.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c uniqlist.c -o uniqlist.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c utils.c -o utils.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c vecseq.c -o vecseq.o
d:/Compiler/rtools40/mingw64/bin/gcc  -I"D:/RCompile/recent/R4/include" -DNDEBUG     -I"d:/Compiler/gcc-4.9.3/local330/include"  -fopenmp   -pedantic -O2 -Wall  -std=gnu99  -c wrappers.c -o wrappers.o
d:/Compiler/rtools40/mingw64/bin/gcc -shared -s -static-libgcc -o data.table.dll tmp.def assign.o between.o bmerge.o chmatch.o cj.o coalesce.o dogroups.o fastmean.o fcast.o fifelse.o fmelt.o forder.o frank.o fread.o freadR.o froll.o frollR.o frolladaptive.o fsort.o fwrite.o fwriteR.o gsumm.o ijoin.o init.o inrange.o nafill.o nqrecreateindices.o openmp-utils.o quickselect.o rbindlist.o reorder.o shift.o subset.o transpose.o types.o uniqlist.o utils.o vecseq.o wrappers.o -fopenmp -lz -Ld:/Compiler/gcc-4.9.3/local330/lib/x64 -Ld:/Compiler/gcc-4.9.3/local330/lib -LD:/RCompile/recent/R4/bin/x64 -lR
mv data.table.dll datatable.dll
if [ "Windows_NT" != "Windows_NT" ] && [ `uname -s` = 'Darwin' ]; then install_name_tool -id datatable.dll datatable.dll; fi
installing to d:/RCompile/CRANguest/R-devel_gcc8/lib/00LOCK-data.table/00new/data.table/libs/x64
** R
** inst
** byte-compile and prepare package for lazy loading
** help
*** installing help indices
** building package indices
** installing vignettes
** testing if installed package can be loaded from temporary location
*** arch - i386
*** arch - x64
** testing if installed package can be loaded from final location
*** arch - i386
*** arch - x64
** testing if installed package keeps a record of temporary installation path
* MD5 sums
packaged installation of 'data.table' as data.table_1.12.7.zip
* DONE (data.table)
```