### PR TITLE
test.data.table gains showProgress=interactive()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@
 
 3. C internals have been standardized to use `PRI[u|d]64` to print `[u]int64_t`. This solves new warnings from `gcc-8` on Windows with `%lld`, [#4062](https://github.com/Rdatatable/data.table/issues/4062), in many cases already working around `snprintf` on Windows not supporting `%zu`. Release procedures have been augmented to prevent any internal use of `llu`, `lld`, `zu` or `zd`.
 
+4. `test.data.table()` gains `showProgress=interactive()` to suppress the thousands of `Running test id <num> ...` lines displayed by CRAN checks when there are warnings or errors.
+
 
 # data.table [v1.12.6](https://github.com/Rdatatable/data.table/milestone/18?closed=1)  (18 Oct 2019)
 

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -282,11 +282,14 @@ test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,no
     # prevtest to a temp file so we know where it got to from this R process. That should be more reliable
     # than what we were doing before which was for test() to always write its test number to output (which might
     # not be flushed to the output upon segfault, depending on OS).
-  } else {
+    rm(showProgress) # if removing this line ensure that 'else' branch below defines 'showProgress = interactive()'
+  } else { # not `test.data.table` but just `cc(F); test(...)`
     memtest = FALSE          # nocov
     filename = NA_character_ # nocov
     foreign = FALSE          # nocov ; assumes users of 'cc(F); test(...)' has LANGUAGE=en
+    #showProgress = interactive() # nocov # not used anywhere down the code so commented out
   }
+
   if (!missing(error) && !missing(y))
     stop("Test ",numStr," is invalid: when error= is provided it does not make sense to pass y as well")  # nocov
 

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -115,9 +115,11 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
 
   options(oldOptions)
   if (inherits(err,"try-error")) {
+    # nocov start
     if (silent) return(FALSE)
-    stop("Failed after test ", env$prevtest, " before the next test() call in ",fn)  # nocov
-    # and the try() above with silent=FALSE will have already printed the error itself
+    stop("Failed after test ", env$prevtest, " before the next test() call in ",fn)
+    # the try() above with silent=FALSE will have already printed the error itself
+    # nocov end
   }
 
   # Sys.setlocale("LC_CTYPE", oldlocale)

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -273,18 +273,13 @@ test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,no
        timings[ as.integer(num), `:=`(time=time+took, nTest=nTest+1L), verbose=FALSE ]
     } )
     if (showProgress)
