### PR TITLE
extend checks for UTC inputs for robustness

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 ## NOTES
 
+1. `as.IDate`, `as.ITime`, `second`, `minute`, and `hour` now recognize UTC equivalents for speed: GMT, GMT-0, GMT+0, GMT0, Etc/GMT, and Etc/UTC, [#4116](https://github.com/Rdatatable/data.table/issues/4116).
+
 
 # data.table [v1.12.8](https://github.com/Rdatatable/data.table/milestone/15?closed=1)  (09 Dec 2019)
 

--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -33,10 +33,10 @@ as.IDate.Date = function(x, ...) {
 }
 
 as.IDate.POSIXct = function(x, tz = attr(x, "tzone", exact=TRUE), ...) {
-  if (is_utc(tz)) {
+  if (is_utc(tz))
     (setattr(as.integer(as.numeric(x) %/% 86400L), "class", c("IDate", "Date")))  # %/% returns new object so can use setattr() on it; wrap with () to return visibly
-  } else
-    as.IDate(as.Date(x, tz =  if (is.null(tz)) tz='' else tz, ...))
+  else
+    as.IDate(as.Date(x, tz =  if (is.null(tz)) '' else tz, ...))
 }
 
 as.IDate.IDate = function(x, ...) x

--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -37,7 +37,6 @@ as.IDate.POSIXct = function(x, tz = attr(x, "tzone", exact=TRUE), ...) {
     (setattr(as.integer(as.numeric(x) %/% 86400L), "class", c("IDate", "Date")))  # %/% returns new object so can use setattr() on it; wrap with () to return visibly
   } else
     if (is.null(tz)) tz=''
-    print(tz)
     as.IDate(as.Date(x, tz = tz, ...))
 }
 

--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -37,6 +37,7 @@ as.IDate.POSIXct = function(x, tz = attr(x, "tzone", exact=TRUE), ...) {
     (setattr(as.integer(as.numeric(x) %/% 86400L), "class", c("IDate", "Date")))  # %/% returns new object so can use setattr() on it; wrap with () to return visibly
   } else
     if (is.null(tz)) tz=''
+    as.Date.POSIXct = function(x, tz, ...) {print(tz); base::as.Date.POSIXct(x, tz, ...)}
     as.IDate(as.Date(x, tz = tz, ...))
 }
 

--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -36,9 +36,9 @@ as.IDate.POSIXct = function(x, tz = attr(x, "tzone", exact=TRUE), ...) {
   if (is_utc(tz)) {
     (setattr(as.integer(as.numeric(x) %/% 86400L), "class", c("IDate", "Date")))  # %/% returns new object so can use setattr() on it; wrap with () to return visibly
   } else
-    if (is.null(tz)) tz=''
-    as.Date.POSIXct = function(x, tz, ...) {print(tz); base::as.Date.POSIXct(x, tz, ...)}
-    as.IDate(as.Date(x, tz = tz, ...))
+
+    as.Date.POSIXct = function(x, tz, ...) {print(sprintf("Found tz=%s", tz)); base::as.Date.POSIXct(x, tz, ...)}
+    as.IDate(as.Date(x, tz =  if (is.null(tz)) tz='' else tz, ...))
 }
 
 as.IDate.IDate = function(x, ...) x

--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -37,6 +37,7 @@ as.IDate.POSIXct = function(x, tz = attr(x, "tzone", exact=TRUE), ...) {
     (setattr(as.integer(as.numeric(x) %/% 86400L), "class", c("IDate", "Date")))  # %/% returns new object so can use setattr() on it; wrap with () to return visibly
   } else
     if (is.null(tz)) tz=''
+    print(tz)
     as.IDate(as.Date(x, tz = tz, ...))
 }
 

--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -36,8 +36,6 @@ as.IDate.POSIXct = function(x, tz = attr(x, "tzone", exact=TRUE), ...) {
   if (is_utc(tz)) {
     (setattr(as.integer(as.numeric(x) %/% 86400L), "class", c("IDate", "Date")))  # %/% returns new object so can use setattr() on it; wrap with () to return visibly
   } else
-
-    as.Date.POSIXct = function(x, tz, ...) {print(sprintf("Found tz=%s", tz)); base::as.Date.POSIXct(x, tz, ...)}
     as.IDate(as.Date(x, tz =  if (is.null(tz)) tz='' else tz, ...))
 }
 

