### PR TITLE
block g[[ on non-atomic input

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -81,6 +81,8 @@ unit = "s")
 
 3. Dispatch of `first` and `last` functions now properly works again for `xts` objects, [#4053](https://github.com/Rdatatable/data.table/issues/4053). Thanks to @ethanbsmith for reporting.
 
+4. `GForce` is deactivated for `[[` on non-atomic input, part of [#4159](https://github.com/Rdatatable/data.table/issues/4159).
+
 ## NOTES
 
 1. `as.IDate`, `as.ITime`, `second`, `minute`, and `hour` now recognize UTC equivalents for speed: GMT, GMT-0, GMT+0, GMT0, Etc/GMT, and Etc/UTC, [#4116](https://github.com/Rdatatable/data.table/issues/4116).

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1522,7 +1522,11 @@ replace_dot_alias = function(e) {
         jvnames = sdvars
       }
     } else if (length(as.character(jsub[[1L]])) == 1L) {  # Else expect problems with <jsub[[1L]] == >
-      subopt = length(jsub) == 3L && (jsub[[1L]] == "[" || jsub[[1L]] == "[[") && (is.numeric(jsub[[3L]]) || jsub[[3L]] == ".N")
+      # g[[ only applies to atomic input, for now, was causing #4159
+      subopt = length(jsub) == 3L &&
+        (jsub[[1L]] == "[" ||
+           (jsub[[1L]] == "[[" && eval(call('is.atomic', jsub[[2L]]), envir = x))) &&
+        (is.numeric(jsub[[3L]]) || jsub[[3L]] == ".N")
       headopt = jsub[[1L]] == "head" || jsub[[1L]] == "tail"
       firstopt = jsub[[1L]] == "first" || jsub[[1L]] == "last" # fix for #2030
       if ((length(jsub) >= 2L && jsub[[2L]] == ".SD") &&
@@ -1649,7 +1653,7 @@ replace_dot_alias = function(e) {
           # otherwise there must be three arguments, and only in two cases:
           #   1) head/tail(x, 1) or 2) x[n], n>0
           length(q)==3L && length(q3 <- q[[3L]])==1L && is.numeric(q3) &&
-            ( (q1c %chin% c("head", "tail") && q3==1L) || ((q1c == "[" || q1c == "[[") && q3>0L) )
+            ( (q1c %chin% c("head", "tail") && q3==1L) || ((q1c == "[" || (q1c == "[[" && eval(call('is.atomic', q[[2L]]), envir=x))) && q3>0L) )
         }
         if (jsub[[1L]]=="list") {
           GForce = TRUE

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -8045,6 +8045,11 @@ options(datatable.optimize=Inf)
 test(1581.14, ans2 <- dt[x %in% letters[15:20], d1[[2]], by=x, verbose=TRUE],
               output = "GForce optimized j")
 test(1581.15, ans1, ans2)
+# also, block for non-atomic input, #4159
+dt = data.table(a=1:3)
+dt[ , l := .(list(1, 2, 3))]
+test(1581.16, dt[ , .(l = l[[1L]]), by=a, verbose=TRUE],
+     dt[ , l := unlist(l)], output='(GForce FALSE)')
 
 # handle NULL value correctly #1429
 test(1582, uniqueN(NULL), 0L)
@@ -16725,7 +16730,6 @@ DT = data.table(
   y = list(s4class(x=1L, y=c("yes", "no"), z=2.5),
            s4class(x=2L, y="yes", z=1)))
 test(2130.03, print(DT), output=c("   x             y", "1: 1 <ex_class[3]>",     "2: 2 <ex_class[3]>"))
-
 
 ########################
 #  Add new tests here  #


### PR DESCRIPTION
Closes #4159 (when combined with #4160)

Again, not sure this is the ideal approach, but it gets the job done. Better would be to write a proper `g[[` for `list` input but that's not in the cards from me for now.