-      cat("\rRunning test id", numStr, "     ")   # nocov
-    # This cat() used to be done always with a flush.console() too for Windows. That was so that if the test script
-    # fully crashed R with a segfault, then at least we'd know it crashed somewhere after the last test number flushed
-    # to the log file and displayed by CRAN. But the downside of that was that when a non-crashing regular R error
-    # occurred inbetween two test() calls, it would be displayed by CRAN with thousands of these test number lines before
-    # and fill up the CRAN error log.
-    # So now we only output the test number in interactive() mode so users can see it it running when they run test.data.table(). In
-    # batch mode (i.e. R CMD check) if an error occurs inbetween two test() calls, test.data.table() now outputs an error stating
-    # which test it occured after so we don't need to rely on the ouput file and scroll through pages and pages of it.
-    # However, if the error is a segfault then we won't know after which point since the try(sys.source()) won't return in that
-    # case. If that becomes a problem, then we could launch a new R process to run the try(sys.source()) and have the prevtest
-    # written out of that process to a 5 byte temp file so the calling R process can tell us after which test it crashed.
+      cat("\rRunning test id", numStr, "     ")   # nocov.
+    # See PR #4090 for comments about change here in Dec 2019.
+    # If a segfault error occurs in future and we'd like to know after which test, then arrange for the
+    # try(sys.source()) in test.data.table() to be run in a separate R process. That process could write out
+    # prevtest to a temp file so we know where it got to from this R process. That should be more reliable
+    # than what we were doing before which was for test() to always write its test number to output (which might
+    # not be flushed to the output upon segfault, depending on OS).
   } else {
     memtest = FALSE          # nocov
     filename = NA_character_ # nocov

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -1,4 +1,4 @@
-test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=FALSE, showProgress=interactive()) {
+test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=FALSE, showProgress=interactive()&&!silent) {
   stopifnot(isTRUEorFALSE(verbose), isTRUEorFALSE(silent), isTRUEorFALSE(showProgress))
   if (exists("test.data.table", .GlobalEnv,inherits=FALSE)) {
     # package developer
@@ -282,14 +282,13 @@ test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,no
     # prevtest to a temp file so we know where it got to from this R process. That should be more reliable
     # than what we were doing before which was for test() to always write its test number to output (which might
     # not be flushed to the output upon segfault, depending on OS).
-    rm(showProgress) # if removing this line ensure that 'else' branch below defines 'showProgress = interactive()'
-  } else { # not `test.data.table` but just `cc(F); test(...)`
+  } else {
+    # not `test.data.table` but developer running tests manually; i.e. `cc(F); test(...)`
     memtest = FALSE          # nocov
     filename = NA_character_ # nocov
     foreign = FALSE          # nocov ; assumes users of 'cc(F); test(...)' has LANGUAGE=en
-    #showProgress = interactive() # nocov # not used anywhere down the code so commented out
+    showProgress = FALSE     # nocov
   }
-
   if (!missing(error) && !missing(y))
     stop("Test ",numStr," is invalid: when error= is provided it does not make sense to pass y as well")  # nocov
 

--- a/man/test.data.table.Rd
+++ b/man/test.data.table.Rd
@@ -5,7 +5,7 @@
   Runs a set of tests to check data.table is working correctly.
 }
 \usage{
-test.data.table(script="tests.Rraw", verbose=FALSE, pkg=".", silent=FALSE, showProgress=interactive())
+test.data.table(script="tests.Rraw", verbose=FALSE, pkg=".", silent=FALSE, showProgress=interactive()&&!silent)
 }
 \arguments{
 \item{script}{ Run arbitrary R test script. }
@@ -15,10 +15,12 @@ test.data.table(script="tests.Rraw", verbose=FALSE, pkg=".", silent=FALSE, showP
 \item{showProgress}{ Output 'Running test <n> ...\\r' at the start of each test? }
 }
 \details{
-   Runs a series of tests. These can be used to see features and examples of usage, too. Running test.data.table will tell you the full location of the test file(s) to open.
+  Runs a series of tests. These can be used to see features and examples of usage, too. Running test.data.table will tell you the full location of the test file(s) to open.
+
+  Setting \code{silent=TRUE} sets \code{showProgress=FALSE} too, via the default of \code{showProgress}.
 }
 \value{
-If all tests were successful, \code{TRUE} is returned. Otherwise, see the \code{silent} argument above. \code{silent=TRUE} is intended for use at the start of production scripts; e.g. \code{stopifnot(test.data.table(silent=TRUE))} to check \code{data.table} is passing its own tests before proceeding.
+  If all tests were successful, \code{TRUE} is returned. Otherwise, see the \code{silent} argument above. \code{silent=TRUE} is intended for use at the start of production scripts; e.g. \code{stopifnot(test.data.table(silent=TRUE))} to check \code{data.table} is passing its own tests before proceeding.
 }
 \seealso{ \code{\link{data.table}}, \code{\link{test}} }
 \keyword{ data }

--- a/man/test.data.table.Rd
+++ b/man/test.data.table.Rd
@@ -5,19 +5,20 @@
   Runs a set of tests to check data.table is working correctly.
 }
 \usage{
-test.data.table(script="tests.Rraw", verbose=FALSE, pkg=".", silent=FALSE)
+test.data.table(script="tests.Rraw", verbose=FALSE, pkg=".", silent=FALSE, showProgress=interactive())
 }
 \arguments{
 \item{script}{ Run arbitrary R test script. }
-\item{verbose}{ If \code{TRUE} sets datatable.verbose to \code{TRUE} for the duration of the tests. }
+\item{verbose}{ \code{TRUE} sets \code{options(datatable.verbose=TRUE)} for the duration of the tests. This tests there are no errors in the branches that produce the verbose output, and produces a lot of output. The output is normally used for tracing bugs or performance tuning. Tests which specifically test the verbose output is correct (typically looking for an expected substring) always run regardless of this option. }
 \item{pkg}{ Root directory name under which all package content (ex: DESCRIPTION, src/, R/, inst/ etc..) resides. Used only in \emph{dev-mode}. }
-\item{silent}{ Logical, default \code{FALSE}, when \code{TRUE} it will not raise error on in case of test fails. }
+\item{silent}{ Controls what happens if a test fails. Like \code{silent} in \code{\link{try}}, \code{TRUE} causes the error message to be suppressed and \code{FALSE} to be returned, otherwise the error is returned. }
+\item{showProgress}{ Output 'Running test <n> ...\\r' at the start of each test? }
 }
 \details{
    Runs a series of tests. These can be used to see features and examples of usage, too. Running test.data.table will tell you the full location of the test file(s) to open.
 }
 \value{
-When \code{silent} equals to \code{TRUE} it will return \code{TRUE} if all tests were successful. \code{FALSE} otherwise. If \code{silent} equals to \code{FALSE} it will return \code{TRUE} if all tests were successful. Error otherwise.
+If all tests were successful, \code{TRUE} is returned. Otherwise, see the \code{silent} argument above. \code{silent=TRUE} is intended for use at the start of production scripts; e.g. \code{stopifnot(test.data.table(silent=TRUE))} to check \code{data.table} is passing its own tests before proceeding.
 }
 \seealso{ \code{\link{data.table}}, \code{\link{test}} }
 \keyword{ data }


