### PR TITLE
More robust setDT

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2703,7 +2703,8 @@ setDT = function(x, keep.rownames=FALSE, key=NULL, check.names=FALSE) {
       x[, (nm[1L]) := rn]
       setcolorder(x, nm)
     }
-  } else if (is.list(x) && length(x)==1L && is.matrix(x[[1L]])) {
+  } 
+  if (is.list(x) && length(x)==1L && is.matrix(x[[1L]])) {
     # a single list(matrix) is unambiguous and depended on by some revdeps, #3581
     x = as.data.table.matrix(x[[1L]])
   } else if (is.null(x) || (is.list(x) && !length(x))) {

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2732,6 +2732,7 @@ setDT = function(x, keep.rownames=FALSE, key=NULL, check.names=FALSE) {
     # Type specific data.table creation can now proceed
     if (is.data.table(x)) {
       setattr(x, "row.names", .set_row_names(n_range[1L]))
+      setattr(x, "class", .resetclass(x, 'data.table'))
       setalloccol(x)
     } else if (is.data.frame(x)) {
       rn = if (!identical(keep.rownames, FALSE)) rownames(x) else NULL

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2711,7 +2711,6 @@ setDT = function(x, keep.rownames=FALSE, key=NULL, check.names=FALSE) {
       # many operations still work in the presence of NULL columns and it might be convenient
       # e.g. in package eplusr which calls setDT on a list when parsing JSON. Operations which
       # fail for NULL columns will give helpful error at that point, #3480 and #3471
-      
       n = vector("integer", length(x))
       col.is.null = vapply_1b(x, is.null)
       n[col.is.null] = NA_integer_
@@ -2731,10 +2730,10 @@ setDT = function(x, keep.rownames=FALSE, key=NULL, check.names=FALSE) {
              brackify(sprintf('%s:%d', names(tbl), tbl)), "\nThe first entry with fewer than ", n_range[2L], " entries is ", which.max(n<n_range[2L]))
       }
     }
-    # Check columns for allowed data types
-    for (i in seq_along(x)) {
-      if (inherits(x[[i]], "POSIXlt")) stop("Column ", i, " is of POSIXlt type. Please convert it to POSIXct using as.POSIXct and run setDT again. We do not recommend use of POSIXlt at all because it uses 40 bytes to store one date.")
-    }
+    # Check columns for disallowed data types
+    col.POSIXlt = vapply_1b(x, inherits, "POSIXlt")
+    if (length(col.POSIXlt) > 0L)
+      stop("Columns ", brackify(col.POSIXlt), " are of POSIXlt type. Please convert it to POSIXct using as.POSIXct and run setDT again. We do not recommend use of POSIXlt at all because it uses 40 bytes to store one date.")
     
     # Type specific data.table creation can now proceed
     if (is.data.table(x)) {

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2725,9 +2725,9 @@ setDT = function(x, keep.rownames=FALSE, key=NULL, check.names=FALSE) {
     }
       
     # Check columns for disallowed data types
-    col.POSIXlt = which(vapply_1b(x, inherits, "POSIXlt"))
-    if (length(col.POSIXlt) > 0L)
-      stop("Columns ", brackify(col.POSIXlt), " are of POSIXlt type. Please convert it to POSIXct using as.POSIXct and run setDT again. We do not recommend use of POSIXlt at all because it uses 40 bytes to store one date.")
+    col.POSIXlt = vapply_1b(x, inherits, "POSIXlt")
+    if (any(col.POSIXlt))
+      stop("Columns ", brackify(which(col.POSIXlt)), " are of POSIXlt type. Please convert it to POSIXct using as.POSIXct and run setDT again. We do not recommend use of POSIXlt at all because it uses 40 bytes to store one date.")
     
     # Type specific data.table creation can now proceed
     if (is.data.table(x)) {

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -8326,7 +8326,7 @@ dt = data.table(d1="1984-03-17")
 ans = data.table(d1="1984-03-17", d2=as.POSIXct("1984-03-17", tz='UTC'))
 test(1612.2, dt[, d2 := strptime(d1, "%Y-%m-%d", tz='UTC')], ans, warning="strptime() usage detected and wrapped with as.POSIXct()")
 ll = list(a=as.POSIXlt("2015-01-01"), b=2L)
-test(1612.3, setDT(ll), error="Column 1 is of POSIXlt type")
+test(1612.3, setDT(ll), error="Columns [1] are of POSIXlt type")
 
 # tests for all.equal.data.table #1106
 # diff nrow

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -16774,3 +16774,17 @@ rm(s1, s2, class2132)
 ########################
 #  Add new tests here  #
 ########################
+
+# Test setDT for robustness
+l = structure(list(A=1:5, B=1), class="data.table")
+test(2133.1, setDT(l), error="All elements in argument 'x' to 'setDT' must be of same length, but the profile of input lengths (length:frequency) is: [1:1, 5:1]")
+
+l = list(A=1:5, B=NULL, C=6:10)
+df = structure(list(A=1:5, B=NULL, C=6:10), class=c("data.frame"))
+test(2133.2, setDT(l), setDT(df))
+
+l = list(A=1:5, B=NULL, C=6:10)
+dt = structure(list(A=1:5, B=NULL, C=6:10), class=c("data.frame", "data.table"))
+test(2133.3, setDT(l), setDT(dt))
+
+


### PR DESCRIPTION
Fixes #4176 

This PR reorganises the code within `setDT()` so that the checks currently made on list objects (checks for POSIXlt and heterogeneous column lengths) are made regardless of the class of the input, and that `setalloccol()` is only called once all checks have passed. This means you now can't bypass these checks by simply adding "data.table" or "data.frame" as a class to a list of mixed column lengths. I've also fixed the column length checking code to ignore NULL columns, as per #3480 and #3471, which would have triggered the range-failure check unless all columns were NULL or otherwise length 0.

Ideally it would be nice to be able to move some of these checks into `setalloccol()`, so that we could use `selfrefok(x) > 0L` as a way of checking an input object is a non-malformed data.table.