### PR TITLE
no need re-order for equi join

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -463,7 +463,7 @@ replace_dot_alias = function(e) {
       allLen1 = ans$allLen1
       f__ = ans$starts
       len__ = ans$lens
-      allGrp1 = FALSE # was previously 'ans$allGrp1'. Fixing #1991. TODO: Revisit about allGrp1 possibility for speedups in certain cases when I find some time.
+      allGrp1 = all(ops==1L) # was previously 'ans$allGrp1'. Fixing #1991. TODO: Revisit about allGrp1 possibility for speedups in certain cases when I find some time.
       indices__ = if (length(ans$indices)) ans$indices else seq_along(f__) # also for #1991 fix
       # length of input nomatch (single 0 or NA) is 1 in both cases.
       # When no match, len__ is 0 for nomatch=0 and 1 for nomatch=NA, so len__ isn't .N

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -14570,7 +14570,7 @@ test(2023.6, DT[, .N, by = CLASS], data.table(CLASS=c("aaaa","dddd","gggg","eeee
 # more verbose timings #1265
 DT = data.table(x=c("a","b","c","b","a","c"), y=c(1,3,6,1,6,3), v=1:6)
 setindex(DT, y)
-test(2024, DT[y==6, v:=10L, verbose=TRUE], output=c("Constructing irows for.*", "Reorder irows for.*"))
+test(2024, DT[y==6, v:=10L, verbose=TRUE], output="Constructing irows for.*")
 
 # fread embedded '\0', #3400
 test(2025.01, fread(testDir("issue_3400_fread.txt"), skip=1, header=TRUE), data.table(A=INT(1,3,4), B=INT(2,2,5), C=INT(3,1,6)))


### PR DESCRIPTION
I think it should be safe for 1.12.9.
allGrp1 is only used for nq join.

```r
library(data.table)
d1=data.table(x=sample.int(1e7L))
d2=data.table(x=sample.int(1e7L))
options(datatable.verbose=TRUE)
system.time(a<-d1[d2, on="x"])
```
before patch
```
i.x has same type (integer) as x.x. No coercion needed.
forder.c received 10000000 rows and 1 columns
Calculated ad hoc index in 0.149s elapsed (2.524s cpu) 
Starting bmerge ...
forder.c received 10000000 rows and 1 columns
bmerge done in 1.864s elapsed (4.511s cpu) 
Constructing irows for '!byjoin || nqbyjoin' ... 0.000s elapsed (0.000s cpu) 
Reorder irows for 'mult=="all" && !allGrp1' ... forder.c received 10000000 rows and 2 columns
0.215s elapsed (0.790s cpu) 
   user  system elapsed 
  8.098   0.398   2.531 
```
after patch
```
i.x has same type (integer) as x.x. No coercion needed.
forder.c received 10000000 rows and 1 columns
Calculated ad hoc index in 0.169s elapsed (2.799s cpu) 
Starting bmerge ...
forder.c received 10000000 rows and 1 columns
bmerge done in 1.683s elapsed (4.120s cpu) 
Constructing irows for '!byjoin || nqbyjoin' ... 0.000s elapsed (0.000s cpu) 
   user  system elapsed 
  7.199   0.484   2.196 
```