### PR TITLE
Subset.i

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -3214,10 +3214,7 @@ filter.at = function(cols, logic, by, all.vars = TRUE){
     #   ind <- ind[dt[['col']][ind] == 5]
     # }
     
-    #use `<-` within substitution; changing to `=` caused errors
-    
-    
-    if (isTRUE(try(cols, silent = T))){
+    if (isTRUE(try(cols, silent = TRUE))){
       logic_eq_start = eval(substitute(substitute(ind <- which(eq), list(x = substitute(x[[1]]))), list(eq = logic)))
       logic_eq_loop = eval(substitute(substitute(for (col in seq_len(length(dt))[-1]){ind <- .Call(CsubsetVector, ind, which(eq))}, list(dt = quote(x), x = substitute(.Call(CsubsetVector, x[[col]], ind)))), list(eq = logic)))
     } else {
@@ -3235,7 +3232,7 @@ filter.at = function(cols, logic, by, all.vars = TRUE){
   
   l_args = list(x = quote(x))
   if (!missing(by)) l_args[['by']] = substitute(by)
-  if (!isTRUE(try(cols, silent = T))) l_args[['.SDcols']] = cols
+  if (!isTRUE(try(cols, silent = TRUE))) l_args[['.SDcols']] = cols
   
   if (which.mFilter) {
     reduce_fx = 'union'

--- a/tests/filter.at.R
+++ b/tests/filter.at.R
@@ -1,4 +1,6 @@
 library(data.table)
+options(datatable.auto.index=FALSE)
+
 ############################### filter.at ################################
 set.seed(123)
 dt <- data.table(replicate(3, sample(c(T, F), 1E2, replace = T)))
@@ -24,12 +26,12 @@ dt[filter.at(V1:V3, x)]
 # to show all identical and not performance:
 options(datatable.verbose=FALSE)
 
-bench::mark(dt[filter.at(cols = TRUE, logic = x)],
-            dt[filter.at(c('V1','V2','V3'), x)],
-            dt[filter.at(patterns('V'), logic = x)],
-            dt[filter.at(V1:V3, x)],
-            dt[V1 & V2 & V3] #creates index with default options
-            )
+#bench::mark(dt[filter.at(cols = TRUE, logic = x)],
+#            dt[filter.at(c('V1','V2','V3'), x)],
+#            dt[filter.at(patterns('V'), logic = x)],
+#            dt[filter.at(V1:V3, x)],
+#            dt[V1 & V2 & V3] #creates index with default options
+#            )
 
 # `|` with no by
 dt[filter.at(cols = TRUE, logic = x, all.vars = F)]
@@ -75,13 +77,22 @@ foo <- data.table(
   z = as.character(runif(n = 10^6))
 )
 
-bench::mark(
-  foo[filter.at(c('x', 'y', 'z'), like(x, '123'))],
-  foo[filter.at(TRUE, like(x, '123'))],
-  foo[filter.at(x:z, like(x, '123'))],
-  foo[like(x, "123")][like(y, "123")][like(z, "123")],
-  foo[like(x, "123") & like(y, "123") & like(z, "123")]
-  )
+#bench::mark(
+#  foo[filter.at(c('x', 'y', 'z'), like(x, '123'))],
+#  foo[filter.at(TRUE, like(x, '123'))],
+#  foo[filter.at(x:z, like(x, '123'))],
+#  foo[like(x, "123")][like(y, "123")][like(z, "123")],
+#  foo[like(x, "123") & like(y, "123") & like(z, "123")]
+#  )
+
+## A tibble: 5 x 13
+#  expression                                              min median `itr/sec` mem_alloc `gc/sec`
+#  <bch:expr>                                            <bch> <bch:>     <dbl> <bch:byt>    <dbl>
+#1 foo[filter.at(c("x", "y", "z"), like(x, "123"))]      315ms  315ms      3.17     7.9MB     3.17
+#2 foo[filter.at(TRUE, like(x, "123"))]                  310ms  313ms      3.20     7.9MB     0   
+#3 foo[filter.at(x:z, like(x, "123"))]                   859ms  859ms      1.16   22.95MB     0   
+#4 foo[like(x, "123")][like(y, "123")][like(z, "123")]   290ms  292ms      3.43    8.13MB     0   
+#5 foo[like(x, "123") & like(y, "123") & like(z, "123")] 858ms  858ms      1.17    22.9MB     0   
 
 # see https://stackoverflow.com/questions/58570110/how-to-delete-rows-for-leading-and-trailing-nas-by-group-in-r
 df1<-data.frame(ID=(rep(c("C1001","C1008","C1009","C1012"),each=17)),
@@ -120,8 +131,8 @@ DT[yyy > 0,.(NewCol = paste(month, day),
 A = "yyy"; B = 0; C = "NewCol"; D = "month";E = "day";G = "foo"; H = c("bar","yyy")
 
 # OP wants:
-DT[..A > ..B , .(..C = paste(..D, ..E),
-                 ..H), by = ..G]
+#DT[..A > ..B , .(..C = paste(..D, ..E),
+#                 ..H), by = ..G]
 
 # a little closer
 DT[filter.at(A, x > B),

--- a/tests/filter.at.R
+++ b/tests/filter.at.R
@@ -55,7 +55,7 @@ dt[filter.at(V1:V3, which.min(x))]
 # with by
 dt[filter.at(TRUE, which.min(x), by = ID)]
 
-# see https://stackoverflow.com/questions/59333424/select-row-from-data-table-in-programming-mode/59338483#59338483
+######### see https://stackoverflow.com/questions/59333424/select-row-from-data-table-in-programming-mode/59338483#59338483 #######
 tb = data.table(g_id = c(1, 1, 1, 2, 2, 2, 3),
                 item_no = sample(c(24,25,26,27,28,29,30)),
                 time_no = c(100, 110, 120, 130, 140, 160, 170)
@@ -67,7 +67,7 @@ grp = "g_id"
 tb[, .SD[which.min(get(mincol))], grp]
 tb[filter.at(mincol, which.min(x), grp)]
 
-# see https://github.com/Rdatatable/data.table/issues/4105
+################### see https://github.com/Rdatatable/data.table/issues/4105 ##############################
 set.seed(1)
 foo <- data.table(
   x = as.character(runif(n = 10^6)),
@@ -102,3 +102,31 @@ df1[filter.at(patterns('x'), !(rleid(x) %in% c(1, max(rleid(x))) & is.na(x)), ID
 
 fx = function (x) {!(rleid(x) %in% c(1, max(rleid(x))) & is.na(x))}
 df1[filter.at(x1:x2, fx, ID)]
+
+################## see https://github.com/Rdatatable/data.table/issues/2655 ##################################
+set.seed(1234)
+DT <- data.table(foo = rep(LETTERS[1:2],8),
+                 bar = rep(letters[17:20],4),
+                 month = rep(month.name[1:4],4),
+                 day = seq_len(16),
+                 yyy = rnorm(16,mean = 0.5,1.5))
+
+## Expression 1: with hard coded columns
+DT[yyy > 0,.(NewCol = paste(month, day),
+             bar,
+             yyy), by = foo]
+
+## Expression 2: everything passed by reference
+A = "yyy"; B = 0; C = "NewCol"; D = "month";E = "day";G = "foo"; H = c("bar","yyy")
+
+# OP wants:
+DT[..A > ..B , .(..C = paste(..D, ..E),
+                 ..H), by = ..G]
+
+# a little closer
+DT[filter.at(A, x > B),
+   .(NewCol = paste(month, day),
+     bar,
+     yyy),
+   by = G]
+

--- a/tests/filter.at.R
+++ b/tests/filter.at.R
@@ -1,0 +1,102 @@
+library(data.table)
+############################### filter.at ################################
+set.seed(123)
+dt <- data.table(replicate(3, sample(c(T, F), 1E2, replace = T)))
+cols <- c('V1', 'V2', 'V3')
+cols2 <- c('V1', 'V2')
+
+# `&` with no by
+#optimized
+options(datatable.verbose=TRUE)
+dt[filter.at(cols = TRUE, logic = x)]
+dt[filter.at(c('V1','V2','V3'), x)]
+dt[filter.at(cols, x)]
+dt[filter.at(cols2, x)]
+dt[filter.at(c('V1'), x)]
+dt[filter.at(V1, x)]
+
+#non-optimized
+dt[filter.at(patterns('V'), logic = x)]
+dt[filter.at(V1:V3, x)]
+
+# to show all identical and not performance:
+options(datatable.verbose=FALSE)
+
+bench::mark(dt[filter.at(cols = TRUE, logic = x)],
+            dt[filter.at(c('V1','V2','V3'), x)],
+            dt[filter.at(patterns('V'), logic = x)],
+            dt[filter.at(V1:V3, x)],
+            dt[V1 & V2 & V3] #creates index with default options
+            )
+
+# `|` with no by
+dt[filter.at(cols = TRUE, logic = x, all.vars = F)]
+
+identical(dt[filter.at(TRUE, x, all.vars = F)],
+          dt[filter.at(c('V1', 'V2', 'V3'), x, all.vars = F)])
+
+identical(dt[filter.at(TRUE, x, all.vars = F)],
+          dt[V1 | V2 | V3])
+
+# which.min and which.max have different properties - they perform Reduce(`union`, ...)
+# this functionality should probably be removed as it adds too much complexity
+
+set.seed(123)
+dt <- data.table(ID = sample(letters[1:5], 1E2, replace = T), replicate(3, round(runif(1E2),2)))
+
+# without by
+dt[filter.at(TRUE, which.min(x))] #warning because of which.min(ID)
+dt[filter.at(c('V1', 'V2', 'V3'), which.min(x))]
+dt[filter.at(patterns('V'), which.min(x))]
+dt[filter.at(V1:V3, which.min(x))]
+
+# with by
+dt[filter.at(TRUE, which.min(x), by = ID)]
+
+# see https://stackoverflow.com/questions/59333424/select-row-from-data-table-in-programming-mode/59338483#59338483
+tb = data.table(g_id = c(1, 1, 1, 2, 2, 2, 3),
+                item_no = sample(c(24,25,26,27,28,29,30)),
+                time_no = c(100, 110, 120, 130, 140, 160, 170)
+)
+
+mincol = "item_no"
+grp = "g_id"
+
+tb[, .SD[which.min(get(mincol))], grp]
+tb[filter.at(mincol, which.min(x), grp)]
+
+# see https://github.com/Rdatatable/data.table/issues/4105
+set.seed(1)
+foo <- data.table(
+  x = as.character(runif(n = 10^6)),
+  y = as.character(runif(n = 10^6)),
+  z = as.character(runif(n = 10^6))
+)
+
+bench::mark(
+  foo[filter.at(c('x', 'y', 'z'), like(x, '123'))],
+  foo[filter.at(TRUE, like(x, '123'))],
+  foo[filter.at(x:z, like(x, '123'))],
+  foo[like(x, "123")][like(y, "123")][like(z, "123")],
+  foo[like(x, "123") & like(y, "123") & like(z, "123")]
+  )
+
+# see https://stackoverflow.com/questions/58570110/how-to-delete-rows-for-leading-and-trailing-nas-by-group-in-r
+df1<-data.frame(ID=(rep(c("C1001","C1008","C1009","C1012"),each=17)),
+                Year=(rep(c(1996:2012),4)),x1=(floor(runif(68,20,75))),x2= 
+                  (floor(runif(68,1,100))))
+
+#Introduce leading / tailing NAs
+df1[cbind(c(1:5, 18:23, 35:42, 49:51, 66:68),c(rep(c(3, 4, 4, 3, 3), c(5,6,8,3,3))))]<-NA
+
+#introduce "gap"- NAs
+set.seed(123); df1$x1[rbinom(68,1,0.1)==1]<-NA; df1$x2[rbinom(68,1,0.1)==1]<-NA
+
+setDT(df1)
+
+df1[filter.at(c('x1','x2'), !(rleid(x) %in% c(1, max(rleid(x))) & is.na(x)), ID)]
+df1[filter.at(x1:x2, !(rleid(x) %in% c(1, max(rleid(x))) & is.na(x)), ID)]
+df1[filter.at(patterns('x'), !(rleid(x) %in% c(1, max(rleid(x))) & is.na(x)), ID)]
+
+fx = function (x) {!(rleid(x) %in% c(1, max(rleid(x))) & is.na(x))}
+df1[filter.at(x1:x2, fx, ID)]

--- a/tests/filter.at.R
+++ b/tests/filter.at.R
@@ -5,6 +5,8 @@ dt <- data.table(replicate(3, sample(c(T, F), 1E2, replace = T)))
 cols <- c('V1', 'V2', 'V3')
 cols2 <- c('V1', 'V2')
 
+# dt[filter.at(cols, logic, by, all.ties = T)]
+
 # `&` with no by
 #optimized
 options(datatable.verbose=TRUE)

--- a/tests/top.n.R
+++ b/tests/top.n.R
@@ -1,0 +1,43 @@
+library(data.table)
+
+######################## top.n ###################################
+dt <- as.data.table(iris)
+options(datatable.verbose=TRUE)
+
+##dt[top.n(n, wt, by, ties = FALSE)]
+
+## no wt
+dt[top.n(3)] 
+dt[top.n(-3)] 
+
+dt[top.n(3, by = Species)]
+dt[top.n(-3, by = Species)]
+dt[top.n(3, by = Species, ties = TRUE)] #ties ignored
+
+## wt
+dt[top.n(3, Sepal.Length)]
+dt[top.n(3, Sepal.Length, ties = TRUE)]
+
+dt[top.n(3, Sepal.Length, Species)]
+dt[top.n(3, Sepal.Length, Species, ties = TRUE)]
+
+## no wt
+options(datatable.verbose=FALSE)
+identical(dt[top.n(3)],
+          dt[1:min(.N, 3)]) #also head(dt, 3)
+
+identical(dt[top.n(-3)],
+          dt[max(1, .N - 3 + 1):.N]) #also tail(dt, 3)
+
+identical(dt[top.n(3, by = Species)],
+          dt[dt[, .I[1:min(.N, 3)], by = Species]$V1])
+
+identical(dt[top.n(-3, by = Species)],
+          dt[dt[, .I[(max(1, .N - 3 + 1):.N)], by = Species]$V1])
+
+# wt
+identical(dt[top.n(3, Sepal.Length)],
+          dt[order(-Sepal.Length)[1:3]])
+
+identical(dt[top.n(3, Sepal.Length, Species)],
+          dt[dt[order(-Sepal.Length), .I[1:3], by = Species]$V1])

--- a/tests/top.n.R
+++ b/tests/top.n.R
@@ -13,13 +13,20 @@ dt[top.n(-3)]
 dt[top.n(3, by = Species)]
 dt[top.n(-3, by = Species)]
 dt[top.n(3, by = Species, ties = TRUE)] #ties ignored
+dt[top.n(-3, Sepal.Length, ties = TRUE)]
 
 ## wt
 dt[top.n(3, Sepal.Length)]
 dt[top.n(3, Sepal.Length, ties = TRUE)]
 
 dt[top.n(3, Sepal.Length, Species)]
+dt[top.n(-3, Sepal.Length, Species)]
 dt[top.n(3, Sepal.Length, Species, ties = TRUE)]
+dt[top.n(-3, Sepal.Length, Species, ties = TRUE)]
+
+#for codecov - produces error message requiring n != 0L.
+dt[top.n(0L)]
+dt[top.n()]
 
 ## no wt
 options(datatable.verbose=FALSE)
@@ -60,5 +67,10 @@ DT = data.table(
 )
 
 system.time({res1 = DT[order(-v3), .(largest2_v3 = head(v3, 2L)), by = id6]})
+#   user  system elapsed 
+#   4.08    0.28    3.45 
 system.time({res2 = DT[top.n(2L, v3, id6), .(id6, largest2_v3 = v3)]})
+#   user  system elapsed 
+#   2.48    0.16    1.75
 identical(res1, res2)
+# [1] TRUE

--- a/tests/top.n.R
+++ b/tests/top.n.R
@@ -25,8 +25,8 @@ dt[top.n(3, Sepal.Length, Species, ties = TRUE)]
 dt[top.n(-3, Sepal.Length, Species, ties = TRUE)]
 
 #for codecov - produces error message requiring n != 0L.
-dt[top.n(0L)]
-dt[top.n()]
+try(dt[top.n(0L)])
+try(dt[top.n()])
 
 ## no wt
 options(datatable.verbose=FALSE)


### PR DESCRIPTION
Allows for two new helper functions in i: ```filter.at(cols, logic, by, all.vars = TRUE)``` and ```top.n(n, wt, by, ties = FALSE)```. Closes https://github.com/Rdatatable/data.table/issues/4133 and https://github.com/Rdatatable/data.table/issues/3804. WIP

The helper functions assist end-users by helping make the ```by``` function available in ```i``` while also allowing developers to optimize for the most likely use cases. For example, depending on the arguments provided, ```top.n``` allows for similarities to ```head(dt, n)```, optimized non-grouping with ```dt[order(-wt)[1:n]]```, and then performant groupings with ```dt[dt[order(-wt), .I[1:n], by = grp]$V1]```. 

See the ```filter.at.R``` and ```top.n.R``` for many use cases which I would use to make a vignette if this is ultimately merged, but here are a few examples:

filter.at:
```
set.seed(123)
dt <- data.table(replicate(3, sample(c(T, F), 1E2, replace = T)))
cols <- c('V1', 'V2', 'V3')

# to show all identical and not performance:
bench::mark(dt[filter.at(cols = TRUE, logic = x)],
            dt[filter.at(c('V1','V2','V3'), x)],
            dt[filter.at(patterns('V'), logic = x)],
            dt[filter.at(cols, x)],
            dt[filter.at(V1:V3, x)],
            dt[V1 & V2 & V3] #creates index with default options
            )

# see https://stackoverflow.com/questions/58570110/how-to-delete-rows-for-leading-and-trailing-nas-by-group-in-r
df1<-data.frame(ID=(rep(c("C1001","C1008","C1009","C1012"),each=17)),
                Year=(rep(c(1996:2012),4)),x1=(floor(runif(68,20,75))),x2= 
                  (floor(runif(68,1,100))))

#Introduce leading / tailing NAs
df1[cbind(c(1:5, 18:23, 35:42, 49:51, 66:68),c(rep(c(3, 4, 4, 3, 3), c(5,6,8,3,3))))]<-NA

#introduce "gap"- NAs
set.seed(123); df1$x1[rbinom(68,1,0.1)==1]<-NA; df1$x2[rbinom(68,1,0.1)==1]<-NA

setDT(df1)

## all the same result
df1[filter.at(c('x1','x2'), !(rleid(x) %in% c(1, max(rleid(x))) & is.na(x)), ID)]
df1[filter.at(x1:x2, !(rleid(x) %in% c(1, max(rleid(x))) & is.na(x)), ID)]
df1[filter.at(patterns('x'), !(rleid(x) %in% c(1, max(rleid(x))) & is.na(x)), ID)]

fx = function (x) {!(rleid(x) %in% c(1, max(rleid(x))) & is.na(x))}
df1[filter.at(x1:x2, fx, ID)]
```
top.n
```
dt <- as.data.table(iris)
options(datatable.verbose=TRUE)

##dt[top.n(n, wt, by, ties = FALSE)]

## no wt
dt[top.n(3)] 
dt[top.n(-3)] 

dt[top.n(3, by = Species)]
dt[top.n(-3, by = Species)]
dt[top.n(3, by = Species, ties = TRUE)] #ties ignored

## wt
dt[top.n(3, Sepal.Length)]
dt[top.n(3, Sepal.Length, ties = TRUE)]

dt[top.n(3, Sepal.Length, Species)]
dt[top.n(3, Sepal.Length, Species, ties = TRUE)]

#0.5 GB groupby benchmark from h2o.ai
N = 10000000
K = 100
set.seed(108)

DT = data.table(
  id1 = sample(sprintf("id%03d",1:K), N, TRUE),      # large groups (char)
  id2 = sample(sprintf("id%03d",1:K), N, TRUE),      # large groups (char)
  id3 = sample(sprintf("id%010d",1:(N/K)), N, TRUE), # small groups (char)
  id4 = sample(K, N, TRUE),                          # large groups (int)
  id5 = sample(K, N, TRUE),                          # large groups (int)
  id6 = sample(N/K, N, TRUE),                        # small groups (int)
  v1 =  sample(5, N, TRUE),                          # int in range [1,5]
  v2 =  sample(5, N, TRUE),                          # int in range [1,5]
  v3 =  round(runif(N,max=100),4)                    # numeric e.g. 23.5749
)

bench::mark(
DT[order(-v3), .(largest2_v3 = head(v3, 2L)), by = id6],
DT[top.n(2L, v3, id6), .(id6, largest2_v3 = v3)]
)

# A tibble: 2 x 13
  expression                                                min median `itr/sec` mem_alloc
  <bch:expr>                                              <bch> <bch:>     <dbl> <bch:byt>
1 DT[order(-v3), .(largest2_v3 = head(v3, 2L)), by = id6] 3.55s  3.55s     0.282     157MB
2 DT[top.n(2L, v3, id6), .(id6, largest2_v3 = v3)]        1.63s  1.63s     0.615     162MB
```
