### PR TITLE
RFC/WIP for fread comment.char

### DIFF
--- a/src/fread.c
+++ b/src/fread.c
@@ -247,6 +247,9 @@ static inline void skip_white(const char **pch) {
  */
 static inline bool eol(const char **pch) {
   const char *ch = *pch;
+  if (*ch == '#') {
+    while (*ch != '\r' && *ch != '\n') ch++;
+  }
   // we call eol() when we expect to be on an eol(), so optimize as if we are on an eol
   while (*ch=='\r') ch++;  // commonly happens once on Windows for type 2
   if (*ch=='\n') {


### PR DESCRIPTION
Very simple version of how we could implement a `comment.char` argument for `fread` (#856). (just testing with a fixed `comment.char='#'` for now)

This addresses line-initial comments, but not line-trailing comments:

```
fread('a,b
#a comment
1,2
#another comment
3,4')
#       V1    V2
#    <int> <int>
# 1:     3     4

fread('a,b#line-trailing comment
1,2')
#        a b#line-trailing comment
#    <int>                   <int>
# 1:     1                       2

fread('a,b
1,2#trailing after numeric')
#        a                        b
#    <int>                   <char>
# 1:     1 2#trailing after numeric
```

Is this good enough to file as a solution for now? How common is the line-trailing use case? Any efficiency concern of this approach when `comment.char` is not used?