### PR TITLE
AsIs objects returned from [.data.table, tests for #4326

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -16846,3 +16846,12 @@ A = data.table(A=c(complex(real = 1:3, imaginary=c(0, -1, 1)), NaN))
 test(2138.3, rbind(A,B), data.table(A=c(as.character(A$A), B$A)))
 A = data.table(A=as.complex(rep(NA, 5)))
 test(2138.4, rbind(A,B), data.table(A=c(as.character(A$A), B$A)))
+
+# allow 'raw' output #4326
+DT = data.table(x = 1:10, y = 1:10 + rnorm(10))
+bad = DT[, lm.fit(cbind(x), y)]
+ok1 = DT[, list(lm.fit(cbind(x), y))][["V1"]]
+ok2 = DT[, I(lm.fit(cbind(x), y))]
+test(2139.1, class(bad), c("data.table","data.frame"))
+test(2139.2, class(ok1), "list")
+#test(2139.3, class(ok2), "list") ## TODO, AsIs class should be removed


### PR DESCRIPTION
TODO:
- implement removing of AsIs class from `j` object
- enable test 2139.3

contribution welcome as I am currently working on a different branch