### PR TITLE
add R 3.4.4 and R 3.5.0 builds

### DIFF
--- a/.ci/README.md
+++ b/.ci/README.md
@@ -8,7 +8,7 @@ On each Pull Request opened in GitHub we run Travis CI and Appveyor to provide p
 
 Test jobs:
 - `test-rel-lin` - `r-release` on Linux, most comprehensive test environment, `-O3 -flto -fno-common -Wunused-result`, extra check for no compilation warnings, includes testing [_with other packages_](./../inst/tests/other.Rraw) ([extended suggests](./../inst/tests/tests-DESCRIPTION))
-- `test-rel-cran-lin` - `--as-cran` on Linux, `-g0`, extra check for `Status: OK` in `R CMD check`
+- `test-rel-cran-lin` - `--as-cran` on Linux, `-g0`, extra check for final status of `R CMD check` where we allow one NOTE (_size of tarball_).
 - `test-dev-cran-lin` - `r-devel` and `--as-cran` on Linux, `--enable-strict-barrier --disable-long-double`
 - `test-rel-vanilla-lin` - `r-release` on Linux, no suggested deps, no OpenMP, `-O0`, tracks memory usage during tests
 - `test-310-cran-lin` - R 3.1.0 on Linux

--- a/.ci/README.md
+++ b/.ci/README.md
@@ -12,6 +12,8 @@ Test jobs:
 - `test-dev-cran-lin` - `r-devel` and `--as-cran` on Linux, `--enable-strict-barrier --disable-long-double`
 - `test-rel-vanilla-lin` - `r-release` on Linux, no suggested deps, no OpenMP, `-O0`, tracks memory usage during tests
 - `test-310-cran-lin` - R 3.1.0 on Linux
