### PR TITLE
R-devel check detects soft issues now

### DIFF
--- a/.ci/README.md
+++ b/.ci/README.md
@@ -9,7 +9,7 @@ On each Pull Request opened in GitHub we run Travis CI and Appveyor to provide p
 Test jobs:
 - `test-rel-lin` - `r-release` on Linux, most comprehensive test environment, `-O3 -flto -fno-common -Wunused-result`, extra check for no compilation warnings, includes testing [_with other packages_](./../inst/tests/other.Rraw) ([extended suggests](./../inst/tests/tests-DESCRIPTION))
 - `test-rel-cran-lin` - `--as-cran` on Linux, `-g0`, extra check for final status of `R CMD check` where we allow one NOTE (_size of tarball_).
-- `test-dev-cran-lin` - `r-devel` and `--as-cran` on Linux, `--enable-strict-barrier --disable-long-double`
+- `test-dev-cran-lin` - `r-devel` and `--as-cran` on Linux, `--with-recommended-packages --enable-strict-barrier --disable-long-double`, tests for compilation warnings in pkg install and new NOTEs/Warnings in pkg check, and because it is R-devel it is marked as allow_failure
 - `test-rel-vanilla-lin` - `r-release` on Linux, no suggested deps, no OpenMP, `-O0`, tracks memory usage during tests
 - `test-310-cran-lin` - R 3.1.0 on Linux
 - `test-344-cran-lin` - R 3.4.4 on Linux
@@ -27,7 +27,7 @@ Artifacts:
   - sources
   - Windows binaries for `r-release` and `r-devel`
 - [CRAN-like homepage](https://rdatatable.gitlab.io/data.table/web/packages/data.table/index.html)
-- [CRAN-like checks results](https://rdatatable.gitlab.io/data.table/web/checks/check_results_data.table.html) - note that all artifacts, including this page, are being published only when all test jobs successfully pass, thus one will not see an _ERROR_ status there (unless `allow_failure` option has been used in a job).
+- [CRAN-like checks results](https://rdatatable.gitlab.io/data.table/web/checks/check_results_data.table.html) - note that all artifacts, including check results page, are being published only when all test jobs successfully pass, thus one will not see an _ERROR_ status there (unless error happened on a job marked as `allow_failure`).
 - [docker images](https://gitlab.com/Rdatatable/data.table/container_registry) - copy/paste-able `docker pull` commands can be found at the bottom of our [CRAN-like homepage](https://rdatatable.gitlab.io/data.table/web/packages/data.table/index.html)
 
 ### [Travis CI](./../.travis.yml)
@@ -64,7 +64,7 @@ Base R implemented helper script to orchestrate generation of most artifacts. It
 Template file to produce `Dockerfile` for, as of now, three docker images. Docker images are being built and published in [_deploy_ stage in GitLab CI pipeline](./../.gitlab-ci.yml).
 - `r-base-dev` using `r-release`: publish docker image of `data.table` on R-release
 - `r-builder` using `r-release`: publish on R-release and OS dependencies for building Rmarkdown vignettes
-- `r-devel`: publish docker image of `data.table` on R-devel
+- `r-devel`: publish docker image of `data.table` on R-devel built with `--with-recommended-packages --enable-strict-barrier --disable-long-double`
 
 ### [`deploy.sh`](./deploy.sh)
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -278,7 +278,6 @@ integration: ## merging all artifacts to produce single R repository, documentat
   tags:
     - linux
   only:
-    - ci5
     - master
   dependencies:
     - mirror-packages

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -194,6 +194,7 @@ test-dev-cran-lin: ## R-devel on Linux, --enable-strict-barrier --disable-long-d
     _R_CHECK_CRAN_INCOMING_: "TRUE"
     _R_CHECK_CRAN_INCOMING_REMOTE_: "FALSE"
   before_script:
+    - break-early
     - *install-deps
     - *cp-src
     - rm -r bus

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -194,7 +194,6 @@ test-dev-cran-lin: ## R-devel on Linux, --enable-strict-barrier --disable-long-d
     _R_CHECK_CRAN_INCOMING_: "TRUE"
     _R_CHECK_CRAN_INCOMING_REMOTE_: "FALSE"
   before_script:
-    - break-early
     - *install-deps
     - *cp-src
     - rm -r bus

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -186,9 +186,25 @@ test-rel-cran-lin: ## R-release on Linux, extra NOTEs check and build pdf manual
     - >-
         Rscript -e 'l=tail(readLines("data.table.Rcheck/00check.log"), 1L); if (!identical(l, "Status: 1 NOTE")) stop("Last line of ", shQuote("00check.log"), " is not ", shQuote("Status: 1 NOTE"), " (size of tarball) but ", shQuote(l)) else q("no")'
 
-test-dev-cran-lin: ## R-devel on Linux, --enable-strict-barrier --disable-long-double
-  <<: *test-cran-lin
+test-dev-cran-lin: ## R-devel on Linux, --enable-strict-barrier --disable-long-double, check for new notes and compilation warnings, thus allow_failure
+  <<: *test-lin
   image: registry.gitlab.com/jangorecki/dockerfiles/r-devel
+  allow_failure: true
+  variables:
+    _R_CHECK_CRAN_INCOMING_: "TRUE"
+    _R_CHECK_CRAN_INCOMING_REMOTE_: "FALSE"
+  before_script:
+    - *install-deps
+    - *cp-src
+    - rm -r bus
+  script:
+    - *mv-src
+    - cd bus/$CI_BUILD_NAME
+    - R CMD check --as-cran --no-manual $(ls -1t data.table_*.tar.gz | head -n 1)
+    - *rm-src
+    - (! grep "warning:" data.table.Rcheck/00install.out)
+    - >-
+        Rscript -e 'l=tail(readLines("data.table.Rcheck/00check.log"), 1L); if (!identical(l, "Status: 3 NOTEs")) stop("Last line of ", shQuote("00check.log"), " is not ", shQuote("Status: 3 NOTEs"), " (size of tarball, installed package size, top-level files) but ", shQuote(l)) else q("no")'
 
 test-310-cran-lin: ## R-3.1.0 on Linux, stated dependency of R
   <<: *test-cran-lin
@@ -262,6 +278,7 @@ integration: ## merging all artifacts to produce single R repository, documentat
   tags:
     - linux
   only:
+    - ci5
     - master
   dependencies:
     - mirror-packages


### PR DESCRIPTION
On our R-devel linux build "soft issues" that were not causing job status to fail were not signalled loudly enough. They required a human to look into log output to spot the issue (#4577).
This PR address that. If there is a breaking change or regression in R-devel, we will see that with an orange color of pipeline badge, even when it is just a new NOTE or a new compilation warning.
Thanks to @mattdowle for idea.

----

when there as an early failure, and no check artifacts are available, job (`dev-cran-lin`) is missing on our check summary: https://jangorecki.gitlab.io/-/data.table/-/jobs/618377341/artifacts/bus/integration/cran/web/checks/check_results_data.table.html

when failure happens due to out strict checks on check.out, then job (`dev-cran-lin`) is listed on our check summary and we can preview install output and check log: [link soon]