### PR TITLE
fast cast to matrix using Rfast

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,7 +50,7 @@ Authors@R: c(
   person("Jim","Hester",           role="ctb"))
 Depends: R (>= 3.1.0)
 Imports: methods
-Suggests: bit64, curl, R.utils, knitr, xts, nanotime, zoo, yaml
+Suggests: bit64, curl, R.utils, knitr, xts, nanotime, zoo, yaml, Rfast
 SystemRequirements: zlib
 Description: Fast aggregation of large data (e.g. 100GB in RAM), fast ordered joins, fast add/modify/delete of columns by group using no copies at all, list columns, friendly and fast character-separated-value read/write. Offers a natural and flexible syntax, for faster development.
 License: MPL-2.0 | file LICENSE

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1841,7 +1841,7 @@ replace_dot_alias = function(e) {
 #    x
 #}
 
-as.matrix.data.table = function(x, rownames=NULL, rownames.value=NULL, ...) {
+as.matrix.data.table = function(x, rownames=NULL, rownames.value=NULL, Rfast=FALSE, ...) {
   # rownames = the rownames column (most common usage)
   if (!is.null(rownames)) {
     if (!is.null(rownames.value)) stop("rownames and rownames.value cannot both be used at the same time")
@@ -1897,6 +1897,16 @@ as.matrix.data.table = function(x, rownames=NULL, rownames.value=NULL, ...) {
   }
   if (any(dm == 0L))
     return(array(NA, dim = dm, dimnames = list(rownames.value, cn)))
+  if (isTRUE(Rfast) && requireNamespace("Rfast", quietly=TRUE)) { # much faster conversion
+    if (length(unique(sapply(X, class))) > 1) {
+      # TODO must manually cast columns to a common type
+    } else {
+      X <- Rfast::data.frame.to_matrix(X, col.names=TRUE, row.names=TRUE)
+      if (length(rownames.value) == 0)
+        rownames(X) <- NULL
+      return(X)
+    }
+  }
   p = dm[2L]
   n = dm[1L]
   collabs = as.list(cn)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -75,6 +75,8 @@ if (exists("test.data.table", .GlobalEnv, inherits=FALSE)) {
   melt = data.table::melt               # reshape2
   last = data.table::last               # xts
   first = data.table::first             # xts, S4Vectors
+  transpose = data.table::transpose     # Rfast
+  
 }
 
 # Load optional Suggests packages, which are tested by Travis for code coverage, and on CRAN
@@ -85,6 +87,7 @@ sugg = c(
   "nanotime",       # fwrite looks for the 'nanotime' class name at C level (but we have our own writer in C, though)
   "R.utils",        # for fread to accept .gz and .bz2 files directly
   "yaml"            # for fread's yaml argument (csvy capability)
+  # Rfast           # for as.matrix's fast conversion with Rfast::data.frame.to_matrix
   # zoo             # In DESCRIPTION:Suggests otherwise R CMD check warning: '::' or ':::' import not declared from: 'zoo'; it is tested in other.Rraw though
 )
 for (s in sugg) {
@@ -16682,3 +16685,4 @@ test(2129, rbind(A,B)$c3, expression(as.character(Sys.time()), as.character(Sys.
 ########################
 #  Add new tests here  #
 ########################
+

--- a/man/as.matrix.Rd
+++ b/man/as.matrix.Rd
@@ -7,7 +7,7 @@ Converts a \code{data.table} into a \code{matrix}, optionally using one
 of the columns in the \code{data.table} as the \code{matrix} \code{rownames}.
 }
 \usage{
-\method{as.matrix}{data.table}(x, rownames=NULL, rownames.value=NULL, \dots)}
+\method{as.matrix}{data.table}(x, rownames=NULL, rownames.value=NULL, Rfast=FALSE, \dots)}
 
 \arguments{
 
@@ -22,6 +22,9 @@ be used.}
 \item{rownames.value}{optional, a vector of values to be used as the
 \code{rownames} in the returned \code{matrix}. It must be the same length
 as \code{nrow(x)}.}
+
+\item{Rfast}{logical; if \code{TRUE}, use the \code{\link[Rfast]{data.frame.to_matrix}} 
+function in the \code{Rfast} package to convert to the \code{matrix}}
 
 \item{\dots}{ Required to be present because the generic `as.matrix` generic has it. Arguments here are not currently used or passed on by this method. }
 


### PR DESCRIPTION
After waiting several hours for `as.matrix.data.table` to convert a 3000 row 1.7 million column data.table to a matrix, I had a look around to see if there were faster ways of converting a data.frame/data.table to a matrix. This lead me to the `data.frame.to_matrix()` function in the `Rfast` package, which was able to perform the above task in under a minute. 

I've set about incorporating this into the `as.matrix` function in the `data.table` package, but this has proved less straightforward than first anticipated. A few things I need to follow-up on:

 - `data.frame.to_matrix` returns an error when columns in the data.table are different types, this is intentional, as the code does not do type conversion/pre checks to enhance speed. We would need to do the type conversion ourselves but I'm not sure how best to detect the type that should be converted to across all columns.

- data.frame.to_matrix` itself is quite janky, it throws a few warnings when it shouldn't due to some bad if-statement checks on their end (hence the somewhat odd choice I've currently made of setting the rownames to NULL post-conversion if there are no rownames)

- When supplied integer columns `data.frame.to_matrix` converts these to numerics, causing many tests to fail. This may need to be fixed upstream, and I also need to check how this function works on other non-numeric types (e.g. character vectors, factors, dates, etc) to make sure it returns the equivalent of as.matrix.

For now, I've simply added an `Rfast=FALSE` argument to `as.matrix`. If the above points can be solved we can simply remove this, otherwise we could potentially give the user the option of explicitly setting Rfast=TRUE to get a numeric matrix (this would be useful purely for the `rownames` functionality of `as.matrix.data.frame`). 