### PR TITLE
Having arg

### DIFF
--- a/src/data.table.h
+++ b/src/data.table.h
@@ -91,6 +91,7 @@ extern SEXP sym_index;
 extern SEXP sym_BY;
 extern SEXP sym_starts, char_starts;
 extern SEXP sym_maxgrpn;
+extern SEXP sym_grplen;
 extern SEXP sym_colClassesAs;
 extern SEXP sym_verbose;
 extern SEXP SelfRefSymbol;

--- a/src/init.c
+++ b/src/init.c
@@ -25,6 +25,7 @@ SEXP sym_index;
 SEXP sym_BY;
 SEXP sym_starts, char_starts;
 SEXP sym_maxgrpn;
+SEXP sym_grplen;
 SEXP sym_colClassesAs;
 SEXP sym_verbose;
 SEXP SelfRefSymbol;
@@ -119,6 +120,7 @@ SEXP lock();
 SEXP unlock();
 SEXP islockedR();
 SEXP allNAR();
+SEXP vecseq_having();
 
 // .Externals
 SEXP fastmean();
@@ -211,6 +213,7 @@ R_CallMethodDef callMethods[] = {
 {"CfrollapplyR", (DL_FUNC) &frollapplyR, -1},
 {"CtestMsgR", (DL_FUNC) &testMsgR, -1},
 {"C_allNAR", (DL_FUNC) &allNAR, -1},
+{"Cvecseq_having", (DL_FUNC) &vecseq_having, -1},
 {NULL, NULL, 0}
 };
 
@@ -339,6 +342,7 @@ void attribute_visible R_init_datatable(DllInfo *info)
   sym_index   = install("index");
   sym_BY      = install(".BY");
   sym_maxgrpn = install("maxgrpn");
+  sym_grplen  = install("grplen");
   sym_colClassesAs = install("colClassesAs");
   sym_verbose = install("datatable.verbose");
   SelfRefSymbol = install(".internal.selfref");


### PR DESCRIPTION
Too early to say it addresses #788. Very much WIP. I am hoping for general feedback from @jangorecki before continuing this path.

Per the initial FR, this includes a new ```having``` argument that requires each group to return a logical vector of length one. Right now only ```gForce``` functions and primitive functions are allowed - I can work on PRs for ```any```, ```all```, ```which.max```, and ```which.min``` gforce funs which would be helpful for this. 

### New ```vecseq_having```

The subsetting workhorse is ```vecseq_having```. The new function returns an integer vector with additional attributes if ```retGrps``` is true. 
``` r
starts = c(1L, 3L, 6L)
lens = c(2L, 3L, 1L)
.Call(data.table:::Cvecseq_having, starts, lens, having = c(TRUE, FALSE, TRUE), retGrps = TRUE)
#> [1] 1 2 6
#> attr(,"starts")
#> [1] 1 3
#> attr(,"grplen")
#> [1] 2 1
.Call(data.table:::Cvecseq_having, starts, lens, having = c(TRUE, FALSE, TRUE), retGrps = FALSE)
#> [1] 1 2 6
```
### New recursive parser

Current ```GForce``` optimizations go one deep. That is, ```mean(x)``` will be optimized while ```mean(x == 2L)``` would not be. To account for this, a new function evaluates an expression to determine if it is a ```gfun```, ```is.primitive```, a ```name``` and whether it exists inside or outside of the environment. This allows for ```mean(x ==2L)``` to be optimized as well as ```mean(x) > 3 & .N > 5L```

### Odds and ends

- Any newly created ad hoc ```by``` cols are ignored in the output. This is something I plan to address.
- The ```by``` columns aren't re-ordered to be the first columns. This would be corrected.
- I am still working out the logic between a subset in ```i``` and the ```having``` arg. It would be simpler if this were a function within the ```i``` arg but it seemed like most people wanted a new ```having``` arg.
- ```j``` has to be ```.SD``` right now but I am laying the ground work to let any expression work. 

### Performance

``` r
library(data.table)

n = 1e5
grps = 1e4
set.seed(123L)
dt = data.table(x = sample(grps, n, TRUE), y = runif(n))

setDTthreads(1L)

bench::mark(
  dt[, .SD, by = x, having = .N > 5L],
  dt[dt[, .I[.N > 5L], by = x]$V1],
  dt[, if (.N > 5L) .SD, by = x],
  dt[, .SD[.N > 5L], by = x],
  time_unit = 's'
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 4 x 6
#>   expression                              min  median `itr/sec` mem_alloc
#>   <bch:expr>                            <dbl>   <dbl>     <dbl> <bch:byt>
#> 1 dt[, .SD, by = x, having = .N > 5L] 0.00558 0.00586   157.       4.14MB
#> 2 dt[dt[, .I[.N > 5L], by = x]$V1]    0.0148  0.0153     59.9      3.25MB
#> 3 dt[, if (.N > 5L) .SD, by = x]      0.313   0.320       3.13     2.98MB
#> 4 dt[, .SD[.N > 5L], by = x]          1.91    1.91        0.523   83.89MB
#> # ... with 1 more variable: `gc/sec` <dbl>

setDTthreads(2L)

#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 4 x 6
#>   expression                              min  median `itr/sec` mem_alloc
#>   <bch:expr>                            <dbl>   <dbl>     <dbl> <bch:byt>
#> 1 dt[, .SD, by = x, having = .N > 5L] 0.00559 0.00619   152.       4.14MB
#> 2 dt[dt[, .I[.N > 5L], by = x]$V1]    0.0150  0.0159     58.6      3.25MB
#> 3 dt[, if (.N > 5L) .SD, by = x]      0.823   0.823       1.21     2.98MB
#> 4 dt[, .SD[.N > 5L], by = x]          2.17    2.17        0.461   83.89MB

bench::mark(
  new_hav = dt[,
     j = .SD,
     by = x,
     having = .N < 2L | sum(y) > 11 | median(y) < 0.7
     ],
  use_I = dt[dt[, .I[.N < 2L | sum(y) > 11 | median(y) < 0.7], by = x]$V1],
  time_unit = 's'
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 2 x 6
#>   expression    min median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>  <dbl>  <dbl>     <dbl> <bch:byt>    <dbl>
#> 1 new_hav    0.0108 0.0119    69.8      7.34MB    14.0 
#> 2 use_I      1.20   1.20       0.836    3.21MB     5.02
