### PR TITLE
Mention the different default of data.frame stringsAsFactors in R >= 4.0

### DIFF
--- a/vignettes/datatable-faq.Rmd
+++ b/vignettes/datatable-faq.Rmd
@@ -384,7 +384,7 @@ A key advantage of column vectors in R is that they are _ordered_, unlike SQL[^2
  - `DT[ColA == ColB]` is simpler than `DF[!is.na(ColA) & !is.na(ColB) & ColA == ColB, ]`
  - `data.frame(list(1:2, "k", 1:4))` creates 3 columns, data.table creates one `list` column.
  - `check.names` is by default `TRUE` in `data.frame` but `FALSE` in data.table, for convenience.
- - For R before version 4.0.0, `stringsAsFactors` is by default `TRUE` in `data.frame` but `FALSE` in data.table, for efficiency. Since a global string cache was added to R, characters items are a pointer to the single cached string and there is no longer a performance benefit of converting to `factor`.
+ - `data.table` has always set `stringsAsFactors=FALSE` by default. In R 4.0.0 (Apr 2020), `data.frame`'s default was changed from `TRUE` to `FALSE` and there is no longer a difference in this regard; see [stringsAsFactors, Kurt Hornik, Feb 2020](https://developer.r-project.org/Blog/public/2020/02/16/stringsasfactors/).
  - Atomic vectors in `list` columns are collapsed when printed using `", "` in `data.frame`, but `","` in data.table with a trailing comma after the 6th item to avoid accidental printing of large embedded objects.
 
 In `[.data.frame` we very often set `drop = FALSE`. When we forget, bugs can arise in edge cases where single columns are selected and all of a sudden a vector is returned rather than a single column `data.frame`. In `[.data.table` we took the opportunity to make it consistent and dropped `drop`.

--- a/vignettes/datatable-faq.Rmd
+++ b/vignettes/datatable-faq.Rmd
@@ -384,7 +384,7 @@ A key advantage of column vectors in R is that they are _ordered_, unlike SQL[^2
  - `DT[ColA == ColB]` is simpler than `DF[!is.na(ColA) & !is.na(ColB) & ColA == ColB, ]`
  - `data.frame(list(1:2, "k", 1:4))` creates 3 columns, data.table creates one `list` column.
  - `check.names` is by default `TRUE` in `data.frame` but `FALSE` in data.table, for convenience.
- - `stringsAsFactors` is by default `TRUE` in `data.frame` but `FALSE` in data.table, for efficiency. Since a global string cache was added to R, characters items are a pointer to the single cached string and there is no longer a performance benefit of converting to `factor`.
+ - For R before version 4.0.0, `stringsAsFactors` is by default `TRUE` in `data.frame` but `FALSE` in data.table, for efficiency. Since a global string cache was added to R, characters items are a pointer to the single cached string and there is no longer a performance benefit of converting to `factor`.
  - Atomic vectors in `list` columns are collapsed when printed using `", "` in `data.frame`, but `","` in data.table with a trailing comma after the 6th item to avoid accidental printing of large embedded objects.
 
 In `[.data.frame` we very often set `drop = FALSE`. When we forget, bugs can arise in edge cases where single columns are selected and all of a sudden a vector is returned rather than a single column `data.frame`. In `[.data.table` we took the opportunity to make it consistent and dropped `drop`.

--- a/vignettes/datatable-intro.Rmd
+++ b/vignettes/datatable-intro.Rmd
@@ -88,8 +88,6 @@ You can also convert existing objects to a `data.table` using `setDT()` (for `da
 
 #### Note that: {.bs-callout .bs-callout-info}
 
-* Unlike in versions of R before 4.0.0, `data.frame`s, columns of `character` type are *never* converted to `factors` by default.
-
 * Row numbers are printed with a `:` in order to visually separate the row number from the first column.
 
 * When the number of rows to print exceeds the global option `datatable.print.nrows` (default = `r getOption("datatable.print.nrows")`), it automatically prints only the top 5 and bottom 5 rows (as can be seen in the [Data](#data) section). If you've had a lot of experience with `data.frame`s, you may have found yourself waiting around while larger tables print-and-page, sometimes seemingly endlessly. You can query the default number like so:

--- a/vignettes/datatable-intro.Rmd
+++ b/vignettes/datatable-intro.Rmd
@@ -88,7 +88,7 @@ You can also convert existing objects to a `data.table` using `setDT()` (for `da
 
 #### Note that: {.bs-callout .bs-callout-info}
 
-* Unlike in versions of R up to, but not incuding, 4.0.0, `data.frame`s, columns of `character` type are *never* converted to `factors` by default.
+* Unlike in versions of R before 4.0.0, `data.frame`s, columns of `character` type are *never* converted to `factors` by default.
 
 * Row numbers are printed with a `:` in order to visually separate the row number from the first column.
 

--- a/vignettes/datatable-intro.Rmd
+++ b/vignettes/datatable-intro.Rmd
@@ -88,7 +88,7 @@ You can also convert existing objects to a `data.table` using `setDT()` (for `da
 
 #### Note that: {.bs-callout .bs-callout-info}
 
-* Unlike `data.frame`s, columns of `character` type are *never* converted to `factors` by default.
+* Unlike in versions of R up to, but not incuding, 4.0.0, `data.frame`s, columns of `character` type are *never* converted to `factors` by default.
 
 * Row numbers are printed with a `:` in order to visually separate the row number from the first column.
 


### PR DESCRIPTION
Closes #4515
This mentions the new behavior of `stringsAsFactors` in R >= 4.0.0.