### PR TITLE
Fast data.table to matrix conversion in C

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1942,7 +1942,12 @@ as.matrix.data.table = function(x, rownames=NULL, rownames.value=NULL, ...) {
       X[[j]] = xj
     }
   }
-  X = unlist(X, recursive = FALSE, use.names = FALSE)
+  colclasses <- sapply(X, class)
+  if (all(unique(colclasses) == "numeric")) {
+    X = .Call(Casmatrix, X, n, length(X))
+  } else {
+    X = unlist(X, recursive = FALSE, use.names = FALSE)
+  }
   dim(X) <- c(n, length(X)/n)
   dimnames(X) <- list(rownames.value, unlist(collabs, use.names = FALSE))
   X

--- a/src/asmatrix.c
+++ b/src/asmatrix.c
@@ -1,15 +1,25 @@
 #include "data.table.h"
 
 SEXP asmatrix(SEXP dt, SEXP nrow, SEXP ncol) {
-  int n = asInteger(nrow);
-  int p = asInteger(ncol);
-  SEXP mat = PROTECT(allocVector(REALSXP, n*p));
-  int vecIndex = 0; // keep track of where we are in mat 
+  int n, p; // row and column numbers
+  SEXP mat; // output matrix
+  SEXP col; // vector to hold each column in dt
+  double *pmat, *pcol; // pointers to casted R objects
+  int vecIdx = 0; // counter to track place in vector underlying matrix
   
+  // Setup output matrix vector
+  n = asInteger(nrow);
+  p = asInteger(ncol);
+  mat = PROTECT(allocVector(REALSXP, n*p));
+  
+  // Iterate through dt and copy into mat 
+  pmat = REAL(mat);
   for (int jj = 0; jj < p; jj++) {
+    col = VECTOR_ELT(dt, jj);
+    pcol = REAL(col);
     for (int ii = 0; ii < n; ii++) {
-      REAL(mat)[vecIndex] = REAL(VECTOR_ELT(dt, jj))[ii];
-      vecIndex++;
+      pmat[vecIdx] = pcol[ii];
+      vecIdx++;
     }
   }
 

--- a/src/asmatrix.c
+++ b/src/asmatrix.c
@@ -1,0 +1,18 @@
+#include "data.table.h"
+
+SEXP asmatrix(SEXP dt, SEXP nrow, SEXP ncol) {
+  int n = asInteger(nrow);
+  int p = asInteger(ncol);
+  SEXP mat = PROTECT(allocVector(REALSXP, n*p));
+  int vecIndex = 0; // keep track of where we are in mat 
+  
+  for (int jj = 0; jj < p; jj++) {
+    for (int ii = 0; ii < n; ii++) {
+      REAL(mat)[vecIndex] = REAL(VECTOR_ELT(dt, jj))[ii];
+      vecIndex++;
+    }
+  }
+
+  UNPROTECT(1);
+  return mat;
+}

--- a/src/init.c
+++ b/src/init.c
@@ -119,6 +119,7 @@ SEXP lock();
 SEXP unlock();
 SEXP islockedR();
 SEXP allNAR();
+SEXP asmatrix();
 
 // .Externals
 SEXP fastmean();
@@ -211,6 +212,7 @@ R_CallMethodDef callMethods[] = {
 {"CfrollapplyR", (DL_FUNC) &frollapplyR, -1},
 {"CtestMsgR", (DL_FUNC) &testMsgR, -1},
 {"C_allNAR", (DL_FUNC) &allNAR, -1},
+{"Casmatrix", (DL_FUNC) &asmatrix, -1},
 {NULL, NULL, 0}
 };
 


### PR DESCRIPTION
Following on from PR #4134 I've started working on C code for faster conversion of data.tables to matrices.

The current code so far works for numeric matrices only, assuming all columns in the data.table are already numeric.

TODO:

- Modify C code so that it will work on all atomic types, not just numeric data.
- Handle type conversion for data.tables with multiple types
- Parallelise C code across input data.table columns