### PR DESCRIPTION
With the errors and warnings on CRAN recently, the many lines of `Running test <num> ...` have been getting in the way. Added `showProgress=interactive()`.  Thereforefore they won't print in `R CMD check` and won't show on CRAN checks page.

I tried this in the past but the roadblock was that if the script failed in between two `test()` we wanted to know where.  So the idea was that `test()` printed its number on every call so we knew where it was. When a user runs `test.data.table()` the `\r` is honored and it shows rudimentary progress.  Whereas in the log file show by CRAN the `\r` is treated as `\n` and there's many lines of output.

* `test.data.table()` caller now catches the `prevtest` and puts that in a new error message, so we know where it got to should it fail in between `test()` calls.  I tested locally with a dummy error and that works; e.g. the output omits all the 'Running test <num> ...` lines and just shows this now:

```
> test.data.table()  # runs the main test suite of 5,000+ tests in /inst/tests/tests.Rraw
getDTthreads(verbose=TRUE):
  omp_get_num_procs()            8
  R_DATATABLE_NUM_PROCS_PERCENT  unset (default 50)
  R_DATATABLE_NUM_THREADS        unset
  omp_get_thread_limit()         2147483647
  omp_get_max_threads()          8
  OMP_THREAD_LIMIT               unset
  OMP_NUM_THREADS                unset
  RestoreAfterFork               true
  data.table is using 4 threads. See ?setDTthreads.
test.data.table() running: /home/mdowle/GitHub/data.table/data.table.Rcheck/data.table/tests/tests.Rraw
Error in eval(exprs[i], envir) : dummy stop in between test() calls
Error in test.data.table() :
  Failed after test 453 before the next test() call in /home/mdowle/GitHub/data.table/data.table.Rcheck/data.table/tests/tests.Rraw
Execution halted
```

* an aside fix is that if `test.data.table()` failed in that circumstance (i.e. in between two `test()` calls) it would not reset the options back to the user's values because the `options(oldOptions)` line wouldn't have been reached.  I didn't test that.

* there was another benefit of test() always outputting its test number. That was if the error was a segfault which caused the entire R process to halt.  In that case it was useful to see the last test number written to the log file.  We lose that with this PR.  However, I'm not sure how reliable that was and it's a very long time since we had a problem like that.  If that crops up again, see the new comment in the code in this PR for a more robust possibility to solve that.

This PR was probably easier now because of the work over the last year or so to move header and footer code up from inside the `.Rraw` script itself, up to the `test.data.table()` caller. Might explain why we didn't do this before because it was harder then to capture the last test number before the error.

* Another benefit is that any output from failed tests (i.e. within a test() call) should now be present in the last 13 lines of output displayed by CRAN 00check.log, too.   Rather than lots of 'Running test id <n> ...' lines after the error/warning filling up the last 13 lines.