+- `test-344-cran-lin` - R 3.4.4 on Linux
+- `test-350-cran-lin` - R 3.5.0 on Linux, no `r-recommended`
 - `test-rel-win` - `r-release` on Windows
 - `test-dev-win` - `r-devel` on Windows
 - `test-rel-osx` - MacOSX build not yet deployed, see [#3326](https://github.com/Rdatatable/data.table/issues/3326) for status

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,6 +33,7 @@ mirror-packages: # download all recursive dependencies of data.table suggests an
     - mkdir -p bus/$CI_BUILD_NAME/cran/src/contrib
     # mirror R dependencies: source, win.binary
     - Rscript -e 'mirror.packages(dcf.dependencies(c("DESCRIPTION","inst/tests/tests-DESCRIPTION"), "all"), repos=c(Sys.getenv("CRAN_MIRROR"), dcf.repos("inst/tests/tests-DESCRIPTION")), repodir="bus/mirror-packages/cran")'
+    - rm bus/$CI_BUILD_NAME/cran/src/contrib/PACKAGES.rds # fallback to PACKAGES dcf so available.packages 3.4.4 works
     - Rscript -e 'sapply(simplify=FALSE, setNames(nm=Sys.getenv(c("R_BIN_VERSION","R_DEVEL_BIN_VERSION"))), function(binary.ver) mirror.packages(type="win.binary", dcf.dependencies("DESCRIPTION", "all"), repos=Sys.getenv("CRAN_MIRROR"), repodir="bus/mirror-packages/cran", binary.ver=binary.ver))'
   <<: *artifacts
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,15 +79,15 @@ build: # build data.table sources as tar.gz archive
 .test-cran-lin-template: &test-cran-lin
   <<: *test-lin
   variables:
-    _R_CHECK_CRAN_INCOMING_: "TRUE"           # stricter --as-cran checks should run in dev pipelines continuously (not sure what they are though)
-    _R_CHECK_CRAN_INCOMING_REMOTE_: "FALSE"   # Other than no URL checking (takes many minutes) or 'Days since last update 0' NOTEs needed, #3284
+    _R_CHECK_CRAN_INCOMING_: "TRUE"
+    _R_CHECK_CRAN_INCOMING_REMOTE_: "FALSE"
   script:
     - Rscript -e 'source(".ci/ci.R"); install.packages(dcf.dependencies("DESCRIPTION", which="most"), quiet=TRUE)'
     - *copy-src
     - rm -r bus
     - *move-src
     - cd bus/$CI_BUILD_NAME
-    - R CMD check --as-cran $(ls -1t data.table_*.tar.gz | head -n 1)
+    - R CMD check --as-cran --no-manual $(ls -1t data.table_*.tar.gz | head -n 1)
     - *cleanup-src
 
 .test-win-template: &test-win
@@ -144,14 +144,24 @@ test-rel-vanilla-lin: # minimal installation, no suggested deps, no vignettes or
     - R CMD check --no-manual --ignore-vignettes $(ls -1t data.table_*.tar.gz | head -n 1)
     - *cleanup-src
 
-test-rel-cran-lin: # currently released R on Linux
-  <<: *test-cran-lin
+test-rel-cran-lin: # currently released R on Linux, extra NOTEs check and build pdf manual thus not from cran-lin template
+  <<: *test-lin
   image: registry.gitlab.com/jangorecki/dockerfiles/r-builder
+  variables:
+    _R_CHECK_CRAN_INCOMING_: "TRUE"           # stricter --as-cran checks should run in dev pipelines continuously (not sure what they are though)
+    _R_CHECK_CRAN_INCOMING_REMOTE_: "FALSE"   # Other than no URL checking (takes many minutes) or 'Days since last update 0' NOTEs needed, #3284
   before_script:
     - mkdir -p ~/.R
     - echo 'CFLAGS=-g0 -O2 -fopenmp -Wall -pedantic -fstack-protector-strong -D_FORTIFY_SOURCE=2'> ~/.R/Makevars # -g0 because -g increases datatable.so size from 0.5MB to 1.5MB and breaches 'installed package size <= 5MB' note
     - echo 'CXXFLAGS=-g0 -O2 -fopenmp -Wall -pedantic -fstack-protector-strong -D_FORTIFY_SOURCE=2' >> ~/.R/Makevars
-  after_script:
+  script:
+    - Rscript -e 'source(".ci/ci.R"); install.packages(dcf.dependencies("DESCRIPTION", which="most"), quiet=TRUE)'
+    - *copy-src
+    - rm -r bus
+    - *move-src
+    - cd bus/$CI_BUILD_NAME
+    - R CMD check --as-cran $(ls -1t data.table_*.tar.gz | head -n 1)
+    - *cleanup-src
     - >-
         Rscript -e 'l<-readLines("data.table.Rcheck/00check.log"); if (!identical(l[length(l)], "Status: 1 NOTE")) stop("Last line of ", shQuote("00check.log"), " is not ", shQuote("Status: 1 NOTE"), "(size of tarball) but ", shQuote(toString(l[length(l)]))) else q("no")'
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -183,6 +183,36 @@ test-310-cran-lin: # test stated R dependency (3.1.0) using Linux
     - R CMD check --as-cran $(ls -1t data.table_*.tar.gz | head -n 1)
     - *cleanup-src
 
+test-344-cran-lin: # test last non-altrep version
+  <<: *test-lin
+  image: registry.gitlab.com/jangorecki/dockerfiles/r-3.4.4
+  variables:
+    _R_CHECK_CRAN_INCOMING_: "TRUE"
+    _R_CHECK_CRAN_INCOMING_REMOTE_: "FALSE"
+  script:
+    - Rscript -e 'source(".ci/ci.R"); install.packages(dcf.dependencies("DESCRIPTION", which="most"), quiet=TRUE)'
+    - *copy-src
+    - rm -r bus
+    - *move-src
+    - cd bus/$CI_BUILD_NAME
+    - R CMD check --as-cran $(ls -1t data.table_*.tar.gz | head -n 1)
+    - *cleanup-src
+
+test-350-cran-lin: # test last first altrep version
+  <<: *test-lin
+  image: registry.gitlab.com/jangorecki/dockerfiles/r-3.5.0
+  variables:
+    _R_CHECK_CRAN_INCOMING_: "TRUE"
+    _R_CHECK_CRAN_INCOMING_REMOTE_: "FALSE"
+  script:
+    - Rscript -e 'source(".ci/ci.R"); install.packages(dcf.dependencies("DESCRIPTION", which="most"), quiet=TRUE)'
+    - *copy-src
+    - rm -r bus
+    - *move-src
+    - cd bus/$CI_BUILD_NAME
+    - R CMD check --as-cran $(ls -1t data.table_*.tar.gz | head -n 1)
+    - *cleanup-src
+
 test-rel-win: # windows test and build binaries
   <<: *test-win
   variables:
@@ -250,6 +280,8 @@ integration: # merging all artifacts to produce single R repository and summarie
   - test-dev-cran-lin
   - test-rel-vanilla-lin
   - test-310-cran-lin
+  - test-344-cran-lin
+  - test-350-cran-lin
   - test-rel-win
   - test-dev-win
   #- test-rel-osx

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,16 +54,13 @@ build: # build data.table sources as tar.gz archive
   <<: *artifacts
 
 .test-copy-src: &copy-src
-  - &copy-src
-    cp $(ls -1t bus/build/cran/src/contrib/data.table_*.tar.gz | head -n 1) .
+  - cp $(ls -1t bus/build/cran/src/contrib/data.table_*.tar.gz | head -n 1) .
 
 .test-move-src: &move-src
-  - &move-src
-    mkdir -p bus/$CI_BUILD_NAME && mv $(ls -1t data.table_*.tar.gz | head -n 1) bus/$CI_BUILD_NAME
+  - mkdir -p bus/$CI_BUILD_NAME && mv $(ls -1t data.table_*.tar.gz | head -n 1) bus/$CI_BUILD_NAME
 
 .test-cleanup-src: &cleanup-src
-  - &cleanup-src
-    rm $(ls -1t data.table_*.tar.gz | head -n 1)
+  - rm $(ls -1t data.table_*.tar.gz | head -n 1)
 
 .test-template: &test
   stage: test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,6 +51,7 @@ build: # build data.table sources as tar.gz archive
     - mkdir -p bus/$CI_BUILD_NAME/cran/src/contrib
     - mv $(ls -1t data.table_*.tar.gz | head -n 1) bus/$CI_BUILD_NAME/cran/src/contrib/.
     - Rscript -e 'tools::write_PACKAGES(contrib.url("bus/build/cran"), fields="Revision", addFiles=TRUE)'
+    - rm bus/$CI_BUILD_NAME/cran/src/contrib/PACKAGES.rds # fallback to PACKAGES dcf so available.packages 3.4.4 works
   <<: *artifacts
 
 .test-copy-src: &copy-src

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,6 +77,20 @@ build: # build data.table sources as tar.gz archive
   tags:
     - linux
 
+.test-cran-lin-template: &test-cran-lin
+  <<: *test-lin
+  variables:
+    _R_CHECK_CRAN_INCOMING_: "TRUE"           # stricter --as-cran checks should run in dev pipelines continuously (not sure what they are though)
+    _R_CHECK_CRAN_INCOMING_REMOTE_: "FALSE"   # Other than no URL checking (takes many minutes) or 'Days since last update 0' NOTEs needed, #3284
+  script:
+    - Rscript -e 'source(".ci/ci.R"); install.packages(dcf.dependencies("DESCRIPTION", which="most"), quiet=TRUE)'
+    - *copy-src
+    - rm -r bus
+    - *move-src
+    - cd bus/$CI_BUILD_NAME
+    - R CMD check --as-cran $(ls -1t data.table_*.tar.gz | head -n 1)
+    - *cleanup-src
+
 .test-win-template: &test-win
   <<: *test
   tags:
@@ -132,86 +146,31 @@ test-rel-vanilla-lin: # minimal installation, no suggested deps, no vignettes or
     - *cleanup-src
 
 test-rel-cran-lin: # currently released R on Linux
-  <<: *test-lin
+  <<: *test-cran-lin
   image: registry.gitlab.com/jangorecki/dockerfiles/r-builder
-  variables:
-    _R_CHECK_CRAN_INCOMING_: "TRUE"           # stricter --as-cran checks should run in dev pipelines continuously (not sure what they are though)
-    _R_CHECK_CRAN_INCOMING_REMOTE_: "FALSE"   # Other than no URL checking (takes many minutes) or 'Days since last update 0' NOTEs needed, #3284
   before_script:
     - mkdir -p ~/.R
     - echo 'CFLAGS=-g0 -O2 -fopenmp -Wall -pedantic -fstack-protector-strong -D_FORTIFY_SOURCE=2'> ~/.R/Makevars # -g0 because -g increases datatable.so size from 0.5MB to 1.5MB and breaches 'installed package size <= 5MB' note
     - echo 'CXXFLAGS=-g0 -O2 -fopenmp -Wall -pedantic -fstack-protector-strong -D_FORTIFY_SOURCE=2' >> ~/.R/Makevars
-  script:
-    - Rscript -e 'source(".ci/ci.R"); install.packages(dcf.dependencies("DESCRIPTION", which="most"), quiet=TRUE)'
-    - *copy-src
-    - rm -r bus
-    - *move-src
-    - cd bus/$CI_BUILD_NAME
-    - R CMD check --as-cran $(ls -1t data.table_*.tar.gz | head -n 1)
-    - *cleanup-src
+  after_script:
     - >-
         Rscript -e 'l<-readLines("data.table.Rcheck/00check.log"); if (!identical(l[length(l)], "Status: 1 NOTE")) stop("Last line of ", shQuote("00check.log"), " is not ", shQuote("Status: 1 NOTE"), "(size of tarball) but ", shQuote(toString(l[length(l)]))) else q("no")'
 
 test-dev-cran-lin: # R-devel on Linux, --enable-strict-barrier --disable-long-double
-  <<: *test-lin
+  <<: *test-cran-lin
   image: registry.gitlab.com/jangorecki/dockerfiles/r-devel
-  allow_failure: false
-  variables:
-    _R_CHECK_CRAN_INCOMING_: "TRUE"
-    _R_CHECK_CRAN_INCOMING_REMOTE_: "FALSE"
-  script:
-    - Rscript -e 'source(".ci/ci.R"); install.packages(dcf.dependencies("DESCRIPTION", which="most"), quiet=TRUE)'
-    - *copy-src
-    - rm -r bus
-    - *move-src
-    - cd bus/$CI_BUILD_NAME
-    - R CMD check --as-cran $(ls -1t data.table_*.tar.gz | head -n 1)
-    - *cleanup-src
 
-test-310-cran-lin: # test stated R dependency (3.1.0) using Linux
-  <<: *test-lin
+test-310-cran-lin: # test stated R dependency 3.1.0
+  <<: *test-cran-lin
   image: registry.gitlab.com/jangorecki/dockerfiles/r-3.1.0
-  variables:
-    _R_CHECK_CRAN_INCOMING_: "TRUE"
-    _R_CHECK_CRAN_INCOMING_REMOTE_: "FALSE"
-  script:
-    - Rscript -e 'source(".ci/ci.R"); install.packages(dcf.dependencies("DESCRIPTION", which="most"), quiet=TRUE)'
-    - *copy-src
-    - rm -r bus
-    - *move-src
-    - cd bus/$CI_BUILD_NAME
-    - R CMD check --as-cran $(ls -1t data.table_*.tar.gz | head -n 1)
-    - *cleanup-src
 
-test-344-cran-lin: # test last non-altrep version
-  <<: *test-lin
+test-344-cran-lin: # test last R non-altrep version
+  <<: *test-cran-lin
   image: registry.gitlab.com/jangorecki/dockerfiles/r-3.4.4
-  variables:
-    _R_CHECK_CRAN_INCOMING_: "TRUE"
-    _R_CHECK_CRAN_INCOMING_REMOTE_: "FALSE"
-  script:
-    - Rscript -e 'source(".ci/ci.R"); install.packages(dcf.dependencies("DESCRIPTION", which="most"), quiet=TRUE)'
-    - *copy-src
-    - rm -r bus
-    - *move-src
-    - cd bus/$CI_BUILD_NAME
-    - R CMD check --as-cran $(ls -1t data.table_*.tar.gz | head -n 1)
-    - *cleanup-src
 
-test-350-cran-lin: # test last first altrep version
-  <<: *test-lin
+test-350-cran-lin: # test first R altrep version
+  <<: *test-cran-lin
   image: registry.gitlab.com/jangorecki/dockerfiles/r-3.5.0
-  variables:
-    _R_CHECK_CRAN_INCOMING_: "TRUE"
-    _R_CHECK_CRAN_INCOMING_REMOTE_: "FALSE"
-  script:
-    - Rscript -e 'source(".ci/ci.R"); install.packages(dcf.dependencies("DESCRIPTION", which="most"), quiet=TRUE)'
-    - *copy-src
-    - rm -r bus
-    - *move-src
-    - cd bus/$CI_BUILD_NAME
-    - R CMD check --as-cran $(ls -1t data.table_*.tar.gz | head -n 1)
-    - *cleanup-src
 
 test-rel-win: # windows test and build binaries
   <<: *test-win

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -341,7 +341,7 @@ test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,no
     if (type=="warning" && length(observed) && !is.null(ignore.warning)) {
       # if a warning containing this string occurs, ignore it. First need for #4182 where warning about 'timedatectl' only
       # occurs in R 3.4, and maybe only on docker too not for users running test.data.table().
-      stopifnot(length(ignore.warning)==1L, is.character(ignore.warning), !is.na(ignore.character), nchar(ignore.warning)>=1L)
+      stopifnot(length(ignore.warning)==1L, is.character(ignore.warning), !is.na(ignore.warning), nchar(ignore.warning)>=1L)
       observed = grep(ignore.warning, observed, value=TRUE, invert=TRUE)
     }
     if (length(expected) != length(observed)) {

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -235,7 +235,7 @@ gc_mem = function() {
   # nocov end
 }
 
-test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,notOutput=NULL) {
+test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,notOutput=NULL,ignore.warning=NULL) {
   # Usage:
   # i) tests that x equals y when both x and y are supplied, the most common usage
   # ii) tests that x is TRUE when y isn't supplied
@@ -338,6 +338,12 @@ test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,no
   if (!fail) for (type in c("warning","error","message")) {
     observed = actual[[type]]
     expected = get(type)
+    if (type=="warning" && length(observed) && !is.null(ignore.warning)) {
+      # if a warning containing this string occurs, ignore it. First need for #4182 where warning about 'timedatectl' only
+      # occurs in R 3.4, and maybe only on docker too not for users running test.data.table().
+      stopifnot(length(ignore.warning)==1L, is.character(ignore.warning), !is.na(ignore.character), nchar(ignore.warning)>=1L)
+      observed = grep(ignore.warning, observed, value=TRUE, invert=TRUE)
+    }
     if (length(expected) != length(observed)) {
       # nocov start
       cat("Test ",numStr," produced ",length(observed)," ",type,"s but expected ",length(expected),"\n",sep="")

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -11184,8 +11184,14 @@ test(1764.2, format(structure(NA_integer_, class = "ITime")), NA_character_)
 # IDateTime error when tzone is NULL, #1973
 x = as.POSIXct('2017-03-17', tz="UTC")
 attr(x, 'tzone') = NULL
-test(1765, print(IDateTime(x)), output=".*idate.*itime.*1: 2017-03-1[67]",
-           ignore.warning="timedatectl") # R 3.4's Sys.timezone() raises this warning in docker, #4182
+test(1765.1, print(IDateTime(x)), output=".*idate.*itime.*1: 2017-03-1[67]",
+             ignore.warning="timedatectl") # R 3.4's Sys.timezone() raises this warning in docker, #4182
+
+# test test's ignore.warning
+test(1765.2, {warning("foo"); 4L}, 4L, ignore.warning="foo")
+test(1765.3, {warning("foo"); 4L}, 4L, ignore.warning="Foo", warning="foo")
+test(1765.4, {warning("foobar1"); warning("foobar2"); warning("FOO"); 4L}, 4L, ignore.warning="bar", warning="FOO")
+test(1765.5, {warning("foobar1"); warning("foobar2"); warning("FOO"); 4L}, 4L, ignore.warning="2", warning=c("foobar1","FOO"))
 
 # print(null.data.table()) should not output NULL as well, #1852
 # use capture.output() in this case rather than output= to ensure NULL is not output

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -11182,12 +11182,10 @@ test(1764.1, format(as.ITime(character(0))), character(0))
 test(1764.2, format(structure(NA_integer_, class = "ITime")), NA_character_)
 
 # IDateTime error when tzone is NULL, #1973
-w = if (base::getRversion() >= "3.4.0" && base::getRversion() < "3.5.0") {
-  rep("timedatectl", 2L) # 3.4's Sys.timezone() raises extra warning in docker
-}
 x = as.POSIXct('2017-03-17', tz="UTC")
 attr(x, 'tzone') = NULL
-test(1765, print(IDateTime(x)), output=".*idate.*itime.*1: 2017-03-1[67]", warning=w)
+test(1765, print(IDateTime(x)), output=".*idate.*itime.*1: 2017-03-1[67]",
+           ignore.warning="timedatectl") # R 3.4's Sys.timezone() raises this warning in docker, #4182
 
 # print(null.data.table()) should not output NULL as well, #1852
 # use capture.output() in this case rather than output= to ensure NULL is not output

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -11182,9 +11182,12 @@ test(1764.1, format(as.ITime(character(0))), character(0))
 test(1764.2, format(structure(NA_integer_, class = "ITime")), NA_character_)
 
 # IDateTime error when tzone is NULL, #1973
+w = if (base::getRversion() >= "3.4.0" && base::getRversion() < "3.5.0") {
+  "timedatectl" # 3.4's Sys.timezone() raises extra warning in docker
+}
 x = as.POSIXct('2017-03-17', tz="UTC")
 attr(x, 'tzone') = NULL
-test(1765, print(IDateTime(x)), output=".*idate.*itime.*1: 2017-03-1[67]")
+test(1765, print(IDateTime(x)), output=".*idate.*itime.*1: 2017-03-1[67]", warning=w)
 
 # print(null.data.table()) should not output NULL as well, #1852
 # use capture.output() in this case rather than output= to ensure NULL is not output

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -11183,7 +11183,7 @@ test(1764.2, format(structure(NA_integer_, class = "ITime")), NA_character_)
 
 # IDateTime error when tzone is NULL, #1973
 w = if (base::getRversion() >= "3.4.0" && base::getRversion() < "3.5.0") {
-  "timedatectl" # 3.4's Sys.timezone() raises extra warning in docker
+  rep("timedatectl", 2L) # 3.4's Sys.timezone() raises extra warning in docker
 }
 x = as.POSIXct('2017-03-17', tz="UTC")
 attr(x, 'tzone') = NULL

--- a/man/test.Rd
+++ b/man/test.Rd
@@ -7,7 +7,7 @@
 \usage{
 test(num, x, y = TRUE,
      error = NULL, warning = NULL, message = NULL,
-     output = NULL, notOutput = NULL)
+     output = NULL, notOutput = NULL, ignore.warning = NULL)
 }
 \arguments{
 \item{num}{ A unique identifier for a test, helpful in identifying the source of failure when testing is not working. Currently, we use a manually-incremented system with tests formatted as \code{n.m}, where essentially \code{n} indexes an issue and \code{m} indexes aspects of that issue. For the most part, your new PR should only have one value of \code{n} (scroll to the end of \code{inst/tests/tests.Rraw} to see the next available ID) and then index the tests within your PR by increasing \code{m}. Note -- \code{n.m} is interpreted as a number, so \code{123.4} and \code{123.40} are actually the same -- please \code{0}-pad as appropriate. Test identifiers are checked to be in increasing order at runtime to prevent duplicates being possible. }
@@ -18,6 +18,7 @@ test(num, x, y = TRUE,
 \item{message}{ Same as \code{warning} but expects \code{message} exception. }
 \item{output}{ If you are testing the printing/console output behaviour; e.g. with \code{verbose=TRUE} or \code{options(datatable.verbose=TRUE)}. Again, regex-compatible and case sensitive. }
 \item{notOutput}{ Or if you are testing that a feature does \emph{not} print particular console output. Case insensitive (unlike output) so that the test does not incorrectly pass just because the string is not found due to case. }
+\item{ignore.warning}{ A single character string. Any warnings emitted by \code{x} that contain this string are dropped. Remaining warnings are compared to the expected \code{warning} as normal. }
 }
 \note{
    \code{NA_real_} and \code{NaN} are treated as equal, use \code{identical} if distinction is needed. See examples below.


### PR DESCRIPTION
follow up of https://github.com/Rdatatable/data.table/pull/4164#issuecomment-574434666
ready to merge: https://gitlab.com/jangorecki/data.table/pipelines

----

side effect of this PR:
in r-devel cran linux build we no longer check pdf manual, we still do it in r-release build.