### PR TITLE
simplified := misuse catcher

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2612,16 +2612,11 @@ vecseq = function(x,y,clamp) .Call(Cvecseq,x,y,clamp)
 address = function(x) .Call(Caddress, eval(substitute(x), parent.frame()))
 
 ":=" = function(...) {
-  # detect common mistake -- using := in i due to forgetting a comma to leave it blank, #4227
-  find_doteq_in_i = function(e) {
-    if (is.call(e)) {
-      if (is.symbol(e[[1L]]) && e[[1L]] == '[.data.table' && is.call(e[[3L]]) && is.symbol(e[[3L]][[1L]]) && e[[3L]][[1L]] == ':=') {
-        stop("Operator := detected in i, the first argument inside DT[...], but is only valid in the second argument, j. Most often, this happens when forgetting the first comma (e.g. DT[newvar := 5] instead of DT[ , new_var := 5]). Please double-check the syntax. Run traceback(), and debugger() to get a line number.")
-      }
-      else lapply(e[-1L], find_doteq_in_i)
-    }
+  for (e in sys.calls()) {
+    # detect common mistake -- using := in i due to forgetting a comma to leave it blank, #4227
+    if (is.call(e) && e[[1L]]=='[.data.table' && is.call(e[[3L]]) && e[[3L]][[1L]]==':=')
+      stop("Operator := detected in i, the first argument inside DT[...], but is only valid in the second argument, j. Most often, this happens when forgetting the first comma (e.g. DT[newvar := 5] instead of DT[ , new_var := 5]). Please double-check the syntax. Run traceback(), and debugger() to get a line number.")
   }
-  for (calli in sys.calls()) find_doteq_in_i(calli)
   stop('Check that is.data.table(DT) == TRUE. Otherwise, := and `:=`(...) are defined for use in j, once only and in particular ways. See help(":=").')
 }
 


### PR DESCRIPTION
Follow up to #4228 

There was an error in GLCI linux-dev (below) which I couldn't follow, but it seems to trip up on this new test, perhaps triggered by an earlier fault.

I couldn't see why the `find_doteq_in_i` function needed to be recursive, so I removed that and no tests broke.  To put that back would need a test to show why it's needed please.

Also a call's first item is always a symbol I thought so there's no need for each `is.symbol`. If it is a character string, then you'd want to compare against the string representation of the function name anyway, and not skip it just because it was character not symbol.  And a length>1 first item to call doesn't make sense so even if it's possible to construct, I imagine that R would just use the first item and ignore the others silently. I saw `sub_is_fun` in #4226 and was wondering similarly about that too.

Anyway, not really sure why we saw the fail below, but I feel more comfortable with a simpler loop in this PR, regardless, as a first step.

```
 ERROR
172 Running the tests in ‘tests/main.R’ failed.
173 Last 13 lines of output:
174   Skipped tests 1830.7 and 1830.8 due to capabilities()["long.double"] == FALSE 
175   Test 2134.1 didn't produce the correct error :
176   Expected: Operator := detected in i, the first argument inside DT[...], but is only valid in the second argument, j. 
177   Observed: changing stack value below R_BCProt pointer 
178   Test 2134.2 didn't produce the correct error :
179   Expected: Operator := detected in i, the first argument inside 
180   Observed: changing stack value below R_BCProt pointer 
181   
182   Sat Feb 15 23:37:35 2020  endian==little, sizeof(long double)==0, sizeof(pointer)==8, TZ=Etc/UTC, locale='LC_CTYPE=en_US.UTF-8;LC_NUMERIC=C;LC_TIME=en_US.UTF-8;LC_COLLATE=en_US.UTF-8;LC_MONETARY=en_US.UTF-8;LC_MESSAGES=en_US.UTF-8;LC_PAPER=en_US.UTF-8;LC_NAME=C;LC_ADDRESS=C;LC_TELEPHONE=C;LC_MEASUREMENT=en_US.UTF-8;LC_IDENTIFICATION=C', l10n_info()='MBCS=TRUE; UTF-8=TRUE; Latin-1=FALSE', getDTthreads()='omp_get_num_procs()==1; R_DATATABLE_NUM_PROCS_PERCENT==unset (default 50); R_DATATABLE_NUM_THREADS==unset; omp_get_thread_limit()==2147483647; omp_get_max_threads()==1; OMP_THREAD_LIMIT==unset; OMP_NUM_THREADS==unset; RestoreAfterFork==true; data.table is using 1 threads. See ?setDTthreads.'
183   Error in test.data.table() : 
184     5 errors out of 9898. Search tests/tests.Rraw for test numbers: 383, 415, 951, 2134.1, 2134.2.
185   In addition: Warning message:
186   In system("timedatectl", intern = TRUE) :
187     running command 'timedatectl' had status 1
188   Execution halted
```