### PR TITLE
rbindlist(..., fill=TRUE) fills missing list columns with NA instead of NULL

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -87,6 +87,8 @@ unit = "s")
 
 6. `all.equal(DT, y)` no longer errors when `y` is not a data.table, [#4042](https://github.com/Rdatatable/data.table/issues/4042). Thanks to @d-sci for reporting and the PR.
 
+7. `rbind` and `rbindlist` with `fill=TRUE` now fill missing `list` columns with `NA` instead of `NULL`, [#4198](https://github.com/Rdatatable/data.table/issues/4198). Thanks to @sritchie73 for reporting and the PR.
+
 ## NOTES
 
 1. `as.IDate`, `as.ITime`, `second`, `minute`, and `hour` now recognize UTC equivalents for speed: GMT, GMT-0, GMT+0, GMT0, Etc/GMT, and Etc/UTC, [#4116](https://github.com/Rdatatable/data.table/issues/4116).

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -14191,7 +14191,7 @@ test(2002.03, rbindlist( list(list(a=1L, b=2L, x=NULL), list(a=2L, b=NULL, x=NUL
              warning="Column 3 ['x'] of item 1 is length 0. This (and 2 others like it) has been filled with NA (NULL for list columns) to make each item uniform.")
 # tests from #1302
 test(2002.04, rbindlist( list(list(a=1L,z=list()), list(a=2L, z=list("m"))) ),
-             data.table(a=1:2, z=list(NULL, "m")),
+             data.table(a=1:2, z=list(NA, "m")),
              warning="Column 2 ['z'] of item 1 is length 0. This (and 0 others like it) has been filled with NA")
 test(2002.05, rbindlist( list( list(a=1L, z=list("z")), list(a=2L, z=list(c("a","b"))) )),
              data.table(a=1:2, z=list("z", c("a","b"))))

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -16770,6 +16770,12 @@ test(2132.2, fifelse(TRUE, 1, s2),       error = "S4 class objects (except nanot
 test(2132.3, fcase(TRUE, s1, FALSE, s2), error = "S4 class objects (except nanotime) are not supported. Please see https://github.com/Rdatatable/data.table/issues/4131.")
 rm(s1, s2, class2132)
 
+# rbindlist(..., fill = TRUE) should fill list columns with NA not NULL
+A = data.table(c1=0L, c2=list(1:3))
+B = data.table(c1=1:2)
+DT = data.table(c1=0:2, c2=list(1:3, NA, NA))
+test(2133, rbind(A,B,fill=TRUE), DT)
+
 
 ########################
 #  Add new tests here  #


### PR DESCRIPTION
Fix for #4198 , if desired.

Current behaviour:

```
> A = data.table(c1=0L, c2=list(1:3))
> B = data.table(c1=1:2)
> rbind(A,B,fill=TRUE)
      c1     c2
   <num> <list>
1:     0  1,2,3
2:     1   
3:     2
```

New behaviour:

```
> rbind(A,B,fill=TRUE)
      c1     c2
   <int> <list>
1:     0  1,2,3
2:     1     NA
3:     2     NA
```