### PR TITLE
openmp detection follow up 

### DIFF
--- a/configure
+++ b/configure
@@ -54,10 +54,14 @@ echo "zlib ${version} is available ok"
 # Find R compilers
 CC=`${R_HOME}/bin/R CMD config CC`
 CFLAGS=`${R_HOME}/bin/R CMD config CFLAGS`
-CPPFLAGS=`${R_HOME}/bin/R CMD config CPPFLAGS`
 
 # Test if we have a OPENMP compatible compiler
-echo "#include <omp.h>\nint main () { return omp_get_num_threads (); }" | ${CC} ${CPPFLAGS} ${PKG_CFLAGS} ${CFLAGS} ${SHLIB_OPENMP_CFLAGS} -E -xc - >/dev/null 2>&1 || R_NO_OPENMP=1;
+# Aside: ${SHLIB_OPENMP_CFLAGS} does not appear to be defined at this point according to Matt's testing on
+# Linux, and R CMD config SHLIB_OPENMP_CFLAGS also returns 'no information for variable'. That's not
+# inconsistent with R-exts$1.2.1.1, though, which states it's 'available for use in Makevars' (so not
+# necessarily here in configure). Hence use -fopenmp directly for this detection step.
+# printf not echo to pass checkbashisms w.r.t. to the \n
+printf "#include <omp.h>\nint main () { return omp_get_num_threads(); }" | ${CC} ${CFLAGS} -fopenmp -xc - >/dev/null 2>&1 || R_NO_OPENMP=1;
 
 # Write to Makevars
 if [ $R_NO_OPENMP ]; then

--- a/configure
+++ b/configure
@@ -62,6 +62,7 @@ CFLAGS=`${R_HOME}/bin/R CMD config CFLAGS`
 # necessarily here in configure). Hence use -fopenmp directly for this detection step.
 # printf not echo to pass checkbashisms w.r.t. to the \n
 printf "#include <omp.h>\nint main () { return omp_get_num_threads(); }" | ${CC} ${CFLAGS} -fopenmp -xc - >/dev/null 2>&1 || R_NO_OPENMP=1;
+rm a.out >/dev/null 2>&1
 
 # Write to Makevars
 if [ $R_NO_OPENMP ]; then


### PR DESCRIPTION
Minor follow up to #3984 
* `echo`=>`printf` to pass the `checkbashism` 'unsafe echo with backslash'
```
$ checkbashisms ./configure
possible bashism in ./configure line 60 (unsafe echo with backslash):
echo "#include <omp.h>\nint main () { return omp_get_num_threads (); }" | ${CC} ${CPPFLAGS} ${PKG_CFLAGS} ${CFLAGS} ${SHLIB_OPENMP_CFLAGS} -E -xc - >/dev/null 2>&1 || R_NO_OPENMP=1;
```

* removed the `-E` too so that this line checks linking too. I tested by making a deliberate typo in the name of the omp_get call.  That took much longer to get right than I expected, as the inline comment alludes.