### PR TITLE
more ignores

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,11 +2,12 @@
 ^data\.table_.*\.tar\.gz$
 ^vignettes/plots/figures$
 ^\.Renviron$
-^.*\.csv$
-^.*\.csvy$
-^.*\.RDS$
-^.*\.diff$
-^.*\.patch$
+^[^/]+\.R$
+^[^/]+\.csv$
+^[^/]+\.csvy$
+^[^/]+\.RDS$
+^[^/]+\.diff$
+^[^/]+\.patch$
 
 ^\.ci$
 ^\.dev$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,6 +1,12 @@
 ^\.Rprofile$
 ^data\.table_.*\.tar\.gz$
 ^vignettes/plots/figures$
+^\.Renviron$
+^.*\.csv$
+^.*\.csvy$
+^.*\.RDS$
+^.*\.diff$
+^.*\.patch$
 
 ^\.ci$
 ^\.dev$
@@ -30,3 +36,5 @@
 
 ^bus$
 ^pkgdown$
+^lib$
+^library$

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-# Source: https://github.com/github/gitignore/blob/master/R.gitignore
 # History files
 .RData
 .Rhistory
@@ -29,7 +28,18 @@ vignettes/plots/figures
 *.so
 *.dll
 
+# temp files
 *~
 .DS_Store
 .idea
 *.sw[op]
+
+# common devel objects
+.Renviron
+lib
+library
+*.csv
+*.csvy
+*.RDS
+*.diff
+*.patch

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ vignettes/plots/figures
 .Renviron
 lib
 library
+*.R
 *.csv
 *.csvy
 *.RDS


### PR DESCRIPTION
few more ignores that are useful in devel

- example `.Renviron`
```sh
cat .Renviron 
#R_LIBS=~/tmp-library
```
so my R processes can keep using already installed data.table, while I can freely rebuild into "local" library.

- ignoring RDS is useful as it is often easy to just dump objects for debugging to RDS, then I don't have to keep moving them to just rebuild pkg

thanks to @HughParsonage and @MichaelChirico for regex tips