### PR TITLE
travis-osx and appveyor-devel off for faster dev

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,7 +32,7 @@ environment:
 
   - R_VERSION: release  # the single Windows.zip binary (both 32bit/64bit) that users following dev version of installation instructions should click
 
-  - R_VERSION: devel   # temporarily off pending R-devel fix of slowdown from 5min to 20-30min (slowing down data.table dev) in July 2019 possibly due to r76734.
+#  - R_VERSION: devel   # When off it's to speed up dev cycle; R-devel is still checked but by GLCI on a roughly hourly cycle.
 
 before_build:
   - cmd: ECHO no Revision metadata added to DESCRIPTION

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ r:
 
 os:
   - linux
-  - osx  # Takes 13m (+9m linux = 22m total); #3357; #3326; #3331. Off by default to speed up dev cycle. AppVeyor covers R-devel and completes in 10m concurrently.
+#  - osx  # Takes 13m (+9m linux = 22m total); #3357; #3326; #3331. When off it's to speed up dev cycle; CRAN_Release.cmd has a reminder to turn back on.
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install llvm &&


### PR DESCRIPTION
Got a lot of PRs to get through.
We'll still test windows r-devel, but GLCI handles that better. GLCI runs on a roughly hourly schedule and catches all the merges to master during that hour,  and tests the final result of master once.   Whereas in PRs, every push is run through appveyor/travis CI.  So if there there 5 pushes queued up, they are all tested in the PR in turn which slows us down. (Queued pushes can be cancelled, but still, it's more efficient not to have to watch and cancel.)
There's no need really to turn R-devel back on in AppVeyor.  Even for release, leaving it to GLCI is the best place. And the final check before release is R-devel on win-builder anyway.

Also turned off travis-osx for the same dev-cycle speed reason.  But osx does need to be turned on again before release until that is added to GLCI. There's already a reminder in CRAN_Release.cmd procedures to turn osx back on.