### PR TITLE
use \file not \code in a few places in man/

### DIFF
--- a/man/fread.Rd
+++ b/man/fread.Rd
@@ -29,7 +29,7 @@ yaml=FALSE, autostart=NA, tmpdir=tempdir()
 }
 \arguments{
   \item{input}{ A single character string. The value is inspected and deferred to either \code{file=} (if no \\n present), \code{text=} (if at least one \\n is present) or \code{cmd=} (if no \\n is present, at least one space is present, and it isn't a file name). Exactly one of \code{input=}, \code{file=}, \code{text=}, or \code{cmd=} should be used in the same call. }
-  \item{file}{ File name in working directory, path to file (passed through \code{\link[base]{path.expand}} for convenience), or a URL starting http://, file://, etc. Compressed files ending \code{.gz} and \code{.bz2} are supported if the \code{R.utils} package is installed. }
+  \item{file}{ File name in working directory, path to file (passed through \code{\link[base]{path.expand}} for convenience), or a URL starting http://, file://, etc. Compressed files with extension \file{.gz} and \file{.bz2} are supported if the \code{R.utils} package is installed. }
   \item{text}{ The input data itself as a character vector of one or more lines, for example as returned by \code{readLines()}. }
   \item{cmd}{ A shell command that pre-processes the file; e.g. \code{fread(cmd=paste("grep",word,"filename")}. See Details. }
   \item{sep}{ The separator between columns. Defaults to the character in the set \code{[,\\t |;:]} that separates the sample of rows into the most number of lines with the same number of fields. Use \code{NULL} or \code{""} to specify no separator; i.e. each line a single character column like \code{base::readLines} does.}
@@ -310,4 +310,3 @@ fread("http://stat-computing.org/dataexpo/2009/1987.csv.bz2")
 }
 }
 \keyword{ data }
-

--- a/man/openmp-utils.Rd
+++ b/man/openmp-utils.Rd
@@ -36,19 +36,18 @@
   Internally parallelized code is used in the following places:
 
   \itemize{
-    \item{\code{between.c} - \code{\link{between}()}}
-    \item{\code{cj.c} - \code{\link{CJ}()}}
-    \item{\code{coalesce.c} - \code{\link{fcoalesce}()}}
-    \item{\code{fifelse.c} - \code{\link{fifelse}()}}
-    \item{\code{fread.c} - \code{\link{fread}()}}
-    \item{\code{forder.c}, \code{fsort.c}, and \code{reorder.c} - \code{\link{forder}()} and related}
-    \item{\code{froll.c}, \code{frolladaptive.c}, and \code{frollR.c} - \code{\link{froll}()} and family}
-    \item{\code{fwrite.c} - \code{\link{fwrite}()}}
-    \item{\code{gsumm.c} - GForce in various places, see \link{GForce}}
-    \item{\code{nafill.c} - \code{\link{nafill}()}}
-    \item{\code{subset.c} - Used in \code{\link[=data.table]{[.data.table}} subsetting}
-    \item{\code{types.c} - Internal testing usage}
+    \item{\file{between.c} - \code{\link{between}()}}
+    \item{\file{cj.c} - \code{\link{CJ}()}}
+    \item{\file{coalesce.c} - \code{\link{fcoalesce}()}}
+    \item{\file{fifelse.c} - \code{\link{fifelse}()}}
+    \item{\file{fread.c} - \code{\link{fread}()}}
+    \item{\file{forder.c}, \file{fsort.c}, and \file{reorder.c} - \code{\link{forder}()} and related}
+    \item{\file{froll.c}, \file{frolladaptive.c}, and \file{frollR.c} - \code{\link{froll}()} and family}
+    \item{\file{fwrite.c} - \code{\link{fwrite}()}}
+    \item{\file{gsumm.c} - GForce in various places, see \link{GForce}}
+    \item{\file{nafill.c} - \code{\link{nafill}()}}
+    \item{\file{subset.c} - Used in \code{\link[=data.table]{[.data.table}} subsetting}
+    \item{\file{types.c} - Internal testing usage}
   }
 }
 \keyword{ data }
-


### PR DESCRIPTION
Reading some `R-devel` code and happened to notice `\file{}` being used in the manual there, found a few places it'd be appropriate on our end too.