### PR TITLE
upgrade DT helpers works for custom library location

### DIFF
--- a/R/devel.R
+++ b/R/devel.R
@@ -1,9 +1,9 @@
 # nocov start
 
-dcf.lib = function(pkg, field, lib.loc){
+dcf.lib = function(pkg, field, lib.loc=NULL){
   # get DESCRIPTION metadata field from local library
   stopifnot(is.character(pkg), is.character(field), length(pkg)==1L, length(field)==1L)
-  dcf = system.file("DESCRIPTION", package=pkg, lib.loc=lib.loc)
+  dcf = system.file("DESCRIPTION", package=pkg, lib.loc=lib.loc, mustWork=TRUE)
   if (nzchar(dcf)) read.dcf(dcf, fields=field)[1L] else NA_character_
 }
 

--- a/R/devel.R
+++ b/R/devel.R
@@ -1,0 +1,46 @@
+# nocov start
+
+dcf.lib = function(pkg, field, lib.loc){
+  # get DESCRIPTION metadata field from local library
+  stopifnot(is.character(pkg), is.character(field), length(pkg)==1L, length(field)==1L)
+  dcf = system.file("DESCRIPTION", package=pkg, lib.loc=lib.loc)
+  if (nzchar(dcf)) read.dcf(dcf, fields=field)[1L] else NA_character_
+}
+
+dcf.repo = function(pkg, repo, field, type){
+  # get DESCRIPTION metadata field from remote PACKAGES file
+  stopifnot(is.character(pkg), is.character(field), length(pkg)==1L, length(field)==1L, is.character(repo), length(repo)==1L, field!="Package")
+  idx = file(file.path(contrib.url(repo, type=type),"PACKAGES"))
+  on.exit(close(idx))
+  dcf = read.dcf(idx, fields=c("Package",field))
+  if (!pkg %in% dcf[,"Package"]) stop("There is no ", pkg, " package in provided repository.")
+  dcf[dcf[,"Package"]==pkg, field][[1L]]
+}
+
+update.dev.pkg = function(object="data.table", repo="https://Rdatatable.gitlab.io/data.table", field="Revision", type=getOption("pkgType"), lib=NULL, ...){
+  pkg = object
+  # perform package upgrade when new Revision present
+  stopifnot(is.character(pkg), length(pkg)==1L, !is.na(pkg),
+            is.character(repo), length(repo)==1L, !is.na(repo),
+            is.character(field), length(field)==1L, !is.na(field),
+            is.null(lib) || (is.character(lib) && length(lib)==1L && !is.na(lib)))
+  una = is.na(ups<-dcf.repo(pkg, repo, field, type))
+  upg = una | !identical(ups, dcf.lib(pkg, field, lib.loc=lib))
+  if (upg) utils::install.packages(pkg, repos=repo, type=type, lib=lib, ...)
+  if (una) cat(sprintf("No commit information found in DESCRIPTION file for %s package. Unsure '%s' is correct field name in PACKAGES file in your devel repository '%s'.\n", pkg, field, file.path(repo, "src","contrib","PACKAGES")))
+  cat(sprintf("R %s package %s %s (%s)\n",
+              pkg,
+              c("is up-to-date at","has been updated to")[upg+1L],
+              dcf.lib(pkg, field, lib.loc=lib),
+              utils::packageVersion(pkg, lib.loc=lib)))
+}
+
+# non-exported utility when using devel version #3272: data.table:::.git()
+.git = function(quiet=FALSE, lib.loc=NULL) {
+  ans = unname(read.dcf(system.file("DESCRIPTION", package="data.table", lib.loc=lib.loc, mustWork=TRUE), fields="Revision")[, "Revision"])
+  if (!quiet && is.na(ans))
+    cat("Git revision is not available. Most likely data.table was installed from CRAN or local archive.\nGit revision is available when installing from our repositories 'https://Rdatatable.gitlab.io/data.table' and 'https://Rdatatable.github.io/data.table'.\n")
+  ans
+}
+
+# nocov end

--- a/R/onAttach.R
+++ b/R/onAttach.R
@@ -29,10 +29,10 @@
   }
 }
 
