### PR TITLE
is.sorted now multi-column and does not use forderv

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -109,6 +109,8 @@ unit = "s")
 
 13. A relatively rare case of segfault when combining non-equi joins with `by=.EACHI` is now fixed, closes [#4388](https://github.com/Rdatatable/data.table/issues/4388).
 
+14. Selecting key columns could incur a large speed penalty, [#4498](https://github.com/Rdatatable/data.table/issues/4498). Thanks to @Jesper on Stack Overflow for the report.
+
 ## NOTES
 
 0. Retrospective license change permission was sought from and granted by 4 contributors who were missed in [PR#2456](https://github.com/Rdatatable/data.table/pull/2456), [#4140](https://github.com/Rdatatable/data.table/pull/4140). We had used [GitHub's contributor page](https://github.com/Rdatatable/data.table/graphs/contributors) which omits 3 of these due to invalid email addresses, unlike GitLab's contributor page which includes the ids. The 4th omission was a PR to a script which should not have been excluded; a script is code too. We are sorry these contributors were not properly credited before. They have now been added to the contributors list as displayed on CRAN. All the contributors of code to data.table hold its copyright jointly; your contributions belong to you. You contributed to data.table when it had a particular license at that time, and you contributed on that basis. This is why in the last license change, all contributors of code were consulted and each had a veto.

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1336,7 +1336,7 @@ replace_dot_alias = function(e) {
 
     if (is.data.table(jval)) {
       setattr(jval, 'class', class(x)) # fix for #64
-      if (haskey(x) && all(key(x) %chin% names(jval)) && suppressWarnings(is.sorted(jval, by=key(x))))  # TO DO: perhaps this usage of is.sorted should be allowed internally then (tidy up and make efficient)
+      if (haskey(x) && all(key(x) %chin% names(jval)) && is.sorted(jval, by=key(x)))
         setattr(jval, 'sorted', key(x))
       if (any(sapply(jval, is.null))) stop("Internal error: j has created a data.table result containing a NULL column") # nocov
     }

--- a/R/setkey.R
+++ b/R/setkey.R
@@ -155,20 +155,16 @@ setreordervec = function(x, order) .Call(Creorder, x, order)
 # The others (order, sort.int etc) are turned off to protect ourselves from using them internally, for speed and for
 # consistency; e.g., consistent twiddling of numeric/integer64, NA at the beginning of integer, locale ordering of character vectors.
 
-is.sorted = function(x, by=seq_along(x)) {
+is.sorted = function(x, by=NULL) {
   if (is.list(x)) {
-    warning("Use 'if (length(o <- forderv(DT,by))) ...' for efficiency in one step, so you have o as well if not sorted.")
-    # could pass through a flag for forderv to return early on first FALSE. But we don't need that internally
-    # since internally we always then need ordering, an it's better in one step. Don't want inefficiency to creep in.
-    # This is only here for user/debugging use to check/test valid keys; e.g. data.table:::is.sorted(DT,by)
-    0L == length(forderv(x,by,retGrp=FALSE,sort=TRUE))
+    if (missing(by)) by = seq_along(x)   # wouldn't make sense when x is a vector; hence by=seq_along(x) is not the argument default
+    if (is.character(by)) by = chmatch(by, names(x))
   } else {
     if (!missing(by)) stop("x is vector but 'by' is supplied")
-    .Call(Cfsorted, x)
   }
-  # Cfsorted could be named CfIsSorted, but since "sorted" is an adjective not verb, it's clear; e.g., Cfsort would sort it ("sort" is verb).
+  .Call(Cfsorted, x, by)
+  # Cfsorted could be renamed Cissorted, and is.sorted could be exported
   # Return value of TRUE/FALSE is relied on in [.data.table quite a bit on vectors. Simple. Stick with that (rather than -1/0/+1)
-  # Important to call forder.c::fsorted here, for consistent character ordering and numeric/integer64 twiddling.
 }
 
 ORDERING_TYPES = c('logical', 'integer', 'double', 'complex', 'character')

--- a/R/setkey.R
+++ b/R/setkey.R
@@ -162,7 +162,7 @@ is.sorted = function(x, by=NULL) {
   } else {
     if (!missing(by)) stop("x is vector but 'by' is supplied")
   }
-  .Call(Cfsorted, x, by)
+  .Call(Cfsorted, x, as.integer(by))
   # Cfsorted could be renamed Cissorted, and is.sorted could be exported
   # Return value of TRUE/FALSE is relied on in [.data.table quite a bit on vectors. Simple. Stick with that (rather than -1/0/+1)
 }

--- a/R/setkey.R
+++ b/R/setkey.R
@@ -162,8 +162,7 @@ is.sorted = function(x, by=NULL) {
   } else {
     if (!missing(by)) stop("x is vector but 'by' is supplied")
   }
-  .Call(Cfsorted, x, as.integer(by))
-  # Cfsorted could be renamed Cissorted, and is.sorted could be exported
+  .Call(Cissorted, x, as.integer(by))
   # Return value of TRUE/FALSE is relied on in [.data.table quite a bit on vectors. Simple. Stick with that (rather than -1/0/+1)
 }
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -4014,8 +4014,8 @@ test(1162.09, length(forderv(DT, by=2:3)), 0L)
 setkey(DT)
 # test number 1162.10 skipped because if it fails it confusingly prints out as 1662.1 not 1662.10
 test(1162.10, length(forderv(DT, by=1:3)), 0L)
-test(1162.11, is.sorted(DT, by=1:3), TRUE, warning="Use.*forderv.*for efficiency in one step, so you have o as well if not sorted")
-test(1162.12, is.sorted(DT, by=2:1), FALSE, warning="Use.*forderv.*for efficiency in one step, so you have o as well if not sorted")
+test(1162.11, is.sorted(DT, by=1:3), TRUE)
+test(1162.12, is.sorted(DT, by=2:1), FALSE)
 
 # FR #351 - last on length=0 arguments
 x <- character(0)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -4025,9 +4025,10 @@ test(1162.16, is.sorted(DT), FALSE)
 test(1162.17, is.sorted(DT, by=2), FALSE)
 if (test_bit64) {
   DT[, A:=as.integer64(A)]
-  test(1162.18, is.sorted(DT, by="A"), TRUE)
-  DT[2, A:=NA]
-  test(1162.19, is.sorted(DT, by="A"), FALSE)
+  test(1162.18, is.sorted(DT, by="A"), TRUE)  # tests the single-column special case
+  test(1162.19, is.sorted(DT), FALSE)         # tests the 2-column case branch for integer64
+  DT[2, B:="b"]
+  test(1162.20, is.sorted(DT), TRUE)
 }
 
 # FR #351 - last on length=0 arguments

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -4016,6 +4016,19 @@ setkey(DT)
 test(1162.10, length(forderv(DT, by=1:3)), 0L)
 test(1162.11, is.sorted(DT, by=1:3), TRUE)
 test(1162.12, is.sorted(DT, by=2:1), FALSE)
+test(1162.13, is.sorted(DT), TRUE)
+DT = data.table(A=INT(1,1,2), B=c(NA,"a",NA))
+test(1162.14, is.sorted(DT), TRUE)
+test(1162.15, is.sorted(DT, by=c("B","A")), FALSE)
+DT = data.table(A=INT(1,1,2), B=c("a",NA,NA))
+test(1162.16, is.sorted(DT), FALSE)
+test(1162.17, is.sorted(DT, by=2), FALSE)
+if (test_bit64) {
+  DT[, A:=as.integer64(A)]
+  test(1162.18, is.sorted(DT, by="A"), TRUE)
+  DT[2, A:=NA]
+  test(1162.19, is.sorted(DT, by="A"), FALSE)
+}
 
 # FR #351 - last on length=0 arguments
 x <- character(0)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -4030,6 +4030,12 @@ if (test_bit64) {
   DT[2, B:="b"]
   test(1162.20, is.sorted(DT), TRUE)
 }
+utf8_strings = c("\u00a1tas", "\u00de")
+latin1_strings = iconv(utf8_strings, from="UTF-8", to="latin1")
+DT = data.table(A=c(utf8_strings, latin1_strings), B=1:4)
+test(1162.21, is.sorted(DT), FALSE)
+setkey(DT)
+test(1162.22, is.sorted(DT), TRUE)
 
 # FR #351 - last on length=0 arguments
 x <- character(0)

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -23,8 +23,8 @@
 #define IS_FALSE(x) (TYPEOF(x)==LGLSXP && LENGTH(x)==1 && LOGICAL(x)[0]==FALSE)
 #define IS_TRUE_OR_FALSE(x) (TYPEOF(x)==LGLSXP && LENGTH(x)==1 && LOGICAL(x)[0]!=NA_LOGICAL)
 
-#define SIZEOF(x) sizes[TYPEOF(x)]
-#define TYPEORDER(x) typeorder[x]
+#define SIZEOF(x) __sizes[TYPEOF(x)]
+#define TYPEORDER(x) __typeorder[x]
 
 #ifdef MIN
 #  undef MIN
@@ -92,8 +92,8 @@ extern SEXP sym_datatable_locked;
 extern double NA_INT64_D;
 extern long long NA_INT64_LL;
 extern Rcomplex NA_CPLX;  // initialized in init.c; see there for comments
-extern size_t sizes[100];  // max appears to be FUNSXP = 99, see Rinternals.h
-extern size_t typeorder[100];
+extern size_t __sizes[100];     // max appears to be FUNSXP = 99, see Rinternals.h
+extern size_t __typeorder[100]; // __ prefix otherwise if we use these names directly, the SIZEOF define ends up using the local one
 
 long long DtoLL(double x);
 double LLtoD(long long x);
@@ -115,7 +115,7 @@ int checkOverAlloc(SEXP x);
 
 // forder.c
 int StrCmp(SEXP x, SEXP y);
-uint64_t dtwiddle(void *p, int i);
+uint64_t dtwiddle(const void *p, int i);
 SEXP forder(SEXP DT, SEXP by, SEXP retGrp, SEXP sortStrArg, SEXP orderArg, SEXP naArg);
 int getNumericRounding_C();
 

--- a/src/forder.c
+++ b/src/forder.c
@@ -1366,7 +1366,7 @@ SEXP fsorted(SEXP x, SEXP by)
         } else {
           ok = (NEED2UTF8(p[0]) || NEED2UTF8(p[-1]) ?  // TODO: provide user option to choose ascii-only mode
                 strcmp(CHAR(ENC2UTF8(p[0])), CHAR(ENC2UTF8(p[-1]))) :
-                strcmp(CHAR(p[0]), CHAR(p[-1]))) > 0;
+                strcmp(CHAR(p[0]), CHAR(p[-1]))) >= 0;
         }
       } break;
       default :

