### PR TITLE
Use consistent types with fwriteMainArgs.nrow.

### DIFF
--- a/src/fwrite.c
+++ b/src/fwrite.c
@@ -629,7 +629,7 @@ void fwriteMain(fwriteMainArgs args)
       for (int j=args.ncol-10; j<args.ncol; j++) DTPRINT(_("%d "), args.whichFun[j]);
     }
     DTPRINT(_("\nargs.doRowNames=%d args.rowNames=%d doQuote=%d args.nrow=%"PRId64" args.ncol=%d eolLen=%d\n"),
-          args.doRowNames, args.rowNames, doQuote, (int64_t)args.nrow, args.ncol, eolLen);
+          args.doRowNames, args.rowNames, doQuote, args.nrow, args.ncol, eolLen);
   }
 
   // Calculate upper bound for line length. Numbers use a fixed maximum (e.g. 12 for integer) while strings find the longest
@@ -788,7 +788,7 @@ void fwriteMain(fwriteMainArgs args)
   if (numBatches < nth) nth = numBatches;
   if (verbose) {
     DTPRINT(_("Writing %"PRId64" rows in %d batches of %d rows (each buffer size %dMB, showProgress=%d, nth=%d)\n"),
-            (int64_t)args.nrow, numBatches, rowsPerBatch, args.buffMB, args.showProgress, nth);
+            args.nrow, numBatches, rowsPerBatch, args.buffMB, args.showProgress, nth);
   }
   t0 = wallclock();
 
@@ -921,7 +921,7 @@ void fwriteMain(fwriteMainArgs args)
               if (verbose && !hasPrinted) DTPRINT("\n");
               DTPRINT("\rWritten %.1f%% of %"PRId64" rows in %d secs using %d thread%s. "
                       "maxBuffUsed=%d%%. ETA %d secs.      ",
-                       (100.0*end)/args.nrow, (int64_t)args.nrow, (int)(now-startTime), nth, nth==1?"":"s",
+                       (100.0*end)/args.nrow, args.nrow, (int)(now-startTime), nth, nth==1?"":"s",
                        maxBuffUsedPC, ETA);
               // TODO: use progress() as in fread
               nextTime = now+1;

--- a/src/fwriteR.c
+++ b/src/fwriteR.c
@@ -26,7 +26,7 @@ int getStringLen(SEXP *col, int64_t row) {
 int getMaxStringLen(const SEXP *col, const int64_t n) {
   int max=0;
   SEXP last=NULL;
-  for (int i=0; i<n; ++i) {
+  for (int64_t i=0; i<n; ++i) {
     SEXP this = *col++;
     if (this==last) continue; // no point calling LENGTH() again on the same string; LENGTH is unlikely as fast as single pointer compare
     int thisnchar = LENGTH(this);
@@ -90,17 +90,17 @@ void writeList(SEXP *col, int64_t row, char **pch) {
 int getMaxListItemLen(const SEXP *col, const int64_t n) {
   int max=0;
   SEXP last=NULL;
-  for (int i=0; i<n; ++i) {
+  for (int64_t i=0; i<n; ++i) {
     SEXP this = *col++;
     if (this==last) continue; // no point calling LENGTH() again on the same string; LENGTH is unlikely as fast as single pointer compare
     int32_t wf = whichWriter(this);
     if (TYPEOF(this)==VECSXP || wf==INT32_MIN || isFactor(this)) {
-      error(_("Row %d of list column is type '%s' - not yet implemented. fwrite() can write list columns containing items which are atomic vectors of type logical, integer, integer64, double, complex and character."),
+      error(_("Row %"PRId64" of list column is type '%s' - not yet implemented. fwrite() can write list columns containing items which are atomic vectors of type logical, integer, integer64, double, complex and character."),
             i+1, isFactor(this) ? "factor" : type2char(TYPEOF(this)));
     }
     int width = writerMaxLen[wf];
     if (width==0) {
-      if (wf!=WF_String) STOP(_("Internal error: row %d of list column has no max length method implemented"), i+1); // # nocov
+      if (wf!=WF_String) STOP(_("Internal error: row %"PRId64" of list column has no max length method implemented"), i+1); // # nocov
       const int l = LENGTH(this);
       for (int j=0; j<l; ++j) width+=LENGTH(STRING_ELT(this, j));
     } else {
@@ -228,8 +228,9 @@ SEXP fwriteR(
   int firstListColumn = 0;
   for (int j=0; j<args.ncol; j++) {
     SEXP column = VECTOR_ELT(DFcoerced, j);
-    if (args.nrow != length(column))
-      error(_("Column %d's length (%d) is not the same as column 1's length (%d)"), j+1, length(column), args.nrow);
+    if (args.nrow != length(column)) {
+      error(_("Column %d's length (%d) is not the same as column 1's length (%"PRId64")"), j+1, length(column), args.nrow);
+    }
     int32_t wf = whichWriter(column);
     if (wf<0) {
       error(_("Column %d's type is '%s' - not yet implemented in fwrite."), j+1, type2char(TYPEOF(column)));


### PR DESCRIPTION
On armv7hl, test 1737.5 fails due to garbage in the column length mismatch error message. This is because the message tries to format `args.nrow` (an `int64_t`) using `%d` (i.e., `int`). Strangely, this does not fail on any other architectures, but this is likely a fluke.

In all the other formatting calls, remove the unnecessary `(int64_t)` type cast, since `fwriteMainArgs.nargs` already is one.

See #3492.