-dcf.lib = function(pkg, field){
+dcf.lib = function(pkg, field, lib.loc){
   # get DESCRIPTION metadata field from local library
   stopifnot(is.character(pkg), is.character(field), length(pkg)==1L, length(field)==1L)
-  dcf = system.file("DESCRIPTION", package=pkg)
+  dcf = system.file("DESCRIPTION", package=pkg, lib.loc=lib.loc)
   if (nzchar(dcf)) read.dcf(dcf, fields=field)[1L] else NA_character_
 }
 
@@ -46,21 +46,22 @@ dcf.repo = function(pkg, repo, field, type){
   dcf[dcf[,"Package"]==pkg, field][[1L]]
 }
 
-update.dev.pkg = function(object="data.table", repo="https://Rdatatable.gitlab.io/data.table", field="Revision", type=getOption("pkgType"), ...){
+update.dev.pkg = function(object="data.table", repo="https://Rdatatable.gitlab.io/data.table", field="Revision", type=getOption("pkgType"), lib=NULL, ...){
   pkg = object
   # perform package upgrade when new Revision present
   stopifnot(is.character(pkg), length(pkg)==1L, !is.na(pkg),
             is.character(repo), length(repo)==1L, !is.na(repo),
-            is.character(field), length(field)==1L, !is.na(field))
+            is.character(field), length(field)==1L, !is.na(field),
+            is.null(lib) || (is.character(lib) && length(lib)==1L && !is.na(lib)))
   una = is.na(ups<-dcf.repo(pkg, repo, field, type))
-  upg = una | !identical(ups, dcf.lib(pkg, field))
-  if (upg) utils::install.packages(pkg, repos=repo, type=type, ...)
+  upg = una | !identical(ups, dcf.lib(pkg, field, lib.loc=lib))
+  if (upg) utils::install.packages(pkg, repos=repo, type=type, lib=lib, ...)
   if (una) cat(sprintf("No commit information found in DESCRIPTION file for %s package. Unsure '%s' is correct field name in PACKAGES file in your devel repository '%s'.\n", pkg, field, file.path(repo, "src","contrib","PACKAGES")))
   cat(sprintf("R %s package %s %s (%s)\n",
               pkg,
               c("is up-to-date at","has been updated to")[upg+1L],
-              dcf.lib(pkg, field),
-              utils::packageVersion(pkg)))
+              dcf.lib(pkg, field, lib.loc=lib),
+              utils::packageVersion(pkg, lib.loc=lib)))
 }
 
 # non-exported utility when using devel version #3272: data.table:::.git()

--- a/R/onAttach.R
+++ b/R/onAttach.R
@@ -65,8 +65,8 @@ update.dev.pkg = function(object="data.table", repo="https://Rdatatable.gitlab.i
 }
 
 # non-exported utility when using devel version #3272: data.table:::.git()
-.git = function(quiet=FALSE) {
-  ans = unname(read.dcf(system.file("DESCRIPTION", package="data.table"), fields="Revision")[, "Revision"])
+.git = function(quiet=FALSE, lib.loc=NULL) {
+  ans = unname(read.dcf(system.file("DESCRIPTION", package="data.table", lib.loc=lib.loc, mustWork=TRUE), fields="Revision")[, "Revision"])
   if (!quiet && is.na(ans))
     cat("Git revision is not available. Most likely data.table was installed from CRAN or local archive.\nGit revision is available when installing from our repositories 'https://Rdatatable.gitlab.io/data.table' and 'https://Rdatatable.github.io/data.table'.\n")
   ans

--- a/R/onAttach.R
+++ b/R/onAttach.R
@@ -29,47 +29,4 @@
   }
 }
 
