### PR TITLE
fixes R-devel foverlaps failures due to c.POSIXct change

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -147,6 +147,8 @@ unit = "s")
 
 7. Added more explanation/examples to `?data.table` for how to use `.BY`, [#1363](https://github.com/Rdatatable/data.table/issues/1363).
 
+8. Change of `c.POSIXct` method planned for R 4.1.0 impacted `foverlaps` function that could raise `'origin' must be supplied` error. Fix for planned change has been provided in [#4428](https://github.com/Rdatatable/data.table/pull/4428).
+
 
 # data.table [v1.12.8](https://github.com/Rdatatable/data.table/milestone/15?closed=1)  (09 Dec 2019)
 

--- a/R/foverlaps.R
+++ b/R/foverlaps.R
@@ -109,6 +109,7 @@ foverlaps = function(x, y, by.x=if (!is.null(key(x))) key(x) else key(y), by.y=k
     setattr(icall, 'names', icols)
     mcall = make_call(mcols, quote(c))
     if (type %chin% c("within", "any")) {
+      if (isposix) mcall[[2L]] = call("unclass", mcall[[2L]]) # fix for R-devel change in c.POSIXct
       mcall[[3L]] = substitute(
         # datetimes before 1970-01-01 are represented as -ve numerics, #3349
         if (isposix) unclass(val)*(1L + sign(unclass(val))*dt_eps())
@@ -128,7 +129,7 @@ foverlaps = function(x, y, by.x=if (!is.null(key(x))) key(x) else key(y), by.y=k
               within =, equal = yintervals)
   call = construct(head(ynames, -2L), uycols, type)
   if (verbose) {last.started.at=proc.time();cat("unique() + setkey() operations done in ...");flush.console()}
-  uy = unique(y[, eval(call)])
+  uy = unique(y[, eval(call)]) # this started to fail from R 4.1 due to c(POSIXct, numeric)
   setkey(uy)[, `:=`(lookup = list(list(integer(0L))), type_lookup = list(list(integer(0L))), count=0L, type_count=0L)]
   if (verbose) {cat(timetaken(last.started.at),"\n"); flush.console()}
   matches = function(ii, xx, del, ...) {


### PR DESCRIPTION
fixes
```
  Test 1390.3 produced 1 errors but expected 0
  Expected:
  Observed: 'origin' must be supplied
  Test 1390.4 produced 1 errors but expected 0
  Expected:
  Observed: 'origin' must be supplied
  Test 1390.5 produced 1 errors but expected 0
  Expected:
  Observed: 'origin' must be supplied
  Test 1985.1 produced 1 errors but expected 0
  Expected:
  Observed: 'origin' must be supplied
  Test 1993.1 produced 1 errors but expected 0
  Expected:
  Observed: 'origin' must be supplied
```