### PR TITLE
Fixed missing slash in print.data.table.Rd

### DIFF
--- a/.dev/CRAN_Release.cmd
+++ b/.dev/CRAN_Release.cmd
@@ -46,7 +46,10 @@ grep -Elr "#pragma omp (?:for|parallel)" src | sort
 grep "[.]Call(\"" ./R/*.R
 
 # Make sure all \dots calls in the manual are parsed as ...
-Rscript -e "setwd('man'); unlist(sapply(list.files('.'), function(rd) rapply(tools::parse_Rd(rd), grep, pattern='dots', value=TRUE)))"
+Rscript -e "setwd('man'); unlist(sapply(list.files('.'), function(rd) rapply(tools::parse_Rd(rd), grep, pattern='dots', fixed = TRUE, value=TRUE)))"
+
+# No unused macros in the manual (e.g. code{} instead of \code{})
+grep -Enr "\b[^\a-z][a-z]+\{[^}]+\}" man
 
 # Ensure no Rprintf in init.c
 grep "Rprintf" ./src/init.c

--- a/man/fread.Rd
+++ b/man/fread.Rd
@@ -117,7 +117,7 @@ When \code{input} begins with http://, https://, ftp://, ftps://, or file://, \c
 
 \bold{Shell commands:}
 
-\code{fread} accepts shell commands for convenience. The input command is run and its output written to a file in \code{tmpdir} (\code{link{tempdir}()} by default) to which \code{fread} is applied "as normal". The details are platform dependent -- \code{system} is used on UNIX environments, \code{shell} otherwise; see \code{\link[base]{system}}.
+\code{fread} accepts shell commands for convenience. The input command is run and its output written to a file in \code{tmpdir} (\code{\link{tempdir}()} by default) to which \code{fread} is applied "as normal". The details are platform dependent -- \code{system} is used on UNIX environments, \code{shell} otherwise; see \code{\link[base]{system}}.
 
 }
 \value{

--- a/man/print.data.table.Rd
+++ b/man/print.data.table.Rd
@@ -30,7 +30,7 @@
   \item{\dots}{ Other arguments ultimately passed to \code{format}. }
 }
 \details{
-  By default, with an eye to the typically large number of observations in a code{data.table}, only the beginning and end of the object are displayed (specifically, \code{head(x, topn)} and \code{tail(x, topn)} are displayed unless \code{nrow(x) < nrows}, in which case all rows will print).
+  By default, with an eye to the typically large number of observations in a \code{data.table}, only the beginning and end of the object are displayed (specifically, \code{head(x, topn)} and \code{tail(x, topn)} are displayed unless \code{nrow(x) < nrows}, in which case all rows will print).
 }
 \seealso{\code{\link{print.default}}}
 \examples{


### PR DESCRIPTION
Hey @MichaelChirico 

As requested, pull request that Closes  #4118

I've read the Contributing guideline and don't think I'm missing anything for such a trivial fix.

Confirmed the fix works:
![image](https://user-images.githubusercontent.com/5267027/70959588-69df2080-20c8-11ea-9be0-1a88a29d536a.png)
