### PR TITLE
Idate tz

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 ## BUG FIXES
 
+1. `as.IDate` and `as.ITime` methods for `POSIXct` input wrongly assigned `NULL` timezone to `UTC` (actually it's the session's default timezone), [#4085](https://github.com/Rdatatable/data.table/issues/4085).
+
 ## NOTES
 
 1. Links in the manual were creating warnings when installing HTML, [#4000](https://github.com/Rdatatable/data.table/issues/4000). Thanks to Morgan Jacob.

--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -33,7 +33,7 @@ as.IDate.Date = function(x, ...) {
 }
 
 as.IDate.POSIXct = function(x, tz = attr(x, "tzone", exact=TRUE), ...) {
-  if (is.null(tz)) tz = "UTC"
+  if (is.null(tz)) tz=''
   if (tz %chin% c("UTC", "GMT")) {
     (setattr(as.integer(as.numeric(x) %/% 86400L), "class", c("IDate", "Date")))  # %/% returns new object so can use setattr() on it; wrap with () to return visibly
   } else
@@ -138,7 +138,7 @@ as.ITime.default = function(x, ...) {
 }
 
 as.ITime.POSIXct = function(x, tz = attr(x, "tzone", exact=TRUE), ...) {
-  if (is.null(tz)) tz = "UTC"
+  if (is.null(tz)) tz=''
   if (tz %chin% c("UTC", "GMT")) as.ITime(unclass(x), ...)
   else as.ITime(as.POSIXlt(x, tz = tz, ...), ...)
 }

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -16381,6 +16381,16 @@ test(2121.5, DT[, .(.N=.N), by=a], data.table(a=c(1,2), .N=2:1)) # user supplied
 ## { ending in NULL should retain that NULL, #4061
 test(2121.6, DT[ , {.(a, b=b+1); NULL}], NULL)
 
+# system timezone is not usually UTC, so as.ITime.POSIXct shouldn't assume so
+oldtz=Sys.getenv('TZ')
+Sys.setenv(TZ='Asia/Jakarta') # UTC+7
+t0 = Sys.time()
+test(2122.1, as.integer(unclass(as.ITime(t0)) %/% 3600), as.POSIXlt(t0)$hour)
+d0 = as.POSIXct(trunc(t0, 'day'))
+# base defaults
+test(2122.2, unclass(as.IDate(d0)), as.integer(as.Date(d0, tz='')))
+Sys.setenv(TZ=oldtz)
+
 
 ###################################
 #  Add new tests above this line  #

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -16384,11 +16384,9 @@ test(2121.6, DT[ , {.(a, b=b+1); NULL}], NULL)
 # system timezone is not usually UTC, so as.ITime.POSIXct shouldn't assume so
 oldtz=Sys.getenv('TZ')
 Sys.setenv(TZ='Asia/Jakarta') # UTC+7
-t0 = Sys.time()
-test(2122.1, as.integer(unclass(as.ITime(t0)) %/% 3600), as.POSIXlt(t0)$hour)
-d0 = as.POSIXct(trunc(t0, 'day'))
-# base defaults
-test(2122.2, unclass(as.IDate(d0)), as.integer(as.Date(d0, tz='')))
+t0 = as.POSIXct('2019-10-01')
+test(2122.1, format(as.ITime(t0)), '00:00:00')
+test(2122.2, format(as.IDate(t0)), '2019-10-01')
 Sys.setenv(TZ=oldtz)
 
 


### PR DESCRIPTION
Closes #4085 

Tried using `!is.null(tz) && tz %chin% c('UTC', 'GMT')`, but I got an error around here:

```
Running test id 1613.43      Error in as.POSIXlt.POSIXct(x, tz = tz, ...) : invalid 'tz' value
```

Though apparently this works: `as.POSIXlt(.POSIXct(0, tz = NULL))` so I'm not sure what happened. Anyway `tz=''` is the same as `is.null(tz)` as near as I can tell.

cc @arunsrinivasan 
 