### PR TITLE
fixed iSD recycle when empty, and added test

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1391,9 +1391,7 @@ replace_dot_alias = function(e) {
     jisvars = if (any(c("get", "mget") %chin% av)) names_i else intersect(gsub("^i[.]","", setdiff(av, xjisvars)), names_i)
     # JIS (non join cols) but includes join columns too (as there are named in i)
     if (length(jisvars)) {
-      if (!nrow(i))
-        stop("internal error: doing byjoin but i has 0 rows") # nocov #4364
-      tt = min(nrow(i),1L)
+      tt = min(nrow(i),1L)  # min() is here for when nrow(i)==0
       SDenv$.iSD = i[tt,jisvars,with=FALSE]
       for (ii in jisvars) {
         assign(ii, SDenv$.iSD[[ii]], SDenv)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -16958,3 +16958,9 @@ test(2145.2, merge(A, B, by=character(0)                                     ), 
 test(2145.3, merge(A, B,                 by.x=character(0), by.y=character(0)), error = "non-empty vector of column names is required")
 # Also shouldn't crash when using internal functions
 test(2145.4, bmerge(A, B, integer(), integer(), 0, c(FALSE, TRUE), NA, 'all', integer(), FALSE), error = 'icols and xcols must be non-empty')
+
+# nrow(i)==0 by-join, #4364 (broke in dev 1.12.9)
+d0 = data.table(id=integer(), n=integer())
+d2 = data.table(id=1:2)
+test(2146, d2[d0, i.n, on="id", by=.EACHI], data.table(id=integer(), i.n=integer()))
+

--- a/src/dogroups.c
+++ b/src/dogroups.c
@@ -47,8 +47,6 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
   N =   PROTECT(findVar(install(".N"), env));   nprotect++; // PROTECT for rchk
   GRP = PROTECT(findVar(install(".GRP"), env)); nprotect++;
   iSD = PROTECT(findVar(install(".iSD"), env)); nprotect++; // 1-row and possibly no cols (if no i variables are used via JIS)
-  if (length(iSD) && !length(VECTOR_ELT(iSD, 0)))
-    error("internal error dogroups: iSD is a zero rows data.table"); // # nocov
   xSD = PROTECT(findVar(install(".xSD"), env)); nprotect++;
   R_len_t maxGrpSize = 0;
   const int *ilens = INTEGER(lens), n=LENGTH(lens);
@@ -127,7 +125,7 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
       defineVar(xknameSyms[j], VECTOR_ELT(xSD, j), env);
     }
 
-    for (int j=0; j<length(iSD); ++j) {   // either this or the next for() will run, not both
+    if (length(iSD) && length(VECTOR_ELT(iSD, 0))/*#4364*/) for (int j=0; j<length(iSD); ++j) {   // either this or the next for() will run, not both
       memrecycle(VECTOR_ELT(iSD,j), R_NilValue, 0, 1, VECTOR_ELT(groups, INTEGER(jiscols)[j]-1), i, 1, j+1, "Internal error assigning to iSD");
       // we're just use memrecycle here to assign a single value
     }


### PR DESCRIPTION
Closes #4364 and adds tests
Follow up to #4365 
Return to 1.12.8 behaviour of empty 2-column result