-dcf.lib = function(pkg, field, lib.loc){
-  # get DESCRIPTION metadata field from local library
-  stopifnot(is.character(pkg), is.character(field), length(pkg)==1L, length(field)==1L)
-  dcf = system.file("DESCRIPTION", package=pkg, lib.loc=lib.loc)
-  if (nzchar(dcf)) read.dcf(dcf, fields=field)[1L] else NA_character_
-}
-
-dcf.repo = function(pkg, repo, field, type){
-  # get DESCRIPTION metadata field from remote PACKAGES file
-  stopifnot(is.character(pkg), is.character(field), length(pkg)==1L, length(field)==1L, is.character(repo), length(repo)==1L, field!="Package")
-  idx = file(file.path(contrib.url(repo, type=type),"PACKAGES"))
-  on.exit(close(idx))
-  dcf = read.dcf(idx, fields=c("Package",field))
-  if (!pkg %in% dcf[,"Package"]) stop("There is no ", pkg, " package in provided repository.")
-  dcf[dcf[,"Package"]==pkg, field][[1L]]
-}
-
-update.dev.pkg = function(object="data.table", repo="https://Rdatatable.gitlab.io/data.table", field="Revision", type=getOption("pkgType"), lib=NULL, ...){
-  pkg = object
-  # perform package upgrade when new Revision present
-  stopifnot(is.character(pkg), length(pkg)==1L, !is.na(pkg),
-            is.character(repo), length(repo)==1L, !is.na(repo),
-            is.character(field), length(field)==1L, !is.na(field),
-            is.null(lib) || (is.character(lib) && length(lib)==1L && !is.na(lib)))
-  una = is.na(ups<-dcf.repo(pkg, repo, field, type))
-  upg = una | !identical(ups, dcf.lib(pkg, field, lib.loc=lib))
-  if (upg) utils::install.packages(pkg, repos=repo, type=type, lib=lib, ...)
-  if (una) cat(sprintf("No commit information found in DESCRIPTION file for %s package. Unsure '%s' is correct field name in PACKAGES file in your devel repository '%s'.\n", pkg, field, file.path(repo, "src","contrib","PACKAGES")))
-  cat(sprintf("R %s package %s %s (%s)\n",
-              pkg,
-              c("is up-to-date at","has been updated to")[upg+1L],
-              dcf.lib(pkg, field, lib.loc=lib),
-              utils::packageVersion(pkg, lib.loc=lib)))
-}
-
-# non-exported utility when using devel version #3272: data.table:::.git()
-.git = function(quiet=FALSE, lib.loc=NULL) {
-  ans = unname(read.dcf(system.file("DESCRIPTION", package="data.table", lib.loc=lib.loc, mustWork=TRUE), fields="Revision")[, "Revision"])
-  if (!quiet && is.na(ans))
-    cat("Git revision is not available. Most likely data.table was installed from CRAN or local archive.\nGit revision is available when installing from our repositories 'https://Rdatatable.gitlab.io/data.table' and 'https://Rdatatable.github.io/data.table'.\n")
-  ans
-}
-
 # nocov end

--- a/man/update.dev.pkg.Rd
+++ b/man/update.dev.pkg.Rd
@@ -11,7 +11,7 @@
 
 \usage{\method{update}{dev.pkg}(object="data.table",
 repo="https://Rdatatable.gitlab.io/data.table", field="Revision",
-type=getOption("pkgType"), \dots)
+type=getOption("pkgType"), lib=NULL, \dots)
 }
 \arguments{
   \item{object}{ character scalar, package name. }
@@ -20,6 +20,8 @@ type=getOption("pkgType"), \dots)
     DESCRIPTION file, default \code{"Revision"}. }
   \item{type}{ character scalar, default \code{getOption("pkgType")}, used
     to define if package has to be installed from sources, binaries or both. }
+  \item{lib}{ character scalar, library location where package is meant to
+    be upgraded. }
   \item{\dots}{ passed to \code{\link[utils]{install.packages}}. }
 }
 \details{
@@ -37,4 +39,3 @@ type=getOption("pkgType"), \dots)
   \code{\link{data.table}}
 }
 \keyword{ data }
-


### PR DESCRIPTION
By default when `lib.loc` or (`loc` in another places in base R) is NULL then `find.package` first looks for loaded namespaces paths, then .libPaths. When calling `update.dev.pkg` we must have had DT namespace loaded, this won't make the difference. This PR allows to call `update.dev.pkg` from DT pkg from library1 but check and upgrade DT in library2.