### PR TITLE
Add errors on separate lines for coverage

### DIFF
--- a/.dev/CRAN_Release.cmd
+++ b/.dev/CRAN_Release.cmd
@@ -153,6 +153,12 @@ grep -nE "(llu|lld|zd|zu)" src/*.[hc]
 grep -P "\t" ./R/*.R
 grep -P "\t" ./src/*.c
 
+# all error branches should be on a new line to be properly included in codecov; exceptions:
+#   (1) in a comment (pattern: after // or after \s*[*]
+#   (2) in '} else error(' pattern (if else is covered, so is the error)
+#   (3) in #define macros
+grep -Enr "\berror[(]" src --include=*.c | grep -Ev "^src/[a-zA-Z-]+[.]c:[0-9]+:\s*(?:error|(?:[}]\s*)?else error|#define|[*]|.*//.*error)"
+
 # No T or F symbols in tests.Rraw. 24 valid F (quoted, column name or in data) and 1 valid T at the time of writing
 grep -n "[^A-Za-z0-9]T[^A-Za-z0-9]" ./inst/tests/tests.Rraw
 grep -n "[^A-Za-z0-9]F[^A-Za-z0-9]" ./inst/tests/tests.Rraw

--- a/src/assign.c
+++ b/src/assign.c
@@ -4,12 +4,15 @@ static void finalizer(SEXP p)
 {
   SEXP x;
   R_len_t n, l, tl;
-  if(!R_ExternalPtrAddr(p)) error(_("Internal error: finalizer hasn't received an ExternalPtr")); // # nocov
+  if(!R_ExternalPtrAddr(p))
+    error(_("Internal error: finalizer hasn't received an ExternalPtr")); // # nocov
   p = R_ExternalPtrTag(p);
-  if (!isString(p)) error(_("Internal error: finalizer's ExternalPtr doesn't see names in tag")); // # nocov
+  if (!isString(p))
+    error(_("Internal error: finalizer's ExternalPtr doesn't see names in tag")); // # nocov
   l = LENGTH(p);
   tl = TRUELENGTH(p);
-  if (l<0 || tl<l) error(_("Internal error: finalizer sees l=%d, tl=%d"),l,tl); // # nocov
+  if (l<0 || tl<l)
+    error(_("Internal error: finalizer sees l=%d, tl=%d"),l,tl); // # nocov
   n = tl-l;
   if (n==0) {
     // gc's ReleaseLargeFreeVectors() will have reduced R_LargeVallocSize by the correct amount
@@ -121,9 +124,11 @@ static int _selfrefok(SEXP x, Rboolean checkNames, Rboolean verbose) {
     if (verbose) Rprintf(_(".internal.selfref ptr is NULL. This is expected and normal for a data.table loaded from disk. Please remember to always setDT() immediately after loading to prevent unexpected behavior. If this table was not loaded from disk or you've already run setDT(), please report to data.table issue tracker.\n"));
     return -1;
   }
-  if (!isNull(p)) error(_("Internal error: .internal.selfref ptr is not NULL or R_NilValue")); // # nocov
+  if (!isNull(p))
+    error(_("Internal error: .internal.selfref ptr is not NULL or R_NilValue")); // # nocov
   tag = R_ExternalPtrTag(v);
-  if (!(isNull(tag) || isString(tag))) error(_("Internal error: .internal.selfref tag isn't NULL or a character vector")); // # nocov
+  if (!(isNull(tag) || isString(tag)))
+    error(_("Internal error: .internal.selfref tag isn't NULL or a character vector")); // # nocov
   names = getAttrib(x, R_NamesSymbol);
   if (names != tag && isString(names))
     SET_TRUELENGTH(names, LENGTH(names));
@@ -165,7 +170,8 @@ static SEXP shallow(SEXP dt, SEXP cols, R_len_t n)
     l = LENGTH(dt);
     for (i=0; i<l; i++) SET_VECTOR_ELT(newdt, i, VECTOR_ELT(dt,i));
     if (length(names)) {
-      if (length(names) < l) error(_("Internal error: length(names)>0 but <length(dt)")); // # nocov
+      if (length(names) < l)
+        error(_("Internal error: length(names)>0 but <length(dt)")); // # nocov
       for (i=0; i<l; i++) SET_STRING_ELT(newnames, i, STRING_ELT(names,i));
     }
     // else an unnamed data.table is valid e.g. unname(DT) done by ggplot2, and .SD may have its names cleared in dogroups, but shallow will always create names for data.table(NULL) which has 100 slots all empty so you can add to an empty data.table by reference ok.
@@ -194,15 +200,19 @@ SEXP alloccol(SEXP dt, R_len_t n, Rboolean verbose)
 {
   SEXP names, klass;   // klass not class at request of pydatatable because class is reserved word in C++, PR #3129
   R_len_t l, tl;
-  if (isNull(dt)) error(_("alloccol has been passed a NULL dt"));
-  if (TYPEOF(dt) != VECSXP) error(_("dt passed to alloccol isn't type VECSXP"));
+  if (isNull(dt))
+    error(_("alloccol has been passed a NULL dt"));
+  if (TYPEOF(dt) != VECSXP)
+    error(_("dt passed to alloccol isn't type VECSXP"));
   klass = getAttrib(dt, R_ClassSymbol);
-  if (isNull(klass)) error(_("dt passed to alloccol has no class attribute. Please report result of traceback() to data.table issue tracker."));
+  if (isNull(klass))
+    error(_("dt passed to alloccol has no class attribute. Please report result of traceback() to data.table issue tracker."));
   l = LENGTH(dt);
   names = getAttrib(dt,R_NamesSymbol);
   // names may be NULL when null.data.table() passes list() to alloccol for example.
   // So, careful to use length() on names, not LENGTH().
-  if (length(names)!=l) error(_("Internal error: length of names (%d) is not length of dt (%d)"),length(names),l); // # nocov
+  if (length(names)!=l)
+    error(_("Internal error: length of names (%d) is not length of dt (%d)"),length(names),l); // # nocov
   if (!selfrefok(dt,verbose))
     return shallow(dt,R_NilValue,(n>l) ? n : l);  // e.g. test 848 and 851 in R > 3.0.2
     // added (n>l) ? ... for #970, see test 1481.
@@ -212,8 +222,10 @@ SEXP alloccol(SEXP dt, R_len_t n, Rboolean verbose)
 
   tl = TRUELENGTH(dt);
   // R <= 2.13.2 and we didn't catch uninitialized tl somehow
-  if (tl<0) error(_("Internal error, tl of class is marked but tl<0.")); // # nocov
-  if (tl>0 && tl<l) error(_("Internal error, please report (including result of sessionInfo()) to data.table issue tracker: tl (%d) < l (%d) but tl of class is marked."), tl, l); // # nocov
+  if (tl<0)
+    error(_("Internal error, tl of class is marked but tl<0.")); // # nocov
+  if (tl>0 && tl<l)
+    error(_("Internal error, please report (including result of sessionInfo()) to data.table issue tracker: tl (%d) < l (%d) but tl of class is marked."), tl, l); // # nocov
   if (tl>l+10000) warning(_("tl (%d) is greater than 10,000 items over-allocated (l = %d). If you didn't set the datatable.alloccol option to be very large, please report to data.table issue tracker including the result of sessionInfo()."),tl,l);
   if (n>tl) return(shallow(dt,R_NilValue,n)); // usual case (increasing alloc)
   if (n<tl && verbose) Rprintf(_("Attempt to reduce allocation from %d to %d ignored. Can only increase allocation via shallow copy. Please do not use DT[...]<- or DT$someCol<-. Use := inside DT[...] instead."),tl,n);
@@ -236,7 +248,8 @@ int checkOverAlloc(SEXP x)
 }
 
 SEXP alloccolwrapper(SEXP dt, SEXP overAllocArg, SEXP verbose) {
-  if (!isLogical(verbose) || length(verbose)!=1) error(_("verbose must be TRUE or FALSE"));
+  if (!isLogical(verbose) || length(verbose)!=1)
+    error(_("verbose must be TRUE or FALSE"));
   int overAlloc = checkOverAlloc(overAllocArg);
   SEXP ans = PROTECT(alloccol(dt, length(dt)+overAlloc, LOGICAL(verbose)[0]));
 
@@ -284,8 +297,10 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values)
   int ndelete=0;  // how many columns are being deleted
   const char *c1, *tc1, *tc2;
   int *buf, newKeyLength, indexNo;
-  if (isNull(dt)) error(_("assign has been passed a NULL dt"));
-  if (TYPEOF(dt) != VECSXP) error(_("dt passed to assign isn't type VECSXP"));
+  if (isNull(dt))
+    error(_("assign has been passed a NULL dt"));
+  if (TYPEOF(dt) != VECSXP)
+    error(_("dt passed to assign isn't type VECSXP"));
   if (islocked(dt))
     error(_(".SD is locked. Updating .SD by reference using := or set are reserved for future use. Use := in j directly. Or use copy(.SD) as a (slow) last resort, until shallow() is exported."));
 
@@ -299,7 +314,8 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values)
 
   oldncol = LENGTH(dt);
   SEXP names = PROTECT(getAttrib(dt, R_NamesSymbol)); protecti++;
-  if (isNull(names)) error(_("dt passed to assign has no names"));
+  if (isNull(names))
+    error(_("dt passed to assign has no names"));
   if (length(names)!=oldncol)
     error(_("Internal error in assign: length of names (%d) is not length of dt (%d)"),length(names),oldncol); // # nocov
   if (isNull(dt)) {
@@ -356,7 +372,8 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values)
       if (INTEGER(tmp)[i] == 0) buf[k++] = i;
     }
     if (k>0) {
-      if (!isDataTable) error(_("set() on a data.frame is for changing existing columns, not adding new ones. Please use a data.table for that. data.table's are over-allocated and don't shallow copy."));
+      if (!isDataTable)
+        error(_("set() on a data.frame is for changing existing columns, not adding new ones. Please use a data.table for that. data.table's are over-allocated and don't shallow copy."));
       newcolnames = PROTECT(allocVector(STRSXP, k)); protecti++;
       for (i=0; i<k; i++) {
         SET_STRING_ELT(newcolnames, i, STRING_ELT(cols, buf[i]));
@@ -372,8 +389,10 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values)
     if (!isInteger(cols))
       error(_("j is type '%s'. Must be integer, character, or numeric is coerced with warning."), type2char(TYPEOF(cols)));
   }
-  if (any_duplicated(cols,FALSE)) error(_("Can't assign to the same column twice in the same query (duplicates detected)."));
-  if (!isNull(newcolnames) && !isString(newcolnames)) error(_("newcolnames is supplied but isn't a character vector"));
+  if (any_duplicated(cols,FALSE))
+    error(_("Can't assign to the same column twice in the same query (duplicates detected)."));
+  if (!isNull(newcolnames) && !isString(newcolnames))
+    error(_("newcolnames is supplied but isn't a character vector"));
   bool RHS_list_of_columns = TYPEOF(values)==VECSXP && length(cols)>1;  // initial value; may be revised below
   if (verbose) Rprintf(_("RHS_list_of_columns == %s\n"), RHS_list_of_columns ? "true" : "false");
   if (TYPEOF(values)==VECSXP && length(cols)==1 && length(values)==1) {
@@ -400,13 +419,16 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values)
   for (i=0; i<length(cols); i++) {
     coln = INTEGER(cols)[i];
     if (coln<1 || coln>oldncol+length(newcolnames)) {
-      if (!isDataTable) error(_("Item %d of column numbers in j is %d which is outside range [1,ncol=%d]. set() on a data.frame is for changing existing columns, not adding new ones. Please use a data.table for that."), i+1, coln, oldncol);
-      else error(_("Item %d of column numbers in j is %d which is outside range [1,ncol=%d]. Use column names instead in j to add new columns."), i+1, coln, oldncol);
+      if (!isDataTable)
+        error(_("Item %d of column numbers in j is %d which is outside range [1,ncol=%d]. set() on a data.frame is for changing existing columns, not adding new ones. Please use a data.table for that."), i+1, coln, oldncol);
+      else
+        error(_("Item %d of column numbers in j is %d which is outside range [1,ncol=%d]. Use column names instead in j to add new columns."), i+1, coln, oldncol);
     }
     coln--;
     SEXP thisvalue = RHS_list_of_columns ? VECTOR_ELT(values, i) : values;
     vlen = length(thisvalue);
-    if (isNull(thisvalue) && !isNull(rows)) error(_("When deleting columns, i should not be provided"));  // #1082, #3089
+    if (isNull(thisvalue) && !isNull(rows))
+      error(_("When deleting columns, i should not be provided"));  // #1082, #3089
     if (coln+1 <= oldncol) colnam = STRING_ELT(names,coln);
     else colnam = STRING_ELT(newcolnames,coln-length(names));
     if (coln+1 <= oldncol && isNull(thisvalue)) continue;  // delete existing column(s) afterwards, near end of this function
@@ -444,7 +466,8 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values)
     oldtncol = TRUELENGTH(dt);   // TO DO: oldtncol can be just called tl now, as we won't realloc here any more.
 
     if (oldtncol<oldncol) {
-      if (oldtncol==0) error(_("This data.table has either been loaded from disk (e.g. using readRDS()/load()) or constructed manually (e.g. using structure()). Please run setDT() or setalloccol() on it first (to pre-allocate space for new columns) before assigning by reference to it."));   // #2996
+      if (oldtncol==0)
+        error(_("This data.table has either been loaded from disk (e.g. using readRDS()/load()) or constructed manually (e.g. using structure()). Please run setDT() or setalloccol() on it first (to pre-allocate space for new columns) before assigning by reference to it."));   // #2996
       error(_("Internal error: oldtncol(%d) < oldncol(%d). Please report to data.table issue tracker, including result of sessionInfo()."), oldtncol, oldncol); // # nocov
     }
     if (oldtncol>oldncol+10000L) warning(_("truelength (%d) is greater than 10,000 items over-allocated (length = %d). See ?truelength. If you didn't set the datatable.alloccol option very large, please report to data.table issue tracker including the result of sessionInfo()."),oldtncol, oldncol);
@@ -466,7 +489,8 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values)
     coln = INTEGER(cols)[i]-1;
     SEXP thisvalue = RHS_list_of_columns ? VECTOR_ELT(values, i) : values;
     if (TYPEOF(thisvalue)==NILSXP) {
-      if (!isNull(rows)) error(_("Internal error: earlier error 'When deleting columns, i should not be provided' did not happen.")); // # nocov
+      if (!isNull(rows))
+        error(_("Internal error: earlier error 'When deleting columns, i should not be provided' did not happen.")); // # nocov
       ndelete++;
       continue;   // delete column(s) afterwards, below this loop
     }
@@ -559,7 +583,8 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values)
         continue; // with next index
       }
       tc1 += 2; // tc1 always marks the start of a key column
-      if (!*tc1) error(_("Internal error: index name ends with trailing __")); // # nocov
+      if (!*tc1)
+        error(_("Internal error: index name ends with trailing __")); // # nocov
       // check the position of the first appearance of an assigned column in the index.
       // the new index will be truncated to this position.
       char *s4 = (char*) malloc(strlen(c1) + 3);
