### PR TITLE
dump z_stream contents to log

### DIFF
--- a/src/fwrite.c
+++ b/src/fwrite.c
@@ -581,6 +581,15 @@ int compressbuff(z_stream *stream, void* dest, size_t *destLen, const void* sour
   return err == Z_STREAM_END ? Z_OK : err;
 }
 
+void print_z_stream(const z_stream *s)   // temporary tracing function for #4099
+{
+  const unsigned char *byte = (unsigned char *)s;
+  for (int i=0; i<sizeof(z_stream); ++i) {
+    DTPRINT("%02x ", byte[i]);
+  }
+  DTPRINT("\n");
+}
+
 void fwriteMain(fwriteMainArgs args)
 {
   double startTime = wallclock();
@@ -731,6 +740,7 @@ void fwriteMain(fwriteMainArgs args)
           free(buff);                                    // # nocov
           STOP("Can't allocate gzip stream structure");  // # nocov
         }
+        if (verbose) {DTPRINT("z_stream for header (1): "); print_z_stream(&stream);}
         size_t zbuffSize = deflateBound(&stream, headerLen);
         char *zbuff = malloc(zbuffSize);
         if (!zbuff) {
@@ -739,6 +749,7 @@ void fwriteMain(fwriteMainArgs args)
         }
         size_t zbuffUsed = zbuffSize;
         ret1 = compressbuff(&stream, zbuff, &zbuffUsed, buff, (size_t)(ch-buff));
+        if (verbose) {DTPRINT("z_stream for header (2): "); print_z_stream(&stream);}
         if (ret1==Z_OK) ret2 = WRITE(f, zbuff, (int)zbuffUsed);
         deflateEnd(&stream);
         free(zbuff);
@@ -819,6 +830,8 @@ void fwriteMain(fwriteMainArgs args)
   char failed_msg[1001] = "";  // to hold zlib's msg; copied out of zlib in ordered section just in case the msg is allocated within zlib
   int failed_write = 0;    // same. could use +ve and -ve in the same code but separate it out to trace Solaris problem, #3931
 
+  if (nth>1) verbose=false; // printing isn't thread safe (there's a temporary print in compressbuff for tracing solaris; #4099)
+
   #pragma omp parallel num_threads(nth)
   {
     int me = omp_get_thread_num();
@@ -835,6 +848,7 @@ void fwriteMain(fwriteMainArgs args)
         failed = true;              // # nocov
         my_failed_compress = -998;  // # nocov
       }
+      if (verbose) {DTPRINT("z_stream for data (1): "); print_z_stream(&mystream);}
     }
 
     #pragma omp for ordered schedule(dynamic)
@@ -866,7 +880,9 @@ void fwriteMain(fwriteMainArgs args)
       // compress buffer if gzip
       if (args.is_gzip && !failed) {
         myzbuffUsed = zbuffSize;
+        if (verbose) {DTPRINT("z_stream for data (2): "); print_z_stream(&mystream);}
         int ret = compressbuff(&mystream, myzBuff, &myzbuffUsed, myBuff, (size_t)(ch-myBuff));
+        if (verbose) {DTPRINT("z_stream for data (3): "); print_z_stream(&mystream);}
         if (ret) { failed=true; my_failed_compress=ret; }
         else deflateReset(&mystream);
       }


### PR DESCRIPTION
For the next release, adds trace of `z_stream` contents since we think that is being clobbered or is invalid in some way, for #4099.  When we get the results from solaris we can map the bytes to the `z_stream` structure members we can see in the headers, and make a next step in tracing what's wrong.

The reason we're not ignoring solaris is because we've often seen in the past that a memory fault that could occur on any platform only occurs on one. Just because it's one (solaris in this case) doesn't necessarily mean that it is due to solaris. It could just be random memory effects. It is strange that "random" memory effects seem to be repeatable on that one machine, and not on any other, but that's just the way it is and is consistent with memory faults (clobber) of this kind.  It's a 32bit box and the only other 32bit we're testing on is 32bit Windows. I'd guess there's a 20% chance the problem is nothing to do with solaris per se.   Having said that, it's a not a priority, and this extra tracing is just something that will help after the next release to CRAN, whenever that is. Because releasing to CRAN is the way we have to see the result. This problem is not worth asking Prof Ripley to spend time on (to run for us) outside of the CRAN automated mechanism.

