### PR TITLE
fcase should save the value0's attributes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -109,6 +109,8 @@ unit = "s")
 
 13. A relatively rare case of segfault when combining non-equi joins with `by=.EACHI` is now fixed, closes [#4388](https://github.com/Rdatatable/data.table/issues/4388).
 
+14. Fix the bug that `fcase` accidentally uses an unprotected value and may result in segfaults or errors in certain cases, [#4378](https://github.com/Rdatatable/data.table/issues/4378). Thanks to @fredguinog for reporting and @shrektan for the PR.
+
 ## NOTES
 
 0. Retrospective license change permission was sought from and granted by 4 contributors who were missed in [PR#2456](https://github.com/Rdatatable/data.table/pull/2456), [#4140](https://github.com/Rdatatable/data.table/pull/4140). We had used [GitHub's contributor page](https://github.com/Rdatatable/data.table/graphs/contributors) which omits 3 of these due to invalid email addresses, unlike GitLab's contributor page which includes the ids. The 4th omission was a PR to a script which should not have been excluded; a script is code too. We are sorry these contributors were not properly credited before. They have now been added to the contributors list as displayed on CRAN. All the contributors of code to data.table hold its copyright jointly; your contributions belong to you. You contributed to data.table when it had a particular license at that time, and you contributed on that basis. This is why in the last license change, all contributors of code were consulted and each had a veto.

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -16853,3 +16853,18 @@ A = data.table(A=c(complex(real = 1:3, imaginary=c(0, -1, 1)), NaN))
 test(2138.3, rbind(A,B), data.table(A=c(as.character(A$A), B$A)))
 A = data.table(A=as.complex(rep(NA, 5)))
 test(2138.4, rbind(A,B), data.table(A=c(as.character(A$A), B$A)))
+
+# ensure fcase won't use unprotect values accidentally, #4378
+n = 1e7
+x = structure(rnorm(n), class = 'abc')
+test(
+  2139, 
+  fcase(x <= -100, structure(x * 1.0, class = 'abc'),
+        x <= -10, structure(x * 1.0, class = 'abc'),
+        x <=  0,  structure(x * 1.0, class = 'abc'),
+        x <=  100, structure(x * 1.0, class = 'abc'), 
+        x <=  1000, structure(x * 1.0, class = 'abc'),
+        x >=  1000, structure(x * 1.0, class = 'abc')),
+  structure(x, class = 'abc')
+)
+

--- a/src/fifelse.c
+++ b/src/fifelse.c
@@ -155,7 +155,9 @@ SEXP fcaseR(SEXP na, SEXP rho, SEXP args) {
   }
   int nprotect = 0, l = 0;
   int64_t len0=0, len1=0, len2=0, idx=0;
-  SEXP ans = R_NilValue, value0 = R_NilValue, tracker = R_NilValue, cons = R_NilValue, outs = R_NilValue;
+  SEXP ans = R_NilValue, tracker = R_NilValue, cons = R_NilValue, outs = R_NilValue;
+  SEXP v0class = R_NilValue, v0levels = R_NilValue;
+  bool v0factor = false;
   PROTECT_INDEX Icons, Iouts;
   PROTECT_WITH_INDEX(cons, &Icons); nprotect++;
   PROTECT_WITH_INDEX(outs, &Iouts); nprotect++;
@@ -177,7 +179,11 @@ SEXP fcaseR(SEXP na, SEXP rho, SEXP args) {
       len0 = xlength(cons);
       len2 = len0;
       type0 = TYPEOF(outs);
-      value0 = outs;
+      v0class = PROTECT(getAttrib(outs,R_ClassSymbol)); nprotect++;
+      v0factor = isFactor(outs);
+      if (v0factor) {
+        v0levels = PROTECT(getAttrib(outs,R_LevelsSymbol)); nprotect++;
+      }
       if (nonna) {
         if (xlength(na) != 1) {
           error("Length of 'default' must be 1.");
@@ -220,16 +226,16 @@ SEXP fcaseR(SEXP na, SEXP rho, SEXP args) {
                  "Please make sure all output values have the same type.",
                  i*2+2, type2char(TYPEOF(outs)), type2char(type0));
       }
-      if (!R_compute_identical(PROTECT(getAttrib(value0,R_ClassSymbol)),  PROTECT(getAttrib(outs,R_ClassSymbol)), 0)) {
+      if (!R_compute_identical(v0class, PROTECT(getAttrib(outs,R_ClassSymbol)), 0)) {
         error("Argument #%d has different class than argument #2, "
                  "Please make sure all output values have the same class.", i*2+2);
       }
-      UNPROTECT(2);
-      if (isFactor(value0)) {
-        if (!R_compute_identical(PROTECT(getAttrib(value0,R_LevelsSymbol)),  PROTECT(getAttrib(outs,R_LevelsSymbol)), 0)) {
+      UNPROTECT(1);
+      if (v0factor) {
+        if (!R_compute_identical(v0levels, PROTECT(getAttrib(outs,R_LevelsSymbol)), 0)) {
           error("Argument #2 and argument #%d are both factor but their levels are different.", i*2+2);
         }
-        UNPROTECT(2);
+        UNPROTECT(1);
       }
     }
     len1 = xlength(outs);

--- a/src/fifelse.c
+++ b/src/fifelse.c
@@ -156,13 +156,16 @@ SEXP fcaseR(SEXP na, SEXP rho, SEXP args) {
   int nprotect = 0, l = 0;
   int64_t len0=0, len1=0, len2=0, idx=0;
   SEXP ans = R_NilValue, value0 = R_NilValue, tracker = R_NilValue, cons = R_NilValue, outs = R_NilValue;
+  PROTECT_INDEX Icons, Iouts;
+  PROTECT_WITH_INDEX(cons, &Icons); nprotect++;
+  PROTECT_WITH_INDEX(outs, &Iouts); nprotect++;
   SEXPTYPE type0;
   bool nonna = !isNull(na), imask = true;
   int *restrict p = NULL;
   n = n/2;
   for (int i=0; i<n; ++i) {
-    cons = PROTECT(eval(SEXPPTR_RO(args)[2*i], rho)); nprotect++;
-    outs = PROTECT(eval(SEXPPTR_RO(args)[2*i+1], rho)); nprotect++;
+    REPROTECT(cons = eval(SEXPPTR_RO(args)[2*i], rho), Icons);
+    REPROTECT(outs = eval(SEXPPTR_RO(args)[2*i+1], rho), Iouts);
     if (isS4(outs) && !INHERITS(outs, char_nanotime)) {
       error("S4 class objects (except nanotime) are not supported. Please see https://github.com/Rdatatable/data.table/issues/4131.");
     }

--- a/src/fifelse.c
+++ b/src/fifelse.c
@@ -156,16 +156,13 @@ SEXP fcaseR(SEXP na, SEXP rho, SEXP args) {
   int nprotect = 0, l = 0;
   int64_t len0=0, len1=0, len2=0, idx=0;
   SEXP ans = R_NilValue, value0 = R_NilValue, tracker = R_NilValue, cons = R_NilValue, outs = R_NilValue;
-  PROTECT_INDEX Icons, Iouts;
-  PROTECT_WITH_INDEX(cons, &Icons); nprotect++;
-  PROTECT_WITH_INDEX(outs, &Iouts); nprotect++;
   SEXPTYPE type0;
   bool nonna = !isNull(na), imask = true;
   int *restrict p = NULL;
   n = n/2;
   for (int i=0; i<n; ++i) {
-    REPROTECT(cons = eval(SEXPPTR_RO(args)[2*i], rho), Icons);
-    REPROTECT(outs = eval(SEXPPTR_RO(args)[2*i+1], rho), Iouts);
+    cons = PROTECT(eval(SEXPPTR_RO(args)[2*i], rho)); nprotect++;
+    outs = PROTECT(eval(SEXPPTR_RO(args)[2*i+1], rho)); nprotect++;
     if (isS4(outs) && !INHERITS(outs, char_nanotime)) {
       error("S4 class objects (except nanotime) are not supported. Please see https://github.com/Rdatatable/data.table/issues/4131.");
     }


### PR DESCRIPTION
Closes #4378

### The reproducible example on my Mac

(Took me some time to find this example)

```r
library(data.table)
n = 1e7
x = structure(rnorm(n), class = 'abc')
invisible(
  fcase(x <= -100, structure(x * 1.1, class = 'abc'),
        x <= -10, structure(x * 1.1, class = 'abc'),
        x <=  0,  structure(x * 1.1, class = 'abc'),
        x <=  100, structure(x * 1.1, class = 'abc'), 
        x <=  1000, structure(x * 1.1, class = 'abc'),
        x >=  1000, structure(x * 1.1, class = 'abc'))
)
```


- Before the PR: it will report an error that the "# 6" has different class
- After the PR: works fine

The cause is, the first value (assigned to variable `value0`) will be touched later,  to ensure all the values have the same class and factor levels. However, at that time, `value0` may have already been garbaged. 

The difficulty to reproduce this issue is due to the fact that **as long as the garbaged memory is not reused, it won't affect anything**. Windows and Mac should have different memory management logic and that may be the reason of the example in #4378 is only reproducible on Windows.