### PR TITLE
added externs to fix warnings in forthcoming gcc10

### DIFF
--- a/.dev/cc.R
+++ b/.dev/cc.R
@@ -62,7 +62,7 @@ cc = function(test=TRUE, clean=FALSE, debug=FALSE, omp=!debug, cc_dir, path=Sys.
   if (debug) {
     ret = system(sprintf("MAKEFLAGS='-j CC=%s PKG_CFLAGS=-f%sopenmp CFLAGS=-std=c99\\ -O0\\ -ggdb\\ -pedantic' R CMD SHLIB -d -o data.table.so *.c", CC, OMP))
   } else {
-    ret = system(sprintf("MAKEFLAGS='-j CC=%s CFLAGS=-f%sopenmp\\ -std=c99\\ -O3\\ -pipe\\ -Wall\\ -pedantic' R CMD SHLIB -o data.table.so *.c", CC, OMP))
+    ret = system(sprintf("MAKEFLAGS='-j CC=%s CFLAGS=-f%sopenmp\\ -std=c99\\ -O3\\ -pipe\\ -Wall\\ -pedantic\\ -fno-common' R CMD SHLIB -o data.table.so *.c", CC, OMP))
     # TODO add -Wextra too?
   }
   if (ret) return()

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -65,36 +65,40 @@ typedef R_xlen_t RLEN;
 #endif
 
 // init.c
-SEXP char_integer64;
-SEXP char_ITime;
-SEXP char_IDate;
-SEXP char_Date;
-SEXP char_POSIXct;
-SEXP char_nanotime;
-SEXP char_lens;
-SEXP char_indices;
-SEXP char_allLen1;
-SEXP char_allGrp1;
-SEXP char_factor;
-SEXP char_ordered;
-SEXP char_datatable;
-SEXP char_dataframe;
-SEXP char_NULL;
-SEXP sym_sorted;
-SEXP sym_index;
-SEXP sym_BY;
-SEXP sym_starts, char_starts;
-SEXP sym_maxgrpn;
-SEXP sym_colClassesAs;
-SEXP sym_verbose;
-SEXP sym_inherits;
-SEXP sym_datatable_locked;
+extern SEXP char_integer64;
+extern SEXP char_ITime;
+extern SEXP char_IDate;
+extern SEXP char_Date;
+extern SEXP char_POSIXct;
+extern SEXP char_nanotime;
+extern SEXP char_lens;
+extern SEXP char_indices;
+extern SEXP char_allLen1;
+extern SEXP char_allGrp1;
+extern SEXP char_factor;
+extern SEXP char_ordered;
+extern SEXP char_datatable;
+extern SEXP char_dataframe;
+extern SEXP char_NULL;
+extern SEXP sym_sorted;
+extern SEXP sym_index;
+extern SEXP sym_BY;
+extern SEXP sym_starts, char_starts;
+extern SEXP sym_maxgrpn;
+extern SEXP sym_colClassesAs;
+extern SEXP sym_verbose;
+extern SEXP SelfRefSymbol;
+extern SEXP sym_inherits;
+extern SEXP sym_datatable_locked;
+extern double NA_INT64_D;
+extern long long NA_INT64_LL;
+extern Rcomplex NA_CPLX;  // initialized in init.c; see there for comments
+extern size_t sizes[100];  // max appears to be FUNSXP = 99, see Rinternals.h
+extern size_t typeorder[100];
+
 long long DtoLL(double x);
 double LLtoD(long long x);
 bool GetVerbose();
-double NA_INT64_D;
-long long NA_INT64_LL;
-Rcomplex NA_CPLX;  // initialized in init.c; see there for comments
 
 // cj.c
 SEXP cj(SEXP base_list);
@@ -102,9 +106,6 @@ SEXP cj(SEXP base_list);
 // dogroups.c
 SEXP keepattr(SEXP to, SEXP from);
 SEXP growVector(SEXP x, R_len_t newlen);
-size_t sizes[100];  // max appears to be FUNSXP = 99, see Rinternals.h
-size_t typeorder[100];
-SEXP SelfRefSymbol;
 
 // assign.c
 SEXP allocNAVector(SEXPTYPE type, R_len_t n);

--- a/src/init.c
+++ b/src/init.c
@@ -3,6 +3,39 @@
 #include <R_ext/Rdynload.h>
 #include <R_ext/Visibility.h>
 
+// global constants extern in data.table.h for gcc10 -fno-common; #4091
+// these are written to once here on initialization, but because of that write they can't be declared const
+SEXP char_integer64;
+SEXP char_ITime;
+SEXP char_IDate;
+SEXP char_Date;
+SEXP char_POSIXct;
+SEXP char_nanotime;
+SEXP char_lens;
+SEXP char_indices;
+SEXP char_allLen1;
+SEXP char_allGrp1;
+SEXP char_factor;
+SEXP char_ordered;
+SEXP char_datatable;
+SEXP char_dataframe;
+SEXP char_NULL;
+SEXP sym_sorted;
+SEXP sym_index;
+SEXP sym_BY;
+SEXP sym_starts, char_starts;
+SEXP sym_maxgrpn;
+SEXP sym_colClassesAs;
+SEXP sym_verbose;
+SEXP SelfRefSymbol;
+SEXP sym_inherits;
+SEXP sym_datatable_locked;
+double NA_INT64_D;
+long long NA_INT64_LL;
+Rcomplex NA_CPLX;
+size_t sizes[100];
+size_t typeorder[100];
+
 // .Calls
 SEXP setattrib();
 SEXP bmerge();


### PR DESCRIPTION
Closes #4091 
Added `-fno-common` to cc.R which is part of CRAN_Release procedures to run.  Maybe Jan can add `-fno-common` to one of the CI jobs too. I confirmed that this reproduced the messages locally using gcc-7, before making the fix.

Many thanks to @joshuaulrich who was very helpful and worked out what to do and gave us a heads up on email to let us know how to solve it:
https://github.com/joshuaulrich/TTR/issues/87
https://github.com/joshuaulrich/xts/issues/316
https://stackoverflow.com/a/12511340/271616