### PR TITLE
be sure to unlock objects returned during grouping

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -81,6 +81,8 @@ unit = "s")
 
 3. Dispatch of `first` and `last` functions now properly works again for `xts` objects, [#4053](https://github.com/Rdatatable/data.table/issues/4053). Thanks to @ethanbsmith for reporting.
 
+4. If `.SD` is returned as-is during grouping, it is now unlocked for downstream usage, part of [#4159](https://github.com/Rdatatable/data.table/issues/4159).
+
 ## NOTES
 
 1. `as.IDate`, `as.ITime`, `second`, `minute`, and `hour` now recognize UTC equivalents for speed: GMT, GMT-0, GMT+0, GMT0, Etc/GMT, and Etc/UTC, [#4116](https://github.com/Rdatatable/data.table/issues/4116).

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1751,6 +1751,15 @@ replace_dot_alias = function(e) {
   } else {
     ans = .Call(Cdogroups, x, xcols, groups, grpcols, jiscols, xjiscols, grporder, o__, f__, len__, jsub, SDenv, cols, newnames, !missing(on), verbose)
   }
+  # unlock any locked data.table components of the answer, #4159
+  runlock = function(x) {
+    if (is.recursive(x)) {
+      if (inherits(x, 'data.table')) .Call(C_unlock, x)
+      else return(lapply(x, runlock))
+    }
+    return(invisible())
+  }
+  runlock(ans)
   if (verbose) {cat(timetaken(last.started.at),"\n"); flush.console()}
   # TO DO: xrows would be a better name for irows: irows means the rows of x that i joins to
   # Grouping by i: icols the joins columns (might not need), isdcols (the non join i and used by j), all __ are length x

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -16726,6 +16726,10 @@ DT = data.table(
            s4class(x=2L, y="yes", z=1)))
 test(2130.03, print(DT), output=c("   x             y", "1: 1 <ex_class[3]>",     "2: 2 <ex_class[3]>"))
 
+# .SD from grouping should be unlocked, part of #4159
+x = data.table(a=1:3, b=4:6)
+test(2131, lapply(x[ , list(dt = list(.SD)), by = a]$dt, attr, '.data.table.locked'),
+     list(NULL, NULL, NULL))
 
 ########################
 #  Add new tests here  #


### PR DESCRIPTION
Part of #4159 

I'm not sure this is the best way to do this, open to alternatives. But I did it recursively since we can really control how "deep down" any usages of `.SD` to be returned would be.