@@ -810,7 +835,8 @@ const char *memrecycle(const SEXP target, const SEXP where, const int start, con
             SEXP s = sourceLevelsD[k];
             int tl = TRUELENGTH(s);
             if (tl) {  // tl negative here
-              if (tl != -nTargetLevels-thisAdd-1) error(_("Internal error: extra level check sum failed")); // # nocov
+              if (tl != -nTargetLevels-thisAdd-1)
+                error(_("Internal error: extra level check sum failed")); // # nocov
               temp[thisAdd++] = s;
               SET_TRUELENGTH(s,0);
             }
@@ -1204,13 +1230,18 @@ void savetl_end() {
 SEXP setcharvec(SEXP x, SEXP which, SEXP newx)
 {
   int w;
-  if (!isString(x)) error(_("x must be a character vector"));
-  if (!isInteger(which)) error(_("'which' must be an integer vector"));
-  if (!isString(newx)) error(_("'new' must be a character vector"));
-  if (LENGTH(newx)!=LENGTH(which)) error(_("'new' is length %d. Should be the same as length of 'which' (%d)"),LENGTH(newx),LENGTH(which));
+  if (!isString(x))
+    error(_("x must be a character vector"));
+  if (!isInteger(which))
+    error(_("'which' must be an integer vector"));
+  if (!isString(newx))
+    error(_("'new' must be a character vector"));
+  if (LENGTH(newx)!=LENGTH(which))
+    error(_("'new' is length %d. Should be the same as length of 'which' (%d)"),LENGTH(newx),LENGTH(which));
   for (int i=0; i<LENGTH(which); i++) {
     w = INTEGER(which)[i];
-    if (w==NA_INTEGER || w<1 || w>LENGTH(x)) error(_("Item %d of 'which' is %d which is outside range of the length %d character vector"), i+1,w,LENGTH(x));
+    if (w==NA_INTEGER || w<1 || w>LENGTH(x))
+      error(_("Item %d of 'which' is %d which is outside range of the length %d character vector"), i+1,w,LENGTH(x));
     SET_STRING_ELT(x, w-1, STRING_ELT(newx, i));
   }
   return R_NilValue;

--- a/src/bmerge.c
+++ b/src/bmerge.c
@@ -45,33 +45,44 @@ SEXP bmerge(SEXP iArg, SEXP xArg, SEXP icolsArg, SEXP xcolsArg, SEXP isorted, SE
 
   // iArg, xArg, icolsArg and xcolsArg
   i = iArg; x = xArg;  // set globals so bmerge_r can see them.
-  if (!isInteger(icolsArg)) error(_("Internal error: icols is not integer vector")); // # nocov
-  if (!isInteger(xcolsArg)) error(_("Internal error: xcols is not integer vector")); // # nocov
-  if (LENGTH(icolsArg) > LENGTH(xcolsArg)) error(_("Internal error: length(icols) [%d] > length(xcols) [%d]"), LENGTH(icolsArg), LENGTH(xcolsArg)); // # nocov
+  if (!isInteger(icolsArg))
+    error(_("Internal error: icols is not integer vector")); // # nocov
+  if (!isInteger(xcolsArg))
+    error(_("Internal error: xcols is not integer vector")); // # nocov
+  if (LENGTH(icolsArg) > LENGTH(xcolsArg))
+    error(_("Internal error: length(icols) [%d] > length(xcols) [%d]"), LENGTH(icolsArg), LENGTH(xcolsArg)); // # nocov
   icols = INTEGER(icolsArg);
   xcols = INTEGER(xcolsArg);
   xN = LENGTH(x) ? LENGTH(VECTOR_ELT(x,0)) : 0;
   iN = ilen = anslen = LENGTH(i) ? LENGTH(VECTOR_ELT(i,0)) : 0;
   ncol = LENGTH(icolsArg);    // there may be more sorted columns in x than involved in the join
   for(int col=0; col<ncol; col++) {
-    if (icols[col]==NA_INTEGER) error(_("Internal error. icols[%d] is NA"), col); // # nocov
-    if (xcols[col]==NA_INTEGER) error(_("Internal error. xcols[%d] is NA"), col); // # nocov
-    if (icols[col]>LENGTH(i) || icols[col]<1) error(_("icols[%d]=%d outside range [1,length(i)=%d]"), col, icols[col], LENGTH(i));
-    if (xcols[col]>LENGTH(x) || xcols[col]<1) error(_("xcols[%d]=%d outside range [1,length(x)=%d]"), col, xcols[col], LENGTH(x));
+    if (icols[col]==NA_INTEGER)
+      error(_("Internal error. icols[%d] is NA"), col); // # nocov
+    if (xcols[col]==NA_INTEGER)
+      error(_("Internal error. xcols[%d] is NA"), col); // # nocov
+    if (icols[col]>LENGTH(i) || icols[col]<1)
+      error(_("icols[%d]=%d outside range [1,length(i)=%d]"), col, icols[col], LENGTH(i));
+    if (xcols[col]>LENGTH(x) || xcols[col]<1)
+      error(_("xcols[%d]=%d outside range [1,length(x)=%d]"), col, xcols[col], LENGTH(x));
     int it = TYPEOF(VECTOR_ELT(i, icols[col]-1));
     int xt = TYPEOF(VECTOR_ELT(x, xcols[col]-1));
-    if (iN && it!=xt) error(_("typeof x.%s (%s) != typeof i.%s (%s)"), CHAR(STRING_ELT(getAttrib(x,R_NamesSymbol),xcols[col]-1)), type2char(xt), CHAR(STRING_ELT(getAttrib(i,R_NamesSymbol),icols[col]-1)), type2char(it));
+    if (iN && it!=xt)
+      error(_("typeof x.%s (%s) != typeof i.%s (%s)"), CHAR(STRING_ELT(getAttrib(x,R_NamesSymbol),xcols[col]-1)), type2char(xt), CHAR(STRING_ELT(getAttrib(i,R_NamesSymbol),icols[col]-1)), type2char(it));
   }
   // raise(SIGINT);
 
   // rollArg, rollendsArg
   roll = 0.0; rollToNearest = FALSE;
   if (isString(rollarg)) {
-    if (strcmp(CHAR(STRING_ELT(rollarg,0)),"nearest") != 0) error(_("roll is character but not 'nearest'"));
-    if (TYPEOF(VECTOR_ELT(i, icols[ncol-1]-1))==STRSXP) error(_("roll='nearest' can't be applied to a character column, yet."));
+    if (strcmp(CHAR(STRING_ELT(rollarg,0)),"nearest") != 0)
+      error(_("roll is character but not 'nearest'"));
+    if (TYPEOF(VECTOR_ELT(i, icols[ncol-1]-1))==STRSXP)
+      error(_("roll='nearest' can't be applied to a character column, yet."));
     roll=1.0; rollToNearest=TRUE;       // the 1.0 here is just any non-0.0, so roll!=0.0 can be used later
   } else {
-    if (!isReal(rollarg)) error(_("Internal error: roll is not character or double")); // # nocov
+    if (!isReal(rollarg))
+      error(_("Internal error: roll is not character or double")); // # nocov
     roll = REAL(rollarg)[0];   // more common case (rolling forwards or backwards) or no roll when 0.0
   }
   rollabs = fabs(roll);
@@ -153,7 +164,8 @@ SEXP bmerge(SEXP iArg, SEXP xArg, SEXP icolsArg, SEXP xcolsArg, SEXP isorted, SE
   // xo arg
   xo = NULL;
   if (length(xoArg)) {
-    if (!isInteger(xoArg)) error(_("Internal error: xoArg is not an integer vector")); // # nocov
+    if (!isInteger(xoArg))
+      error(_("Internal error: xoArg is not an integer vector")); // # nocov
     xo = INTEGER(xoArg);
   }
 
@@ -268,7 +280,8 @@ void bmerge_r(int xlowIn, int xuppIn, int ilowIn, int iuppIn, int col, int thisg
       case LT : xupp = xlow + 1; xlow = xlowIn; break;
       case GE : if (ival.i != NA_INTEGER) xupp = xuppIn; break;
       case GT : xlow = xupp - 1; if (ival.i != NA_INTEGER) xupp = xuppIn; break;
-      default : error(_("Internal error in bmerge_r for '%s' column. Unrecognized value op[col]=%d"), type2char(TYPEOF(xc)), op[col]); // #nocov
+      default :
+        error(_("Internal error in bmerge_r for '%s' column. Unrecognized value op[col]=%d"), type2char(TYPEOF(xc)), op[col]); // #nocov
       }
       // for LE/LT cases, we need to ensure xlow excludes NA indices, != EQ is checked above already
       if (op[col] <= 3 && xlow<xupp-1 && ival.i != NA_INTEGER && INTEGER(xc)[XIND(xlow+1)] == NA_INTEGER) {
@@ -300,7 +313,8 @@ void bmerge_r(int xlowIn, int xuppIn, int ilowIn, int iuppIn, int col, int thisg
   }
     break;
   case STRSXP : {
-    if (op[col] != EQ) error(_("Only '==' operator is supported for columns of type %s."), type2char(TYPEOF(xc)));
+    if (op[col] != EQ)
+      error(_("Only '==' operator is supported for columns of type %s."), type2char(TYPEOF(xc)));
     ival.s = ENC2UTF8(STRING_ELT(ic,ir));
     while(xlow < xupp-1) {
       int mid = xlow + (xupp-xlow)/2;
@@ -376,7 +390,8 @@ void bmerge_r(int xlowIn, int xuppIn, int ilowIn, int iuppIn, int col, int thisg
       case LT : xupp = xlow + 1; if (!isivalNA) xlow = xlowIn; break;
       case GE : if (!isivalNA) xupp = xuppIn; break;
       case GT : xlow = xupp - 1; if (!isivalNA) xupp = xuppIn; break;
-      default : error(_("Internal error in bmerge_r for '%s' column. Unrecognized value op[col]=%d"), type2char(TYPEOF(xc)), op[col]); // #nocov
+      default :
+        error(_("Internal error in bmerge_r for '%s' column. Unrecognized value op[col]=%d"), type2char(TYPEOF(xc)), op[col]); // #nocov
       }
       // for LE/LT cases, we need to ensure xlow excludes NA indices, != EQ is checked above already
       if (op[col] <= 3 && xlow<xupp-1 && !isivalNA && (!isInt64 ? ISNAN(dxc[XIND(xlow+1)]) : (DtoLL(dxc[XIND(xlow+1)]) == NA_INT64_LL))) {
@@ -465,7 +480,8 @@ void bmerge_r(int xlowIn, int xuppIn, int ilowIn, int iuppIn, int col, int thisg
     }
   } else if (roll!=0.0 && col==ncol-1) {
     // runs once per i row (not each search test), so not hugely time critical
-    if (xlow != xupp-1 || xlow<xlowIn || xupp>xuppIn) error(_("Internal error: xlow!=xupp-1 || xlow<xlowIn || xupp>xuppIn")); // # nocov
+    if (xlow != xupp-1 || xlow<xlowIn || xupp>xuppIn)
+      error(_("Internal error: xlow!=xupp-1 || xlow<xlowIn || xupp>xuppIn")); // # nocov
     if (rollToNearest) {   // value of roll ignored currently when nearest
       if ( (!lowmax || xlow>xlowIn) && (!uppmax || xupp<xuppIn) ) {
         if (  ( TYPEOF(ic)==REALSXP && REAL(ic)[ir]-REAL(xc)[XIND(xlow)] <= REAL(xc)[XIND(xupp)]-REAL(ic)[ir] ) // TODO remove macro here requires bigger rewrite

--- a/src/dogroups.c
+++ b/src/dogroups.c
@@ -12,13 +12,19 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
   clock_t tstart=0, tblock[10]={0}; int nblock[10]={0};
   const bool verbose = LOGICAL(verboseArg)[0]==1;
 
-  if (!isInteger(order)) error(_("Internal error: order not integer vector")); // # nocov
-  if (TYPEOF(starts) != INTSXP) error(_("Internal error: starts not integer")); // # nocov
-  if (TYPEOF(lens) != INTSXP) error(_("Internal error: lens not integer")); // # nocov
+  if (!isInteger(order))
+    error(_("Internal error: order not integer vector")); // # nocov
+  if (TYPEOF(starts) != INTSXP)
+    error(_("Internal error: starts not integer")); // # nocov
+  if (TYPEOF(lens) != INTSXP)
+    error(_("Internal error: lens not integer")); // # nocov
   // starts can now be NA (<0): if (INTEGER(starts)[0]<0 || INTEGER(lens)[0]<0) error(_("starts[1]<0 or lens[1]<0"));
-  if (!isNull(jiscols) && LENGTH(order) && !LOGICAL(on)[0]) error(_("Internal error: jiscols not NULL but o__ has length")); // # nocov
-  if (!isNull(xjiscols) && LENGTH(order) && !LOGICAL(on)[0]) error(_("Internal error: xjiscols not NULL but o__ has length")); // # nocov
-  if(!isEnvironment(env)) error(_("'env' should be an environment"));
+  if (!isNull(jiscols) && LENGTH(order) && !LOGICAL(on)[0])
+    error(_("Internal error: jiscols not NULL but o__ has length")); // # nocov
+  if (!isNull(xjiscols) && LENGTH(order) && !LOGICAL(on)[0])
+    error(_("Internal error: xjiscols not NULL but o__ has length")); // # nocov
+  if(!isEnvironment(env))
+    error(_("'env' should be an environment"));
   ngrp = length(starts);  // the number of groups  (nrow(groups) will be larger when by)
   ngrpcols = length(grpcols);
   nrowgroups = length(VECTOR_ELT(groups,0));
@@ -41,7 +47,8 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
   }
   setAttrib(BY, R_NamesSymbol, bynames); // Fix for #42 - BY doesn't retain names anymore
   R_LockBinding(sym_BY, env);
-  if (isNull(jiscols) && (length(bynames)!=length(groups) || length(bynames)!=length(grpcols))) error(_("!length(bynames)[%d]==length(groups)[%d]==length(grpcols)[%d]"),length(bynames),length(groups),length(grpcols));
+  if (isNull(jiscols) && (length(bynames)!=length(groups) || length(bynames)!=length(grpcols)))
+    error(_("!length(bynames)[%d]==length(groups)[%d]==length(grpcols)[%d]"),length(bynames),length(groups),length(grpcols));
   // TO DO: check this check above.
 
   N =   PROTECT(findVar(install(".N"), env));   nprotect++; // PROTECT for rchk
@@ -60,14 +67,17 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
   // fetch rownames of .SD.  rownames[1] is set to -thislen for each group, in case .SD is passed to
   // non data.table aware package that uses rownames
   for (s = ATTRIB(SD); s != R_NilValue && TAG(s)!=R_RowNamesSymbol; s = CDR(s));  // getAttrib0 basically but that's hidden in attrib.c
-  if (s==R_NilValue) error(_("row.names attribute of .SD not found"));
+  if (s==R_NilValue)
+    error(_("row.names attribute of .SD not found"));
   rownames = CAR(s);
-  if (!isInteger(rownames) || LENGTH(rownames)!=2 || INTEGER(rownames)[0]!=NA_INTEGER) error(_("row.names of .SD isn't integer length 2 with NA as first item; i.e., .set_row_names(). [%s %d %d]"),type2char(TYPEOF(rownames)),LENGTH(rownames),INTEGER(rownames)[0]);
+  if (!isInteger(rownames) || LENGTH(rownames)!=2 || INTEGER(rownames)[0]!=NA_INTEGER)
+    error(_("row.names of .SD isn't integer length 2 with NA as first item; i.e., .set_row_names(). [%s %d %d]"),type2char(TYPEOF(rownames)),LENGTH(rownames),INTEGER(rownames)[0]);
 
   // fetch names of .SD and prepare symbols. In case they are copied-on-write by user assigning to those variables
   // using <- in j (which is valid, useful and tested), they are repointed to the .SD cols for each group.
   SEXP names = PROTECT(getAttrib(SDall, R_NamesSymbol)); nprotect++;
-  if (length(names) != length(SDall)) error(_("length(names)!=length(SD)"));
+  if (length(names) != length(SDall))
+    error(_("length(names)!=length(SD)"));
   SEXP *nameSyms = (SEXP *)R_alloc(length(names), sizeof(SEXP));
   for(int i=0; i<length(SDall); ++i) {
     if (SIZEOF(VECTOR_ELT(SDall, i))==0)
@@ -81,7 +91,8 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
   if (length(SDall)) origSDnrow = length(VECTOR_ELT(SDall, 0));
 
   SEXP xknames = PROTECT(getAttrib(xSD, R_NamesSymbol)); nprotect++;
-  if (length(xknames) != length(xSD)) error(_("length(xknames)!=length(xSD)"));
+  if (length(xknames) != length(xSD))
+    error(_("length(xknames)!=length(xSD)"));
   SEXP *xknameSyms = (SEXP *)R_alloc(length(xknames), sizeof(SEXP));
   for(int i=0; i<length(xSD); ++i) {
     if (SIZEOF(VECTOR_ELT(xSD, i))==0)
@@ -89,8 +100,10 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
     xknameSyms[i] = install(CHAR(STRING_ELT(xknames, i)));
   }
 
-  if (length(iSD)!=length(jiscols)) error(_("length(iSD)[%d] != length(jiscols)[%d]"),length(iSD),length(jiscols));
-  if (length(xSD)!=length(xjiscols)) error(_("length(xSD)[%d] != length(xjiscols)[%d]"),length(xSD),length(xjiscols));
+  if (length(iSD)!=length(jiscols))
+    error(_("length(iSD)[%d] != length(jiscols)[%d]"),length(iSD),length(jiscols));
+  if (length(xSD)!=length(xjiscols))
+    error(_("length(xSD)[%d] != length(xjiscols)[%d]"),length(xSD),length(xjiscols));
 
   SEXP listwrap = PROTECT(allocVector(VECSXP, 1)); nprotect++;
   Rboolean jexpIsSymbolOtherThanSD = (isSymbol(jexp) && strcmp(CHAR(PRINTNAME(jexp)),".SD")!=0);  // test 559
@@ -227,7 +240,8 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
         RHS = VECTOR_ELT(jval,j%LENGTH(jval));
         if (isNull(target)) {
           // first time adding to new column
-          if (TRUELENGTH(dt) < colj+1) error(_("Internal error: Trying to add new column by reference but tl is full; setalloccol should have run first at R level before getting to this point in dogroups")); // # nocov
+          if (TRUELENGTH(dt) < colj+1)
+            error(_("Internal error: Trying to add new column by reference but tl is full; setalloccol should have run first at R level before getting to this point in dogroups")); // # nocov
           target = PROTECT(allocNAVectorLike(RHS, n));
           // Even if we could know reliably to switch from allocNAVectorLike to allocVector for slight speedup, user code could still
           // contain a switched halt, and in that case we'd want the groups not yet done to have NA rather than 0 or uninitialized.
@@ -249,7 +263,8 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
     }
     maxn = 0;
     if (njval==0) njval = LENGTH(jval);   // for first group, then the rest (when non 0) must conform to the first >0 group
-    if (njval!=LENGTH(jval)) error(_("j doesn't evaluate to the same number of columns for each group"));  // this would be a problem even if we unlisted afterwards. This way the user finds out earlier though so he can fix and rerun sooner.
+    if (njval!=LENGTH(jval))
+      error(_("j doesn't evaluate to the same number of columns for each group"));  // this would be a problem even if we unlisted afterwards. This way the user finds out earlier though so he can fix and rerun sooner.
     for (int j=0; j<njval; ++j) {
       int k = length(VECTOR_ELT(jval,j));  // might be NULL, so length not LENGTH
       maxn = k>maxn ? k : maxn;
@@ -309,7 +324,8 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
       } else {
         estn = ((double)ngrp/i)*1.1*(ansloc+maxn);
         if (verbose) Rprintf(_("dogroups: growing from %d to %d rows\n"), length(VECTOR_ELT(ans,0)), estn);
-        if (length(ans) != ngrpcols + njval) error(_("dogroups: length(ans)[%d]!=ngrpcols[%d]+njval[%d]"),length(ans),ngrpcols,njval);
+        if (length(ans) != ngrpcols + njval)
+          error(_("dogroups: length(ans)[%d]!=ngrpcols[%d]+njval[%d]"),length(ans),ngrpcols,njval);
         for (int j=0; j<length(ans); ++j) SET_VECTOR_ELT(ans, j, growVector(VECTOR_ELT(ans,j), estn));
       }
     }
@@ -361,7 +377,8 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
   for (int j=0; j<length(SDall); ++j) SETLENGTH(VECTOR_ELT(SDall,j), origSDnrow);
   SETLENGTH(I, origIlen);
   if (verbose) {
-    if (nblock[0] && nblock[1]) error(_("Internal error: block 0 [%d] and block 1 [%d] have both run"), nblock[0], nblock[1]); // # nocov
+    if (nblock[0] && nblock[1])
+      error(_("Internal error: block 0 [%d] and block 1 [%d] have both run"), nblock[0], nblock[1]); // # nocov
     int w = nblock[1]>0;
     Rprintf(_("\n  %s took %.3fs for %d groups\n"), w ? "collecting discontiguous groups" : "memcpy contiguous groups",
                           1.0*tblock[w]/CLOCKS_PER_SEC, nblock[w]);
@@ -389,7 +406,8 @@ SEXP growVector(SEXP x, const R_len_t newlen)
   // * much shorter and faster
   SEXP newx;
   R_len_t len = length(x);
-  if (isNull(x)) error(_("growVector passed NULL"));
+  if (isNull(x))
+    error(_("growVector passed NULL"));
   PROTECT(newx = allocVector(TYPEOF(x), newlen));   // TO DO: R_realloc(?) here?
   if (newlen < len) len=newlen;   // i.e. shrink
   switch (TYPEOF(x)) {

--- a/src/fcast.c
+++ b/src/fcast.c
@@ -75,7 +75,8 @@ SEXP fcast(SEXP lhs, SEXP val, SEXP nrowArg, SEXP ncolArg, SEXP idxArg, SEXP fil
         }
       }
       break;
-    default: error(_("Unsupported column type in fcast val: '%s'"), type2char(TYPEOF(thiscol))); // #nocov
+    default:
+      error(_("Unsupported column type in fcast val: '%s'"), type2char(TYPEOF(thiscol))); // #nocov
     }
     UNPROTECT(nprotect);
   }

--- a/src/fmelt.c
+++ b/src/fmelt.c
@@ -15,8 +15,10 @@ SEXP seq_int(int n, int start) {
 
 // very specific "set_diff" for integers
 SEXP set_diff(SEXP x, int n) {
-  if (TYPEOF(x) != INTSXP) error(_("'x' must be an integer"));
-  if (n <= 0) error(_("'n' must be a positive integer"));
+  if (TYPEOF(x) != INTSXP)
+    error(_("'x' must be an integer"));
+  if (n <= 0)
+    error(_("'n' must be a positive integer"));
   SEXP table = PROTECT(seq_int(n, 1));       // TODO: using match to 1:n seems odd here, why use match at all
   SEXP xmatch = PROTECT(match(x, table, 0)); // Old comment:took a while to realise: matches vec against x - thanks to comment from Matt in assign.c!
   const int *ixmatch = INTEGER(xmatch);
@@ -38,7 +40,8 @@ SEXP which(SEXP x, Rboolean val) {
 
   int j=0, n = length(x);
   SEXP ans;
-  if (!isLogical(x)) error(_("Argument to 'which' must be logical"));
+  if (!isLogical(x))
+    error(_("Argument to 'which' must be logical"));
   const int *ix = LOGICAL(x);
   int *buf = (int *) R_alloc(n, sizeof(int));
   for (int i=0; i<n; ++i) {
@@ -67,8 +70,10 @@ SEXP concat(SEXP vec, SEXP idx) {
   SEXP s, t, v;
   int nidx=length(idx);
 
-  if (TYPEOF(vec) != STRSXP) error(_("concat: 'vec must be a character vector"));
-  if (!isInteger(idx) || length(idx) < 0) error(_("concat: 'idx' must be an integer vector of length >= 0"));
+  if (TYPEOF(vec) != STRSXP)
+    error(_("concat: 'vec must be a character vector"));
+  if (!isInteger(idx) || length(idx) < 0)
+    error(_("concat: 'idx' must be an integer vector of length >= 0"));
   const int *iidx = INTEGER(idx);
   for (int i=0; i<length(idx); ++i) {
     if (iidx[i] < 0 || iidx[i] > length(vec))
@@ -99,7 +104,8 @@ SEXP measurelist(SEXP measure, SEXP dtnames) {
       case STRSXP  : tmp = PROTECT(chmatch(VECTOR_ELT(measure, i), dtnames, 0)); protecti++; break;
       case REALSXP : tmp = PROTECT(coerceVector(VECTOR_ELT(measure, i), INTSXP)); protecti++; break;
       case INTSXP  : tmp = VECTOR_ELT(measure, i); break;
-      default : error(_("Unknown 'measure.vars' type %s at index %d of list"), type2char(TYPEOF(VECTOR_ELT(measure, i))), i+1);
+      default :
+        error(_("Unknown 'measure.vars' type %s at index %d of list"), type2char(TYPEOF(VECTOR_ELT(measure, i))), i+1);
     }
     SET_VECTOR_ELT(ans, i, tmp);
   }
@@ -151,7 +157,8 @@ SEXP checkVars(SEXP DT, SEXP id, SEXP measure, Rboolean verbose) {
       case STRSXP  : PROTECT(tmp = chmatch(id, dtnames, 0)); protecti++; break;
       case REALSXP : PROTECT(tmp = coerceVector(id, INTSXP)); protecti++; break;
       case INTSXP  : tmp = id; break;
-      default : error(_("Unknown 'id.vars' type %s, must be character or integer vector"), type2char(TYPEOF(id)));
+      default :
+        error(_("Unknown 'id.vars' type %s, must be character or integer vector"), type2char(TYPEOF(id)));
     }
     booltmp = PROTECT(duplicated(tmp, FALSE)); protecti++;
     for (i=0; i<length(tmp); i++) {
@@ -181,7 +188,8 @@ SEXP checkVars(SEXP DT, SEXP id, SEXP measure, Rboolean verbose) {
       case REALSXP : tmp2 = PROTECT(coerceVector(measure, INTSXP)); protecti++; break;
       case INTSXP  : tmp2 = measure; break;
       case VECSXP  : tmp2 = PROTECT(measurelist(measure, dtnames)); protecti++; break;
-      default : error(_("Unknown 'measure.vars' type %s, must be character or integer vector/list"), type2char(TYPEOF(measure)));
+      default :
+        error(_("Unknown 'measure.vars' type %s, must be character or integer vector/list"), type2char(TYPEOF(measure)));
     }
     tmp = tmp2;
     if (isNewList(measure)) {
@@ -216,7 +224,8 @@ SEXP checkVars(SEXP DT, SEXP id, SEXP measure, Rboolean verbose) {
       case STRSXP  : tmp = PROTECT(chmatch(id, dtnames, 0)); protecti++; break;
       case REALSXP : tmp = PROTECT(coerceVector(id, INTSXP)); protecti++; break;
       case INTSXP  : tmp = id; break;
-      default : error(_("Unknown 'id.vars' type %s, must be character or integer vector"), type2char(TYPEOF(id)));
+      default :
+        error(_("Unknown 'id.vars' type %s, must be character or integer vector"), type2char(TYPEOF(id)));
     }
     for (i=0; i<length(tmp); i++) {
       if (INTEGER(tmp)[i] <= 0 || INTEGER(tmp)[i] > ncol)
@@ -228,7 +237,8 @@ SEXP checkVars(SEXP DT, SEXP id, SEXP measure, Rboolean verbose) {
       case REALSXP : tmp2 = PROTECT(coerceVector(measure, INTSXP)); protecti++; break;
       case INTSXP  : tmp2 = measure; break;
       case VECSXP  : tmp2 = PROTECT(measurelist(measure, dtnames)); protecti++; break;
-      default : error(_("Unknown 'measure.vars' type %s, must be character or integer vector"), type2char(TYPEOF(measure)));
+      default :
+        error(_("Unknown 'measure.vars' type %s, must be character or integer vector"), type2char(TYPEOF(measure)));
     }
     tmp = tmp2;
     if (isNewList(measure)) {
@@ -273,7 +283,8 @@ static void preprocess(SEXP DT, SEXP id, SEXP measure, SEXP varnames, SEXP valna
   data->lvalues = length(data->valuecols);
   data->narm = narm;
   if (length(valnames) != data->lvalues) {
-    if (isNewList(measure)) error(_("When 'measure.vars' is a list, 'value.name' must be a character vector of length =1 or =length(measure.vars)."));
+    if (isNewList(measure))
+      error(_("When 'measure.vars' is a list, 'value.name' must be a character vector of length =1 or =length(measure.vars)."));
     else error(_("When 'measure.vars' is either not specified or a character/integer vector, 'value.name' must be a character vector of length =1."));
   }
   if (length(varnames) != 1)
@@ -326,10 +337,12 @@ static SEXP combineFactorLevels(SEXP factorLevels, SEXP target, int * factorType
   int maxlevels=0, nitem=length(factorLevels);
   for (int i=0; i<nitem; ++i) {
     SEXP this = VECTOR_ELT(factorLevels, i);
-    if (!isString(this)) error(_("Internal error: combineFactorLevels in fmelt.c expects all-character input"));  // # nocov
+    if (!isString(this))
+      error(_("Internal error: combineFactorLevels in fmelt.c expects all-character input"));  // # nocov
     maxlevels+=length(this);
   }
-  if (!isString(target)) error(_("Internal error: combineFactorLevels in fmelt.c expects a character target to factorize"));  // # nocov
+  if (!isString(target))
+    error(_("Internal error: combineFactorLevels in fmelt.c expects a character target to factorize"));  // # nocov
   int nrow = length(target);
   SEXP ans = PROTECT(allocVector(INTSXP, nrow));
   SEXP *levelsRaw = (SEXP *)R_alloc(maxlevels, sizeof(SEXP));  // allocate for worst-case all-unique levels
@@ -659,7 +672,8 @@ SEXP getidcols(SEXP DT, SEXP dtnames, Rboolean verbose, struct processData *data
       }
     }
       break;
-    default : error(_("Unknown column type '%s' for column '%s' in 'data'"), type2char(TYPEOF(thiscol)), CHAR(STRING_ELT(dtnames, INTEGER(data->idcols)[i]-1)));
+    default :
+      error(_("Unknown column type '%s' for column '%s' in 'data'"), type2char(TYPEOF(thiscol)), CHAR(STRING_ELT(dtnames, INTEGER(data->idcols)[i]-1)));
     }
   }
   UNPROTECT(1);
@@ -670,13 +684,20 @@ SEXP fmelt(SEXP DT, SEXP id, SEXP measure, SEXP varfactor, SEXP valfactor, SEXP 
   SEXP dtnames, ansvals, ansvars, ansids, ansnames, ans;
   Rboolean narm=FALSE, verbose=FALSE;
 
-  if (!isNewList(DT)) error(_("Input is not of type VECSXP, expected a data.table, data.frame or list"));
-  if (!isLogical(valfactor)) error(_("Argument 'value.factor' should be logical TRUE/FALSE"));
-  if (!isLogical(varfactor)) error(_("Argument 'variable.factor' should be logical TRUE/FALSE"));
-  if (!isLogical(narmArg)) error(_("Argument 'na.rm' should be logical TRUE/FALSE."));
-  if (!isString(varnames)) error(_("Argument 'variable.name' must be a character vector"));
-  if (!isString(valnames)) error(_("Argument 'value.name' must be a character vector"));
-  if (!isLogical(verboseArg)) error(_("Argument 'verbose' should be logical TRUE/FALSE"));
+  if (!isNewList(DT))
+    error(_("Input is not of type VECSXP, expected a data.table, data.frame or list"));
+  if (!isLogical(valfactor))
+    error(_("Argument 'value.factor' should be logical TRUE/FALSE"));
+  if (!isLogical(varfactor))
+    error(_("Argument 'variable.factor' should be logical TRUE/FALSE"));
+  if (!isLogical(narmArg))
+    error(_("Argument 'na.rm' should be logical TRUE/FALSE."));
+  if (!isString(varnames))
+    error(_("Argument 'variable.name' must be a character vector"));
+  if (!isString(valnames))
+    error(_("Argument 'value.name' must be a character vector"));
+  if (!isLogical(verboseArg))
+    error(_("Argument 'verbose' should be logical TRUE/FALSE"));
   if (LOGICAL(verboseArg)[0] == TRUE) verbose = TRUE;
   int ncol = LENGTH(DT);
   if (!ncol) {
@@ -685,7 +706,8 @@ SEXP fmelt(SEXP DT, SEXP id, SEXP measure, SEXP varfactor, SEXP valfactor, SEXP 
   }
   int protecti=0;
   dtnames = PROTECT(getAttrib(DT, R_NamesSymbol)); protecti++;
-  if (isNull(dtnames)) error(_("names(data) is NULL. Please report to data.table-help"));
+  if (isNull(dtnames))
+    error(_("names(data) is NULL. Please report to data.table-help"));
   if (LOGICAL(narmArg)[0] == TRUE) narm = TRUE;
   if (LOGICAL(verboseArg)[0] == TRUE) verbose = TRUE;
   struct processData data;

--- a/src/forder.c
+++ b/src/forder.c
@@ -374,8 +374,10 @@ static uint64_t dmask=0;
 SEXP setNumericRounding(SEXP droundArg)
 // init.c has initial call with default of 2
 {
-  if (!isInteger(droundArg) || LENGTH(droundArg)!=1) error(_("Must an integer or numeric vector length 1"));
-  if (INTEGER(droundArg)[0] < 0 || INTEGER(droundArg)[0] > 2) error(_("Must be 2, 1 or 0"));
+  if (!isInteger(droundArg) || LENGTH(droundArg)!=1)
+    error(_("Must an integer or numeric vector length 1"));
+  if (INTEGER(droundArg)[0] < 0 || INTEGER(droundArg)[0] > 2)
+    error(_("Must be 2, 1 or 0"));
   dround = INTEGER(droundArg)[0];
   dmask = dround ? 1 << (8*dround-1) : 0;
   return R_NilValue;
@@ -1307,11 +1309,14 @@ SEXP isOrderedSubset(SEXP x, SEXP nrowArg)
 // specialized for use in [.data.table only
 // Ignores 0s but heeds NAs and any out-of-range (which result in NA)
 {
-  if (!isNull(x) && !isInteger(x)) error(_("x must be either NULL or an integer vector"));
+  if (!isNull(x) && !isInteger(x))
+    error(_("x must be either NULL or an integer vector"));
   if (length(x)<=1) return(ScalarLogical(TRUE));  // a single NA when length(x)==1 is ordered (e.g. tests 128 & 130) otherwise anyNA => FALSE
-  if (!isInteger(nrowArg) || LENGTH(nrowArg)!=1) error(_("nrow must be integer vector length 1"));
+  if (!isInteger(nrowArg) || LENGTH(nrowArg)!=1)
+    error(_("nrow must be integer vector length 1"));
   const int nrow = INTEGER(nrowArg)[0];
-  if (nrow<0) error(_("nrow==%d but must be >=0"), nrow);
+  if (nrow<0)
+    error(_("nrow==%d but must be >=0"), nrow);
   const int *xd = INTEGER(x), xlen=LENGTH(x);
   for (int i=0, last=INT_MIN; i<xlen; ++i) {
     int elem = xd[i];
@@ -1328,7 +1333,8 @@ SEXP binary(SEXP x)
 {
   char buffer[69];
   int j;
-  if (!isReal(x)) error(_("x must be type 'double'"));
+  if (!isReal(x))
+    error(_("x must be type 'double'"));
   SEXP ans = PROTECT(allocVector(STRSXP, LENGTH(x)));
   uint64_t *xd = (uint64_t *)REAL(x);
   for (int i=0; i<LENGTH(x); i++) {

--- a/src/frank.c
+++ b/src/frank.c
@@ -6,8 +6,10 @@
 SEXP dt_na(SEXP x, SEXP cols) {
   int n=0, elem;
 
-  if (!isNewList(x)) error(_("Internal error. Argument 'x' to Cdt_na is type '%s' not 'list'"), type2char(TYPEOF(x))); // # nocov
-  if (!isInteger(cols)) error(_("Internal error. Argument 'cols' to Cdt_na is type '%s' not 'integer'"), type2char(TYPEOF(cols))); // # nocov
+  if (!isNewList(x))
+    error(_("Internal error. Argument 'x' to Cdt_na is type '%s' not 'list'"), type2char(TYPEOF(x))); // # nocov
+  if (!isInteger(cols))
+    error(_("Internal error. Argument 'cols' to Cdt_na is type '%s' not 'integer'"), type2char(TYPEOF(cols))); // # nocov
   for (int i=0; i<LENGTH(cols); ++i) {
     elem = INTEGER(cols)[i];
     if (elem<1 || elem>LENGTH(x))
@@ -136,7 +138,8 @@ SEXP frank(SEXP xorderArg, SEXP xstartArg, SEXP xlenArg, SEXP ties_method) {
     //       INTEGER(ans)[xorder[j]-1] = k++;
     //   }
     //   break;
-    default: error(_("Internal error: unknown ties value in frank: %d"), ties); // #nocov
+    default:
+      error(_("Internal error: unknown ties value in frank: %d"), ties); // #nocov
     }
   }
   UNPROTECT(1);
@@ -147,8 +150,10 @@ SEXP frank(SEXP xorderArg, SEXP xstartArg, SEXP xlenArg, SEXP ties_method) {
 SEXP anyNA(SEXP x, SEXP cols) {
   int i, j, n=0, elem;
 
-  if (!isNewList(x)) error(_("Internal error. Argument 'x' to CanyNA is type '%s' not 'list'"), type2char(TYPEOF(x))); // #nocov
-  if (!isInteger(cols)) error(_("Internal error. Argument 'cols' to CanyNA is type '%s' not 'integer'"), type2char(TYPEOF(cols))); // # nocov
+  if (!isNewList(x))
+    error(_("Internal error. Argument 'x' to CanyNA is type '%s' not 'list'"), type2char(TYPEOF(x))); // #nocov
+  if (!isInteger(cols))
+    error(_("Internal error. Argument 'cols' to CanyNA is type '%s' not 'integer'"), type2char(TYPEOF(cols))); // # nocov
   for (i=0; i<LENGTH(cols); i++) {
     elem = INTEGER(cols)[i];
     if (elem<1 || elem>LENGTH(x))

--- a/src/freadR.c
+++ b/src/freadR.c
@@ -150,14 +150,16 @@ SEXP freadR(
   args.skipEmptyLines = LOGICAL(skipEmptyLinesArg)[0];
   args.fill = LOGICAL(fillArg)[0];
   args.showProgress = LOGICAL(showProgressArg)[0];
-  if (INTEGER(nThreadArg)[0]<1) error(_("nThread(%d)<1"), INTEGER(nThreadArg)[0]);
+  if (INTEGER(nThreadArg)[0]<1)
+    error(_("nThread(%d)<1"), INTEGER(nThreadArg)[0]);
   args.nth = (uint32_t)INTEGER(nThreadArg)[0];
   args.verbose = verbose;
   args.warningsAreErrors = warningsAreErrors;
   args.keepLeadingZeros = LOGICAL(keepLeadingZerosArgs)[0];
 
   // === extras used for callbacks ===
-  if (!isString(integer64Arg) || LENGTH(integer64Arg)!=1) error(_("'integer64' must be a single character string"));
+  if (!isString(integer64Arg) || LENGTH(integer64Arg)!=1)
+    error(_("'integer64' must be a single character string"));
   const char *tt = CHAR(STRING_ELT(integer64Arg,0));
   if (strcmp(tt, "integer64")==0) {
     readInt64As = CT_INT64;

--- a/src/fsort.c
+++ b/src/fsort.c
@@ -108,7 +108,8 @@ SEXP fsort(SEXP x, SEXP verboseArg) {
   if (!isLogical(verboseArg) || LENGTH(verboseArg)!=1 || LOGICAL(verboseArg)[0]==NA_LOGICAL)
     error(_("verbose must be TRUE or FALSE"));
   Rboolean verbose = LOGICAL(verboseArg)[0];
-  if (!isNumeric(x)) error(_("x must be a vector of type 'double' currently"));
+  if (!isNumeric(x))
+    error(_("x must be a vector of type 'double' currently"));
   // TODO: not only detect if already sorted, but if it is, just return x to save the duplicate
 
   SEXP ansVec = PROTECT(allocVector(REALSXP, xlength(x)));
@@ -154,7 +155,8 @@ SEXP fsort(SEXP x, SEXP verboseArg) {
     if (maxs[i]>max) max=maxs[i];
   }
   if (verbose) Rprintf(_("Range = [%g,%g]\n"), min, max);
-  if (min < 0.0) error(_("Cannot yet handle negatives."));
+  if (min < 0.0)
+    error(_("Cannot yet handle negatives."));
   // TODO: -0ULL should allow negatives
   //       avoid twiddle function call as expensive in recent tests (0.34 vs 2.7)
   //       possibly twiddle once to *ans, then untwiddle at the end in a fast parallel sweep
@@ -170,7 +172,8 @@ SEXP fsort(SEXP x, SEXP verboseArg) {
   if (verbose) Rprintf(_("maxBit=%d; MSBNbits=%d; shift=%d; MSBsize=%d\n"), maxBit, MSBNbits, shift, MSBsize);
 
   R_xlen_t *counts = calloc(nBatch*MSBsize, sizeof(R_xlen_t));
-  if (counts==NULL) error(_("Unable to allocate working memory"));
+  if (counts==NULL)
+    error(_("Unable to allocate working memory"));
   // provided MSBsize>=9, each batch is a multiple of at least one 4k page, so no page overlap
   // TODO: change all calloc, malloc and free to Calloc and Free to be robust to error() and catch ooms.
 
@@ -228,7 +231,8 @@ SEXP fsort(SEXP x, SEXP verboseArg) {
     // sort bins by size, largest first to minimise last-man-home
     R_xlen_t *msbCounts = counts + (nBatch-1)*MSBsize;
     // msbCounts currently contains the ending position of each MSB (the starting location of the next) even across empty
-    if (msbCounts[MSBsize-1] != xlength(x)) error(_("Internal error: counts[nBatch-1][MSBsize-1] != length(x)")); // # nocov
+    if (msbCounts[MSBsize-1] != xlength(x))
+      error(_("Internal error: counts[nBatch-1][MSBsize-1] != length(x)")); // # nocov
     R_xlen_t *msbFrom = malloc(MSBsize*sizeof(R_xlen_t));
     int *order = malloc(MSBsize*sizeof(int));
     R_xlen_t cumSum = 0;

--- a/src/fwriteR.c
+++ b/src/fwriteR.c
@@ -38,7 +38,8 @@ int getMaxStringLen(const SEXP *col, const int64_t n) {
 
 int getMaxCategLen(SEXP col) {
   col = getAttrib(col, R_LevelsSymbol);
-  if (!isString(col)) error(_("Internal error: col passed to getMaxCategLen is missing levels"));
+  if (!isString(col))
+    error(_("Internal error: col passed to getMaxCategLen is missing levels"));
   return getMaxStringLen( STRING_PTR(col), LENGTH(col) );
 }
 
@@ -167,7 +168,8 @@ SEXP fwriteR(
   SEXP verbose_Arg
   )
 {
-  if (!isNewList(DF)) error(_("fwrite must be passed an object of type list; e.g. data.frame, data.table"));
+  if (!isNewList(DF))
+    error(_("fwrite must be passed an object of type list; e.g. data.frame, data.table"));
   fwriteMainArgs args;
   args.is_gzip = LOGICAL(is_gzip_Arg)[0];
   args.bom = LOGICAL(bom_Arg)[0];

--- a/src/gsumm.c
+++ b/src/gsumm.c
@@ -40,11 +40,15 @@ static int nbit(int n)
 SEXP gforce(SEXP env, SEXP jsub, SEXP o, SEXP f, SEXP l, SEXP irowsArg) {
   double started = wallclock();
   const bool verbose = GetVerbose();
-  if (TYPEOF(env) != ENVSXP) error(_("env is not an environment"));
+  if (TYPEOF(env) != ENVSXP)
+    error(_("env is not an environment"));
   // The type of jsub is pretty flexbile in R, so leave checking to eval() below.
-  if (!isInteger(o)) error(_("%s is not an integer vector"), "o");
-  if (!isInteger(f)) error(_("%s is not an integer vector"), "f");
-  if (!isInteger(l)) error(_("%s is not an integer vector"), "l");
+  if (!isInteger(o))
+    error(_("%s is not an integer vector"), "o");
+  if (!isInteger(f))
+    error(_("%s is not an integer vector"), "f");
+  if (!isInteger(l))
+    error(_("%s is not an integer vector"), "l");
   if (isNull(irowsArg)) {
     irows = NULL;
     irowslen = -1;
@@ -55,7 +59,8 @@ SEXP gforce(SEXP env, SEXP jsub, SEXP o, SEXP f, SEXP l, SEXP irowsArg) {
   }
   else error(_("irowsArg is neither an integer vector nor NULL"));  // # nocov
   ngrp = LENGTH(l);
-  if (LENGTH(f) != ngrp) error(_("length(f)=%d != length(l)=%d"), LENGTH(f), ngrp);
+  if (LENGTH(f) != ngrp)
+    error(_("length(f)=%d != length(l)=%d"), LENGTH(f), ngrp);
   nrow=0;
   grpsize = INTEGER(l);
   maxgrpn = 0;
@@ -63,10 +68,12 @@ SEXP gforce(SEXP env, SEXP jsub, SEXP o, SEXP f, SEXP l, SEXP irowsArg) {
     nrow+=grpsize[i];
     if (grpsize[i]>maxgrpn) maxgrpn = grpsize[i];  // old comment to be checked: 'needed for #2046 and #2111 when maxgrpn attribute is not attached to empty o'
   }
-  if (LENGTH(o) && LENGTH(o)!=nrow) error(_("o has length %d but sum(l)=%d"), LENGTH(o), nrow);
+  if (LENGTH(o) && LENGTH(o)!=nrow)
+    error(_("o has length %d but sum(l)=%d"), LENGTH(o), nrow);
   {
     SEXP tt = getAttrib(o, install("maxgrpn"));
-    if (length(tt)==1 && INTEGER(tt)[0]!=maxgrpn) error(_("Internal error: o's maxgrpn attribute mismatches recalculated maxgrpn")); // # nocov
+    if (length(tt)==1 && INTEGER(tt)[0]!=maxgrpn)
+      error(_("Internal error: o's maxgrpn attribute mismatches recalculated maxgrpn")); // # nocov
   }
 
   int nb = nbit(ngrp-1);
@@ -113,7 +120,8 @@ SEXP gforce(SEXP env, SEXP jsub, SEXP o, SEXP f, SEXP l, SEXP irowsArg) {
     //Rprintf(_("When assigning grp[o] = g, highSize=%d  nb=%d  shift=%d  nBatch=%d\n"), highSize, nb, shift, nBatch);
     int *counts = calloc(nBatch*highSize, sizeof(int));  // TODO: cache-line align and make highSize a multiple of 64
     int *TMP   = malloc(nrow*2*sizeof(int));
-    if (!counts || !TMP ) error(_("Internal error: Failed to allocate counts or TMP when assigning g in gforce"));
+    if (!counts || !TMP )
+      error(_("Internal error: Failed to allocate counts or TMP when assigning g in gforce"));
     #pragma omp parallel for num_threads(getDTthreads())   // schedule(dynamic,1)
     for (int b=0; b<nBatch; b++) {
       const int howMany = b==nBatch-1 ? lastBatchSize : batchSize;
@@ -339,15 +347,18 @@ void *gather(SEXP x, bool *anyNA)
 
 SEXP gsum(SEXP x, SEXP narmArg, SEXP warnOverflowArg)
 {
-  if (!isLogical(narmArg) || LENGTH(narmArg)!=1 || LOGICAL(narmArg)[0]==NA_LOGICAL) error(_("na.rm must be TRUE or FALSE"));
+  if (!isLogical(narmArg) || LENGTH(narmArg)!=1 || LOGICAL(narmArg)[0]==NA_LOGICAL)
+    error(_("na.rm must be TRUE or FALSE"));
   const bool narm = LOGICAL(narmArg)[0];
   const bool warnOverflow = LOGICAL(warnOverflowArg)[0];
-  if (inherits(x, "factor")) error(_("sum is not meaningful for factors."));
+  if (inherits(x, "factor"))
+    error(_("sum is not meaningful for factors."));
   const int n = (irowslen == -1) ? length(x) : irowslen;
   double started = wallclock();
   const bool verbose=GetVerbose();
   if (verbose) Rprintf(_("This gsum took (narm=%s) ... "), narm?"TRUE":"FALSE");
-  if (nrow != n) error(_("nrow [%d] != length(x) [%d] in %s"), nrow, n, "gsum");
+  if (nrow != n)
+    error(_("nrow [%d] != length(x) [%d] in %s"), nrow, n, "gsum");
   bool anyNA=false;
   SEXP ans;
   switch(TYPEOF(x)) {
@@ -574,9 +585,12 @@ SEXP gmean(SEXP x, SEXP narm)
 {
   SEXP ans=R_NilValue;
   //clock_t start = clock();
-  if (!isLogical(narm) || LENGTH(narm)!=1 || LOGICAL(narm)[0]==NA_LOGICAL) error(_("na.rm must be TRUE or FALSE"));
-  if (!isVectorAtomic(x)) error(_("GForce mean can only be applied to columns, not .SD or similar. Likely you're looking for 'DT[,lapply(.SD,mean),by=,.SDcols=]'. See ?data.table."));
-  if (inherits(x, "factor")) error(_("mean is not meaningful for factors."));
+  if (!isLogical(narm) || LENGTH(narm)!=1 || LOGICAL(narm)[0]==NA_LOGICAL)
+    error(_("na.rm must be TRUE or FALSE"));
+  if (!isVectorAtomic(x))
+    error(_("GForce mean can only be applied to columns, not .SD or similar. Likely you're looking for 'DT[,lapply(.SD,mean),by=,.SDcols=]'. See ?data.table."));
+  if (inherits(x, "factor"))
+    error(_("mean is not meaningful for factors."));
   if (!LOGICAL(narm)[0]) {
     int protecti=0;
     ans = PROTECT(gsum(x, narm, /*#986, warnOverflow=*/ScalarLogical(FALSE))); protecti++;
@@ -603,13 +617,16 @@ SEXP gmean(SEXP x, SEXP narm)
   }
   // na.rm=TRUE.  Similar to gsum, but we need to count the non-NA as well for the divisor
   const int n = (irowslen == -1) ? length(x) : irowslen;
-  if (nrow != n) error(_("nrow [%d] != length(x) [%d] in %s"), nrow, n, "gsum");
+  if (nrow != n)
+    error(_("nrow [%d] != length(x) [%d] in %s"), nrow, n, "gsum");
 
   long double *s = calloc(ngrp, sizeof(long double)), *si=NULL;  // s = sum; si = sum imaginary just for complex
-  if (!s) error(_("Unable to allocate %d * %d bytes for sum in gmean na.rm=TRUE"), ngrp, sizeof(long double));
+  if (!s)
+    error(_("Unable to allocate %d * %d bytes for sum in gmean na.rm=TRUE"), ngrp, sizeof(long double));
 
   int *c = calloc(ngrp, sizeof(int));
-  if (!c) error(_("Unable to allocate %d * %d bytes for counts in gmean na.rm=TRUE"), ngrp, sizeof(int));
+  if (!c)
+    error(_("Unable to allocate %d * %d bytes for counts in gmean na.rm=TRUE"), ngrp, sizeof(int));
 
   switch(TYPEOF(x)) {
   case LGLSXP: case INTSXP: {
@@ -635,7 +652,8 @@ SEXP gmean(SEXP x, SEXP narm)
   case CPLXSXP: {
     const Rcomplex *xd = COMPLEX(x);
     si = calloc(ngrp, sizeof(long double));
-    if (!si) error(_("Unable to allocate %d * %d bytes for si in gmean na.rm=TRUE"), ngrp, sizeof(long double));
+    if (!si)
+      error(_("Unable to allocate %d * %d bytes for si in gmean na.rm=TRUE"), ngrp, sizeof(long double));
     for (int i=0; i<n; i++) {
       int thisgrp = grp[i];
       int ix = (irowslen == -1) ? i : irows[i]-1;
@@ -683,14 +701,18 @@ SEXP gmean(SEXP x, SEXP narm)
 // gmin
 SEXP gmin(SEXP x, SEXP narm)
 {
-  if (!isLogical(narm) || LENGTH(narm)!=1 || LOGICAL(narm)[0]==NA_LOGICAL) error(_("na.rm must be TRUE or FALSE"));
-  if (!isVectorAtomic(x)) error(_("GForce min can only be applied to columns, not .SD or similar. To find min of all items in a list such as .SD, either add the prefix base::min(.SD) or turn off GForce optimization using options(datatable.optimize=1). More likely, you may be looking for 'DT[,lapply(.SD,min),by=,.SDcols=]'"));
-  if (inherits(x, "factor") && !inherits(x, "ordered")) error(_("min is not meaningful for factors."));
+  if (!isLogical(narm) || LENGTH(narm)!=1 || LOGICAL(narm)[0]==NA_LOGICAL)
+    error(_("na.rm must be TRUE or FALSE"));
+  if (!isVectorAtomic(x))
+    error(_("GForce min can only be applied to columns, not .SD or similar. To find min of all items in a list such as .SD, either add the prefix base::min(.SD) or turn off GForce optimization using options(datatable.optimize=1). More likely, you may be looking for 'DT[,lapply(.SD,min),by=,.SDcols=]'"));
+  if (inherits(x, "factor") && !inherits(x, "ordered"))
+    error(_("min is not meaningful for factors."));
   R_len_t i, ix, thisgrp=0;
   int n = (irowslen == -1) ? length(x) : irowslen;
   //clock_t start = clock();
   SEXP ans;
-  if (nrow != n) error(_("nrow [%d] != length(x) [%d] in %s"), nrow, n, "gmin");
+  if (nrow != n)
+    error(_("nrow [%d] != length(x) [%d] in %s"), nrow, n, "gmin");
   int protecti=0;
   switch(TYPEOF(x)) {
   case LGLSXP: case INTSXP:
@@ -802,14 +824,18 @@ SEXP gmin(SEXP x, SEXP narm)
 // gmax
 SEXP gmax(SEXP x, SEXP narm)
 {
-  if (!isLogical(narm) || LENGTH(narm)!=1 || LOGICAL(narm)[0]==NA_LOGICAL) error(_("na.rm must be TRUE or FALSE"));
-  if (!isVectorAtomic(x)) error(_("GForce max can only be applied to columns, not .SD or similar. To find max of all items in a list such as .SD, either add the prefix base::max(.SD) or turn off GForce optimization using options(datatable.optimize=1). More likely, you may be looking for 'DT[,lapply(.SD,max),by=,.SDcols=]'"));
-  if (inherits(x, "factor") && !inherits(x, "ordered")) error(_("max is not meaningful for factors."));
+  if (!isLogical(narm) || LENGTH(narm)!=1 || LOGICAL(narm)[0]==NA_LOGICAL)
+    error(_("na.rm must be TRUE or FALSE"));
+  if (!isVectorAtomic(x))
+    error(_("GForce max can only be applied to columns, not .SD or similar. To find max of all items in a list such as .SD, either add the prefix base::max(.SD) or turn off GForce optimization using options(datatable.optimize=1). More likely, you may be looking for 'DT[,lapply(.SD,max),by=,.SDcols=]'"));
+  if (inherits(x, "factor") && !inherits(x, "ordered"))
+    error(_("max is not meaningful for factors."));
   R_len_t i, ix, thisgrp=0;
   int n = (irowslen == -1) ? length(x) : irowslen;
   //clock_t start = clock();
   SEXP ans;
-  if (nrow != n) error(_("nrow [%d] != length(x) [%d] in %s"), nrow, n, "gmax");
+  if (nrow != n)
+    error(_("nrow [%d] != length(x) [%d] in %s"), nrow, n, "gmax");
 
   // TODO rework gmax in the same way as gmin and remove this *update
   char *update = (char *)R_alloc(ngrp, sizeof(char));
@@ -947,12 +973,16 @@ SEXP gmax(SEXP x, SEXP narm)
 
 // gmedian, always returns numeric type (to avoid as.numeric() wrap..)
 SEXP gmedian(SEXP x, SEXP narmArg) {
-  if (!isLogical(narmArg) || LENGTH(narmArg)!=1 || LOGICAL(narmArg)[0]==NA_LOGICAL) error(_("na.rm must be TRUE or FALSE"));
-  if (!isVectorAtomic(x)) error(_("GForce median can only be applied to columns, not .SD or similar. To find median of all items in a list such as .SD, either add the prefix stats::median(.SD) or turn off GForce optimization using options(datatable.optimize=1). More likely, you may be looking for 'DT[,lapply(.SD,median),by=,.SDcols=]'"));
-  if (inherits(x, "factor")) error(_("median is not meaningful for factors."));
+  if (!isLogical(narmArg) || LENGTH(narmArg)!=1 || LOGICAL(narmArg)[0]==NA_LOGICAL)
+    error(_("na.rm must be TRUE or FALSE"));
+  if (!isVectorAtomic(x))
+    error(_("GForce median can only be applied to columns, not .SD or similar. To find median of all items in a list such as .SD, either add the prefix stats::median(.SD) or turn off GForce optimization using options(datatable.optimize=1). More likely, you may be looking for 'DT[,lapply(.SD,median),by=,.SDcols=]'"));
+  if (inherits(x, "factor"))
+    error(_("median is not meaningful for factors."));
   const bool isInt64 = INHERITS(x, char_integer64), narm = LOGICAL(narmArg)[0];
   int n = (irowslen == -1) ? length(x) : irowslen;
-  if (nrow != n) error(_("nrow [%d] != length(x) [%d] in %s"), nrow, n, "gmedian");
+  if (nrow != n)
+    error(_("nrow [%d] != length(x) [%d] in %s"), nrow, n, "gmedian");
   SEXP ans = PROTECT(allocVector(REALSXP, ngrp));
   double *ansd = REAL(ans);
   switch(TYPEOF(x)) {
@@ -1002,7 +1032,8 @@ SEXP glast(SEXP x) {
   R_len_t i,k;
   int n = (irowslen == -1) ? length(x) : irowslen;
   SEXP ans;
-  if (nrow != n) error(_("nrow [%d] != length(x) [%d] in %s"), nrow, n, "gtail");
+  if (nrow != n)
+    error(_("nrow [%d] != length(x) [%d] in %s"), nrow, n, "gtail");
   switch(TYPEOF(x)) {
   case LGLSXP: {
     const int *ix = LOGICAL(x);
@@ -1082,7 +1113,8 @@ SEXP gfirst(SEXP x) {
   R_len_t i,k;
   int n = (irowslen == -1) ? length(x) : irowslen;
   SEXP ans;
-  if (nrow != n) error(_("nrow [%d] != length(x) [%d] in %s"), nrow, n, "ghead");
+  if (nrow != n)
+    error(_("nrow [%d] != length(x) [%d] in %s"), nrow, n, "ghead");
   switch(TYPEOF(x)) {
   case LGLSXP: {
     int const *ix = LOGICAL(x);
@@ -1158,22 +1190,26 @@ SEXP gfirst(SEXP x) {
 }
 
 SEXP gtail(SEXP x, SEXP valArg) {
-  if (!isInteger(valArg) || LENGTH(valArg)!=1 || INTEGER(valArg)[0]!=1) error(_("Internal error, gtail is only implemented for n=1. This should have been caught before. please report to data.table issue tracker.")); // # nocov
+  if (!isInteger(valArg) || LENGTH(valArg)!=1 || INTEGER(valArg)[0]!=1)
+    error(_("Internal error, gtail is only implemented for n=1. This should have been caught before. please report to data.table issue tracker.")); // # nocov
   return (glast(x));
 }
 
 SEXP ghead(SEXP x, SEXP valArg) {
-  if (!isInteger(valArg) || LENGTH(valArg)!=1 || INTEGER(valArg)[0]!=1) error(_("Internal error, ghead is only implemented for n=1. This should have been caught before. please report to data.table issue tracker.")); // # nocov
+  if (!isInteger(valArg) || LENGTH(valArg)!=1 || INTEGER(valArg)[0]!=1)
+    error(_("Internal error, ghead is only implemented for n=1. This should have been caught before. please report to data.table issue tracker.")); // # nocov
   return (gfirst(x));
 }
 
 SEXP gnthvalue(SEXP x, SEXP valArg) {
 
-  if (!isInteger(valArg) || LENGTH(valArg)!=1 || INTEGER(valArg)[0]<=0) error(_("Internal error, `g[` (gnthvalue) is only implemented single value subsets with positive index, e.g., .SD[2]. This should have been caught before. please report to data.table issue tracker.")); // # nocov
+  if (!isInteger(valArg) || LENGTH(valArg)!=1 || INTEGER(valArg)[0]<=0)
+    error(_("Internal error, `g[` (gnthvalue) is only implemented single value subsets with positive index, e.g., .SD[2]. This should have been caught before. please report to data.table issue tracker.")); // # nocov
   R_len_t i,k, val=INTEGER(valArg)[0];
   int n = (irowslen == -1) ? length(x) : irowslen;
   SEXP ans;
-  if (nrow != n) error(_("nrow [%d] != length(x) [%d] in %s"), nrow, n, "ghead");
+  if (nrow != n)
+    error(_("nrow [%d] != length(x) [%d] in %s"), nrow, n, "ghead");
   switch(TYPEOF(x)) {
   case LGLSXP: {
     const int *ix = LOGICAL(x);
@@ -1258,12 +1294,16 @@ SEXP gnthvalue(SEXP x, SEXP valArg) {
 // implemented this similar to gmedian to balance well between speed and memory usage. There's one extra allocation on maximum groups and that's it.. and that helps speed things up extremely since we don't have to collect x's values for each group for each step (mean, residuals, mean again and then variance).
 SEXP gvarsd1(SEXP x, SEXP narm, Rboolean isSD)
 {
-  if (!isLogical(narm) || LENGTH(narm)!=1 || LOGICAL(narm)[0]==NA_LOGICAL) error(_("na.rm must be TRUE or FALSE"));
-  if (!isVectorAtomic(x)) error(_("GForce var/sd can only be applied to columns, not .SD or similar. For the full covariance matrix of all items in a list such as .SD, either add the prefix stats::var(.SD) (or stats::sd(.SD)) or turn off GForce optimization using options(datatable.optimize=1). Alternatively, if you only need the diagonal elements, 'DT[,lapply(.SD,var),by=,.SDcols=]' is the optimized way to do this."));
-  if (inherits(x, "factor")) error(_("var/sd is not meaningful for factors."));
+  if (!isLogical(narm) || LENGTH(narm)!=1 || LOGICAL(narm)[0]==NA_LOGICAL)
+    error(_("na.rm must be TRUE or FALSE"));
+  if (!isVectorAtomic(x))
+    error(_("GForce var/sd can only be applied to columns, not .SD or similar. For the full covariance matrix of all items in a list such as .SD, either add the prefix stats::var(.SD) (or stats::sd(.SD)) or turn off GForce optimization using options(datatable.optimize=1). Alternatively, if you only need the diagonal elements, 'DT[,lapply(.SD,var),by=,.SDcols=]' is the optimized way to do this."));
+  if (inherits(x, "factor"))
+    error(_("var/sd is not meaningful for factors."));
   long double m, s, v;
   R_len_t i, j, ix, thisgrpsize = 0, n = (irowslen == -1) ? length(x) : irowslen;
-  if (nrow != n) error(_("nrow [%d] != length(x) [%d] in %s"), nrow, n, "gvar");
+  if (nrow != n)
+    error(_("nrow [%d] != length(x) [%d] in %s"), nrow, n, "gvar");
   SEXP sub, ans = PROTECT(allocVector(REALSXP, ngrp));
   Rboolean ans_na;
   switch(TYPEOF(x)) {
@@ -1399,16 +1439,21 @@ SEXP gsd(SEXP x, SEXP narm) {
 
 SEXP gprod(SEXP x, SEXP narm)
 {
-  if (!isLogical(narm) || LENGTH(narm)!=1 || LOGICAL(narm)[0]==NA_LOGICAL) error(_("na.rm must be TRUE or FALSE"));
-  if (!isVectorAtomic(x)) error(_("GForce prod can only be applied to columns, not .SD or similar. To multiply all items in a list such as .SD, either add the prefix base::prod(.SD) or turn off GForce optimization using options(datatable.optimize=1). More likely, you may be looking for 'DT[,lapply(.SD,prod),by=,.SDcols=]'"));
-  if (inherits(x, "factor")) error(_("prod is not meaningful for factors."));
+  if (!isLogical(narm) || LENGTH(narm)!=1 || LOGICAL(narm)[0]==NA_LOGICAL)
+    error(_("na.rm must be TRUE or FALSE"));
+  if (!isVectorAtomic(x))
+    error(_("GForce prod can only be applied to columns, not .SD or similar. To multiply all items in a list such as .SD, either add the prefix base::prod(.SD) or turn off GForce optimization using options(datatable.optimize=1). More likely, you may be looking for 'DT[,lapply(.SD,prod),by=,.SDcols=]'"));
+  if (inherits(x, "factor"))
+    error(_("prod is not meaningful for factors."));
   int i, ix, thisgrp;
   int n = (irowslen == -1) ? length(x) : irowslen;
   //clock_t start = clock();
   SEXP ans;
-  if (nrow != n) error(_("nrow [%d] != length(x) [%d] in %s"), nrow, n, "gprod");
+  if (nrow != n)
+    error(_("nrow [%d] != length(x) [%d] in %s"), nrow, n, "gprod");
   long double *s = malloc(ngrp * sizeof(long double));
-  if (!s) error(_("Unable to allocate %d * %d bytes for gprod"), ngrp, sizeof(long double));
+  if (!s)
+    error(_("Unable to allocate %d * %d bytes for gprod"), ngrp, sizeof(long double));
   for (i=0; i<ngrp; i++) s[i] = 1.0;
   ans = PROTECT(allocVector(REALSXP, ngrp));
   switch(TYPEOF(x)) {

--- a/src/ijoin.c
+++ b/src/ijoin.c
@@ -53,7 +53,8 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
           if (count[i]) type_count[i] = 1;
       }
       break;
-    default: error(_("Internal error: unknown type in mult=%d in lookup: %d"), mult, type); // #nocov
+    default:
+      error(_("Internal error: unknown type in mult=%d in lookup: %d"), mult, type); // #nocov
     }
     break;
 
@@ -118,10 +119,12 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
         }
       }
       break;
-    default: error(_("Internal error: unknown type in mult=%d in lookup: %d"), mult, type); // #nocov
+    default:
+      error(_("Internal error: unknown type in mult=%d in lookup: %d"), mult, type); // #nocov
     }
     break;
-  default: error(_("Internal error: unknown mult in lookup: %d"), mult); // #nocov
+  default:
+    error(_("Internal error: unknown mult in lookup: %d"), mult); // #nocov
   }
   pass1 = clock() - start;
   if (LOGICAL(verbose)[0])
@@ -157,7 +160,8 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
       INTEGER(VECTOR_ELT(lookup, to[i]-1))[idx[to[i]-1]++] = i+1;
     }
     break;
-  default: error(_("Internal error: unknown type lookup should have been caught earlier: %d"), type); // #nocov
+  default:
+    error(_("Internal error: unknown type lookup should have been caught earlier: %d"), type); // #nocov
   }
   Free(idx);
   // generate type_lookup
@@ -209,10 +213,12 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
         //         INTEGER(tt)[j] = INTEGER(vv)[j];
         // }
         break; // #nocov
-      default: error(_("Internal error: unknown type in mult=%d in lookup should have been caught earlier: %d"), mult, type); // #nocov
+      default:
+        error(_("Internal error: unknown type in mult=%d in lookup should have been caught earlier: %d"), mult, type); // #nocov
       }
      break;
-    default: error(_("Internal error: unknown mult in lookup: %d"), mult); // #nocov
+    default:
+      error(_("Internal error: unknown mult in lookup: %d"), mult); // #nocov
     }
   }
   pass3 = clock() - start;
@@ -320,7 +326,8 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
           ++totlen;
       }
       break;
-    default: error(_("Internal error: unknown type in mult=ALL in overlaps: %d"), mult, type); // #nocov
+    default:
+      error(_("Internal error: unknown type in mult=ALL in overlaps: %d"), mult, type); // #nocov
     }
   } else totlen = rows;
   end1 = clock() - start;
@@ -461,7 +468,8 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
          }
       }
       break;
-    default: error(_("Internal error: unknown type in mult=%d in overlaps: %d"), mult, type); // #nocov
+    default:
+      error(_("Internal error: unknown type in mult=%d in overlaps: %d"), mult, type); // #nocov
     }
     break;
 
@@ -568,7 +576,8 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
         }
       }
       break;
-    default: error(_("Internal error: unknown type in mult=%d in overlaps: %d"), mult, type); // #nocov
+    default:
+      error(_("Internal error: unknown type in mult=%d in overlaps: %d"), mult, type); // #nocov
     }
     break;
 
@@ -717,10 +726,12 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
          }
       }
       break;
-    default: error(_("Internal error: unknown type in mult=%d in overlaps: %d"), mult, type); // #nocov
+    default:
+      error(_("Internal error: unknown type in mult=%d in overlaps: %d"), mult, type); // #nocov
     }
     break;
-  default: error(_("Internal error: unknown mult in overlaps: %d"), mult); // #nocov
+  default:
+    error(_("Internal error: unknown mult in overlaps: %d"), mult); // #nocov
   }
   end2 = clock() - start;
   if (LOGICAL(verbose)[0])

--- a/src/init.c
+++ b/src/init.c
@@ -230,7 +230,8 @@ static void setSizes() {
   sizes[CPLXSXP] = sizeof(Rcomplex);  typeorder[CPLXSXP] = 4;
   sizes[STRSXP] =  sizeof(SEXP *);    typeorder[STRSXP] =  5;
   sizes[VECSXP] =  sizeof(SEXP *);    typeorder[VECSXP] =  6;   // list column
-  if (sizeof(char *)>8) error(_("Pointers are %d bytes, greater than 8. We have not tested on any architecture greater than 64bit yet."), sizeof(char *));
+  if (sizeof(char *)>8)
+    error(_("Pointers are %d bytes, greater than 8. We have not tested on any architecture greater than 64bit yet."), sizeof(char *));
   // One place we need the largest sizeof is the working memory malloc in reorder.c
 }
 
@@ -244,59 +245,88 @@ void attribute_visible R_init_datatable(DllInfo *info)
   R_useDynamicSymbols(info, FALSE);
   setSizes();
   const char *msg = "... failed. Please forward this message to maintainer('data.table').";
-  if ((int)NA_INTEGER != (int)INT_MIN) error(_("Checking NA_INTEGER [%d] == INT_MIN [%d] %s"), NA_INTEGER, INT_MIN, msg);
-  if ((int)NA_INTEGER != (int)NA_LOGICAL) error(_("Checking NA_INTEGER [%d] == NA_LOGICAL [%d] %s"), NA_INTEGER, NA_LOGICAL, msg);
-  if (sizeof(int) != 4) error(_("Checking sizeof(int) [%d] is 4 %s"), sizeof(int), msg);
-  if (sizeof(double) != 8) error(_("Checking sizeof(double) [%d] is 8 %s"), sizeof(double), msg);     // 8 on both 32bit and 64bit
+  if ((int)NA_INTEGER != (int)INT_MIN)
+    error(_("Checking NA_INTEGER [%d] == INT_MIN [%d] %s"), NA_INTEGER, INT_MIN, msg);
+  if ((int)NA_INTEGER != (int)NA_LOGICAL)
+    error(_("Checking NA_INTEGER [%d] == NA_LOGICAL [%d] %s"), NA_INTEGER, NA_LOGICAL, msg);
+  if (sizeof(int) != 4)
+    error(_("Checking sizeof(int) [%d] is 4 %s"), sizeof(int), msg);
+  if (sizeof(double) != 8)
+    error(_("Checking sizeof(double) [%d] is 8 %s"), sizeof(double), msg);     // 8 on both 32bit and 64bit
   // alignof not available in C99: if (alignof(double) != 8) error(_("Checking alignof(double) [%d] is 8 %s"), alignof(double), msg);  // 8 on both 32bit and 64bit
-  if (sizeof(long long) != 8) error(_("Checking sizeof(long long) [%d] is 8 %s"), sizeof(long long), msg);
-  if (sizeof(char *) != 4 && sizeof(char *) != 8) error(_("Checking sizeof(pointer) [%d] is 4 or 8 %s"), sizeof(char *), msg);
-  if (sizeof(SEXP) != sizeof(char *)) error(_("Checking sizeof(SEXP) [%d] == sizeof(pointer) [%d] %s"), sizeof(SEXP), sizeof(char *), msg);
-  if (sizeof(uint64_t) != 8) error(_("Checking sizeof(uint64_t) [%d] is 8 %s"), sizeof(uint64_t), msg);
-  if (sizeof(int64_t) != 8) error(_("Checking sizeof(int64_t) [%d] is 8 %s"), sizeof(int64_t), msg);
-  if (sizeof(signed char) != 1) error(_("Checking sizeof(signed char) [%d] is 1 %s"), sizeof(signed char), msg);
-  if (sizeof(int8_t) != 1) error(_("Checking sizeof(int8_t) [%d] is 1 %s"), sizeof(int8_t), msg);
-  if (sizeof(uint8_t) != 1) error(_("Checking sizeof(uint8_t) [%d] is 1 %s"), sizeof(uint8_t), msg);
-  if (sizeof(int16_t) != 2) error(_("Checking sizeof(int16_t) [%d] is 2 %s"), sizeof(int16_t), msg);
-  if (sizeof(uint16_t) != 2) error(_("Checking sizeof(uint16_t) [%d] is 2 %s"), sizeof(uint16_t), msg);
+  if (sizeof(long long) != 8)
+    error(_("Checking sizeof(long long) [%d] is 8 %s"), sizeof(long long), msg);
+  if (sizeof(char *) != 4 && sizeof(char *) != 8)
+    error(_("Checking sizeof(pointer) [%d] is 4 or 8 %s"), sizeof(char *), msg);
+  if (sizeof(SEXP) != sizeof(char *))
+    error(_("Checking sizeof(SEXP) [%d] == sizeof(pointer) [%d] %s"), sizeof(SEXP), sizeof(char *), msg);
+  if (sizeof(uint64_t) != 8)
+    error(_("Checking sizeof(uint64_t) [%d] is 8 %s"), sizeof(uint64_t), msg);
+  if (sizeof(int64_t) != 8)
+    error(_("Checking sizeof(int64_t) [%d] is 8 %s"), sizeof(int64_t), msg);
+  if (sizeof(signed char) != 1)
+    error(_("Checking sizeof(signed char) [%d] is 1 %s"), sizeof(signed char), msg);
+  if (sizeof(int8_t) != 1)
+    error(_("Checking sizeof(int8_t) [%d] is 1 %s"), sizeof(int8_t), msg);
+  if (sizeof(uint8_t) != 1)
+    error(_("Checking sizeof(uint8_t) [%d] is 1 %s"), sizeof(uint8_t), msg);
+  if (sizeof(int16_t) != 2)
+    error(_("Checking sizeof(int16_t) [%d] is 2 %s"), sizeof(int16_t), msg);
+  if (sizeof(uint16_t) != 2)
+    error(_("Checking sizeof(uint16_t) [%d] is 2 %s"), sizeof(uint16_t), msg);
 
   SEXP tmp = PROTECT(allocVector(INTSXP,2));
-  if (LENGTH(tmp)!=2) error(_("Checking LENGTH(allocVector(INTSXP,2)) [%d] is 2 %s"), LENGTH(tmp), msg);
-  if (TRUELENGTH(tmp)!=0) error(_("Checking TRUELENGTH(allocVector(INTSXP,2)) [%d] is 0 %s"), TRUELENGTH(tmp), msg);
+  if (LENGTH(tmp)!=2)
+    error(_("Checking LENGTH(allocVector(INTSXP,2)) [%d] is 2 %s"), LENGTH(tmp), msg);
+  if (TRUELENGTH(tmp)!=0)
+    error(_("Checking TRUELENGTH(allocVector(INTSXP,2)) [%d] is 0 %s"), TRUELENGTH(tmp), msg);
   UNPROTECT(1);
 
   // According to IEEE (http://en.wikipedia.org/wiki/IEEE_754-1985#Zero) we can rely on 0.0 being all 0 bits.
   // But check here anyway just to be sure, just in case this answer is right (http://stackoverflow.com/a/2952680/403310).
   int i = 314;
   memset(&i, 0, sizeof(int));
-  if (i != 0) error(_("Checking memset(&i,0,sizeof(int)); i == (int)0 %s"), msg);
+  if (i != 0)
+    error(_("Checking memset(&i,0,sizeof(int)); i == (int)0 %s"), msg);
   unsigned int ui = 314;
   memset(&ui, 0, sizeof(unsigned int));
-  if (ui != 0) error(_("Checking memset(&ui, 0, sizeof(unsigned int)); ui == (unsigned int)0 %s"), msg);
+  if (ui != 0)
+    error(_("Checking memset(&ui, 0, sizeof(unsigned int)); ui == (unsigned int)0 %s"), msg);
   double d = 3.14;
   memset(&d, 0, sizeof(double));
-  if (d != 0.0) error(_("Checking memset(&d, 0, sizeof(double)); d == (double)0.0 %s"), msg);
+  if (d != 0.0)
+    error(_("Checking memset(&d, 0, sizeof(double)); d == (double)0.0 %s"), msg);
   long double ld = 3.14;
   memset(&ld, 0, sizeof(long double));
-  if (ld != 0.0) error(_("Checking memset(&ld, 0, sizeof(long double)); ld == (long double)0.0 %s"), msg);
+  if (ld != 0.0)
+    error(_("Checking memset(&ld, 0, sizeof(long double)); ld == (long double)0.0 %s"), msg);
 
   // Check unsigned cast used in fread.c. This isn't overflow/underflow, just cast.
-  if ((uint_fast8_t)('0'-'/') != 1) error(_("The ascii character '/' is not just before '0'"));
-  if ((uint_fast8_t)('/'-'0') < 10) error(_("The C expression (uint_fast8_t)('/'-'0')<10 is true. Should be false."));
-  if ((uint_fast8_t)(':'-'9') != 1) error(_("The ascii character ':' is not just after '9'"));
-  if ((uint_fast8_t)('9'-':') < 10) error(_("The C expression (uint_fast8_t)('9'-':')<10 is true. Should be false."));
+  if ((uint_fast8_t)('0'-'/') != 1)
+    error(_("The ascii character '/' is not just before '0'"));
+  if ((uint_fast8_t)('/'-'0') < 10)
+    error(_("The C expression (uint_fast8_t)('/'-'0')<10 is true. Should be false."));
+  if ((uint_fast8_t)(':'-'9') != 1)
+    error(_("The ascii character ':' is not just after '9'"));
+  if ((uint_fast8_t)('9'-':') < 10)
+    error(_("The C expression (uint_fast8_t)('9'-':')<10 is true. Should be false."));
 
   // Variables rather than #define for NA_INT64 to ensure correct usage; i.e. not casted
   NA_INT64_LL = LLONG_MIN;
   NA_INT64_D = LLtoD(NA_INT64_LL);
-  if (NA_INT64_LL != DtoLL(NA_INT64_D)) error(_("Conversion of NA_INT64 via double failed %"PRId64"!=%"PRId64), (int64_t)NA_INT64_LL, (int64_t)DtoLL(NA_INT64_D));
+  if (NA_INT64_LL != DtoLL(NA_INT64_D))
+    error(_("Conversion of NA_INT64 via double failed %"PRId64"!=%"PRId64), (int64_t)NA_INT64_LL, (int64_t)DtoLL(NA_INT64_D));
   // LLONG_MIN when punned to double is the sign bit set and then all zeros in exponent and significand i.e. -0.0
   //   That's why we must never test for NA_INT64_D using == in double type. Must always DtoLL and compare long long types.
   //   Assigning NA_INT64_D to a REAL is ok however.
-  if (NA_INT64_D != 0.0)  error(_("NA_INT64_D (negative -0.0) is not == 0.0."));
-  if (NA_INT64_D != -0.0) error(_("NA_INT64_D (negative -0.0) is not ==-0.0."));
-  if (ISNAN(NA_INT64_D)) error(_("ISNAN(NA_INT64_D) is TRUE but should not be"));
-  if (isnan(NA_INT64_D)) error(_("isnan(NA_INT64_D) is TRUE but should not be"));
+  if (NA_INT64_D != 0.0)
+    error(_("NA_INT64_D (negative -0.0) is not == 0.0."));
+  if (NA_INT64_D != -0.0)
+    error(_("NA_INT64_D (negative -0.0) is not ==-0.0."));
+  if (ISNAN(NA_INT64_D))
+    error(_("ISNAN(NA_INT64_D) is TRUE but should not be"));
+  if (isnan(NA_INT64_D))
+    error(_("isnan(NA_INT64_D) is TRUE but should not be"));
 
   NA_CPLX.r = NA_REAL;  // NA_REAL is defined as R_NaReal which is not a strict constant and thus initializer {NA_REAL, NA_REAL} can't be used in .h
   NA_CPLX.i = NA_REAL;  // https://github.com/Rdatatable/data.table/pull/3689/files#r304117234
@@ -394,7 +424,8 @@ SEXP hasOpenMP() {
 extern int *_Last_updated;  // assign.c
 
 SEXP initLastUpdated(SEXP var) {
-  if (!isInteger(var) || LENGTH(var)!=1) error(_(".Last.value in namespace is not a length 1 integer"));
+  if (!isInteger(var) || LENGTH(var)!=1)
+    error(_(".Last.value in namespace is not a length 1 integer"));
   _Last_updated = INTEGER(var);
   return R_NilValue;
 }

--- a/src/nafill.c
+++ b/src/nafill.c
@@ -187,7 +187,8 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP nan_is_na_arg, SEXP inplace, S
     case INTSXP : {
       nafillInteger(ix[i], inx[i], itype, ifill, &vans[i], verbose);
     } break;
-    default: error(_("Internal error: invalid type argument in nafillR function, should have been caught before. Please report to data.table issue tracker.")); // # nocov
+    default:
+      error(_("Internal error: invalid type argument in nafillR function, should have been caught before. Please report to data.table issue tracker.")); // # nocov
     }
   }
   if (verbose)

--- a/src/openmp-utils.c
+++ b/src/openmp-utils.c
@@ -64,7 +64,8 @@ static const char *mygetenv(const char *name, const char *unset) {
 }
 
 SEXP getDTthreads_R(SEXP verbose) {
-  if (!isLogical(verbose) || LENGTH(verbose)!=1 || INTEGER(verbose)[0]==NA_LOGICAL) error(_("'verbose' must be TRUE or FALSE"));
+  if (!isLogical(verbose) || LENGTH(verbose)!=1 || INTEGER(verbose)[0]==NA_LOGICAL)
+    error(_("'verbose' must be TRUE or FALSE"));
   if (LOGICAL(verbose)[0]) {
     #ifndef _OPENMP
       Rprintf(_("This installation of data.table has not been compiled with OpenMP support.\n"));
@@ -102,9 +103,11 @@ SEXP setDTthreads(SEXP threads, SEXP restore_after_fork, SEXP percent) {
     // reflect that and a call to setDTthreads(threads=NULL) will update DTthreads.
   } else {
     int n=0, protecti=0;
-    if (length(threads)!=1) error(_("threads= must be either NULL (default) or a single number. It has length %d"), length(threads));
+    if (length(threads)!=1)
+      error(_("threads= must be either NULL (default) or a single number. It has length %d"), length(threads));
     if (isReal(threads)) { threads = PROTECT(coerceVector(threads, INTSXP)); protecti++; }
-    if (!isInteger(threads)) error(_("threads= must be either NULL (default) or type integer/numeric"));
+    if (!isInteger(threads))
+      error(_("threads= must be either NULL (default) or type integer/numeric"));
     if ((n=INTEGER(threads)[0]) < 0) {  // <0 catches NA too since NA is negative (INT_MIN)
       error(_("threads= must be either NULL or a single integer >= 0. See ?setDTthreads."));
     }
@@ -114,7 +117,8 @@ SEXP setDTthreads(SEXP threads, SEXP restore_after_fork, SEXP percent) {
       error(_("Internal error: percent= must be TRUE or FALSE at C level"));  // # nocov
     }
     if (LOGICAL(percent)[0]) {
-      if (n<2 || n>100) error(_("Internal error: threads==%d should be between 2 and 100 (percent=TRUE at C level)."), n);  // # nocov
+      if (n<2 || n>100)
+        error(_("Internal error: threads==%d should be between 2 and 100 (percent=TRUE at C level)."), n);  // # nocov
       n = num_procs*n/100;  // if 0 it will be reset to 1 in the imax() below
     } else {
       if (n==0 || n>num_procs) n = num_procs; // setDTthreads(0) == setDTthread(percent=100); i.e. use all logical CPUs (the default in 1.12.0 and before, from 1.12.2 it's 50%)

--- a/src/rbindlist.c
+++ b/src/rbindlist.c
@@ -9,7 +9,8 @@ SEXP rbindlist(SEXP l, SEXP usenamesArg, SEXP fillArg, SEXP idcolArg)
   if (!isLogical(usenamesArg) || LENGTH(usenamesArg)!=1)
     error(_("use.names= should be TRUE, FALSE, or not used (\"check\" by default)"));  // R levels converts "check" to NA
   if (!length(l)) return(l);
-  if (TYPEOF(l) != VECSXP) error(_("Input to rbindlist must be a list. This list can contain data.tables, data.frames or plain lists."));
+  if (TYPEOF(l) != VECSXP)
+    error(_("Input to rbindlist must be a list. This list can contain data.tables, data.frames or plain lists."));
   Rboolean usenames = LOGICAL(usenamesArg)[0];
   const bool fill = LOGICAL(fillArg)[0];
   if (fill && usenames!=TRUE) {
@@ -17,7 +18,8 @@ SEXP rbindlist(SEXP l, SEXP usenamesArg, SEXP fillArg, SEXP idcolArg)
     usenames=TRUE;
   }
   const bool idcol = !isNull(idcolArg);
-  if (idcol && (!isString(idcolArg) || LENGTH(idcolArg)!=1)) error(_("Internal error: rbindlist.c idcol is not a single string"));  // # nocov
+  if (idcol && (!isString(idcolArg) || LENGTH(idcolArg)!=1))
+    error(_("Internal error: rbindlist.c idcol is not a single string"));  // # nocov
   int ncol=0, first=0;
   int64_t nrow=0, upperBoundUniqueNames=1;
   bool anyNames=false;
@@ -28,7 +30,8 @@ SEXP rbindlist(SEXP l, SEXP usenamesArg, SEXP fillArg, SEXP idcolArg)
     eachMax[i] = 0;
     SEXP li = VECTOR_ELT(l, i);
     if (isNull(li)) continue;
-    if (TYPEOF(li) != VECSXP) error(_("Item %d of input is not a data.frame, data.table or list"), i+1);
+    if (TYPEOF(li) != VECSXP)
+      error(_("Item %d of input is not a data.frame, data.table or list"), i+1);
     const int thisncol = length(li);
     if (!thisncol) continue;
     // delete as now more flexible ... if (fill && isNull(getAttrib(li, R_NamesSymbol))) error(_("When fill=TRUE every item of the input must have column names. Item %d does not."), i+1);
@@ -36,17 +39,20 @@ SEXP rbindlist(SEXP l, SEXP usenamesArg, SEXP fillArg, SEXP idcolArg)
       if (thisncol>ncol) ncol=thisncol;  // this section initializes ncol with max ncol. ncol may be increased when usenames is accounted for further down
     } else {
       if (ncol==0) { ncol=thisncol; first=i; }
-      else if (thisncol!=ncol) error(_("Item %d has %d columns, inconsistent with item %d which has %d columns. To fill missing columns use fill=TRUE."), i+1, thisncol, first+1, ncol);
+      else if (thisncol!=ncol)
+        error(_("Item %d has %d columns, inconsistent with item %d which has %d columns. To fill missing columns use fill=TRUE."), i+1, thisncol, first+1, ncol);
     }
     int nNames = length(getAttrib(li, R_NamesSymbol));
-    if (nNames>0 && nNames!=thisncol) error(_("Item %d has %d columns but %d column names. Invalid object."), i+1, thisncol, nNames);
+    if (nNames>0 && nNames!=thisncol)
+      error(_("Item %d has %d columns but %d column names. Invalid object."), i+1, thisncol, nNames);
     if (nNames>0) anyNames=true;
     upperBoundUniqueNames += nNames;
     int maxLen=0, whichMax=0;
     for (int j=0; j<thisncol; ++j) { int tt=length(VECTOR_ELT(li,j)); if (tt>maxLen) { maxLen=tt; whichMax=j; } }
     for (int j=0; j<thisncol; ++j) {
       int tt = length(VECTOR_ELT(li, j));
-      if (tt>1 && tt!=maxLen) error(_("Column %d of item %d is length %d inconsistent with column %d which is length %d. Only length-1 columns are recycled."), j+1, i+1, tt, whichMax+1, maxLen);
+      if (tt>1 && tt!=maxLen)
+        error(_("Column %d of item %d is length %d inconsistent with column %d which is length %d. Only length-1 columns are recycled."), j+1, i+1, tt, whichMax+1, maxLen);
       if (tt==0 && maxLen>0 && numZero++==0) { firstZeroCol = j; firstZeroItem=i; }
     }
     eachMax[i] = maxLen;
@@ -59,8 +65,10 @@ SEXP rbindlist(SEXP l, SEXP usenamesArg, SEXP fillArg, SEXP idcolArg)
             firstZeroCol+1, ch, firstZeroItem+1, numZero-1, numZero==2?"":"s");
   }
   if (nrow==0 && ncol==0) return(R_NilValue);
-  if (nrow>INT32_MAX) error(_("Total rows in the list is %"PRId64" which is larger than the maximum number of rows, currently %d"), (int64_t)nrow, INT32_MAX);
-  if (usenames==TRUE && !anyNames) error(_("use.names=TRUE but no item of input list has any names"));
+  if (nrow>INT32_MAX)
+    error(_("Total rows in the list is %"PRId64" which is larger than the maximum number of rows, currently %d"), (int64_t)nrow, INT32_MAX);
+  if (usenames==TRUE && !anyNames)
+    error(_("use.names=TRUE but no item of input list has any names"));
 
   int *colMap=NULL; // maps each column in final result to the column of each list item
   if (usenames==TRUE || usenames==NA_LOGICAL) {
@@ -68,7 +76,8 @@ SEXP rbindlist(SEXP l, SEXP usenamesArg, SEXP fillArg, SEXP idcolArg)
     // when use.names==NA we also proceed here as if use.names was TRUE to save new code and then check afterwards the map is 1:ncol for every item
     // first find number of unique column names present; i.e. length(unique(unlist(lapply(l,names))))
     SEXP *uniq = (SEXP *)malloc(upperBoundUniqueNames * sizeof(SEXP));  // upperBoundUniqueNames was initialized with 1 to ensure this is defined (otherwise 0 when no item has names)
-    if (!uniq) error(_("Failed to allocate upper bound of %"PRId64" unique column names [sum(lapply(l,ncol))]"), (int64_t)upperBoundUniqueNames);
+    if (!uniq)
+      error(_("Failed to allocate upper bound of %"PRId64" unique column names [sum(lapply(l,ncol))]"), (int64_t)upperBoundUniqueNames);
     savetl_init();
     int nuniq=0;
     for (int i=0; i<LENGTH(l); i++) {
@@ -188,7 +197,8 @@ SEXP rbindlist(SEXP l, SEXP usenamesArg, SEXP fillArg, SEXP idcolArg)
     // for (int i=0; i<LENGTH(l); ++i) { for (int j=0; j<ncol; ++j) Rprintf(_("%2d "),colMap[i*ncol + j]);  Rprintf(_("\n")); }
   }
 
-  if (fill && usenames==NA_LOGICAL) error(_("Internal error: usenames==NA but fill=TRUE. usenames should have been set to TRUE earlier with warning."));
+  if (fill && usenames==NA_LOGICAL)
+    error(_("Internal error: usenames==NA but fill=TRUE. usenames should have been set to TRUE earlier with warning."));
   if (!fill && (usenames==TRUE || usenames==NA_LOGICAL)) {
     // Ensure no missings in both cases, and (when usenames==NA) all columns in same order too
     // We proceeded earlier as if fill was true, so varying ncol items will have missings here
@@ -203,19 +213,22 @@ SEXP rbindlist(SEXP l, SEXP usenamesArg, SEXP fillArg, SEXP idcolArg)
         if (w==-1) {
           int missi = i;
           while (colMap[i*ncol + j]==-1 && i<LENGTH(l)) i++;
-          if (i==LENGTH(l)) error(_("Internal error: could not find the first column name not present in earlier item"));
+          if (i==LENGTH(l))
+            error(_("Internal error: could not find the first column name not present in earlier item"));
           SEXP s = getAttrib(VECTOR_ELT(l, i), R_NamesSymbol);
           int w2 = colMap[i*ncol + j];
           const char *str = isString(s) ? CHAR(STRING_ELT(s,w2)) : "";
           snprintf(buff, 1000, _("Column %d ['%s'] of item %d is missing in item %d. Use fill=TRUE to fill with NA (NULL for list columns), or use.names=FALSE to ignore column names.%s"),
                         w2+1, str, i+1, missi+1, extra );
-          if (usenames==TRUE) error(buff);
+          if (usenames==TRUE)
+            error(buff);
           i = LENGTH(l); // break from outer i loop
           break;         // break from inner j loop
         }
         if (w!=j && usenames==NA_LOGICAL) {
           SEXP s = getAttrib(VECTOR_ELT(l, i), R_NamesSymbol);
-          if (!isString(s) || i==0) error(_("Internal error: usenames==NA but an out-of-order name has been found in an item with no names or the first item. [%d]"), i);
+          if (!isString(s) || i==0)
+            error(_("Internal error: usenames==NA but an out-of-order name has been found in an item with no names or the first item. [%d]"), i);
           snprintf(buff, 1000, _("Column %d ['%s'] of item %d appears in position %d in item %d. Set use.names=TRUE to match by column name, or use.names=FALSE to ignore column names.%s"),
                                w+1, CHAR(STRING_ELT(s,w)), i+1, j+1, i, extra);
           i = LENGTH(l);
@@ -231,7 +244,8 @@ SEXP rbindlist(SEXP l, SEXP usenamesArg, SEXP fillArg, SEXP idcolArg)
         const char *o = isNull(opt) ? "message" : CHAR(STRING_ELT(opt,0));
         if      (strcmp(o,"message")==0) { eval(PROTECT(lang2(install("message"),PROTECT(ScalarString(mkChar(buff))))), R_GlobalEnv); UNPROTECT(2); }
         else if (strcmp(o,"warning")==0) warning(buff);
-        else if (strcmp(o,"error")==0)   error(buff);
+        else if (strcmp(o,"error")==0)
+          error(buff);
         else if (strcmp(o,"none")!=0)    warning(_("options()$datatable.rbindlist.check=='%s' which is not 'message'|'warning'|'error'|'none'. See news item 5 in v1.12.2."), o);
       }
     }
@@ -295,7 +309,8 @@ SEXP rbindlist(SEXP l, SEXP usenamesArg, SEXP fillArg, SEXP idcolArg)
       // Use >= for #546 -- TYPEORDER=0 for both LGLSXP and EXPRSXP (but also NULL)
       if (TYPEORDER(thisType)>=TYPEORDER(maxType) && !isNull(thisCol)) maxType=thisType;
       if (isFactor(thisCol)) {
-        if (isNull(getAttrib(thisCol,R_LevelsSymbol))) error(_("Column %d of item %d has type 'factor' but has no levels; i.e. malformed."), w+1, i+1);
+        if (isNull(getAttrib(thisCol,R_LevelsSymbol)))
+          error(_("Column %d of item %d has type 'factor' but has no levels; i.e. malformed."), w+1, i+1);
         factor = true;
         if (isOrdered(thisCol)) {
           orderedFactor = true;
@@ -359,7 +374,10 @@ SEXP rbindlist(SEXP l, SEXP usenamesArg, SEXP fillArg, SEXP idcolArg)
         const SEXP *sd = STRING_PTR(longestLevels);
         nLevel = allocLevel = longestLen;
         levelsRaw = (SEXP *)malloc(nLevel * sizeof(SEXP));
-        if (!levelsRaw) { savetl_end(); error(_("Failed to allocate working memory for %d ordered factor levels of result column %d"), nLevel, idcol+j+1); }
+        if (!levelsRaw) {
+          savetl_end();
+          error(_("Failed to allocate working memory for %d ordered factor levels of result column %d"), nLevel, idcol+j+1);
+        }
         for (int k=0; k<longestLen; ++k) {
           SEXP s = sd[k];
           if (TRUELENGTH(s)>0) savetl(s);

--- a/src/reorder.c
+++ b/src/reorder.c
@@ -25,13 +25,16 @@ SEXP reorder(SEXP x, SEXP order)
   } else {
     if (SIZEOF(x)!=4 && SIZEOF(x)!=8 && SIZEOF(x)!=16)
       error(_("reorder accepts vectors but this non-VECSXP is type '%s' which isn't yet supported (SIZEOF=%d)"), type2char(TYPEOF(x)), SIZEOF(x));
-    if (ALTREP(x)) error(_("Internal error in reorder.c: cannot reorder an ALTREP vector. Please see NEWS item 2 in v1.11.4 and report this as a bug.")); // # nocov
+    if (ALTREP(x))
+      error(_("Internal error in reorder.c: cannot reorder an ALTREP vector. Please see NEWS item 2 in v1.11.4 and report this as a bug.")); // # nocov
     maxSize = SIZEOF(x);
     nrow = length(x);
     ncol = 1;
   }
-  if (!isInteger(order)) error(_("order must be an integer vector"));
-  if (length(order) != nrow) error(_("nrow(x)[%d]!=length(order)[%d]"),nrow,length(order));
+  if (!isInteger(order))
+    error(_("order must be an integer vector"));
+  if (length(order) != nrow)
+    error(_("nrow(x)[%d]!=length(order)[%d]"),nrow,length(order));
   int nprotect = 0;
   if (ALTREP(order)) { order=PROTECT(copyAsPlain(order)); nprotect++; }  // TODO: if it's an ALTREP sequence some optimizations are possible rather than expand
 
@@ -102,7 +105,8 @@ SEXP setcolorder(SEXP x, SEXP o)
 {
   SEXP names = getAttrib(x, R_NamesSymbol);
   const int ncol=LENGTH(x);
-  if (isNull(names)) error(_("dt passed to setcolorder has no names"));
+  if (isNull(names))
+    error(_("dt passed to setcolorder has no names"));
   if (ncol != LENGTH(names))
     error(_("Internal error: dt passed to setcolorder has %d columns but %d names"), ncol, LENGTH(names));  // # nocov
   SEXP tt = PROTECT(allocVector(VECSXP, 2));

--- a/src/shift.c
+++ b/src/shift.c
@@ -25,12 +25,17 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type) {
   if (!strcmp(CHAR(STRING_ELT(type, 0)), "lag")) stype = LAG;
   else if (!strcmp(CHAR(STRING_ELT(type, 0)), "lead")) stype = LEAD;
   else if (!strcmp(CHAR(STRING_ELT(type, 0)), "shift")) stype = LAG; // when we get rid of nested if branches we can use SHIFT, for now it maps to LAG
-  else error(_("Internal error: invalid type for shift(), should have been caught before. please report to data.table issue tracker")); // # nocov
+  else
+    error(_("Internal error: invalid type for shift(), should have been caught before. please report to data.table issue tracker")); // # nocov
 
   int nx = length(x), nk = length(k);
-  if (!isInteger(k)) error(_("Internal error: k must be integer")); // # nocov
+  if (!isInteger(k))
+    error(_("Internal error: k must be integer")); // # nocov
   const int *kd = INTEGER(k);
-  for (int i=0; i<nk; i++) if (kd[i]==NA_INTEGER) error(_("Item %d of n is NA"), i+1);  // NA crashed (#3354); n is called k at C level
+  for (int i=0; i<nk; i++) {
+    if (kd[i]==NA_INTEGER)
+      error(_("Item %d of n is NA"), i+1);  // NA crashed (#3354); n is called k at C level
+  }
 
   ans = PROTECT(allocVector(VECSXP, nk * nx)); protecti++;
   for (int i=0; i<nx; i++) {

--- a/src/subset.c
+++ b/src/subset.c
@@ -4,7 +4,8 @@ void subsetVectorRaw(SEXP ans, SEXP source, SEXP idx, const bool anyNA)
 // Used here by subsetDT() and by dogroups.c
 {
   const int n = length(idx);
-  if (length(ans)!=n) error(_("Internal error: subsetVectorRaw length(ans)==%d n=%d"), length(ans), n);
+  if (length(ans)!=n)
+    error(_("Internal error: subsetVectorRaw length(ans)==%d n=%d"), length(ans), n);
 
   const int *restrict idxp = INTEGER(idx);
   // anyNA refers to NA _in idx_; if there's NA in the data (source) that's just regular data to be copied
@@ -89,7 +90,8 @@ static const char *check_idx(SEXP idx, int max, bool *anyNA_out, bool *orderedSu
 // error if any negatives, zeros or >max since they should have been dealt with by convertNegAndZeroIdx() called ealier at R level.
 // single cache efficient sweep with prefetch, so very low priority to go parallel
 {
-  if (!isInteger(idx)) error(_("Internal error. 'idx' is type '%s' not 'integer'"), type2char(TYPEOF(idx))); // # nocov
+  if (!isInteger(idx))
+    error(_("Internal error. 'idx' is type '%s' not 'integer'"), type2char(TYPEOF(idx))); // # nocov
   bool anyLess=false, anyNA=false;
   int last = INT32_MIN;
   int *idxp = INTEGER(idx), n=LENGTH(idx);
@@ -113,11 +115,15 @@ SEXP convertNegAndZeroIdx(SEXP idx, SEXP maxArg, SEXP allowOverMax)
   // + a little more efficient than negativeSubscript in src/main/subscript.c (it's private to R so we can't call it anyway)
   // allowOverMaxArg is false when := (test 1024), otherwise true for selecting
 
-  if (!isInteger(idx)) error(_("Internal error. 'idx' is type '%s' not 'integer'"), type2char(TYPEOF(idx))); // # nocov
-  if (!isInteger(maxArg) || length(maxArg)!=1) error(_("Internal error. 'maxArg' is type '%s' and length %d, should be an integer singleton"), type2char(TYPEOF(maxArg)), length(maxArg)); // # nocov
-  if (!isLogical(allowOverMax) || LENGTH(allowOverMax)!=1 || LOGICAL(allowOverMax)[0]==NA_LOGICAL) error(_("Internal error: allowOverMax must be TRUE/FALSE"));  // # nocov
+  if (!isInteger(idx))
+    error(_("Internal error. 'idx' is type '%s' not 'integer'"), type2char(TYPEOF(idx))); // # nocov
+  if (!isInteger(maxArg) || length(maxArg)!=1)
+    error(_("Internal error. 'maxArg' is type '%s' and length %d, should be an integer singleton"), type2char(TYPEOF(maxArg)), length(maxArg)); // # nocov
+  if (!isLogical(allowOverMax) || LENGTH(allowOverMax)!=1 || LOGICAL(allowOverMax)[0]==NA_LOGICAL)
+    error(_("Internal error: allowOverMax must be TRUE/FALSE"));  // # nocov
   int max = INTEGER(maxArg)[0], n=LENGTH(idx);
-  if (max<0) error(_("Internal error. max is %d, must be >= 0."), max); // # nocov    includes NA which will print as INT_MIN
+  if (max<0)
+    error(_("Internal error. max is %d, must be >= 0."), max); // # nocov    includes NA which will print as INT_MIN
   int *idxp = INTEGER(idx);
 
   bool stop = false;
@@ -215,7 +221,8 @@ SEXP convertNegAndZeroIdx(SEXP idx, SEXP maxArg, SEXP allowOverMax)
 
 static void checkCol(SEXP col, int colNum, int nrow, SEXP x)
 {
-  if (isNull(col)) error(_("Column %d is NULL; malformed data.table."), colNum);
+  if (isNull(col))
+    error(_("Column %d is NULL; malformed data.table."), colNum);
   if (isNewList(col) && INHERITS(col, char_dataframe)) {
     SEXP names = getAttrib(x, R_NamesSymbol);
     error(_("Column %d ['%s'] is a data.frame or data.table; malformed data.table."),
@@ -239,7 +246,8 @@ static void checkCol(SEXP col, int colNum, int nrow, SEXP x)
 
 SEXP subsetDT(SEXP x, SEXP rows, SEXP cols) { // API change needs update NEWS.md and man/cdt.Rd
   int nprotect=0;
-  if (!isNewList(x)) error(_("Internal error. Argument 'x' to CsubsetDT is type '%s' not 'list'"), type2char(TYPEOF(rows))); // # nocov
+  if (!isNewList(x))
+    error(_("Internal error. Argument 'x' to CsubsetDT is type '%s' not 'list'"), type2char(TYPEOF(rows))); // # nocov
   if (!length(x)) return(x);  // return empty list
 
   const int nrow = length(VECTOR_ELT(x,0));
@@ -249,13 +257,16 @@ SEXP subsetDT(SEXP x, SEXP rows, SEXP cols) { // API change needs update NEWS.md
     SEXP max = PROTECT(ScalarInteger(nrow)); nprotect++;
     rows = PROTECT(convertNegAndZeroIdx(rows, max, ScalarLogical(TRUE))); nprotect++;
     const char *err = check_idx(rows, nrow, &anyNA, &orderedSubset);
-    if (err!=NULL) error(err);
+    if (err!=NULL)
+      error(err);
   }
 
-  if (!isInteger(cols)) error(_("Internal error. Argument 'cols' to Csubset is type '%s' not 'integer'"), type2char(TYPEOF(cols))); // # nocov
+  if (!isInteger(cols))
+    error(_("Internal error. Argument 'cols' to Csubset is type '%s' not 'integer'"), type2char(TYPEOF(cols))); // # nocov
   for (int i=0; i<LENGTH(cols); i++) {
     int this = INTEGER(cols)[i];
-    if (this<1 || this>LENGTH(x)) error(_("Item %d of 'cols' is %d which is outside 1-based range [1,ncol(x)=%d]"), i+1, this, LENGTH(x));
+    if (this<1 || this>LENGTH(x))
+      error(_("Item %d of 'cols' is %d which is outside 1-based range [1,ncol(x)=%d]"), i+1, this, LENGTH(x));
   }
 
   int overAlloc = checkOverAlloc(GetOption(install("datatable.alloccol"), R_NilValue));

--- a/src/uniqlist.c
+++ b/src/uniqlist.c
@@ -11,12 +11,16 @@ SEXP uniqlist(SEXP l, SEXP order)
   // (maximum length the number of rows) and the length returned in anslen.
   // No NA in order which is guaranteed since internal-only. Used at R level internally (Cuniqlist) but is not and should not be exported.
   // DONE: ans is now grown
-  if (!isNewList(l)) error(_("Internal error: uniqlist has not been passed a list of columns")); // # nocov
+  if (!isNewList(l))
+    error(_("Internal error: uniqlist has not been passed a list of columns")); // # nocov
   R_len_t ncol = length(l);
   R_len_t nrow = length(VECTOR_ELT(l,0));
-  if (!isInteger(order)) error(_("Internal error: uniqlist has been passed a non-integer order")); // # nocov
-  if (LENGTH(order)<1) error(_("Internal error: uniqlist has been passed a length-0 order")); // # nocov
-  if (LENGTH(order)>1 && LENGTH(order)!=nrow) error(_("Internal error: uniqlist has been passed length(order)==%d but nrow==%d"), LENGTH(order), nrow); // # nocov
+  if (!isInteger(order))
+    error(_("Internal error: uniqlist has been passed a non-integer order")); // # nocov
+  if (LENGTH(order)<1)
+    error(_("Internal error: uniqlist has been passed a length-0 order")); // # nocov
+  if (LENGTH(order)>1 && LENGTH(order)!=nrow)
+    error(_("Internal error: uniqlist has been passed length(order)==%d but nrow==%d"), LENGTH(order), nrow); // # nocov
   bool via_order = INTEGER(order)[0] != -1;  // has an ordering vector been passed in that we have to hop via? Don't use MISSING() here as it appears unstable on Windows
 
   unsigned long long *ulv; // for numeric check speed-up
@@ -145,8 +149,10 @@ SEXP uniqlist(SEXP l, SEXP order)
 
 SEXP uniqlengths(SEXP x, SEXP n) {
   // seems very similar to rbindlist.c:uniq_lengths. TODO: centralize into common function
-  if (TYPEOF(x) != INTSXP) error(_("Input argument 'x' to 'uniqlengths' must be an integer vector"));
-  if (TYPEOF(n) != INTSXP || length(n) != 1) error(_("Input argument 'n' to 'uniqlengths' must be an integer vector of length 1"));
+  if (TYPEOF(x) != INTSXP)
+    error(_("Input argument 'x' to 'uniqlengths' must be an integer vector"));
+  if (TYPEOF(n) != INTSXP || length(n) != 1)
+    error(_("Input argument 'n' to 'uniqlengths' must be an integer vector of length 1"));
   R_len_t len = length(x);
   SEXP ans = PROTECT(allocVector(INTSXP, len));
   for (R_len_t i=1; i<len; i++) {
@@ -164,14 +170,17 @@ SEXP rleid(SEXP l, SEXP cols) {
   R_xlen_t nrow = xlength(VECTOR_ELT(l, 0));
   R_len_t ncol = length(l), lencols = length(cols);
   if (!nrow || !ncol) return(allocVector(INTSXP, 0));
-  if (!isInteger(cols) || lencols==0) error(_("cols must be an integer vector with length >= 1"));
+  if (!isInteger(cols) || lencols==0)
+    error(_("cols must be an integer vector with length >= 1"));
   int *icols = INTEGER(cols);
   for (int i=0; i<lencols; i++) {
     int elem = icols[i];
-    if (elem<1 || elem>ncol) error(_("Item %d of cols is %d which is outside range of l [1,length(l)=%d]"), i+1, elem, ncol);
+    if (elem<1 || elem>ncol)
+      error(_("Item %d of cols is %d which is outside range of l [1,length(l)=%d]"), i+1, elem, ncol);
   }
   for (int i=1; i<ncol; i++) {
-    if (xlength(VECTOR_ELT(l,i)) != nrow) error(_("All elements to input list must be of same length. Element [%d] has length %"PRIu64" != length of first element = %"PRIu64"."), i+1, (uint64_t)xlength(VECTOR_ELT(l,i)), (uint64_t)nrow);
+    if (xlength(VECTOR_ELT(l,i)) != nrow)
+      error(_("All elements to input list must be of same length. Element [%d] has length %"PRIu64" != length of first element = %"PRIu64"."), i+1, (uint64_t)xlength(VECTOR_ELT(l,i)), (uint64_t)nrow);
   }
   SEXP ans = PROTECT(allocVector(INTSXP, nrow));
   int *ians = INTEGER(ans);
@@ -252,16 +261,19 @@ SEXP rleid(SEXP l, SEXP cols) {
 SEXP nestedid(SEXP l, SEXP cols, SEXP order, SEXP grps, SEXP resetvals, SEXP multArg) {
   Rboolean byorder = (length(order)>0);
   SEXP v, ans;
-  if (!isNewList(l) || length(l) < 1) error(_("Internal error: nestedid was not passed a list length 1 or more")); // # nocov
+  if (!isNewList(l) || length(l) < 1)
+    error(_("Internal error: nestedid was not passed a list length 1 or more")); // # nocov
   R_len_t nrows = length(VECTOR_ELT(l,0)), ncols = length(cols);
   if (nrows==0) return(allocVector(INTSXP, 0));
   R_len_t thisi, previ, ansgrpsize=1000, nansgrp=0;
   R_len_t *ansgrp = Calloc(ansgrpsize, R_len_t), starts, grplen; // #3401 fix. Needs to be Calloc due to Realloc below .. else segfaults.
   R_len_t ngrps = length(grps);
   bool *i64 = (bool *)R_alloc(ncols, sizeof(bool));
-  if (ngrps==0) error(_("Internal error: nrows[%d]>0 but ngrps==0"), nrows); // # nocov
+  if (ngrps==0)
+    error(_("Internal error: nrows[%d]>0 but ngrps==0"), nrows); // # nocov
   R_len_t resetctr=0, rlen = length(resetvals) ? INTEGER(resetvals)[0] : 0;
-  if (!isInteger(cols) || ncols == 0) error(_("cols must be an integer vector of positive length"));
+  if (!isInteger(cols) || ncols == 0)
+    error(_("cols must be an integer vector of positive length"));
   // mult arg
   enum {ALL, FIRST, LAST} mult = ALL;
   if (!strcmp(CHAR(STRING_ELT(multArg, 0)), "all")) mult = ALL;
@@ -346,8 +358,10 @@ SEXP nestedid(SEXP l, SEXP cols, SEXP order, SEXP grps, SEXP resetvals, SEXP mul
 
 SEXP uniqueNlogical(SEXP x, SEXP narmArg) {
   // single pass; short-circuit and return as soon as all 3 values are found
-  if (!isLogical(x)) error(_("x is not a logical vector"));
-  if (!isLogical(narmArg) || length(narmArg)!=1 || INTEGER(narmArg)[0]==NA_INTEGER) error(_("na.rm must be TRUE or FALSE"));
+  if (!isLogical(x))
+    error(_("x is not a logical vector"));
+  if (!isLogical(narmArg) || length(narmArg)!=1 || INTEGER(narmArg)[0]==NA_INTEGER)
+    error(_("na.rm must be TRUE or FALSE"));
   bool narm = LOGICAL(narmArg)[0]==1;
   const R_xlen_t n = xlength(x);
   if (n==0)

--- a/src/utils.c
+++ b/src/utils.c
@@ -64,7 +64,7 @@ bool allNA(SEXP x, bool errorForBadType) {
     return true;
   case CPLXSXP: {
     const Rcomplex *xd = COMPLEX(x);
-    for (int i=0; i<n; ++i) if (!ISNAN_COMPLEX(xd[i])) { 
+    for (int i=0; i<n; ++i) if (!ISNAN_COMPLEX(xd[i])) {
       return false;
     }
     return true;
@@ -142,7 +142,8 @@ SEXP colnamesInt(SEXP x, SEXP cols, SEXP check_dups) {
 }
 
 void coerceFill(SEXP fill, double *dfill, int32_t *ifill, int64_t *i64fill) {
-  if (xlength(fill) != 1) error(_("%s: fill argument must be length 1"), __func__);
+  if (xlength(fill) != 1)
+    error(_("%s: fill argument must be length 1"), __func__);
   if (isInteger(fill)) {
     if (INTEGER(fill)[0]==NA_INTEGER) {
       ifill[0] = NA_INTEGER; dfill[0] = NA_REAL; i64fill[0] = NA_INTEGER64;

--- a/src/vecseq.c
+++ b/src/vecseq.c
@@ -10,9 +10,12 @@ SEXP vecseq(SEXP x, SEXP len, SEXP clamp)
   // Specially for use by [.data.table after binary search. Now so specialized that for general use
   // bit::vecseq is recommended (Jens has coded it in C now).
 
-  if (!isInteger(x)) error(_("x must be an integer vector"));
-  if (!isInteger(len)) error(_("len must be an integer vector"));
-  if (LENGTH(x) != LENGTH(len)) error(_("x and len must be the same length"));
+  if (!isInteger(x))
+    error(_("x must be an integer vector"));
+  if (!isInteger(len))
+    error(_("len must be an integer vector"));
+  if (LENGTH(x) != LENGTH(len))
+    error(_("x and len must be the same length"));
   const int *ix = INTEGER(x);
   const int *ilen = INTEGER(len), nlen=LENGTH(len);
   int reslen = 0;
@@ -22,10 +25,13 @@ SEXP vecseq(SEXP x, SEXP len, SEXP clamp)
     reslen += ilen[i];
   }
   if (!isNull(clamp)) {
-    if (!isNumeric(clamp) || LENGTH(clamp)!=1) error(_("clamp must be a double vector length 1"));
+    if (!isNumeric(clamp) || LENGTH(clamp)!=1)
+      error(_("clamp must be a double vector length 1"));
     double limit = REAL(clamp)[0];
-    if (limit<0) error(_("clamp must be positive"));
-    if (reslen>limit) error(_("Join results in %d rows; more than %d = nrow(x)+nrow(i). Check for duplicate key values in i each of which join to the same group in x over and over again. If that's ok, try by=.EACHI to run j for each group to avoid the large allocation. If you are sure you wish to proceed, rerun with allow.cartesian=TRUE. Otherwise, please search for this error message in the FAQ, Wiki, Stack Overflow and data.table issue tracker for advice."), reslen, (int)limit);
+    if (limit<0)
+      error(_("clamp must be positive"));
+    if (reslen>limit)
+      error(_("Join results in %d rows; more than %d = nrow(x)+nrow(i). Check for duplicate key values in i each of which join to the same group in x over and over again. If that's ok, try by=.EACHI to run j for each group to avoid the large allocation. If you are sure you wish to proceed, rerun with allow.cartesian=TRUE. Otherwise, please search for this error message in the FAQ, Wiki, Stack Overflow and data.table issue tracker for advice."), reslen, (int)limit);
   }
   SEXP ans = PROTECT(allocVector(INTSXP, reslen));
   int *ians = INTEGER(ans);

--- a/src/wrappers.c
+++ b/src/wrappers.c
@@ -8,7 +8,8 @@
 
 SEXP setattrib(SEXP x, SEXP name, SEXP value)
 {
-  if (!isString(name) || LENGTH(name)!=1) error(_("Attribute name must be a character vector of length 1"));
+  if (!isString(name) || LENGTH(name)!=1)
+    error(_("Attribute name must be a character vector of length 1"));
   if (!isNewList(x) &&
       strcmp(CHAR(STRING_ELT(name,0)),"class")==0 &&
       isString(value) && LENGTH(value)>0 &&
@@ -63,10 +64,13 @@ SEXP setlistelt(SEXP l, SEXP i, SEXP value)
 {
   R_len_t i2;
   // Internal use only. So that := can update elements of a list of data.table, #2204. Just needed to overallocate/grow the VECSXP.
-  if (!isNewList(l)) error(_("First argument to setlistelt must be a list()"));
-  if (!isInteger(i) || LENGTH(i)!=1) error(_("Second argument to setlistelt must a length 1 integer vector"));
+  if (!isNewList(l))
+    error(_("First argument to setlistelt must be a list()"));
+  if (!isInteger(i) || LENGTH(i)!=1)
+    error(_("Second argument to setlistelt must a length 1 integer vector"));
   i2 = INTEGER(i)[0];
-  if (LENGTH(l) < i2 || i2<1) error(_("i (%d) is outside the range of items [1,%d]"),i2,LENGTH(l));
+  if (LENGTH(l) < i2 || i2<1)
+    error(_("i (%d) is outside the range of items [1,%d]"),i2,LENGTH(l));
   SET_VECTOR_ELT(l, i2-1, value);
   return(R_NilValue);
 }
@@ -88,7 +92,8 @@ SEXP expandAltRep(SEXP x)
   // At R level (for example [.data.table) we use and benefit from altrep vectors very much. It's just as columns that we expand them.
   // See extensive discussion in issue #2866
 
-  if (TYPEOF(x) != VECSXP) error(_("x isn't a VECSXP"));
+  if (TYPEOF(x) != VECSXP)
+    error(_("x isn't a VECSXP"));
   for (int i=0; i<LENGTH(x); i++) {
     SEXP col = VECTOR_ELT(x,i);
     if (ALTREP(col)) {


### PR DESCRIPTION
```
if (FALSE) error("failed");
```

Is not caught by Codecov because it doesn't build a proper AST for C code. So we have to put `error` branches on their own line to be properly detected by Codecov.

Only done this for `error` so far. A few more patterns could be included:

 - [ ] `warning`
 - [ ] Verbose output? `Rprintf` etc, not sure how important it is to cover these
 - [ ] `STOP` in `fread.c`
 - ...