### PR TITLE
light setDT

### DIFF
--- a/man/setDT.Rd
+++ b/man/setDT.Rd
@@ -8,13 +8,15 @@
 
 }
 \usage{
-setDT(x, keep.rownames=FALSE, key=NULL, check.names=FALSE)
+setDT(x, keep.rownames=FALSE, key=NULL, check.names=FALSE, asis=FALSE, return=FALSE)
 }
 \arguments{
   \item{x}{ A named or unnamed \code{list}, \code{data.frame} or \code{data.table}. }
   \item{keep.rownames}{ For \code{data.frame}s, \code{TRUE} retains the \code{data.frame}'s row names under a new column \code{rn}. \code{keep.rownames = "id"} names the column \code{"id"} instead. } 
   \item{key}{Character vector of one or more column names which is passed to \code{\link{setkeyv}}. It may be a single comma separated string such as \code{key="x,y,z"}, or a vector of names such as \code{key=c("x","y","z")}. }
   \item{check.names}{ Just as \code{check.names} in \code{\link{data.frame}}. }
+  \item{asis}{ Logical, setting to \code{TRUE} can be used to remove the overhead related to input checking of \code{x} argument. \code{x} is then taken \emph{as is}, thus \code{keep.rownames}, \code{key}, \code{check.names} are ignored. Use with caution. }
+  \item{return}{ Logical, setting to \code{TRUE} will make function to return new object, rather than modifying existing one. }
 }
 
 \details{
@@ -22,7 +24,9 @@ setDT(x, keep.rownames=FALSE, key=NULL, check.names=FALSE)
 }
 
 \value{
-    The input is modified by reference, and returned (invisibly) so it can be used in compound statements; e.g., \code{setDT(X)[, sum(B), by=A]}. If you require a copy, take a copy first (using \code{DT2 = copy(DT)}). See \code{?copy}.
+  The input is modified by reference, and returned (invisibly) so it can be used in compound statements; e.g., \code{setDT(X)[, sum(B), by=A]}.
+  If \code{return} argument is \code{TRUE} then input is not modified by reference, but a new \code{data.table} object is (visibly) returned from function. New object shares the columns data with \code{x} input.
+  If you require a copy, take a copy first (using \code{DT2 = copy(DT)}). See \code{?copy}.
 }
 
 \seealso{ \code{\link{data.table}}, \code{\link{as.data.table}}, \code{\link{setDF}}, \code{\link{copy}}, \code{\link{setkey}}, \code{\link{setcolorder}}, \code{\link{setattr}}, \code{\link{setnames}}, \code{\link{set}}, \code{\link{:=}}, \code{\link{setorder}}

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -89,6 +89,8 @@ extern SEXP sym_verbose;
 extern SEXP SelfRefSymbol;
 extern SEXP sym_inherits;
 extern SEXP sym_datatable_locked;
+extern SEXP sym_rownames;
+extern SEXP sym_alloccol;
 extern double NA_INT64_D;
 extern long long NA_INT64_LL;
 extern Rcomplex NA_CPLX;  // initialized in init.c; see there for comments
@@ -238,3 +240,6 @@ SEXP testMsgR(SEXP status, SEXP x, SEXP k);
 //fifelse.c
 SEXP fifelseR(SEXP l, SEXP a, SEXP b, SEXP na);
 SEXP fcaseR(SEXP na, SEXP rho, SEXP args);
+
+// dt.c
+SEXP makeDT(SEXP x);

--- a/src/dt.c
+++ b/src/dt.c
@@ -1,0 +1,42 @@
+#include "data.table.h"
+
+int NROW(SEXP x) {
+  if (!LENGTH(x))
+    return 0; // # nocov # not yet reached from anywhere, cbindlist uses it but escapes for !NCOL(x)
+  return length(VECTOR_ELT(x, 0));
+}
+
+// c("data.table","data.frame")
+static SEXP char2_dtdf() {
+  SEXP char2_dtdf = PROTECT(allocVector(STRSXP, 2));
+  SET_STRING_ELT(char2_dtdf, 0, char_datatable);
+  SET_STRING_ELT(char2_dtdf, 1, char_dataframe);
+  UNPROTECT(1);
+  return char2_dtdf;
+}
+// .set_row_names(x)
+static SEXP set_row_names(int n) {
+  SEXP ans = R_NilValue;
+  if (n) {
+    ans = PROTECT(allocVector(INTSXP, 2));
+    INTEGER(ans)[0] = NA_INTEGER;
+    INTEGER(ans)[1] = -n;
+  } else {
+    ans = PROTECT(allocVector(INTSXP, 0));
+  }
+  UNPROTECT(1);
+  return ans;
+}
+
+// like setDT(x) but not in-place
+SEXP makeDT(SEXP x) {
+  if (!isNewList(x))
+    error("Argument 'x' must be a 'list', 'data.frame' or 'data.table'");
+  R_len_t n = length(x)+INTEGER(GetOption(sym_alloccol, R_NilValue))[0];
+  Rboolean verbose = (Rboolean)LOGICAL(GetOption(sym_verbose, R_NilValue))[0];
+  SEXP ans = PROTECT(alloccol(x, n, verbose));
+  setAttrib(ans, R_ClassSymbol, char2_dtdf());
+  setAttrib(ans, sym_rownames, set_row_names(NROW(x)));
+  UNPROTECT(1);
+  return ans;
+}

--- a/src/init.c
+++ b/src/init.c
@@ -30,6 +30,8 @@ SEXP sym_verbose;
 SEXP SelfRefSymbol;
 SEXP sym_inherits;
 SEXP sym_datatable_locked;
+SEXP sym_rownames;
+SEXP sym_alloccol;
 double NA_INT64_D;
 long long NA_INT64_LL;
 Rcomplex NA_CPLX;
@@ -211,6 +213,7 @@ R_CallMethodDef callMethods[] = {
 {"CfrollapplyR", (DL_FUNC) &frollapplyR, -1},
 {"CtestMsgR", (DL_FUNC) &testMsgR, -1},
 {"C_allNAR", (DL_FUNC) &allNAR, -1},
+{"CmakeDT", (DL_FUNC) &makeDT, -1},
 {NULL, NULL, 0}
 };
 
@@ -344,6 +347,8 @@ void attribute_visible R_init_datatable(DllInfo *info)
   SelfRefSymbol = install(".internal.selfref");
   sym_inherits = install("inherits");
   sym_datatable_locked = install(".data.table.locked");
+  sym_rownames = install("row.names");
+  sym_alloccol = install("datatable.alloccol");
 
   initDTthreads();
   avoid_openmp_hang_within_fork();


### PR DESCRIPTION
Provides more lightweight interface for `setDT`.  Use cases are rather uncommon, of using `setDT` in big loops, which is described in #4476.
It may be useful for our internal usage of `setDT` where its input is already produced by our code and not provided by user.
There was also request for interface to `alloccol` on C level, the C function here is well addressing that, #4439.
```r
library(data.table)
df1 = data.frame(x=1:4, y=1:2)
df2 = copy(df1)
microbenchmark::microbenchmark(times=1000,
  normal = setDT(df1)[, sum(x), y],
  simple = setDT(df2, asis=TRUE, return=TRUE)[, sum(x), y]
)
#Unit: microseconds
#   expr     min       lq     mean   median       uq      max neval
# normal 654.000 676.3505 730.4088 707.9065 725.1735 9311.567  1000
# simple 571.862 594.5105 652.3667 626.2590 642.4785 8279.154  1000

microbenchmark::microbenchmark(times=1,
  normal = for (i in 1:1e3) setDT(df1),
  simple = for (i in 1:1e3) setDT(df2, asis=TRUE, return=TRUE)
)
#Unit: milliseconds
#   expr       min        lq      mean    median        uq       max neval
# normal 77.017866 77.017866 77.017866 77.017866 77.017866 77.017866     1
# simple  8.291629  8.291629  8.291629  8.291629  8.291629  8.291629     1
```
no tests yet.