### PR TITLE
`j = <expr>:<expr>` is now with=TRUE with at least one call expr

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -53,7 +53,7 @@ rowwiseDT(
     # [1] "V1" "b" "c"
     ```
 
-5. Queries like `DT[, min(x):max(x)]` now works as expected, i.e. the same as `DT[, seq(min(x), max(x))]` or `with(DT, min(x):max(x))`, [#2069](https://github.com/Rdatatable/data.table/issues/2069). Shorthand like `DT[, a:b]` meaning "select from columns `a` through `b`" still works. Thanks to @franknarf1 for reporting and @jangorecki for the fix.
+5. Queries like `DT[, min(x):max(x)]` now work as expected, i.e. the same as `DT[, seq(min(x), max(x))]` or `with(DT, min(x):max(x))`, [#2069](https://github.com/Rdatatable/data.table/issues/2069). Shorthand like `DT[, a:b]` meaning "select from columns `a` through `b`" still works. Thanks to @franknarf1 for reporting and @jangorecki for the fix.
 
 ## NOTES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -53,7 +53,7 @@ rowwiseDT(
     # [1] "V1" "b" "c"
     ```
 
-5. When using `:` operator on a _call_ object(s) inside `j` argument, it could have been improperly recognised as an attempt to select columns (`with=FALSE`) rather than evaluate expression within a data.table, [#2069](https://github.com/Rdatatable/data.table/issues/2069). Thanks to @franknarf1 for reporting.
+5. Queries like `DT[, min(x):max(x)]` now works as expected, i.e. the same as `DT[, seq(min(x), max(x))]` or `with(DT, min(x):max(x))`, [#2069](https://github.com/Rdatatable/data.table/issues/2069). Shorthand like `DT[, a:b]` meaning "select from columns `a` through `b`" still works. Thanks to @franknarf1 for reporting and @jangorecki for the fix.
 
 ## NOTES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -53,6 +53,8 @@ rowwiseDT(
     # [1] "V1" "b" "c"
     ```
 
+5. When using `:` operator on a _call_ object(s) inside `j` argument, it could have been improperly recognised as an attempt to select columns (`with=FALSE`) rather than evaluate expression within a data.table, [#2069](https://github.com/Rdatatable/data.table/issues/2069). Thanks to @franknarf1 for reporting.
+
 ## NOTES
 
 1. Tests run again when some Suggests packages are missing, [#6411](https://github.com/Rdatatable/data.table/issues/6411). Thanks @aadler for the note and @MichaelChirico for the fix.

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -244,10 +244,10 @@ replace_dot_alias = function(e) {
   if (!missing(j)) {
     jsub = replace_dot_alias(jsub)
     root = root_name(jsub)
-    if (root == ":" ||
-        (root %chin% c("-","!") && jsub[[2L]] %iscall% '(' && jsub[[2L]][[2L]] %iscall% ':') ||
-        ( (!length(av<-all.vars(jsub)) || all(startsWith(av, ".."))) &&
-          root %chin% c("","c","paste","paste0","-","!") &&
+    if ((root == ":" && !is.call(jsub[[2L]]) && !is.call(jsub[[3L]])) ||                        ## x[, V1:V2]; but not x[, (V1):(V2)] #2069
+        (root %chin% c("-","!") && jsub[[2L]] %iscall% '(' && jsub[[2L]][[2L]] %iscall% ':') || ## x[, !(V8:V10)]
+        ( (!length(av<-all.vars(jsub)) || all(startsWith(av, ".."))) &&                         ## x[, "V1"]; x[, ..v]
+          root %chin% c("","c","paste","paste0","-","!") &&                                     ## x[, c("V1","V2")]; x[, paste("V",1:2,sep="")]; x[, paste0("V",1:2)]
           missingby )) {   # test 763. TODO: likely that !missingby iff with==TRUE (so, with can be removed)
       # When no variable names (i.e. symbols) occur in j, scope doesn't matter because there are no symbols to find.
       # If variable names do occur, but they are all prefixed with .., then that means look up in calling scope.

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -19157,8 +19157,11 @@ for (opt in c(0, 1, 2)) {
 }
 
 # Confusing behavior with DT[, min(var):max(var)] #2069
-DT = data.table(
-  id = c(1L, 1L, 1L, 2L, 2L, 2L, 3L, 3L, 3L, 4L, 4L, 4L, 5L, 5L, 5L, 6L, 6L, 6L),
-  t = c(4L, 9L, 14L, 1L, 4L, 9L, 5L, 14L, 18L, 1L, 3L, 12L, 3L, 5L, 7L, 4L, 10L, 13L)
-)
-test(2284, DT[, min(t):max(t)], with(DT, min(t):max(t)))
+DT = data.table(t = c(2L, 1L, 3L))
+test(2284.1, DT[, min(t):max(t)], with(DT, min(t):max(t)))
+test(2284.2, DT[, 1:max(t)], with(DT, 1:max(t)))
+test(2284.3, DT[, max(t):1], with(DT, max(t):1))
+test(2284.4, DT[, 1:t[1L]], with(DT, 1:t[1L]))
+test(2284.5, DT[, t[2L]:1], with(DT, t[2L]:1))
+test(2284.6, DT[1L, t:max(t)], with(DT[1L], t:max(t)))
+test(2284.7, DT[1L, min(t):t], with(DT[1L], min(t):t))

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -19155,3 +19155,10 @@ for (opt in c(0, 1, 2)) {
        names(M[, c(mpg[1], list(mpg, b=hp), c(lapply(.SD, mean))), by="cyl", .SDcols=c("vs", "am")]),
        c("cyl", "V1", "V2", "b", "vs", "am"))
 }
+
+# Confusing behavior with DT[, min(var):max(var)] #2069
+DT = data.table(
+  id = c(1L, 1L, 1L, 2L, 2L, 2L, 3L, 3L, 3L, 4L, 4L, 4L, 5L, 5L, 5L, 6L, 6L, 6L),
+  t = c(4L, 9L, 14L, 1L, 4L, 9L, 5L, 14L, 18L, 1L, 3L, 12L, 3L, 5L, 7L, 4L, 10L, 13L)
+)
+test(2284, DT[, min(t):max(t)], with(DT, min(t):max(t)))


### PR DESCRIPTION
closes #2069