### PR TITLE
Update locale in test.data.table

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 ## BUG FIXES
 
+1. `test.data.table()` could fail the 2nd time it is run by a user in the same R session on Windows due to not resetting locale properly after testing Chinese translation, [#4630](https://github.com/Rdatatable/data.table/pull/4630). Thanks to Cole Miller for investigating and fixing.
+
 ## NOTES
 
 1. `bit64` v4.0.2 released on 30th July broke `data.table`'s tests. It seems that reverse dependency testing of `bit64` (i.e. testing of the packages which use `bit64`) did not include `data.table` because `data.table` merely suggests `bit64` and does not depend on it. Like other packages on our `Suggest` list, we test `data.table` works with `bit64` in our tests. In testing of our own reverse dependencies (packages which use `data.table`) we do include packages which suggest `data.table`, although it appears it is not CRAN policy to do so. We have requested that CRAN policy be changed to include suggests in reverse dependency testing.

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -16965,12 +16965,8 @@ if (.Platform$OS.type=="windows") local({
     LC_NUMERIC = "C",
     LC_TIME = "Chinese (Simplified)_China.936"
   )
-  for (i in seq_along(x)) {
-    lc = names(x)[[i]]
-    old = Sys.getlocale(lc)
-    Sys.setlocale(lc, x[[i]])
-    on.exit(Sys.setlocale(lc, old), add = TRUE)
-  }
+  x_old = Map(Sys.getlocale, names(x))
+  invisible(Map(Sys.setlocale, names(x), x))
   old = Sys.getenv('LANGUAGE')
   Sys.setenv('LANGUAGE' = 'zh_CN')
   on.exit({
@@ -16978,6 +16974,7 @@ if (.Platform$OS.type=="windows") local({
       Sys.setenv('LANGUAGE' = old)
     else
       Sys.unsetenv('LANGUAGE')
+    invisible(Map(Sys.setlocale, names(x_old), x_old))
   }, add = TRUE)
   # triggered segfault here in #4402, Windows-only under translation.
   # test that the argument order changes correctly (the 'item 2' moves to the beginning of the message)


### PR DESCRIPTION
On Windows, the locale would not get reset after the ```test.data.table()``` was complete. For me, that meant that the first test would be successful but then I had these weird UTC errors. 

The issue was caused by ```on.exit()``` being used in a for loop for a test. It turns out when you use a variable assigned in a for loop within ```on.exit()```, the last instance of the variable is used on exit. Follow-up to #4524 .

``` r
double_on_exit = function() {
    for (i in 1:2) {
        lc = letters[i]
        on.exit(print(lc), add = TRUE)
    }
    on.exit(print('bye'), add = TRUE)
}
double_on_exit()
#> [1] "b"
#> [1] "b"
#> [1] "bye"
```
