### PR TITLE
All non-atomic types are now converted to lists in rbindlist

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -69,7 +69,7 @@ unit = "s")
 
 8. Compiler support for OpenMP is now detected during installation, which allows data.table to compile from source (in single threaded mode) on macOS which, frustratingly, does not include OpenMP support by default, [#2161](https://github.com/Rdatatable/data.table/issues/2161), unlike Windows and Linux. A helpful message is emitted during installation from source, and on package startup as before. Many thanks to @jimhester for the PR. This was typically a problem just after release to CRAN in the few days before macOS binaries (which do support OpenMP) are made available by CRAN.
 
-9. `rbindlist` now supports columns of type `expression`, [#546](https://github.com/Rdatatable/data.table/issues/546). Thanks @jangorecki for the report.
+9. `rbindlist` now supports columns of type `expression`, [#546](https://github.com/Rdatatable/data.table/issues/546). Thanks @jangorecki for the report and @sritchie73 for the PR.
 
 10. The dimensions of objects in a `list` column are now displayed, [#3671](https://github.com/Rdatatable/data.table/issues/3671). Thanks to @randomgambit for the request, and Tyson Barrett for the PR.
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -16774,7 +16774,7 @@ if (test_bit64) {
   A = data.table(A=list(1, 2:3, 4))
   B = data.table(A=as.integer64(5:7))
   target = data.table(A=list(1, 2:3, 4, as.integer64(5), as.integer64(6), as.integer64(7)))
-  test(2129.6, rbind(A,B), target) # list of atomic vectors should preserve class
+  test(2129.7, rbind(A,B), target) # list of atomic vectors should preserve class
 }
 
 # print dims in list-colrmns, #3671

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -16761,6 +16761,13 @@ test(2129.4, rbind(A, B)$c2, list(quote(1+1), quote(1+1), quote(1+1), 'asd')) # 
 A = data.table(c1 = 1:3, c2 = pairlist(A=1, B=list(1, 2:3), C=pairlist(C1=1, C2=3:4)))
 test(2129.5, rbind(A,B)$c2, c(as.list(A$c2), 'asd')) # top level pairlist becomes list
 
+if (test_bit64) {
+  A = data.table(A=list(1, 2:3, 4))
+  B = data.table(A=as.integer64(5:7))
+  target = data.table(A=list(1, 2:3, 4, as.integer64(5), as.integer64(6), as.integer64(7)))
+  test(2129.6, rbind(A,B), target) # list of atomic vectors should preserve class
+}
+
 # print dims in list-colrmns, #3671
 DT = data.table(
   x = 1:2,

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -16736,7 +16736,23 @@ test(2128.5, DT[, .SD, .SDcols=function(x) NA],   error='conditions were not met
 # expression columns in rbindlist, #546
 A = data.table(c1 = 1, c2 = 'asd', c3 = expression(as.character(Sys.time())))
 B = data.table(c1 = 3, c2 = 'qwe', c3 = expression(as.character(Sys.time()+5)))
-test(2129, rbind(A,B)$c3, expression(as.character(Sys.time()), as.character(Sys.time()+5)))
+DT = data.table(c1 = c(1, 3), c2 = c("asd", "qwe"), 
+                c3 = list(expression(as.character(Sys.time())), expression(as.character(Sys.time() + 5))))
+test(2129.1, rbind(A,B), DT)
+
+A = data.table(c1 = 1, c2 = 'asd', c3 = expression(as.character(Sys.time())))
+B = data.table(c1 = 3:5, c2 = c('qwe', "foo", "bar"), 
+               c3 = expression(1+1, print("test"), as.character(Sys.time()+5)))
+DT = data.table(c1 = c(1, 3:5), c2 = c("asd", "qwe", "foo", "bar"), 
+                c3 = list(expression(as.character(Sys.time())), expression(1+1), expression(print("test")), 
+                          expression(as.character(Sys.time()+5))))
+test(2129.2, rbind(A,B), DT)
+
+A = data.table(c1 = 1, c2 = 'asd', c3 = expression(as.character(Sys.time())))
+B = data.table(c1 = 3:5, c2 = c('qwe', "foo", "bar"), c3 = 4:6)
+DT = data.table(c1 = c(1, 3:5), c2 = c("asd", "qwe", "foo", "bar"), 
+                c3 = list(expression(as.character(Sys.time())), 4L, 5L, 6L))
+test(2129.3, rbind(A,B), DT)
 
 # print dims in list-columns, #3671
 DT = data.table(

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -16748,18 +16748,27 @@ DT = data.table(c1 = c(1, 3:5), c2 = c("asd", "qwe", "foo", "bar"),
                           expression(as.character(Sys.time()+5))))
 test(2129.2, rbind(A,B), DT)
 
+A = data.table(c1 = 1:2, c2 = c('asd', 'xzy'), c3 = expression(as.character(Sys.time()), 1+2))
+B = data.table(c1 = 3:5, c2 = c('qwe', "foo", "bar"), 
+               c3 = expression(1+1, print("test"), as.character(Sys.time()+5)))
+DT = data.table(c1 = c(1:2, 3:5), c2 = c("asd", "xzy", "qwe", "foo", "bar"), 
+                c3 = list(expression(as.character(Sys.time())), expression(1+2), 
+                          expression(1+1), expression(print("test")), 
+                          expression(as.character(Sys.time()+5))))
+test(2129.3, rbind(A,B), DT)                          
+
 A = data.table(c1 = 1, c2 = 'asd', c3 = expression(as.character(Sys.time())))
 B = data.table(c1 = 3:5, c2 = c('qwe', "foo", "bar"), c3 = 4:6)
 DT = data.table(c1 = c(1, 3:5), c2 = c("asd", "qwe", "foo", "bar"), 
                 c3 = list(expression(as.character(Sys.time())), 4L, 5L, 6L))
-test(2129.3, rbind(A,B), DT)
+test(2129.4, rbind(A,B), DT)
 
 A = data.table(c1 = 1, c2 = quote(1+1)) # length(quote(1+1)) = 3, so A[,.N] = 3 with c1 recycled
 B = data.table(c1 = 2, c2 = 'asd')
-test(2129.4, rbind(A, B)$c2, list(quote(1+1), quote(1+1), quote(1+1), 'asd')) # list(quote(1+1)) is recycled
+test(2129.5, rbind(A, B)$c2, list(quote(1+1), quote(1+1), quote(1+1), 'asd')) # list(quote(1+1)) is recycled
 
 A = data.table(c1 = 1:3, c2 = pairlist(A=1, B=list(1, 2:3), C=pairlist(C1=1, C2=3:4)))
-test(2129.5, rbind(A,B)$c2, c(as.list(A$c2), 'asd')) # top level pairlist becomes list
+test(2129.6, rbind(A,B)$c2, c(as.list(A$c2), 'asd')) # top level pairlist becomes list
 
 if (test_bit64) {
   A = data.table(A=list(1, 2:3, 4))

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -16733,7 +16733,7 @@ test(2128.3, DT[, .SD, .SDcols=function(x) x==1], error='conditions were not met
 test(2128.4, DT[, .SD, .SDcols=function(x) 2L],   error='conditions were not met for: [a, b, c]')
 test(2128.5, DT[, .SD, .SDcols=function(x) NA],   error='conditions were not met for: [a, b, c]')
 
-# expression columns in rbindlist, #546
+# Test non-atomic columns in rbindlist, e.g. expressions, #546
 A = data.table(c1 = 1, c2 = 'asd', c3 = expression(as.character(Sys.time())))
 B = data.table(c1 = 3, c2 = 'qwe', c3 = expression(as.character(Sys.time()+5)))
 DT = data.table(c1 = c(1, 3), c2 = c("asd", "qwe"), 
@@ -16754,7 +16754,14 @@ DT = data.table(c1 = c(1, 3:5), c2 = c("asd", "qwe", "foo", "bar"),
                 c3 = list(expression(as.character(Sys.time())), 4L, 5L, 6L))
 test(2129.3, rbind(A,B), DT)
 
-# print dims in list-columns, #3671
+A = data.table(c1 = 1, c2 = quote(1+1)) # length(quote(1+1)) = 3, so A[,.N] = 3 with c1 recycled
+B = data.table(c1 = 2, c2 = 'asd')
+test(2129.4, rbind(A, B)$c2, list(quote(1+1), quote(1+1), quote(1+1), 'asd')) # list(quote(1+1)) is recycled
+
+A = data.table(c1 = 1:3, c2 = pairlist(A=1, B=list(1, 2:3), C=pairlist(C1=1, C2=3:4)))
+test(2129.5, rbind(A,B)$c2, c(as.list(A$c2), 'asd')) # top level pairlist becomes list
+
+# print dims in list-colrmns, #3671
 DT = data.table(
   x = 1:2,
   y = list(data.table(x=1, y=1),

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -233,6 +233,7 @@ bool islocked(SEXP x);
 SEXP islockedR(SEXP x);
 bool need2utf8(SEXP x);
 SEXP coerceUtf8IfNeeded(SEXP x);
+SEXP coerceAsList(SEXP x, int len);
 
 // types.c
 char *end(char *start);

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -233,7 +233,7 @@ bool islocked(SEXP x);
 SEXP islockedR(SEXP x);
 bool need2utf8(SEXP x);
 SEXP coerceUtf8IfNeeded(SEXP x);
-SEXP coerceAsList(SEXP x, int len);
+SEXP coerceAsList(SEXP x, int len, int *nprotect);
 
 // types.c
 char *end(char *start);

--- a/src/init.c
+++ b/src/init.c
@@ -221,7 +221,7 @@ R_ExternalMethodDef externalMethods[] = {
 };
 
 static void setSizes() {
-  for (int i=0; i<100; ++i) { sizes[i]=0; typeorder[i]=7; }
+  for (int i=0; i<100; ++i) { sizes[i]=0; typeorder[i]=7; } // typeorder init value must be > listed types below
   // only these types are currently allowed as column types :
   sizes[LGLSXP] =  sizeof(int);       typeorder[LGLSXP] =  0;
   sizes[RAWSXP] =  sizeof(Rbyte);     typeorder[RAWSXP] =  1;

--- a/src/init.c
+++ b/src/init.c
@@ -221,7 +221,7 @@ R_ExternalMethodDef externalMethods[] = {
 };
 
 static void setSizes() {
-  for (int i=0; i<100; ++i) { sizes[i]=0; typeorder[i]=0; }
+  for (int i=0; i<100; ++i) { sizes[i]=0; typeorder[i]=7; }
   // only these types are currently allowed as column types :
   sizes[LGLSXP] =  sizeof(int);       typeorder[LGLSXP] =  0;
   sizes[RAWSXP] =  sizeof(Rbyte);     typeorder[RAWSXP] =  1;

--- a/src/rbindlist.c
+++ b/src/rbindlist.c
@@ -528,6 +528,6 @@ SEXP rbindlist(SEXP l, SEXP usenamesArg, SEXP fillArg, SEXP idcolArg)
       }
     }
   }
-  UNPROTECT(nprotect);  // ans, coercedForFactor, thisCol, thisElement
+  UNPROTECT(nprotect);  // ans, coercedForFactor, thisCol
   return(ans);
 }

--- a/src/rbindlist.c
+++ b/src/rbindlist.c
@@ -322,7 +322,7 @@ SEXP rbindlist(SEXP l, SEXP usenamesArg, SEXP fillArg, SEXP idcolArg)
 
     if (!foundName) { static char buff[12]; sprintf(buff,"V%d",j+1), SET_STRING_ELT(ansNames, idcol+j, mkChar(buff)); foundName=buff; }
     if (factor) maxType=INTSXP;  // if any items are factors then a factor is created (could be an option)
-    if (int64 && maxType!=REALSXP)
+    if (int64 && maxType!=REALSXP && maxType!=VECSXP)
       error(_("Internal error: column %d of result is determined to be integer64 but maxType=='%s' != REALSXP"), j+1, type2char(maxType)); // # nocov
     SEXP target;
     SET_VECTOR_ELT(ans, idcol+j, target=allocVector(maxType, nrow));  // does not initialize logical & numerics, but does initialize character and list
@@ -517,6 +517,7 @@ SEXP rbindlist(SEXP l, SEXP usenamesArg, SEXP fillArg, SEXP idcolArg)
           if (TYPEOF(target)==VECSXP) {
             thisCol = PROTECT(coerceAsList(thisCol, thisnrow)); nprotect++;
           }
+
           // else coerces if needed within memrecycle; with a no-alloc direct coerce from 1.12.4 (PR #3909)
           const char *ret = memrecycle(target, R_NilValue, ansloc, thisnrow, thisCol, 0, -1, idcol+j+1, foundName);
           if (ret) warning(_("Column %d of item %d: %s"), w+1, i+1, ret);

--- a/src/rbindlist.c
+++ b/src/rbindlist.c
@@ -519,7 +519,7 @@ SEXP rbindlist(SEXP l, SEXP usenamesArg, SEXP fillArg, SEXP idcolArg)
             SEXP thisColList = PROTECT(allocVector(VECSXP, length(thisCol))); nprotect++;
             for(int r=0; r<length(thisCol); ++r) {
               SEXP thisElement = VECTOR_ELT(thisCol, r);
-              if (TYPEOF(thisCol) == EXPRSXP) thisElement = coerceVector(thisElement, EXPRSXP); // otherwise LANGSXP
+              if (TYPEOF(thisCol) == EXPRSXP) thisElement = PROTECT(coerceVector(thisElement, EXPRSXP)); nprotect++; // otherwise LANGSXP
               SET_VECTOR_ELT(thisColList, r, thisElement);
             }
             thisCol = thisColList;

--- a/src/rbindlist.c
+++ b/src/rbindlist.c
@@ -552,6 +552,6 @@ SEXP rbindlist(SEXP l, SEXP usenamesArg, SEXP fillArg, SEXP idcolArg)
       }
     }
   }
-  UNPROTECT(nprotect);  // ans, coercedForFactor, thisCol
+  UNPROTECT(nprotect);  // ans, coercedForFactor, thisCol, thisElement
   return(ans);
 }

--- a/src/rbindlist.c
+++ b/src/rbindlist.c
@@ -309,7 +309,7 @@ SEXP rbindlist(SEXP l, SEXP usenamesArg, SEXP fillArg, SEXP idcolArg)
       }
       if (firsti==-1) { firsti=i; firstw=w; firstCol=thisCol; }
       else {
-        if (!factor && !int64) {
+        if (!factor && !int64 && maxType != VECSXP) {
           if (!R_compute_identical(PROTECT(getAttrib(thisCol, R_ClassSymbol)),
                                    PROTECT(getAttrib(firstCol, R_ClassSymbol)),
                                    0)) {

--- a/src/rbindlist.c
+++ b/src/rbindlist.c
@@ -514,33 +514,8 @@ SEXP rbindlist(SEXP l, SEXP usenamesArg, SEXP fillArg, SEXP idcolArg)
         if (w==-1 || !length(thisCol=VECTOR_ELT(li, w))) {  // !length for zeroCol warning above; #1871
           writeNA(target, ansloc, thisnrow);  // writeNA is integer64 aware and writes INT64_MIN
         } else {
-          if ((TYPEOF(target)==VECSXP) && (isVectorAtomic(thisCol) || TYPEOF(thisCol)==LISTSXP)) {
-            // do an as.list() on the atomic column; #3528
-            // pairlists (LISTSXP) can also be coerced to lists using coerceVector
-            thisCol = PROTECT(coerceVector(thisCol, TYPEOF(target))); nprotect++;
-          } else if ((TYPEOF(target)==VECSXP) && TYPEOF(thisCol)==EXPRSXP) {
-            // For EXPRSXP each element to be wrapped in a list, e.g. expression vectors #546
-            SEXP thisColList = PROTECT(allocVector(VECSXP, length(thisCol))); nprotect++;
-            for(int r=0; r<length(thisCol); ++r) {
-              SEXP thisElement = VECTOR_ELT(thisCol, r);
-              thisElement = PROTECT(coerceVector(thisElement, EXPRSXP)); nprotect++; // otherwise LANGSXP
-              SET_VECTOR_ELT(thisColList, r, thisElement);
-            }
-            thisCol = thisColList;
-          } else if ((TYPEOF(target)==VECSXP) && !isVector(thisCol) && TYPEOF(thisCol)!=TYPEOF(target)) { 
-            // Anything not a vector we can assign directly through SET_VECTOR_ELT
-            // Although tecnically there should only be one list element for any type met here,
-            // the length of the type may be > 1, in which case the other columns in data.table
-            // will have been recycled. We therefore in turn have to recycle the list elements
-            // to match the number of rows.
-            SEXP thisColList = PROTECT(allocVector(VECSXP, length(thisCol))); nprotect++;
-            for(int r=0; r<length(thisCol); ++r) {
-              SET_VECTOR_ELT(thisColList, r, thisCol);
-            }
-            thisCol = thisColList;
-          } else if ((TYPEOF(target)==VECSXP) && TYPEOF(thisCol)!=TYPEOF(target)) {
-            // should be unreachable
-            error("Internal error: rbindlist cannot handle type %s\n", type2char(TYPEOF(thisCol))); // # nocov
+          if (TYPEOF(target)==VECSXP) {
+            thisCol = PROTECT(coerceAsList(thisCol, thisnrow)); nprotect++;
           }
           // else coerces if needed within memrecycle; with a no-alloc direct coerce from 1.12.4 (PR #3909)
           const char *ret = memrecycle(target, R_NilValue, ansloc, thisnrow, thisCol, 0, -1, idcol+j+1, foundName);

--- a/src/rbindlist.c
+++ b/src/rbindlist.c
@@ -326,7 +326,7 @@ SEXP rbindlist(SEXP l, SEXP usenamesArg, SEXP fillArg, SEXP idcolArg)
       error(_("Internal error: column %d of result is determined to be integer64 but maxType=='%s' != REALSXP"), j+1, type2char(maxType)); // # nocov
     SEXP target;
     SET_VECTOR_ELT(ans, idcol+j, target=allocVector(maxType, nrow));  // does not initialize logical & numerics, but does initialize character and list
-    if (!factor) copyMostAttrib(firstCol, target); // all but names,dim and dimnames; mainly for class. And if so, we want a copy here, not keepattr's SET_ATTRIB.
+    if (!factor & maxType != VECSXP) copyMostAttrib(firstCol, target); // all but names,dim and dimnames; mainly for class. And if so, we want a copy here, not keepattr's SET_ATTRIB.
 
     if (factor && anyNotStringOrFactor) {
       // in future warn, or use list column instead ... warning(_("Column %d contains a factor but not all items for the column are character or factor"), idcol+j+1);
@@ -523,10 +523,6 @@ SEXP rbindlist(SEXP l, SEXP usenamesArg, SEXP fillArg, SEXP idcolArg)
           if (ret) warning(_("Column %d of item %d: %s"), w+1, i+1, ret);
           // e.g. when precision is lost like assigning 3.4 to integer64; test 2007.2
           // TODO: but maxType should handle that and this should never warn
-       
-          // memrecycle incorrectly adds integer64 class to whole list if any element has class integer64
-          if (maxType == VECSXP && INHERITS(target, char_integer64)) 
-            setAttrib(target, R_ClassSymbol, R_NilValue);
         }
         ansloc += thisnrow;
       }

--- a/src/rbindlist.c
+++ b/src/rbindlist.c
@@ -514,7 +514,7 @@ SEXP rbindlist(SEXP l, SEXP usenamesArg, SEXP fillArg, SEXP idcolArg)
         if (w==-1 || !length(thisCol=VECTOR_ELT(li, w))) {  // !length for zeroCol warning above; #1871
           writeNA(target, ansloc, thisnrow);  // writeNA is integer64 aware and writes INT64_MIN
         } else {
-          if (TYPEOF(target)==VECSXP) {
+          if (maxType==VECSXP) {
             thisCol = PROTECT(coerceAsList(thisCol, thisnrow)); nprotect++;
           }
 
@@ -523,6 +523,10 @@ SEXP rbindlist(SEXP l, SEXP usenamesArg, SEXP fillArg, SEXP idcolArg)
           if (ret) warning(_("Column %d of item %d: %s"), w+1, i+1, ret);
           // e.g. when precision is lost like assigning 3.4 to integer64; test 2007.2
           // TODO: but maxType should handle that and this should never warn
+       
+          // memrecycle incorrectly adds integer64 class to whole list if any element has class integer64
+          if (maxType == VECSXP && INHERITS(target, char_integer64)) 
+            setAttrib(target, R_ClassSymbol, R_NilValue);
         }
         ansloc += thisnrow;
       }

--- a/src/rbindlist.c
+++ b/src/rbindlist.c
@@ -326,7 +326,7 @@ SEXP rbindlist(SEXP l, SEXP usenamesArg, SEXP fillArg, SEXP idcolArg)
       error(_("Internal error: column %d of result is determined to be integer64 but maxType=='%s' != REALSXP"), j+1, type2char(maxType)); // # nocov
     SEXP target;
     SET_VECTOR_ELT(ans, idcol+j, target=allocVector(maxType, nrow));  // does not initialize logical & numerics, but does initialize character and list
-    if (!factor & maxType != VECSXP) copyMostAttrib(firstCol, target); // all but names,dim and dimnames; mainly for class. And if so, we want a copy here, not keepattr's SET_ATTRIB.
+    if (!factor && maxType != VECSXP) copyMostAttrib(firstCol, target); // all but names,dim and dimnames; mainly for class. And if so, we want a copy here, not keepattr's SET_ATTRIB.
 
     if (factor && anyNotStringOrFactor) {
       // in future warn, or use list column instead ... warning(_("Column %d contains a factor but not all items for the column are character or factor"), idcol+j+1);

--- a/src/utils.c
+++ b/src/utils.c
@@ -365,10 +365,10 @@ SEXP coerceAsList(SEXP x, int len) {
     // do an as.list() on the atomic column; #3528
     // pairlists (LISTSXP) can also be coerced to lists using coerceVector
     coerced = PROTECT(coerceVector(x, VECSXP)); nprotect++;
-  } else if (TYPEOF(thisCol)==EXPRSXP) {
+  } else if (TYPEOF(x)==EXPRSXP) {
     // For EXPRSXP each element to be wrapped in a list, e.g. expression vectors #546
-    coerced = PROTECT(allocVector(VECSXP, len)); nprotect++;
-    for(int i=0; i<len); ++i) {
+    coerced = PROTECT(allocVector(VECSXP, length(x))); nprotect++;
+    for(int i=0; i<length(x); ++i) {
       SEXP thisElement = VECTOR_ELT(x, i);
       thisElement = PROTECT(coerceVector(thisElement, EXPRSXP)); nprotect++; // otherwise LANGSXP
       SET_VECTOR_ELT(coerced, i, thisElement);
@@ -379,9 +379,11 @@ SEXP coerceAsList(SEXP x, int len) {
     // the length of the type may be > 1, in which case the other columns in data.table
     // will have been recycled. We therefore in turn have to recycle the list elements
     // to match the number of rows.
+    if (len < 1) // len used here instead of length(x) because length(x) does not reflect length of target vector data.table
+      error("Internal Error: len provided to C function coerceAsList must be > 0\n"); // # nocov
     coerced = PROTECT(allocVector(VECSXP, len)); nprotect++;
-    for(int i=0; i<len); ++i) {
-      SET_VECTOR_ELT(coerced, i, thisElement);
+    for(int i=0; i<len; ++i) {
+      SET_VECTOR_ELT(coerced, i, x);
     }
   } else {
     // should be unreachable

--- a/src/utils.c
+++ b/src/utils.c
@@ -361,8 +361,14 @@ SEXP coerceAsList(SEXP x, int len) {
   int nprotect = 0;
   if (TYPEOF(x)==VECSXP) {
     return(x);
-  } else if (isVectorAtomic(x) || TYPEOF(x)==LISTSXP) {
+  } else if (isVectorAtomic(x)) {
     // do an as.list() on the atomic column; #3528
+    coerced = PROTECT(coerceVector(x, VECSXP)); nprotect++;
+    // propogate any class attributes onto each list element:
+    for(int i=0; i<length(x); ++i) {
+      copyMostAttrib(x, VECTOR_ELT(coerced, i)); 
+    }
+  } else if(TYPEOF(x)==LISTSXP) {
     // pairlists (LISTSXP) can also be coerced to lists using coerceVector
     coerced = PROTECT(coerceVector(x, VECSXP)); nprotect++;
   } else if (TYPEOF(x)==EXPRSXP) {


### PR DESCRIPTION
Closes #546 and fixes #3811

Example:

```
> A = data.table(c1 = 1, c2 = 'asd', c3 = expression(as.character(Sys.time())))
> B = data.table(c1 = 3, c2 = 'qwe', c3 = expression(as.character(Sys.time()+5)))
> rbind(A,B)
      c1     c2              c3
   <num> <char>          <list>
1:     1    asd <expression[1]>
2:     3    qwe <expression[1]>
> rbind(A,B)$c3
[[1]]
expression(as.character(Sys.time()))

[[2]]
expression(as.character(Sys.time() + 5))
```

A consequence of this PR is that where a data.table has > 1 row and an expression column, each expression is separated out into its own list element:

```
> A = data.table(c1 = 1, c2 = 'asd', c3 = expression(as.character(Sys.time())))
> B = data.table(c1 = 3:5, c2 = c('qwe', "foo", "bar"), 
+                c3 = expression(1+1, print("test"), as.character(Sys.time()+5)))
> rbind(A,B)
      c1     c2              c3
   <num> <char>          <list>
1:     1    asd <expression[1]>
2:     3    qwe <expression[1]>
3:     4    foo <expression[1]>
4:     5    bar <expression[1]>
> rbind(A,B)$c3
[[1]]
expression(as.character(Sys.time()))

[[2]]
expression(1 + 1)

[[3]]
expression(print("test"))

[[4]]
expression(as.character(Sys.time() + 5))
```

I don't know if this is desired behaviour, or whether we should default back to base R's coercion rules (i.e. returning an expression vector) - presumably if the user has constructed an expression vector column of length > 1 they would desire an expression vector back? E.g. #4040 is requesting expression columns to be preserved.