### PR TITLE
build and install stuff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,3 +42,6 @@ test:
 check:
 	_R_CHECK_CRAN_INCOMING_REMOTE_=false $(R) CMD check data.table_1.12.9.tar.gz --as-cran --ignore-vignettes --no-stop-on-test-error
 
+.PHONY: revision
+revision:
+	echo "Revision: $(shell git rev-parse HEAD)" >> DESCRIPTION

--- a/configure
+++ b/configure
@@ -3,9 +3,9 @@
 # Find R compilers
 CC=`${R_HOME}/bin/R CMD config CC`
 CFLAGS=`${R_HOME}/bin/R CMD config CFLAGS`
-# compiler and flags to 'compilation' file
-echo "CC=${CC}" > inst/compilation
-echo "CFLAGS=${CFLAGS}" >> inst/compilation
+# compiler and flags to 'cc' file
+echo "CC=${CC}" > inst/cc
+echo "CFLAGS=${CFLAGS}" >> inst/cc
 
 # compiler info to output #3291
 if [ "$CC"=~"gcc" ]; then

--- a/configure
+++ b/configure
@@ -1,4 +1,18 @@
 #!/bin/sh
+
+# Find R compilers
+CC=`${R_HOME}/bin/R CMD config CC`
+CFLAGS=`${R_HOME}/bin/R CMD config CFLAGS`
+# compiler and flags to 'compilation' file
+echo "CC=${CC}" > inst/compilation
+echo "CFLAGS=${CFLAGS}" >> inst/compilation
+
+# compiler info to output #3291
+if [ "$CC"=~"gcc" ]; then
+  GCCV=`${CC} -dumpfullversion -dumpversion`
+  echo "$CC $GCCV"
+fi
+
 # Let's keep this simple. If pkg-config is available, use it. Otherwise print
 # the helpful message to aid user if compilation does fail. Note 25 of R-exts:
 # "[pkg-config] is available on the machines used to produce the CRAN binary packages"
@@ -51,10 +65,6 @@ fi
 version=`pkg-config --modversion zlib`
 echo "zlib ${version} is available ok"
 
-# Find R compilers
-CC=`${R_HOME}/bin/R CMD config CC`
-CFLAGS=`${R_HOME}/bin/R CMD config CFLAGS`
-
 # Test if we have a OPENMP compatible compiler
 # Aside: ${SHLIB_OPENMP_CFLAGS} does not appear to be defined at this point according to Matt's testing on
 # Linux, and R CMD config SHLIB_OPENMP_CFLAGS also returns 'no information for variable'. That's not
@@ -75,12 +85,6 @@ if [ $R_NO_OPENMP ]; then
 else
   echo "OpenMP supported"
   sed -e "s|@openmp_cflags@|\$(SHLIB_OPENMP_CFLAGS)|" src/Makevars.in > src/Makevars
-fi
-
-# compiler info to output #3291
-if [ "$CC"=~"gcc" ]; then
-  GCCV=`${CC} -dumpfullversion -dumpversion`
-  echo "$CC $GCCV"
 fi
 
 exit 0

--- a/configure
+++ b/configure
@@ -7,11 +7,11 @@ CFLAGS=`${R_HOME}/bin/R CMD config CFLAGS`
 echo "CC=${CC}" > inst/cc
 echo "CFLAGS=${CFLAGS}" >> inst/cc
 
-# compiler info to output #3291
-if [ "$CC"=~"gcc" ]; then
+# gcc compiler info to output #3291
+case $CC in gcc*)
   GCCV=`${CC} -dumpfullversion -dumpversion`
   echo "$CC $GCCV"
-fi
+esac
 
 # Let's keep this simple. If pkg-config is available, use it. Otherwise print
 # the helpful message to aid user if compilation does fail. Note 25 of R-exts:


### PR DESCRIPTION
- [x] closes #4441: moved printing gcc version to the top of configure script
- [x] new make target to more easily store git revision to be used before `make build && make install`
- [x] extra output to file of `CC` and `CFLAGS` in configure to retain compilation information so we can access that later after installation:
```r
cat(readLines(system.file(package="data.table", "cc")),sep="\n")
#CC=gcc -std=gnu99
#CFLAGS=-O3 -mtune=native
```
- [x] properly detect `CC` string to start with `gcc`, current condition will incorrectly match `CC=cc` as well.