### PR TITLE
use only private runner for windows

### DIFF
--- a/.ci/README.md
+++ b/.ci/README.md
@@ -1,6 +1,6 @@
 # data.table continuous integration and deployment
 
-On each Pull Request opened in GitHub we run Travis CI and Appveyor to provide prompt feedback about the status of PR. Our main CI pipeline runs on GitLab CI. GitLab repository automatically mirrors our GitHub repository and runs pipeline on `master` branch. It tests more environments and different configurations. It publish variety of artifacts.
+On each Pull Request opened in GitHub we run Travis CI and Appveyor to provide prompt feedback about the status of PR. Our main CI pipeline runs on GitLab CI. GitLab repository automatically mirrors our GitHub repository and runs pipeline on `master` branch. It tests more environments and different configurations. It publish variety of artifacts. Windows jobs are being run on our private windows CI runner.
 
 ## Environments
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -81,6 +81,7 @@ build: # build data.table sources as tar.gz archive
   <<: *test
   tags:
     - windows
+    - private
   before_script:
     - export PATH="/c/$R_DIR/bin:/c/Rtools/bin:$PATH"
     - rm -rf /tmp/$R_DIR/library && mkdir -p /tmp/$R_DIR/library


### PR DESCRIPTION
Recent failures of dev-win CI job were caused by the fact, that when release-win job was running on our private windows runner, then dev-win job was waiting and it was being picked up by gitlab public windows runners (finally it is there!). Those public runners has different configuration, thus `export PATH` was already failing. This PR should solve the problem. Extra `private` tag has been added to our private windows runner.