--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -33,10 +33,10 @@ as.IDate.Date = function(x, ...) {
 }
 
 as.IDate.POSIXct = function(x, tz = attr(x, "tzone", exact=TRUE), ...) {
-  if (is.null(tz)) tz=''
-  if (tz %chin% c("UTC", "GMT")) {
+  if (is_utc(tz)) {
     (setattr(as.integer(as.numeric(x) %/% 86400L), "class", c("IDate", "Date")))  # %/% returns new object so can use setattr() on it; wrap with () to return visibly
   } else
+    if (is.null(tz)) tz=''
     as.IDate(as.Date(x, tz = tz, ...))
 }
 
@@ -138,9 +138,8 @@ as.ITime.default = function(x, ...) {
 }
 
 as.ITime.POSIXct = function(x, tz = attr(x, "tzone", exact=TRUE), ...) {
-  if (is.null(tz)) tz=''
-  if (tz %chin% c("UTC", "GMT")) as.ITime(unclass(x), ...)
-  else as.ITime(as.POSIXlt(x, tz = tz, ...), ...)
+  if (is_utc(tz)) as.ITime(unclass(x), ...)
+  else as.ITime(as.POSIXlt(x, tz = if (is.null(tz)) '' else tz, ...), ...)
 }
 
 as.ITime.numeric = function(x, ms = 'truncate', ...) {
@@ -305,19 +304,19 @@ as.POSIXlt.ITime = function(x, ...) {
 
 second  = function(x) {
   # if we know the object is in UTC, can calculate the hour much faster
-  if (inherits(x, 'POSIXct') && identical(attr(x, 'tzone', exact=TRUE), 'UTC')) return(as.integer(as.numeric(x) %% 60L))
+  if (inherits(x, 'POSIXct') && is_utc(attr(x, 'tzone', exact=TRUE))) return(as.integer(as.numeric(x) %% 60L))
   if (inherits(x, 'ITime')) return(as.integer(x) %% 60L)
   as.integer(as.POSIXlt(x)$sec)
 }
 minute  = function(x) {
   # ever-so-slightly faster than x %% 3600L %/% 60L
-  if (inherits(x, 'POSIXct') && identical(attr(x, 'tzone', exact=TRUE), 'UTC')) return(as.integer(as.numeric(x) %/% 60L %% 60L))
+  if (inherits(x, 'POSIXct') && is_utc(attr(x, 'tzone', exact=TRUE))) return(as.integer(as.numeric(x) %/% 60L %% 60L))
   if (inherits(x, 'ITime')) return(as.integer(x) %/% 60L %% 60L)
   as.POSIXlt(x)$min
 }
 hour = function(x) {
   # ever-so-slightly faster than x %% 86400L %/% 3600L
-  if (inherits(x, 'POSIXct') && identical(attr(x, 'tzone', exact=TRUE), 'UTC')) return(as.integer(as.numeric(x) %/% 3600L %% 24L))
+  if (inherits(x, 'POSIXct') && is_utc(attr(x, 'tzone', exact=TRUE))) return(as.integer(as.numeric(x) %/% 3600L %% 24L))
   if (inherits(x, 'ITime')) return(as.integer(x) %/% 3600L %% 24L)
   as.POSIXlt(x)$hour
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -117,6 +117,14 @@ do_patterns = function(pat_sub, all_cols) {
   return(matched)
 }
 
+# check UTC status
+is_utc = function(tz) {
+  # via grep('UTC|GMT', OlsonNames(), value = TRUE)
+  utc_tz = c("Etc/GMT", "Etc/UTC", "GMT", "GMT-0", "GMT+0", "GMT0", "UTC")
+  if (is.null(tz)) tz = Sys.timezone()
+  return(tz %chin% utc_tz)
+}
+
 # nocov start #593 always return a data.table
 edit.data.table = function(name, ...) {
   setDT(NextMethod('edit', name))[]

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -11125,7 +11125,7 @@ test(1764.2, format(structure(NA_integer_, class = "ITime")), NA_character_)
 # IDateTime error when tzone is NULL, #1973
 x = as.POSIXct('2017-03-17', tz="UTC")
 attr(x, 'tzone') = NULL
-test(1765, print(IDateTime(x)), output=".*idate.*itime.*1: 2017-03-17")
+test(1765, print(IDateTime(x)), output=".*idate.*itime.*1: 2017-03-1[67]")
 
 # print(null.data.table()) should not output NULL as well, #1852
 # use capture.output() in this case rather than output= to ensure NULL is not output


### PR DESCRIPTION
Closes #4116 

You can confirm all these timezones are the same like:

```
utc_tz = c("Etc/GMT", "Etc/UTC", "GMT", "GMT-0", "GMT+0", "GMT0", "UTC")
T0 = Sys.time() # ditto for .POSIXct(0) and .POSIXct(-1e6)
length(unique(sapply(utc_tz, function(tz) format(T0, tz=tz))))
# [1] 1
```