### PR TITLE
GCC / Fortran conflict in OSX Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,7 @@
 language: r
-dist: trusty
-sudo: required
+dist: bionic
 cache: packages   # to rebuild cache see tweet thread ending here https://twitter.com/jimhester_/status/1115718589804421121
 warnings_are_errors: true
-
-branches:
-  only:
-    - "master"
 
 r:
   - release
@@ -15,17 +10,15 @@ os:
   - linux
   - osx  # Takes 13m (+9m linux = 22m total); #3357; #3326; #3331. When off it's to speed up dev cycle; CRAN_Release.cmd has a reminder to turn back on.
 
-before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install llvm &&
-    export PATH="/usr/local/opt/llvm/bin:$PATH" &&
-    export LDFLAGS="-L/usr/local/opt/llvm/lib -L/usr/local/opt/libffi/lib" &&
-    export CFLAGS="-I/usr/local/opt/llvm/include" &&
-    export CPPFLAGS="-I/usr/local/opt/libffi/include" &&
-    export PKG_CONFIG_PATH="/usr/local/opt/libffi/lib/pkgconfig"; fi
+brew_packages:
+  - llvm
 
 r_packages:
   - drat      # used in .ci/deploy.sh to publish tar.gz to github.io/Rdatatable/data.table
   - covr
+
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rm "/usr/local/bin/gfortran"; fi
 
 before_script:
   - echo "Revision:" $TRAVIS_COMMIT >> ./DESCRIPTION


### PR DESCRIPTION
In respons to #4623:

Hi @mattdowle, it seems there is a conflict between the `llvm` and `fortran` installations, see [this line](https://travis-ci.org/github/Rdatatable/data.table/jobs/710240029#L642-L648) in the Travis output. 

To fix, simplify and update the Travis build, I've:

* added a line to the _before\_install_ section with a command to remove the `fortran` symlink.
* moved the `llvm` installation to a new _brew\_packages_ section (only a single line needed to install `llvm`).
* updated the linux image to the more recent _bionic_ (if there was a specific reason to keep using _trusty_, my apologies for that :-))

I believe that [should fix](https://travis-ci.org/github/MarcusKlik/data.table.test/jobs/710337647) the OSX build!

all the best