### PR TITLE
WIP: psum / pprod

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -56,6 +56,7 @@ export(nafill)
 export(setnafill)
 export(.Last.updated)
 export(fcoalesce)
+export(psum)
 
 S3method("[", data.table)
 S3method("[<-", data.table)

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -8,6 +8,8 @@ setcoalesce = function(...) .Call(Ccoalesce, list(...), TRUE)
 fifelse = function(test, yes, no, na=NA) .Call(CfifelseR, test, yes, no, na)
 fcase   = function(..., default=NA) .Call(CfcaseR, default, parent.frame(), as.list(substitute(list(...)))[-1L])
 
+psum = function(..., na.rm=FALSE) .Call(Cpsum, list(...), na.rm)
+
 colnamesInt = function(x, cols, check_dups=FALSE) .Call(CcolnamesInt, x, cols, check_dups)
 coerceFill = function(x) .Call(CcoerceFillR, x)
 

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -219,6 +219,9 @@ SEXP between(SEXP x, SEXP lower, SEXP upper, SEXP incbounds, SEXP NAbounds, SEXP
 // coalesce.c
 SEXP coalesce(SEXP x, SEXP inplace);
 
+// psum.c
+SEXP psum(SEXP x, SEXP narmArg);
+
 // utils.c
 bool isRealReallyInt(SEXP x);
 SEXP isReallyReal(SEXP x);

--- a/src/init.c
+++ b/src/init.c
@@ -119,6 +119,7 @@ SEXP lock();
 SEXP unlock();
 SEXP islockedR();
 SEXP allNAR();
+SEXP psum();
 
 // .Externals
 SEXP fastmean();
@@ -211,6 +212,7 @@ R_CallMethodDef callMethods[] = {
 {"CfrollapplyR", (DL_FUNC) &frollapplyR, -1},
 {"CtestMsgR", (DL_FUNC) &testMsgR, -1},
 {"C_allNAR", (DL_FUNC) &allNAR, -1},
+{"Cpsum", (DL_FUNC) &psum, -1},
 {NULL, NULL, 0}
 };
 

--- a/src/psum.c
+++ b/src/psum.c
@@ -1,0 +1,93 @@
+#include "data.table.h"
+
+// like base::p{max,min}, but for sum, prod
+SEXP psum(SEXP x, SEXP narmArg) {
+  if (!isNewList(x)) error(_("Internal error: x must be a list"));
+  if (!isLogical(narmArg) || LENGTH(narmArg)!=1 || LOGICAL(narmArg)[0]==NA_LOGICAL) error(_("na.rm must be TRUE or FALSE"));
+
+  int J=LENGTH(x);
+  SEXPTYPE outtype = INTSXP;
+  int n = -1;
+  for (int j=0; j<J; j++) {
+    SEXP xj=VECTOR_ELT(x, j);
+    switch(TYPEOF(xj)) {
+    case INTSXP:
+      break;
+    case REALSXP:
+      outtype = REALSXP;
+      break;
+    default:
+      error(_("Only numeric inputs are supported for psum"));
+    }
+    if (n >= 0) {
+      if (n != LENGTH(xj)) {
+        error(_("Inconsistent input lengths -- first found %d, but %d element has length %d"), n, j+1, LENGTH(xj));
+      }
+    } else { // initialize
+      n = LENGTH(xj);
+    }
+  }
+
+
+  // TODO: support int->double conversion
+  SEXP out = PROTECT(allocVector(outtype, n));
+  if (LOGICAL(narmArg)[0]) {
+    if (outtype == INTSXP) {
+      int *outp = INTEGER(out);
+      // initialize to NA to facilitate all-NA rows --> NA output
+      for (int i=0; i<n; i++) outp[i] = NA_INTEGER;
+      for (int j=0; j<J; j++) {
+        int *xjp = INTEGER(VECTOR_ELT(x, j));
+        for (int i=0; i<n; i++) {
+          if (xjp[i] != NA_INTEGER) {
+            outp[i] = outp[i] == NA_INTEGER ? xjp[i] : outp[i] + xjp[i];
+          } // else remain as NA
+        }
+      }
+    } else { // REALSXP; cut-and-paste except for NA
+      double *outp = REAL(out);
+      for (int i=0; i<n; i++) outp[i] = NA_REAL;
+      for (int j=0; j<J; j++) {
+        double *xjp = REAL(VECTOR_ELT(x, j));
+        for (int i=0; i<n; i++) {
+          if (xjp[i] != NA_REAL) {
+            outp[i] = outp[i] == NA_REAL ? xjp[i] : outp[i] + xjp[i];
+          }
+        }
+      }
+    }
+  } else { // na.rm=FALSE
+    if (outtype == INTSXP) {
+      int *outp = INTEGER(out);
+      int *xj0p = INTEGER(VECTOR_ELT(x, 0));
+      for (int i=0; i<n; i++) outp[i] = xj0p[i];
+      if (J == 1) {
+        UNPROTECT(1);
+        return out;
+      }
+      for (int j=1; j<J; j++) {
+        int *xjp = INTEGER(VECTOR_ELT(x, j));
+        for (int i=0; i<n; i++) {
+          outp[i] = outp[i] == NA_INTEGER || xjp[i] == NA_INTEGER ? NA_INTEGER : outp[i] + xjp[i];
+        }
+      }
+    } else { // REALSXP
+      double *outp = REAL(out);
+      double *xj0p = REAL(VECTOR_ELT(x, 0));
+      for (int i=0; i<n; i++) outp[i] = xj0p[i];
+      if (J == 1) {
+        UNPROTECT(1);
+        return out;
+      }
+      for (int j=1; j<J; j++) {
+        double *xjp = REAL(VECTOR_ELT(x, j));
+        for (int i=0; i<n; i++) {
+          outp[i] = outp[i] == NA_REAL || xjp[i] == NA_REAL ? NA_REAL : outp[i] + xjp[i];
+        }
+      }
+    }
+  }
+
+  UNPROTECT(1);
+  return out;
+}

--- a/src/psum.c
+++ b/src/psum.c
@@ -50,8 +50,8 @@ SEXP psum(SEXP x, SEXP narmArg) {
       for (int j=0; j<J; j++) {
         double *xjp = REAL(VECTOR_ELT(x, j));
         for (int i=0; i<n; i++) {
-          if (xjp[i] != NA_REAL) {
-            outp[i] = outp[i] == NA_REAL ? xjp[i] : outp[i] + xjp[i];
+          if (!ISNAN(xjp[i])) {
+            outp[i] = ISNAN(outp[i]) ? xjp[i] : outp[i] + xjp[i];
           }
         }
       }


### PR DESCRIPTION
NB: Hewing to the suggestion in the original r-devel thread, all-`NA` "rows" will be `NA` output.

This is consistent with the difference in `base` for `pmin` vs `min`:

```
x = c(1L, 3L, NA, NA, 5L)
y = c(2L, NA, 4L, NA, 1L)
pmin(x, y, na.rm = TRUE)
# [1]  1  3  4 NA  1
apply(cbind(x, y), 1L, min, na.rm = TRUE)
# [1]   1   3   4 Inf   1
```

> Warning message: In `FUN(newX[, i], ...)` : no non-missing arguments to `min`; returning `Inf`

TODO:
 - [ ] Fix mixed types (`INTSXP` + `REALSXP` in input)
 - [ ] Handle overflow? `INTSXP` --> `REALSXP` 
 - [ ] Handle `CPLXSXP`?
 - [ ] Handle `integer64`?
 - [ ] `pprod` as well [overflow even more important here]
 - [ ] `prange`, `pany`, `pall` to round out the `groupGeneric`s?

For the last point, @mattdowle said in the original thread:

> Wouldn't make sense for `prange`, `pall` or `pany`

But I don't follow -- we regularly see questions asking to do rowwise `|` or `&` on SO, e.g.

Any feedback on the priority of the above appreciated.