### PR TITLE
remove obsolete Makefile

### DIFF
--- a/vignettes/Makefile
+++ b/vignettes/Makefile
@@ -1,7 +1,0 @@
-# Makefile to use knitr for package vignettes
-
-clean:
-	rm -rf *.tex *.bbl *.blg *.aux *.out *.toc *.log *.spl *tikzDictionary *.md figure/
-
-%.html: %.Rmd
-	$(R_HOME)/bin/Rscript -e "if (getRversion() < '3.0.0') knitr::knit2html('$*.Rmd')"


### PR DESCRIPTION
Just noticed this file... seems it's been here & unused a long time (it won't do anything if R is < 3.0.0? which is 7+ years ago?)