### PR TITLE
change fread default na.strings from 'NA' to ''

### DIFF
--- a/R/fread.R
+++ b/R/fread.R
@@ -1,6 +1,6 @@
 fread = function(
 input="", file=NULL, text=NULL, cmd=NULL, sep="auto", sep2="auto", dec=".", quote="\"", nrows=Inf, header="auto",
-na.strings=getOption("datatable.na.strings","NA"), stringsAsFactors=FALSE, verbose=getOption("datatable.verbose",FALSE),
+na.strings=getOption("datatable.na.strings",""), stringsAsFactors=FALSE, verbose=getOption("datatable.verbose",FALSE),
 skip="__auto__", select=NULL, drop=NULL, colClasses=NULL, integer64=getOption("datatable.integer64","integer64"),
 col.names, check.names=FALSE, encoding="unknown", strip.white=TRUE, fill=FALSE, blank.lines.skip=FALSE, key=NULL, index=NULL,
 showProgress=getOption("datatable.showProgress",interactive()), data.table=getOption("datatable.fread.datatable",TRUE),

--- a/man/fread.Rd
+++ b/man/fread.Rd
@@ -11,7 +11,7 @@
 \usage{
 fread(input, file, text, cmd, sep="auto", sep2="auto", dec=".", quote="\"",
 nrows=Inf, header="auto",
-na.strings=getOption("datatable.na.strings","NA"),  # due to change to ""; see NEWS
+na.strings=getOption("datatable.na.strings",""),
 stringsAsFactors=FALSE, verbose=getOption("datatable.verbose", FALSE),
 skip="__auto__", select=NULL, drop=NULL, colClasses=NULL,
 integer64=getOption("datatable.integer64", "integer64"),


### PR DESCRIPTION
2 years removed from the declared intention to do so:

https://github.com/Rdatatable/data.table/commit/29e2d461942b620ee04d638e941bb965df29b87e

I made the quick change, but it breaks a lot of tests.

Some are nontrivial to fix -- looking at 880/881, it's hard to get consistency vs. `write.table`/`read.csv` -- I'll have to take a bit more time to understand how those functions distinguish `x,` and `x,''` for string columns. At first glance I didn't see a way.