### PR TITLE
fix compiler warning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,8 @@ Authors@R: c(
   person("Manish","Saraswat",      role="ctb"),
   person("Morgan","Jacob",         role="ctb"),
   person("Michael","Schubmehl",    role="ctb"),
-  person("Davis","Vaughan",        role="ctb"))
+  person("Davis","Vaughan",        role="ctb"),
+  person("Toby","Hocking",         role="ctb"))
 Depends: R (>= 3.1.0)
 Imports: methods
 Suggests: bit64, curl, R.utils, knitr, xts, nanotime, zoo, yaml

--- a/src/fread.c
+++ b/src/fread.c
@@ -1130,7 +1130,7 @@ int freadMain(freadMainArgs _args) {
       STOP("freadMain: NAstring <<%s>> is recognized as type boolean, this is not permitted.", ch);
     char *end;
     errno = 0;
-    strtod(ch, &end);  // careful not to let "" get to here (see continue above) as strtod considers "" numeric
+    double ignored = strtod(ch, &end);  // careful not to let "" get to here (see continue above) as strtod considers "" numeric
     if (errno==0 && (size_t)(end - ch) == nchar) any_number_like_NAstrings = true;
     nastr++;
   }


### PR DESCRIPTION
Hi this small fix is to avoid the compiler warning "ignoring return value of 'strtod', declared with attribute warn_unused_result [-Wunused-result]" which I get when compiling data.table with gcc on CentOS.