--- a/src/forder.c
+++ b/src/forder.c
@@ -1257,19 +1257,20 @@ void radix_r(const int from, const int to, const int radix) {
 }
 
 
-SEXP fsorted(SEXP x, SEXP by)
+SEXP issorted(SEXP x, SEXP by)
 {
   // Just checks if ordered and returns FALSE early if not. Does not return ordering if so, unlike forder.
   // Always increasing order with NA's first
-  // Similar to base:is.unsorted but accepts NA at the beginning (standard in data.table and considered sorted) rather than returning NA when NA present.
+  // Similar to base:is.unsorted but accepts NA at the beginning (standard in data.table and considered sorted) rather than
+  // returning NA when NA present, and is multi-column.
   // TODO: test in big steps first to return faster if unsortedness is at the end (a common case of rbind'ing data to end)
-  // These are all sequential access to x, so very quick and cache efficient. Could be parallel by checking continuity at batch boundaries.
+  // These are all sequential access to x, so quick and cache efficient. Could be parallel by checking continuity at batch boundaries.
   
-  if (!isNull(by) && !isInteger(by)) STOP(_("Internal error: fsorted 'by' must be NULL or integer vector"));
+  if (!isNull(by) && !isInteger(by)) STOP(_("Internal error: issorted 'by' must be NULL or integer vector"));
   if (isVectorAtomic(x) || length(by)==1) {
     // one-column special case is very common so specialize it by avoiding column-type switches inside the row-loop later
     if (length(by)==1) {
-      if (INTEGER(by)[0]<1 || INTEGER(by)[0]>length(x)) STOP(_("fsorted 'by' [%d] out of range [1,%d]"), INTEGER(by)[0], length(x));
+      if (INTEGER(by)[0]<1 || INTEGER(by)[0]>length(x)) STOP(_("issorted 'by' [%d] out of range [1,%d]"), INTEGER(by)[0], length(x));
       x = VECTOR_ELT(x, INTEGER(by)[0]-1);
     }
     const int n = length(x);
@@ -1319,7 +1320,7 @@ SEXP fsorted(SEXP x, SEXP by)
   int *types =                (int *)R_alloc(ncol, sizeof(int));
   for (int j=0; j<ncol; ++j) {
     int c = INTEGER(by)[j];
-    if (c<1 || c>length(x)) STOP(_("fsorted 'by' [%d] out of range [1,%d]"), c, length(x));
+    if (c<1 || c>length(x)) STOP(_("issorted 'by' [%d] out of range [1,%d]"), c, length(x));
     SEXP col = VECTOR_ELT(x, c-1);
     sizes[j] = SIZEOF(col);
     switch(TYPEOF(col)) {

--- a/src/forder.c
+++ b/src/forder.c
@@ -215,7 +215,7 @@ int StrCmp(SEXP x, SEXP y)
   if (x == y) return 0;             // same cached pointer (including NA_STRING==NA_STRING)
   if (x == NA_STRING) return -1;    // x<y
   if (y == NA_STRING) return 1;     // x>y
-  return strcmp(CHAR(ENC2UTF8(x)), CHAR(ENC2UTF8(y)));
+  return strcmp(CHAR(ENC2UTF8(x)), CHAR(ENC2UTF8(y)));  // TODO: always calling ENC2UTF8 here could be expensive 
 }
 /* ENC2UTF8 handles encoding issues by converting all marked non-utf8 encodings alone to utf8 first. The function could be wrapped
    in the first if-statement already instead of at the last stage, but this is to ensure that all-ascii cases are handled with maximum efficiency.
@@ -394,7 +394,7 @@ int getNumericRounding_C()
 
 // for signed integers it's easy: flip sign bit to swap positives and negatives; the resulting unsigned is in the right order with INT_MIN ending up as 0
 // for floating point finite you have to flip the other bits too if it was signed: http://stereopsis.com/radix.html
-uint64_t dtwiddle(void *p, int i)
+uint64_t dtwiddle(const void *p, int i)
 {
   union {
     double d;
@@ -1257,50 +1257,126 @@ void radix_r(const int from, const int to, const int radix) {
 }
 
 
-SEXP fsorted(SEXP x)
+SEXP fsorted(SEXP x, SEXP by)
 {
   // Just checks if ordered and returns FALSE early if not. Does not return ordering if so, unlike forder.
   // Always increasing order with NA's first
   // Similar to base:is.unsorted but accepts NA at the beginning (standard in data.table and considered sorted) rather than returning NA when NA present.
   // TODO: test in big steps first to return faster if unsortedness is at the end (a common case of rbind'ing data to end)
   // These are all sequential access to x, so very quick and cache efficient. Could be parallel by checking continuity at batch boundaries.
-  const int n = length(x);
-  if (n <= 1) return(ScalarLogical(TRUE));
-  if (!isVectorAtomic(x)) STOP(_("is.sorted (R level) and fsorted (C level) only to be used on vectors. If needed on a list/data.table, you'll need the order anyway if not sorted, so use if (length(o<-forder(...))) for efficiency in one step, or equivalent at C level"));
-  int i=1;
-  switch(TYPEOF(x)) {
-  case INTSXP : case LGLSXP : {
-    int *xd = INTEGER(x);
-    while (i<n && xd[i]>=xd[i-1]) i++;
-  } break;
-  case REALSXP :
-    if (inherits(x,"integer64")) {
-      int64_t *xd = (int64_t *)REAL(x);
+  
+  if (!isNull(by) && !isInteger(by)) STOP(_("Internal error: fsorted 'by' must be NULL or integer vector"));
+  if (isVectorAtomic(x) || length(by)==1) {
+    // one-column special case is very common so specialize it by avoiding column-type switches inside the row-loop later
+    if (length(by)==1) {
+      if (INTEGER(by)[0]<1 || INTEGER(by)[0]>length(x)) STOP(_("fsorted 'by' [%d] out of range [1,%d]"), INTEGER(by)[0], length(x));
+      x = VECTOR_ELT(x, INTEGER(by)[0]-1);
+    }
+    const int n = length(x);
+    if (n <= 1) return(ScalarLogical(TRUE));
+    if (!isVectorAtomic(x)) STOP(_("is.sorted does not work on list columns"));
+    int i=1;
+    switch(TYPEOF(x)) {
+    case INTSXP : case LGLSXP : {
+      int *xd = INTEGER(x);
       while (i<n && xd[i]>=xd[i-1]) i++;
-    } else {
-      double *xd = REAL(x);
-      while (i<n && dtwiddle(xd,i)>=dtwiddle(xd,i-1)) i++;
+    } break;
+    case REALSXP :
+      if (inherits(x,"integer64")) {
+        int64_t *xd = (int64_t *)REAL(x);
+        while (i<n && xd[i]>=xd[i-1]) i++;
+      } else {
+        double *xd = REAL(x);
+        while (i<n && dtwiddle(xd,i)>=dtwiddle(xd,i-1)) i++;  // TODO: change to loop over any NA or -Inf at the beginning and then proceed without dtwiddle() (but rounding)
+      }
+      break;
+    case STRSXP : {
+      SEXP *xd = STRING_PTR(x);
+      i = 0;
+      while (i<n && xd[i]==NA_STRING) i++;
+      bool need = NEED2UTF8(xd[i]);
+      i++; // pass over first non-NA_STRING
+      while (i<n) {
+        if (xd[i]==xd[i-1]) {i++; continue;}
+        if (xd[i]==NA_STRING) break;
+        if (!need) need = NEED2UTF8(xd[i]);
+        if ((need ? strcmp(CHAR(ENC2UTF8(xd[i])), CHAR(ENC2UTF8(xd[i-1]))) :
+                    strcmp(CHAR(xd[i]), CHAR(xd[i-1]))) < 0) break;
+        i++;
+      }
+    } break;
+    default :
+      STOP(_("type '%s' is not yet supported"), type2char(TYPEOF(x)));
     }
-    break;
-  case STRSXP : {
-    SEXP *xd = STRING_PTR(x);
-    i = 0;
-    while (i<n && xd[i]==NA_STRING) i++;
-    bool need = NEED2UTF8(xd[i]);
-    i++; // pass over first non-NA_STRING
-    while (i<n) {
-      if (xd[i]==xd[i-1]) {i++; continue;}
-      if (xd[i]==NA_STRING) break;
-      if (!need) need = NEED2UTF8(xd[i]);
-      if ((need ? strcmp(CHAR(ENC2UTF8(xd[i])), CHAR(ENC2UTF8(xd[i-1]))) :
-                  strcmp(CHAR(xd[i]), CHAR(xd[i-1]))) < 0) break;
-      i++;
-    }
-  } break;
-  default :
-    STOP(_("type '%s' is not yet supported"), type2char(TYPEOF(x)));
+    return ScalarLogical(i==n);
   }
-  return ScalarLogical(i==n);
+  const int ncol = length(by);
+  const R_xlen_t nrow = xlength(VECTOR_ELT(x,0));
+  // ncol>1
+  // pre-save lookups to save deep switch later for each column type
+  size_t *sizes =          (size_t *)R_alloc(ncol, sizeof(size_t));
+  const char **ptrs = (const char **)R_alloc(ncol, sizeof(char *));
+  int *types =                (int *)R_alloc(ncol, sizeof(int));
+  for (int j=0; j<ncol; ++j) {
+    int c = INTEGER(by)[j];
+    if (c<1 || c>length(x)) STOP(_("fsorted 'by' [%d] out of range [1,%d]"), c, length(x));
+    SEXP col = VECTOR_ELT(x, c-1);
+    sizes[j] = SIZEOF(col);
+    switch(TYPEOF(col)) {
+    case INTSXP: case LGLSXP:
+      types[j] = 0;
+      ptrs[j] = (const char *)INTEGER(col);
+      break;
+    case REALSXP:
+      types[j] = inherits(col, "integer64") ? 2 : 1;
+      ptrs[j] = (const char *)REAL(col);
+      break;
+    case STRSXP:
+      types[j] = 3;
+      ptrs[j] = (const char *)STRING_PTR(col);
+      break;
+    default:
+      STOP(_("type '%s' is not yet supported"), type2char(TYPEOF(col)));  // # nocov
+    }
+  }
+  for (R_xlen_t i=1; i<nrow; ++i) {
+    int j = -1;
+    while (++j<ncol) {
+      size_t size = sizes[j];
+      const char *colp = ptrs[j] + size*i;
+      if (memcmp(colp, colp-size, size)==0) continue;  // in all-but-last column, we see many repeats so we can save the switch for those
+      bool ok = false;
+      switch (types[j]) {
+      case 0 : {   // INTSXP, LGLSXP
+        const int *p = (const int *)colp;
+        ok = p[0]>p[-1];
+      } break;
+      case 1: {   // regular double in REALSXP
+        const double *p = (const double *)colp;
+        ok = dtwiddle(p,0)>dtwiddle(p,-1);  // TODO: avoid dtwiddle by looping over any NA at the beginning, and remove NumericRounding.
+      } break;
+      case 2: {  // integer64 in REALSXP
+        const int64_t *p = (const int64_t *)colp;
+        ok = p[0]>p[-1];
+      } break;
+      case 3 : { // STRSXP
+        const SEXP *p = (const SEXP *)colp;
+        if (*p==NA_STRING) {
+          ok = false; // previous value not NA (otherwise memcmp would have returned equal above) so can't be ordered
+        } else {
+          ok = (NEED2UTF8(p[0]) || NEED2UTF8(p[-1]) ?  // TODO: provide user option to choose ascii-only mode
+                strcmp(CHAR(ENC2UTF8(p[0])), CHAR(ENC2UTF8(p[-1]))) :
+                strcmp(CHAR(p[0]), CHAR(p[-1]))) > 0;
+        }
+      } break;
+      default :
+        STOP(_("type '%s' is not yet supported"), type2char(TYPEOF(x)));  // # nocov
+      }
+      if (!ok) return ScalarLogical(FALSE);  // not sorted so return early
+      break; // this item is greater than previous in this column so ignore any remaining columns on this row
+    }
+  }
+  return ScalarLogical(TRUE);
 }
 
 SEXP isOrderedSubset(SEXP x, SEXP nrowArg)

--- a/src/init.c
+++ b/src/init.c
@@ -66,7 +66,7 @@ SEXP fcast();
 SEXP uniqlist();
 SEXP uniqlengths();
 SEXP forder();
-SEXP fsorted();
+SEXP issorted();
 SEXP gforce();
 SEXP gsum();
 SEXP gmean();
@@ -152,7 +152,7 @@ R_CallMethodDef callMethods[] = {
 {"Cuniqlist", (DL_FUNC) &uniqlist, -1},
 {"Cuniqlengths", (DL_FUNC) &uniqlengths, -1},
 {"Cforder", (DL_FUNC) &forder, -1},
-{"Cfsorted", (DL_FUNC) &fsorted, -1},
+{"Cissorted", (DL_FUNC) &issorted, -1},
 {"Cgforce", (DL_FUNC) &gforce, -1},
 {"Cgsum", (DL_FUNC) &gsum, -1},
 {"Cgmean", (DL_FUNC) &gmean, -1},

--- a/src/init.c
+++ b/src/init.c
@@ -33,8 +33,8 @@ SEXP sym_datatable_locked;
 double NA_INT64_D;
 long long NA_INT64_LL;
 Rcomplex NA_CPLX;
-size_t sizes[100];
-size_t typeorder[100];
+size_t __sizes[100];
+size_t __typeorder[100];
 
 // .Calls
 SEXP setattrib();
@@ -221,15 +221,15 @@ R_ExternalMethodDef externalMethods[] = {
 };
 
 static void setSizes() {
-  for (int i=0; i<100; ++i) { sizes[i]=0; typeorder[i]=0; }
+  for (int i=0; i<100; ++i) { __sizes[i]=0; __typeorder[i]=0; }
   // only these types are currently allowed as column types :
-  sizes[LGLSXP] =  sizeof(int);       typeorder[LGLSXP] =  0;
-  sizes[RAWSXP] =  sizeof(Rbyte);     typeorder[RAWSXP] =  1;
-  sizes[INTSXP] =  sizeof(int);       typeorder[INTSXP] =  2;   // integer and factor
-  sizes[REALSXP] = sizeof(double);    typeorder[REALSXP] = 3;   // numeric and integer64
-  sizes[CPLXSXP] = sizeof(Rcomplex);  typeorder[CPLXSXP] = 4;
-  sizes[STRSXP] =  sizeof(SEXP *);    typeorder[STRSXP] =  5;
-  sizes[VECSXP] =  sizeof(SEXP *);    typeorder[VECSXP] =  6;   // list column
+  __sizes[LGLSXP] =  sizeof(int);       __typeorder[LGLSXP] =  0;
+  __sizes[RAWSXP] =  sizeof(Rbyte);     __typeorder[RAWSXP] =  1;
+  __sizes[INTSXP] =  sizeof(int);       __typeorder[INTSXP] =  2;   // integer and factor
+  __sizes[REALSXP] = sizeof(double);    __typeorder[REALSXP] = 3;   // numeric and integer64
+  __sizes[CPLXSXP] = sizeof(Rcomplex);  __typeorder[CPLXSXP] = 4;
+  __sizes[STRSXP] =  sizeof(SEXP *);    __typeorder[STRSXP] =  5;
+  __sizes[VECSXP] =  sizeof(SEXP *);    __typeorder[VECSXP] =  6;   // list column
   if (sizeof(char *)>8) error(_("Pointers are %d bytes, greater than 8. We have not tested on any architecture greater than 64bit yet."), sizeof(char *));
   // One place we need the largest sizeof is the working memory malloc in reorder.c
 }

--- a/src/uniqlist.c
+++ b/src/uniqlist.c
@@ -114,6 +114,7 @@ SEXP uniqlist(SEXP l, SEXP order)
           // fix for #469, when key is set, duplicated calls uniqlist, where encoding
           // needs to be taken care of.
           b=ENC2UTF8(STRING_ELT(v,thisi))==ENC2UTF8(STRING_ELT(v,previ)); break;  // marked non-utf8 encodings are converted to utf8 so as to match properly when inputs are of different encodings.
+          // TODO: surely faster way than this two deep STRING_ELT()
         case REALSXP :
           ulv = (unsigned long long *)REAL(v);
           b = ulv[thisi] == ulv[previ]; // (gives >=2x speedup)


### PR DESCRIPTION
Towards #4498 
As per https://github.com/Rdatatable/data.table/pull/4501#issuecomment-634868192

```R
# Original example from S.O. with the large number of unique long strings
# 1.12.8
x <- as.data.table(as.character(rnorm(20000000,1,0.5)))
system.time(setkey(x))
#   user  system elapsed 
# 28.531   0.163  16.662 
system.time(x[,.(V1)])
#   user  system elapsed 
# 40.720   0.155  28.494 

# with this PR
x <- as.data.table(as.character(rnorm(20000000,1,0.5)))
system.time(setkey(x))
#   user  system elapsed 
# 29.489   0.164  17.186 
system.time(x[,.(V1)])
#   user  system elapsed 
#  0.808   0.040   0.848 

# 1-0.85/28.5 is a 97% reduction

# Now with the simpler integer case
# v1.12.8
> x <- as.data.table(sample(20000000))
> system.time(setkey(x))
   user  system elapsed 
  1.697   0.091   0.324 
> system.time(x[,.(V1)])
   user  system elapsed 
  0.518   0.063   0.185 

# with this PR
x <- as.data.table(sample(20000000))
system.time(setkey(x))
#   user  system elapsed 
#  1.863   0.000   0.471 
system.time(x[,.(V1)])
#   user  system elapsed 
#  0.027   0.000   0.028
```

Now, avoiding is.sorted will be even better. But at least is.sorted is doing what it should be doing now and we can move the decision on to the new scale.