### PR TITLE
remove const which is meaningless for function return value

### DIFF
--- a/src/fwrite.c
+++ b/src/fwrite.c
@@ -42,10 +42,10 @@ static bool squashDateTime=false;      // 0=ISO(yyyy-mm-dd) 1=squash(yyyymmdd)
 static bool verbose=false;
 
 extern const char *getString(void *, int64_t);
-extern const int getStringLen(void *, int64_t);
-extern const int getMaxStringLen(void *, int64_t);
-extern const int getMaxCategLen(void *);
-extern const int getMaxListItemLen(void *, int64_t);
+extern int getStringLen(void *, int64_t);
+extern int getMaxStringLen(void *, int64_t);
+extern int getMaxCategLen(void *);
+extern int getMaxListItemLen(void *, int64_t);
 extern const char *getCategString(void *, int64_t);
 extern double wallclock(void);
 

--- a/src/fwriteR.c
+++ b/src/fwriteR.c
@@ -19,11 +19,11 @@ const char *getString(SEXP *col, int64_t row) {   // TODO: inline for use in fwr
   return x==NA_STRING ? NULL : CHAR(x);
 }
 
-const int getStringLen(SEXP *col, int64_t row) {
+int getStringLen(SEXP *col, int64_t row) {
   return LENGTH(col[row]);  // LENGTH of CHARSXP is nchar
 }
 
-const int getMaxStringLen(const SEXP *col, const int64_t n) {
+int getMaxStringLen(const SEXP *col, const int64_t n) {
   int max=0;
   SEXP last=NULL;
   for (int i=0; i<n; ++i) {
@@ -36,7 +36,7 @@ const int getMaxStringLen(const SEXP *col, const int64_t n) {
   return max;
 }
 
-const int getMaxCategLen(SEXP col) {
+int getMaxCategLen(SEXP col) {
   col = getAttrib(col, R_LevelsSymbol);
   if (!isString(col)) error("Internal error: col passed to getMaxCategLen is missing levels");
   return getMaxStringLen( STRING_PTR(col), LENGTH(col) );
@@ -87,7 +87,7 @@ void writeList(SEXP *col, int64_t row, char **pch) {
   *pch = ch;
 }
 
-const int getMaxListItemLen(const SEXP *col, const int64_t n) {
+int getMaxListItemLen(const SEXP *col, const int64_t n) {
   int max=0;
   SEXP last=NULL;
   for (int i=0; i<n; ++i) {


### PR DESCRIPTION
hi this is to avoid icc compiler warnings, (and possible confusion)
```
icc -I"/cvmfs/soft.computecanada.ca/easybuild/software/2017/avx2/Compiler/intel2016.4/r/3.5.0/lib64/R/i\
nclude" -DNDEBUG   -I/home/thocking/include  -fopenmp -fpic  -O2 -xCore-AVX2 -ftz -fp-speculation=safe \
-fp-model source  -c fwrite.c -o fwrite.o
fwrite.c(45): warning #858: type qualifier on return type is meaningless
  extern const int getStringLen(void *, int64_t);
         ^

fwrite.c(46): warning #858: type qualifier on return type is meaningless
  extern const int getMaxStringLen(void *, int64_t);
         ^

fwrite.c(47): warning #858: type qualifier on return type is meaningless
  extern const int getMaxCategLen(void *);
         ^

fwrite.c(48): warning #858: type qualifier on return type is meaningless
  extern const int getMaxListItemLen(void *, int64_t);
         ^

```
this message is documented here, https://software.intel.com/en-us/articles/cdiag858/

the version is
```
[thocking@cdr659 R-net]$ icc --version
icc (ICC) 16.0.4 20160811
Copyright (C) 1985-2016 Intel Corporation.  All rights reserved.
```