### PR TITLE
order optimizes to forderv, uses key or index, forder more consistent to base order

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -99,11 +99,71 @@ replace_dot_alias = function(e) {
   e
 }
 
-.massagei = function(x) {
+.massagei = function(x, dt=NULL, verbose=FALSE, ienv=NULL) {
   # J alias for list as well in i, just if the first symbol
   # if x = substitute(base::order) then as.character(x[[1L]]) == c("::", "base", "order")
   if (x %iscall% c("J","."))
     x[[1L]] = quote(list)
+  # optimize order() to forderv(); evaluates: decreasing, method, na.last. #3023, possibly #3261 as well
+  if (!is.null(dt) && getOption("datatable.optimize")>=1L && x%iscall%"order") {
+    call.nm = names(x)
+    ## escape unsupported method
+    if ("method" %chin% call.nm) {
+      method = x[["method"]]
+      if (!is.character(method)) method = eval(method, ienv)
+      if (!identical(method, "radix")) return(x)
+    }
+    ## escape invalid decreasing, outsource raising error
+    if ("decreasing" %chin% call.nm) {
+      decreasing = x[["decreasing"]]
+      if (!is.logical(decreasing)) decreasing = eval(decreasing, ienv)
+      if (!is.logical(decreasing) || !length(decreasing) || anyNA(decreasing)) return(x)
+    } else decreasing = NULL
+    ## escape invalid na.last, outsource raising error
+    if ("na.last" %chin% call.nm) {
+      na.last = x[["na.last"]]
+      if (!is.logical(na.last)) na.last = eval(na.last, ienv)
+      if (!is.logical(na.last)) return(x)
+    } else na.last = TRUE
+    ## decompose variables in dots
+    order.args = c("decreasing","method","na.last") ## formalArgs(order) - "..."
+    order.call = if (!is.null(call.nm)) x[!call.nm %chin% order.args] else x
+    dots = as.list(order.call[-1])
+    ## escapy empty input
+    if (!length(dots)) return(x)
+    order.vars = all.vars(order.call)
+    ## escape constant order(x, 1L)
+    if (length(dots)!=length(order.vars)) return(x)
+    ## escape for any non-dt var
+    if (any(!order.vars %chin% names(dt))) return(x)
+    ## escape for any unsupported type
+    supported = c("integer","double","logical","character","complex")
+    if (any(vapply(order.vars, function(v) !typeof(dt[[v]])%chin%supported, NA))) return(x)
+    ## decreasing recycle
+    decreasing = if (is.null(decreasing)) rep(FALSE, length(order.vars)) else {
+      if (!(length(decreasing)==1L || length(decreasing)==length(order.vars))) stop("'decreasing' must be either length 1, or length of the variables passed to order")
+      if (length(decreasing)==1L && length(order.vars)>1L) decreasing = rep(decreasing, length(order.vars)) else decreasing
+    }
+    ## forderv arguments
+    by = vector("character", length(order.vars))
+    order = rep.int(1L, length(order.vars))
+    order[decreasing] = -1L
+    ## language objects for each of order dots element
+    for (i in seq_along(dots)) {
+      dot = dots[[i]]
+      while (dot %iscall% c("-", "+") && length(dot)==2L) {
+        if (dot[[1L]]=="-") order[i] = -order[i]
+        dot = dot[[2L]]
+      }
+      if (is.symbol(dot)) {
+        var = as.character(dot)
+        if (!var %chin% order.vars) stop("internal error: a dots element is symbol but is not any of order.vars, should have been caught already") # nocov
+        by[i] = var
+      } else return(x)
+    }
+    x = as.call(list(quote(forderv), quote(x), by=by, retGrp=FALSE, sort=TRUE, order=order, na.last=na.last))
+    if (verbose) cat(sprintf("order call in 'i' optimized to '%s'\n", deparse(x, width.cutoff=500L)[1L]))
+  }
   x
 }
 
@@ -355,8 +415,13 @@ replace_dot_alias = function(e) {
     }
     else if (!is.name(isub)) {
       ienv = new.env(parent=parent.frame())
+      isub = .massagei(isub, dt=x, verbose=verbose, ienv=ienv)
+      ## this functionality has been moved to .massagei+forderv (#3023) branch below, but this forder will be still used when a variable in `order` is not a DT column, or order(x, (y)), order(-(x)), etc
       if (getOption("datatable.optimize")>=1L) assign("order", forder, ienv)
-      i = tryCatch(eval(.massagei(isub), x, ienv), error=function(e) {
+      i = if (is.call(isub) && isub[[1L]]==quote(forderv)) { ## order has been optimized to forderv #3023
+        fo = eval(isub) ## forderv(x, ...)
+        if (!length(fo)) seq_len(nrow(x)) else fo
+      } else tryCatch(eval(isub, x, ienv), error=function(e) {
         if (grepl(":=.*defined for use in j.*only", e$message))
           stop("Operator := detected in i, the first argument inside DT[...], but is only valid in the second argument, j. Most often, this happens when forgetting the first comma (e.g. DT[newvar := 5] instead of DT[ , new_var := 5]). Please double-check the syntax. Run traceback(), and debugger() to get a line number.")
         else

--- a/R/setkey.R
+++ b/R/setkey.R
@@ -186,18 +186,18 @@ forderv = function(x, by=seq_along(x), retGrp=FALSE, sort=TRUE, order=1L, na.las
   .Call(Cforder, x, by, retGrp, sort, order, na.last)  # returns integer() if already sorted, regardless of sort=TRUE|FALSE
 }
 
-forder = function(..., na.last=TRUE, decreasing=FALSE)
+forder = function(..., na.last=TRUE, decreasing=FALSE, method=c("auto","shell","radix"))
 {
+  if (!missing(method) && !identical(method, "radix")) return(base::order(...=..., na.last=na.last, decreasing=decreasing, method=method))
   sub = substitute(list(...))
   tt = sapply(sub, function(x) is.null(x) || (is.symbol(x) && !nzchar(x)))
-  if (any(tt)) sub[tt] = NULL  # remove any NULL or empty arguments; e.g. test 1962.052: forder(DT, NULL) and forder(DT, )
+  if (any(tt)) stop("[f]order argument ", paste(which(tt)-1L, collapse=", "), " is NULL or empty") # raises error consistent to base::order, invalidates  e.g. test 1962.052: forder(DT, NULL) and forder(DT, )
   if (length(sub)<2L) return(NULL)  # forder() with no arguments returns NULL consistent with base::order
   asc = rep.int(1L, length(sub)-1L)  # ascending (1) or descending (-1) per column
   # the idea here is to intercept - (and unusual --+ deriving from built expressions) before vectors in forder(DT, -colA, colB) so that :
   # 1) - on character vector works; ordinarily in R that fails with type error
   # 2) each column/expression can have its own +/- more easily that having to use a separate decreasing=TRUE/FALSE
   # 3) we can pass the decreasing (-) flag to C and avoid what normally happens in R; i.e. allocate a new vector and apply - to every element first
-  # We intercept the unevaluated expressions and massage them before evaluating in with(DT) scope or not depending on the first item.
   for (i in seq.int(2L, length(sub))) {
     v = sub[[i]]
     while (v %iscall% c('-', '+') && length(v)==2L) {
@@ -219,10 +219,10 @@ forder = function(..., na.last=TRUE, decreasing=FALSE)
   } else {
     data = eval(sub, parent.frame(), parent.frame())
   }
-  stopifnot(isTRUEorFALSE(decreasing))
-  o = forderv(data, seq_along(data), sort=TRUE, retGrp=FALSE, order= if (decreasing) -asc else asc, na.last)
-  if (!length(o) && length(data)>=1L) o = seq_along(data[[1L]]) else o
-  o
+  stopifnot(is.logical(decreasing), !anyNA(decreasing))
+  asc[decreasing] = -(asc[decreasing])
+  o = forderv(data, seq_along(data), sort=TRUE, retGrp=FALSE, order=asc, na.last=na.last)
+  if (!length(o) && length(data)>=1L) seq_along(data[[1L]]) else o
 }
 
 fsort = function(x, decreasing=FALSE, na.last=FALSE, internal=FALSE, verbose=FALSE, ...)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -16911,6 +16911,16 @@ test(TEST+0.41, notOutput=opt.msg, d[order(NULL), verbose=TRUE], error="order ar
 test(TEST+0.42, notOutput=opt.msg, d[order(1,,2,NULL), verbose=TRUE], error="order argument 2, 4 is NULL or empty")
 test(TEST+0.43, notOutput=opt.msg, d[order(NULL, na.last=FALSE), verbose=TRUE], error="order argument 1 is NULL or empty")
 test(TEST+0.44, notOutput=opt.msg, d[order(na.last=FALSE, NULL), verbose=TRUE], error="order argument 1 is NULL or empty")
+if ("lazy" %chin% formalArgs(forderv)) { ## this tests kicks in when #4386 merged
+  d = data.table(x=3:1, y=c(2L,1L,3L), z=1:3)
+  test(TEST+0.81, output="forder.*opt=-1", d[order(x, na.last=FALSE), verbose=TRUE], d[3:1])
+  setindexv(d, list("x","y","z",c("x","y","z"),c("y","z")))
+  test(TEST+0.82, output="forder.*opt=2", d[order(x, na.last=FALSE), verbose=TRUE], d[3:1])
+  test(TEST+0.83, output="forder.*opt=2", d[order(x, y, z, na.last=FALSE), verbose=TRUE], d[3:1])
+  test(TEST+0.84, output="forder.*opt=2", d[order(z, na.last=FALSE), verbose=TRUE], d)
+  setkeyv(d, "z")
+  test(TEST+0.85, output="forder.*opt=1", d[order(z, na.last=FALSE), verbose=TRUE], d)
+}
 # method and decreasing properly handled in in forder #4456
 d = data.table(x=2:1); ans = data.table(x=1:2)
 test(TEST+0.91, output=opt.msg, d[order(x, method="radix"), verbose=TRUE], ans)                           # forderv

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -13373,18 +13373,19 @@ test(1962.0471, forderv(mean),                         error="'x' argument must 
 test(1962.0472, forderv(DT, by=mean),                  error="argument specifying columns must be character or numeric")
 test(1962.0473, forderv(NULL),                         error="DT is an empty list() of 0 columns")
 
-setDF(DT)
-test(1962.0481, forder(DT), 3:1)
-L = as.list(DT)
-test(1962.0482, forder(L), 3:1)
-test(1962.0483, forder(), NULL)
-setDT(DT)
-test(1962.049, forder(DT[ , 0L]), error = 'Attempting to order a 0-column')
-test(1962.050, forder(DT, decreasing = NA), error = 'isTRUEorFALSE(decreasing) is not TRUE')
-test(1962.051, forder(DT, decreasing = 1.4), error = 'isTRUEorFALSE(decreasing) is not TRUE')
-test(1962.052, forder(DT, NULL), 3:1)
-test(1962.053, forder(DT), 3:1)
-test(1962.054, forder(DT, ), 3:1)
+## made inactive by #4346: forder should not accept list, but forderv should
+#setDF(DT)
+#test(1962.0481, forder(DT), 3:1)
+#L = as.list(DT)
+#test(1962.0482, forder(L), 3:1)
+#test(1962.0483, forder(), NULL)
+#setDT(DT)
+#test(1962.049, forder(DT[ , 0L]), error = 'Attempting to order a 0-column')
+#test(1962.050, forder(DT, decreasing = NA), error = 'isTRUEorFALSE(decreasing) is not TRUE')
+#test(1962.051, forder(DT, decreasing = 1.4), error = 'isTRUEorFALSE(decreasing) is not TRUE')
+#test(1962.052, forder(DT, NULL), 3:1)
+#test(1962.053, forder(DT), 3:1)
+#test(1962.054, forder(DT, ), 3:1)
 
 test(1962.055, fsort(as.double(DT$a), internal = TRUE),
      error = 'Internal code should not be being called on type double')
@@ -16853,3 +16854,70 @@ A = data.table(A=c(complex(real = 1:3, imaginary=c(0, -1, 1)), NaN))
 test(2138.3, rbind(A,B), data.table(A=c(as.character(A$A), B$A)))
 A = data.table(A=as.complex(rep(NA, 5)))
 test(2138.4, rbind(A,B), data.table(A=c(as.character(A$A), B$A)))
+
+# optimize order() to forderv(); evaluates: decreasing, method, na.last. #3023, possibly #3261 as well
+TEST = 2139
+opt.msg = "order call in 'i' optimized to 'forderv.*"
+# test base R order arguments because we rely on that during order->forderv optimization
+order.args = c("...", "na.last", "decreasing", "method")
+if (base::getRversion() < "3.3.0") order.args = setdiff(order.args, "method")
+test(TEST+0.01, formalArgs(order), order.args)
+test(TEST+0.02, isTRUE(formals(order)$na.last)) # quite unlikely that would be changed, but doesnt hurt to test
+# test new optimization
+d = data.table(x=3:1, y=c(2L,1L,3L), z=1:3)
+ix = with(d, order(x, z=y))
+test(TEST+0.11, output=opt.msg, d[order(x, z=y, na.last=TRUE), verbose=TRUE], d[ix]) # named dots are fine
+ix = with(d, order(x, z=I(y)))
+test(TEST+0.12, notOutput=opt.msg, d[order(x, z=I(y), na.last=TRUE), verbose=TRUE], d[ix]) # calls arent fine because we would need to evaluate dots
+ix = with(d, order(x, I(y)))
+test(TEST+0.13, notOutput=opt.msg, d[order(x, I(y), na.last=TRUE), verbose=TRUE], d[ix]) # unnamed as well wont work
+ix = with(d, order(x, y, decreasing=c(FALSE,FALSE)))
+test(TEST+0.14, output=opt.msg, d[order(x, y, decreasing=c(FALSE,FALSE)), verbose=TRUE], d[ix]) # decreasing evaluated
+ix = with(d, order(x, y, na.last=TRUE))
+test(TEST+0.15, output=opt.msg, d[order(x, y, na.last=TRUE), verbose=TRUE], d[ix])
+ix = with(d, order(y, x, na.last=TRUE))
+test(TEST+0.16, output=opt.msg, d[order(y, x, na.last=TRUE), verbose=TRUE], d[ix])
+ix = with(d, order(x, y, na.last=FALSE))
+test(TEST+0.17, output=opt.msg, d[order(x, y, na.last=as.logical(FALSE)), verbose=TRUE], d[ix]) ## evaluates na.last
+ix = with(d, order(y, x, na.last=FALSE))
+test(TEST+0.18, output=opt.msg, d[order(y, x, na.last=as.logical(FALSE)), verbose=TRUE], d[ix])
+ix = with(d, order(y, x, decreasing=TRUE))
+test(TEST+0.19, output=opt.msg, d[order(-y, -x), verbose=TRUE], d[ix])
+test(TEST+0.20, output=opt.msg, d[order(y, x, decreasing=TRUE), verbose=TRUE], d[ix])
+test(TEST+0.21, output=opt.msg, d[order(+y, +x, decreasing=TRUE), verbose=TRUE], d[ix])
+ix = with(d, order(y, x, decreasing=c(FALSE,FALSE)))
+test(TEST+0.22, output=opt.msg, d[order(-y, -x, decreasing=c(TRUE,TRUE)), verbose=TRUE], d[ix])
+test(TEST+0.23, output=opt.msg, d[order(y, x, decreasing=c(FALSE,FALSE)), verbose=TRUE], d[ix])
+test(TEST+0.24, output=opt.msg, d[order(+y, +x, decreasing=c(FALSE,FALSE)), verbose=TRUE], d[ix])
+test(TEST+0.25, output=opt.msg, d[order(+y, -x, decreasing=c(FALSE,TRUE)), verbose=TRUE], d[ix])
+test(TEST+0.26, output=opt.msg, d[order(-y, +x, decreasing=c(TRUE,FALSE)), verbose=TRUE], d[ix])
+ix = with(d, order(x, decreasing=FALSE))
+test(TEST+0.27, output=opt.msg, d[order(-x, decreasing=TRUE), verbose=TRUE], d[ix])
+test(TEST+0.28, output=opt.msg, d[order(x), verbose=TRUE], d[ix])
+ix = with(d, order(x, decreasing=TRUE))
+test(TEST+0.29, output=opt.msg, d[order(x, decreasing=TRUE), verbose=TRUE], d[ix])
+test(TEST+0.30, output=opt.msg, d[order(-x), verbose=TRUE], d[ix])
+ix = with(d, order(x))
+test(TEST+0.31, output=opt.msg, d[order(-++-++x), verbose=TRUE], d[ix])
+ix = with(d, order(x, decreasing=TRUE))
+test(TEST+0.32, output=opt.msg, d[order(-++-++x, decreasing=TRUE), verbose=TRUE], d[ix])
+ix = with(d, order(x, y, x))
+test(TEST+0.33, notOutput=opt.msg, output="forder.c", d[order(x, y, x), verbose=TRUE], d[ix]) # test duplicated order vars redirect to forder
+ix = with(d, order())
+test(TEST+0.34, notOutput=opt.msg, d[order(), verbose=TRUE], d[ix]) # zero length input
+ix = with(d, order(na.last=FALSE))
+test(TEST+0.35, notOutput=opt.msg, d[order(na.last=FALSE), verbose=TRUE], d[ix])
+test(TEST+0.41, notOutput=opt.msg, d[order(NULL), verbose=TRUE], error="order argument 1 is NULL or empty")
+test(TEST+0.42, notOutput=opt.msg, d[order(1,,2,NULL), verbose=TRUE], error="order argument 2, 4 is NULL or empty")
+test(TEST+0.43, notOutput=opt.msg, d[order(NULL, na.last=FALSE), verbose=TRUE], error="order argument 1 is NULL or empty")
+test(TEST+0.44, notOutput=opt.msg, d[order(na.last=FALSE, NULL), verbose=TRUE], error="order argument 1 is NULL or empty")
+# method and decreasing properly handled in in forder #4456
+d = data.table(x=2:1); ans = data.table(x=1:2)
+test(TEST+0.91, output=opt.msg, d[order(x, method="radix"), verbose=TRUE], ans)                           # forderv
+test(TEST+0.92, notOutput=opt.msg, output="forder.c", d[order(((x)), method="radix"), verbose=TRUE], ans) # forder
+test(TEST+0.93, notOutput="forder.*", d[order(x, method="auto"), verbose=TRUE], ans)                      # base::order
+test(TEST+0.94, output=opt.msg, data.table(x=2:1, y=2L)[order(x, y, decreasing=c(FALSE,FALSE)), verbose=TRUE], data.table(x=1:2,y=2L))
+test(TEST+0.95, notOutput=opt.msg, output="forder.c", data.table(x=2:1, y=2L)[order((x), y, decreasing=c(FALSE,FALSE)), verbose=TRUE], data.table(x=1:2, y=2L))
+d = data.table(x=3:1, y=c(2L,1L,3L), z=1:3)
+ix = with(d, order(x, y, decreasing=c(FALSE,FALSE)))
+test(TEST+0.96, d[with(d, order(x, y, decreasing=c(FALSE,FALSE)))], d[ix]) ## order masked with forder


### PR DESCRIPTION
- [x] `order` could utilize existing index #3023 (once #4386 merged)

using main.Rraw as of current master (not counting tests in this PR), optimization DT[order->forderv] from this PR kicks in 46 times

- [x] `DT[order(.), ...]` could create index on DT #3261 (once #4386 merged, and `setindex` from C forder enabled)

- [x] order optimization does recognize all order args properly #4456
- [ ] forder should not accept list, but forderv should #4346