### PR TITLE
(void) rather than ignored=

### DIFF
--- a/src/fread.c
+++ b/src/fread.c
@@ -1130,7 +1130,7 @@ int freadMain(freadMainArgs _args) {
       STOP("freadMain: NAstring <<%s>> is recognized as type boolean, this is not permitted.", ch);
     char *end;
     errno = 0;
-    double ignored = strtod(ch, &end);  // careful not to let "" get to here (see continue above) as strtod considers "" numeric
+    (void)strtod(ch, &end);  // careful not to let "" get to here (see continue above) as strtod considers "" numeric
     if (errno==0 && (size_t)(end - ch) == nchar) any_number_like_NAstrings = true;
     nastr++;
   }


### PR DESCRIPTION
Follow up to #4109 
`(void)` rather than `ignored=` to avoid the unused-variable warning:
```
fread.c:1133:12: warning: unused variable ‘ignored’ [-Wunused-variable]
     double ignored = strtod(ch, &end);
```
@tdhock Does this still pass your compiler without warning?