### PR TITLE
add rmarkdown to suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -62,7 +62,7 @@ Authors@R: c(
   person("Kevin","Ushey",          role="ctb"))
 Depends: R (>= 3.1.0)
 Imports: methods
-Suggests: bit64, curl, R.utils, knitr, xts, nanotime, zoo, yaml, rmarkdown
+Suggests: bit64, curl, R.utils, xts, nanotime, zoo, yaml, knitr, rmarkdown
 SystemRequirements: zlib
 Description: Fast aggregation of large data (e.g. 100GB in RAM), fast ordered joins, fast add/modify/delete of columns by group using no copies at all, list columns, friendly and fast character-separated-value read/write. Offers a natural and flexible syntax, for faster development.
 License: MPL-2.0 | file LICENSE

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -62,7 +62,7 @@ Authors@R: c(
   person("Kevin","Ushey",          role="ctb"))
 Depends: R (>= 3.1.0)
 Imports: methods
-Suggests: bit64, curl, R.utils, knitr, xts, nanotime, zoo, yaml
+Suggests: bit64, curl, R.utils, knitr, xts, nanotime, zoo, yaml, rmarkdown
 SystemRequirements: zlib
 Description: Fast aggregation of large data (e.g. 100GB in RAM), fast ordered joins, fast add/modify/delete of columns by group using no copies at all, list columns, friendly and fast character-separated-value read/write. Offers a natural and flexible syntax, for faster development.
 License: MPL-2.0 | file LICENSE


### PR DESCRIPTION
To address this warning from win-builder.
```
* checking re-building of vignette outputs ... [1s] WARNING
Error(s) in re-building vignettes:
--- re-building 'datatable-benchmarking.Rmd' using rmarkdown
Warning in engine$weave(file, quiet = quiet, encoding = enc) :
  The vignette engine knitr::rmarkdown is not available, because the rmarkdown package is not installed. Please install it.
Error: processing vignette 'datatable-benchmarking.Rmd' failed with diagnostics:
The 'markdown' package should be declared as a dependency of the 'data.table' package (e.g., in the  'Suggests' field of DESCRIPTION), because it contains vignette(s) built with the 'markdown' package. Please see https://github.com/yihui/knitr/issues/1864 for more information.
--- failed re-building 'datatable-benchmarking.Rmd'
```

Reading through https://github.com/yihui/knitr/issues/1864 it seems we should actually add `rmarkdown` to Suggests not `markdown`.   Odd that R CMD check claims that the `rmarkdown` package is not installed (surely it is installed on win-builder!) so maybe that is a red herring. Or maybe win-builder runs each check in an isolated library where it is indeed the case that packages that are not suggested do not appear to be installed. Anyway, let's add `rmarkdown` to suggests and see where we are then.
