### PR TITLE
should allow whitespaces in `data.table(key=)`

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -62,7 +62,7 @@ data.table = function(..., keep.rownames=FALSE, check.names=FALSE, key=NULL, str
   if (!is.null(key)) {
     if (!is.character(key)) stop("key argument of data.table() must be character")
     if (length(key)==1L) {
-      key = trimws(strsplit(key,split=",")[[1L]])
+      key = trimws(strsplit(key,split=",",fixed=TRUE)[[1L]])
       # eg key="A,B"; a syntax only useful in key argument to data.table(), really.
     }
     setkeyv(ans,key)

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -62,7 +62,7 @@ data.table = function(..., keep.rownames=FALSE, check.names=FALSE, key=NULL, str
   if (!is.null(key)) {
     if (!is.character(key)) stop("key argument of data.table() must be character")
     if (length(key)==1L) {
-      key = strsplit(key,split=",")[[1L]]
+      key = trimws(strsplit(key,split=",")[[1L]])
       # eg key="A,B"; a syntax only useful in key argument to data.table(), really.
     }
     setkeyv(ans,key)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -16846,3 +16846,6 @@ A = data.table(A=c(complex(real = 1:3, imaginary=c(0, -1, 1)), NaN))
 test(2138.3, rbind(A,B), data.table(A=c(as.character(A$A), B$A)))
 A = data.table(A=as.complex(rep(NA, 5)))
 test(2138.4, rbind(A,B), data.table(A=c(as.character(A$A), B$A)))
+
+# Allow whitespaces in `data.table(key=)`, #4292
+test(2139, data.table(A=1,B=2,C=3, key="A, B"), data.table(A=1,B=2,C=3, key=c("A","B")))


### PR DESCRIPTION
Closes #4292 

Should allow whitespaces in `data.table(key=)` when `key` is a scalar string. 

Now this works.

```r
data.table(A=1,B=2,C=3, key="A, B")
```