### PR TITLE
Non-equi joins are allow.cartesian = TRUE

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -109,6 +109,8 @@ unit = "s")
 
 13. A relatively rare case of segfault when combining non-equi joins with `by=.EACHI` is now fixed, closes [#4388](https://github.com/Rdatatable/data.table/issues/4388).
 
+14. Non-equi joins now automatically set allow.cartesian to `TRUE`. Closes [4489](https://github.com/Rdatatable/data.table/issues/4489)
+
 ## NOTES
 
 0. Retrospective license change permission was sought from and granted by 4 contributors who were missed in [PR#2456](https://github.com/Rdatatable/data.table/pull/2456), [#4140](https://github.com/Rdatatable/data.table/pull/4140). We had used [GitHub's contributor page](https://github.com/Rdatatable/data.table/graphs/contributors) which omits 3 of these due to invalid email addresses, unlike GitLab's contributor page which includes the ids. The 4th omission was a PR to a script which should not have been excluded; a script is code too. We are sorry these contributors were not properly credited before. They have now been added to the contributors list as displayed on CRAN. All the contributors of code to data.table hold its copyright jointly; your contributions belong to you. You contributed to data.table when it had a particular license at that time, and you contributed on that basis. This is why in the last license change, all contributors of code were consulted and each had a veto.

--- a/NEWS.md
+++ b/NEWS.md
@@ -109,7 +109,7 @@ unit = "s")
 
 13. A relatively rare case of segfault when combining non-equi joins with `by=.EACHI` is now fixed, closes [#4388](https://github.com/Rdatatable/data.table/issues/4388).
 
-14. Non-equi joins now automatically set allow.cartesian to `TRUE`. Closes [4489](https://github.com/Rdatatable/data.table/issues/4489)
+14. Non-equi joins now automatically set allow.cartesian to `TRUE`. Closes [4489](https://github.com/Rdatatable/data.table/issues/4489). Thanks to @Henrik-P for reporting.
 
 ## NOTES
 

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -429,9 +429,6 @@ replace_dot_alias = function(e) {
         on = on_ops[[1L]]
         ops = on_ops[[2L]]
         if (any(ops > 1L)) { ## fix for #4489;  ops = c("==", "<=", "<", ">=", ">", "!=")
-          ## include new warning? warning seems obnoxious. Tests affected with warning:
-          #### 1654, 1655.4, 1655.5, 1660.1, 1660.2, 1682.1, 1682.2, 1682.3, 1682.4, 1682.5, 1682.6, 1682.7, 1683.1, 1683.2, 1845.1, 1845.2, 1846.1, 1846.2, 1872.13, 1948.01, 1948.02, 1948.03, 1948.04, 1948.05, 1948.06, 1948.09, 1967.73, 1967.74, 1984.02, 1989.1, 2062.1, 2062.2, 2092.3, 2105.1, 2105.2
-          # if (!allow.cartesian) warning("allow.cartesian is FALSE but non-equi join detected. Non-equi joins typically result in more rows. Therefore, allow.cartesian is being changed to TRUE")
           allow.cartesian = TRUE
         }
         # TODO: collect all '==' ops first to speeden up Cnestedid

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -428,6 +428,12 @@ replace_dot_alias = function(e) {
         on_ops = .parse_on(substitute(on), isnull_inames)
         on = on_ops[[1L]]
         ops = on_ops[[2L]]
+        if (any(ops > 1L)) { ## fix for #4489;  ops = c("==", "<=", "<", ">=", ">", "!=")
+          ## include new warning? warning seems obnoxious. Tests affected with warning:
+          #### 1654, 1655.4, 1655.5, 1660.1, 1660.2, 1682.1, 1682.2, 1682.3, 1682.4, 1682.5, 1682.6, 1682.7, 1683.1, 1683.2, 1845.1, 1845.2, 1846.1, 1846.2, 1872.13, 1948.01, 1948.02, 1948.03, 1948.04, 1948.05, 1948.06, 1948.09, 1967.73, 1967.74, 1984.02, 1989.1, 2062.1, 2062.2, 2092.3, 2105.1, 2105.2
+          # if (!allow.cartesian) warning("allow.cartesian is FALSE but non-equi join detected. Non-equi joins typically result in more rows. Therefore, allow.cartesian is being changed to TRUE")
+          allow.cartesian = TRUE
+        }
         # TODO: collect all '==' ops first to speeden up Cnestedid
         rightcols = colnamesInt(x, names(on), check_dups=FALSE)
         leftcols  = colnamesInt(i, unname(on), check_dups=FALSE)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -16861,3 +16861,12 @@ A = data.table(A=c(complex(real = 1:3, imaginary=c(0, -1, 1)), NaN))
 test(2138.3, rbind(A,B), data.table(A=c(as.character(A$A), B$A)))
 A = data.table(A=as.complex(rep(NA, 5)))
 test(2138.4, rbind(A,B), data.table(A=c(as.character(A$A), B$A)))
+
+# Set allow.cartesian = TRUE when non-equi #4489
+
+set.seed(2)
+dt = data.table(time = 1:8, v = sample(8))
+dt[time == 2L, v := 2L]
+d[time == 7L, v := 7L]
+
+test(2139.1, dt[dt, on = .(time > time, v > v), .N, by = .EACHI], data.table(time = 1:8, v = INT(5,2,6,1,8,4,7,3), N = INT(3,5,2,4,0,1,0,0)))

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -16867,6 +16867,6 @@ test(2138.4, rbind(A,B), data.table(A=c(as.character(A$A), B$A)))
 set.seed(2)
 dt = data.table(time = 1:8, v = sample(8))
 dt[time == 2L, v := 2L]
-d[time == 7L, v := 7L]
+dt[time == 7L, v := 7L]
 
 test(2139.1, dt[dt, on = .(time > time, v > v), .N, by = .EACHI], data.table(time = 1:8, v = INT(5,2,6,1,8,4,7,3), N = INT(3,5,2,4,0,1,0,0)))

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -16864,8 +16864,7 @@ test(2138.4, rbind(A,B), data.table(A=c(as.character(A$A), B$A)))
 
 # Set allow.cartesian = TRUE when non-equi #4489
 
-set.seed(2)
-dt = data.table(time = 1:8, v = sample(8))
+dt = data.table(time = 1:8, v = INT(5,7,6,1,8,4,2,3))
 dt[time == 2L, v := 2L]
 dt[time == 7L, v := 7L]
 


### PR DESCRIPTION
Close #4489 

If any non-equi joins are detected ```c(">", ">=", "<", "<=", "!=")```, ```allow.cartesian``` is set to TRUE per Arun's suggestion. Debated including warning about this ```allow.cartesian``` change but for non-equi joins it seems like users should expect a one to many join.