### PR TITLE
add more checks to detect internal error more early, #4364

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1388,6 +1388,8 @@ replace_dot_alias = function(e) {
     jisvars = if (any(c("get", "mget") %chin% av)) names_i else intersect(gsub("^i[.]","", setdiff(av, xjisvars)), names_i)
     # JIS (non join cols) but includes join columns too (as there are named in i)
     if (length(jisvars)) {
+      if (!nrow(i))
+        stop("internal error: doing byjoin but i has 0 rows") # nocov #4364
       tt = min(nrow(i),1L)
       SDenv$.iSD = i[tt,jisvars,with=FALSE]
       for (ii in jisvars) {

--- a/src/dogroups.c
+++ b/src/dogroups.c
@@ -41,7 +41,6 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
   }
   setAttrib(BY, R_NamesSymbol, bynames); // Fix for #42 - BY doesn't retain names anymore
   R_LockBinding(sym_BY, env);
-
   if (isNull(jiscols) && (length(bynames)!=length(groups) || length(bynames)!=length(grpcols))) error(_("!length(bynames)[%d]==length(groups)[%d]==length(grpcols)[%d]"),length(bynames),length(groups),length(grpcols));
   // TO DO: check this check above.
 

--- a/src/dogroups.c
+++ b/src/dogroups.c
@@ -41,12 +41,15 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
   }
   setAttrib(BY, R_NamesSymbol, bynames); // Fix for #42 - BY doesn't retain names anymore
   R_LockBinding(sym_BY, env);
+
   if (isNull(jiscols) && (length(bynames)!=length(groups) || length(bynames)!=length(grpcols))) error(_("!length(bynames)[%d]==length(groups)[%d]==length(grpcols)[%d]"),length(bynames),length(groups),length(grpcols));
   // TO DO: check this check above.
 
   N =   PROTECT(findVar(install(".N"), env));   nprotect++; // PROTECT for rchk
   GRP = PROTECT(findVar(install(".GRP"), env)); nprotect++;
   iSD = PROTECT(findVar(install(".iSD"), env)); nprotect++; // 1-row and possibly no cols (if no i variables are used via JIS)
+  if (length(iSD) && !length(VECTOR_ELT(iSD, 0)))
+    error("internal error dogroups: iSD is a zero rows data.table"); // # nocov
   xSD = PROTECT(findVar(install(".xSD"), env)); nprotect++;
   R_len_t maxGrpSize = 0;
   const int *ilens = INTEGER(lens), n=LENGTH(lens);


### PR DESCRIPTION
Towards #4364 but not resolving.

```r
d0 = data.table(id=integer(), n=integer())
d2 = data.table(id=1:2)
d2[d0, i.n, on="id", by=.EACHI]
#Error in `[.data.table`(d2, d0, i.n, on = "id", by = .EACHI) : 
#  internal error: doing byjoin but i has 0 rows
```