### PR TITLE
Fixed typeorder coercion rules for RAWSXP and LGLSXP to match base R

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -87,6 +87,8 @@ unit = "s")
 
 6. `all.equal(DT, y)` no longer errors when `y` is not a data.table, [#4042](https://github.com/Rdatatable/data.table/issues/4042). Thanks to @d-sci for reporting and the PR.
 
+7. `rbindlist()` now correctly coerces raw to logical instead of vice-versa [#4172](https://github.com/Rdatatable/data.table/issues/4172), making it consistent with base R's coercion rules. Thanks to @sritchie73 for reporting and fixing.
+
 ## NOTES
 
 1. `as.IDate`, `as.ITime`, `second`, `minute`, and `hour` now recognize UTC equivalents for speed: GMT, GMT-0, GMT+0, GMT0, Etc/GMT, and Etc/UTC, [#4116](https://github.com/Rdatatable/data.table/issues/4116).

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -16780,7 +16780,7 @@ DT1 = data.table(a=as.raw(1), b=as.raw(2), c=as.raw(3), d=as.raw(4), e=as.raw(5)
 DT2 = data.table(a=as.raw(1), b=TRUE, c=1L, d=1.5, e=complex(real=3, imaginary=1), f="a", g=list(3:5), h=expression(1+1))
 DT3 = setDT(lapply(names(DT1), function(j) c(DT1[[j]], DT2[[j]])))
 setnames(DT3, names(DT1))
-test(2133, rbind(DT1, DT2), DT3)
+test(2133, rbind(DT1, DT2), DT3, warning="Column 2 of item 1: 2 (type 'raw') at RHS position 1 taken as TRUE when assigning to type 'logical' (column 2 named 'b')") # warning expected due to loss of precision when coercing raw to logical
 
 
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -16774,3 +16774,13 @@ rm(s1, s2, class2132)
 ########################
 #  Add new tests here  #
 ########################
+
+# Check rbindlist coercion rules for raw match base R (e.g. using c()) #4172
+DT1 = data.table(a=as.raw(1), b=as.raw(2), c=as.raw(3), d=as.raw(4), e=as.raw(5), f=as.raw(6), g=as.raw(7), h=as.raw(8))
+DT2 = data.table(a=as.raw(1), b=TRUE, c=1L, d=1.5, e=complex(real=3, imaginary=1), f="a", g=list(3:5), h=expression(1+1))
+DT3 = setDT(lapply(names(DT1), function(j) c(DT1[[j]], DT2[[j]])))
+setnames(DT3, names(DT1))
+test(2133, rbind(DT1, DT2), DT3)
+
+
+

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -16770,11 +16770,6 @@ test(2132.2, fifelse(TRUE, 1, s2),       error = "S4 class objects (except nanot
 test(2132.3, fcase(TRUE, s1, FALSE, s2), error = "S4 class objects (except nanotime) are not supported. Please see https://github.com/Rdatatable/data.table/issues/4131.")
 rm(s1, s2, class2132)
 
-
-########################
-#  Add new tests here  #
-########################
-
 # Check rbindlist coercion rules for raw match base R (e.g. using c()) #4172
 DT1 = data.table(a=as.raw(1), b=as.raw(2), c=as.raw(3), d=as.raw(4), e=as.raw(5), f=as.raw(6), g=as.raw(7), h=as.raw(8))
 DT2 = data.table(a=as.raw(1), b=TRUE, c=1L, d=1.5, e=complex(real=3, imaginary=1), f="a", g=list(3:5), h=expression(1+1))
@@ -16782,5 +16777,6 @@ DT3 = setDT(lapply(names(DT1), function(j) c(DT1[[j]], DT2[[j]])))
 setnames(DT3, names(DT1))
 test(2133, rbind(DT1, DT2), DT3, warning="Column 2 of item 1: 2 (type 'raw') at RHS position 1 taken as TRUE when assigning to type 'logical' (column 2 named 'b')") # warning expected due to loss of precision when coercing raw to logical
 
-
-
+########################
+#  Add new tests here  #
+########################

--- a/src/init.c
+++ b/src/init.c
@@ -223,8 +223,8 @@ R_ExternalMethodDef externalMethods[] = {
 static void setSizes() {
   for (int i=0; i<100; ++i) { sizes[i]=0; typeorder[i]=0; }
   // only these types are currently allowed as column types :
-  sizes[LGLSXP] =  sizeof(int);       typeorder[LGLSXP] =  0;
-  sizes[RAWSXP] =  sizeof(Rbyte);     typeorder[RAWSXP] =  1;
+  sizes[RAWSXP] =  sizeof(Rbyte);     typeorder[RAWSXP] =  0;
+  sizes[LGLSXP] =  sizeof(int);       typeorder[LGLSXP] =  1;
   sizes[INTSXP] =  sizeof(int);       typeorder[INTSXP] =  2;   // integer and factor
   sizes[REALSXP] = sizeof(double);    typeorder[REALSXP] = 3;   // numeric and integer64
   sizes[CPLXSXP] = sizeof(Rcomplex);  typeorder[CPLXSXP] = 4;

--- a/src/rbindlist.c
+++ b/src/rbindlist.c
@@ -293,7 +293,7 @@ SEXP rbindlist(SEXP l, SEXP usenamesArg, SEXP fillArg, SEXP idcolArg)
       SEXP thisCol = VECTOR_ELT(li, w);
       int thisType = TYPEOF(thisCol);
       // Use >= for #546 -- TYPEORDER=0 for both RAWSXP and EXPRSXP. For NULL, keep maxType as -1 
-      if (!isNull(thisCol) && TYPEORDER(thisType)>=TYPEORDER(maxType)) maxType=thisType;
+      if (!isNull(thisCol) && (maxType == -1 || TYPEORDER(thisType)>=TYPEORDER(maxType))) maxType=thisType;
       if (isFactor(thisCol)) {
         if (isNull(getAttrib(thisCol,R_LevelsSymbol))) error(_("Column %d of item %d has type 'factor' but has no levels; i.e. malformed."), w+1, i+1);
         factor = true;

--- a/src/rbindlist.c
+++ b/src/rbindlist.c
@@ -271,7 +271,7 @@ SEXP rbindlist(SEXP l, SEXP usenamesArg, SEXP fillArg, SEXP idcolArg)
 
   SEXP coercedForFactor = NULL;
   for(int j=0; j<ncol; ++j) {
-    int maxType=LGLSXP;  // initialize with LGLSXP for test 2002.3 which has col x NULL in both lists to be filled with NA for #1871
+    int maxType=RAWSXP;  // initialize with LGLSXP for test 2002.3 which has col x NULL in both lists to be filled with NA for #1871
     bool factor=false, orderedFactor=false;     // ordered factor is class c("ordered","factor"). isFactor() is true when isOrdered() is true.
     int longestLen=0, longestW=-1, longestI=-1; // just for ordered factor
     SEXP longestLevels=R_NilValue;              // just for ordered factor


### PR DESCRIPTION
Closes #4172

Base R coercion rules mean that raw are coerced to logical, not the other way round:

```
c(as.raw(0), TRUE)
# [1] FALSE  TRUE
```

This PR fixes the typeorder in src/init.c to match the base R coercion rules. This impacts rbindlist, which will now coerce a raw column to a logical column when binding these two together.