The output I see locally : 
```
> fwrite(DT, file=f3<-tempfile(), compress="gzip", verbose=TRUE)   # compress to filename not ending .gz
  omp_get_num_procs()            8
  R_DATATABLE_NUM_PROCS_PERCENT  unset (default 50)
  R_DATATABLE_NUM_THREADS        unset
  omp_get_thread_limit()         2147483647
  omp_get_max_threads()          8
  OMP_THREAD_LIMIT               unset
  OMP_NUM_THREADS                unset
  RestoreAfterFork               true
  data.table is using 4 threads. See ?setDTthreads.
No list columns are present. Setting sep2='' otherwise quote='auto' would quote fields containing sep2.
Column writers: 3 3 
args.doRowNames=0 args.rowNames=0 doQuote=-128 args.nrow=200 args.ncol=2 eolLen=1
maxLineLen=51. Found in 0.000s
Writing bom (false), yaml (0 characters) and column names (true) ... z_stream for header (1): 00 00 00 00 00 00 00 00 33 c3 f7 2d c0 7c d7 41 00 00 00 00 00 00 00 00 00 00 80 00 00 00 00 00 19 0a 80 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 d0 57 48 b9 29 56 00 00 00 f1 a1 43 aa 7f 00 00 10 f1 a1 43 aa 7f 00 00 00 00 00 00 00 00 00 00 02 00 00 00 29 56 00 00 00 00 00 00 00 00 00 00 c0 76 63 b3 29 56 00 00 
deflate input stream: 0x5629be749b00 39 0x5629ba213790 4
deflate returned 1 with stream->total_out==24; Z_FINISH==4, Z_OK==0, Z_STREAM_END==1
z_stream for header (2): 94 37 21 ba 29 56 00 00 00 00 00 00 c0 7c d7 41 04 00 00 00 00 00 00 00 18 9b 74 be 29 56 00 00 0f 00 00 00 00 00 00 00 18 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 d0 57 48 b9 29 56 00 00 00 f1 a1 43 aa 7f 00 00 10 f1 a1 43 aa 7f 00 00 00 00 00 00 00 00 00 00 01 00 00 00 29 56 00 00 c5 10 97 24 00 00 00 00 c0 76 63 b3 29 56 00 00 
done in 0.002s
Writing 200 rows in 1 batches of 200 rows (each buffer size 8MB, showProgress=1, nth=1)
z_stream for data (1): 00 00 00 00 00 00 00 00 08 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 70 72 eb b5 29 56 00 00 60 93 da 42 aa 7f 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 d0 57 48 b9 29 56 00 00 00 f1 a1 43 aa 7f 00 00 10 f1 a1 43 aa 7f 00 00 00 00 00 00 00 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 18 06 00 00 00 00 00 00 
z_stream for data (2): 00 00 00 00 00 00 00 00 08 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 70 72 eb b5 29 56 00 00 60 93 da 42 aa 7f 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 d0 57 48 b9 29 56 00 00 00 f1 a1 43 aa 7f 00 00 10 f1 a1 43 aa 7f 00 00 00 00 00 00 00 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 18 06 00 00 00 00 00 00 
deflate input stream: 0x5629c27ae950 8391193 0x5629c0ef34b0 800
deflate returned 1 with stream->total_out==50; Z_FINISH==4, Z_OK==0, Z_STREAM_END==1
z_stream for data (3): d0 37 ef c0 29 56 00 00 00 00 00 00 00 00 00 00 20 03 00 00 00 00 00 00 82 e9 7a c2 29 56 00 00 e7 09 80 00 aa 7f 00 00 32 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 d0 57 48 b9 29 56 00 00 00 f1 a1 43 aa 7f 00 00 10 f1 a1 43 aa 7f 00 00 00 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00 f8 f0 0e c1 00 00 00 00 18 06 00 00 00 00 00 00 
> 
```