### PR TITLE
reworked fmelt.c:concat to survive gctorture

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -3056,7 +3056,7 @@ test(1034, as.data.table(x<-as.character(sample(letters, 5))), data.table(V1=x))
        ans <- data.table(a=c(1, 2), b=c(2, 3), variable=factor('c'), value=c(3, 4)))
   test(1035.152, melt(x, measure.vars=as.raw(0)), error="Unknown 'measure.vars' type raw")
   test(1035.153, melt(x, measure.vars=3L, verbose=TRUE), ans,
-       output="'id.vars' is missing. Assigning all.*Assigned 'id.vars' are")
+       output="'id.vars' is missing. Assigning all.*Assigned 'id.vars' are [[]a, b[]]")
   test(1035.16, melt(x, id.vars="a", measure.vars="d"), error="One or more values")
   test(1035.17, melt(x, id.vars="d", measure.vars="a"), error="One or more values")
 
@@ -3065,10 +3065,11 @@ test(1034, as.data.table(x<-as.character(sample(letters, 5))), data.table(V1=x))
   foo = function(input, by, var) {
       melt(input, id.vars = by, measure.vars=var)
   }
-  test(1035.18, foo(DT, by="x"), data.table(x=rep(DT$x, 2L), variable=factor(rep(c("y", "v"), each=9L), levels=c("y", "v")), value=c(DT$y, DT$v)), warning="are not all of the same type. By order of hierarchy, the molten data value column will be of type 'double'")
+  test(1035.18, foo(DT, by="x"), data.table(x=rep(DT$x, 2L), variable=factor(rep(c("y", "v"), each=9L), levels=c("y", "v")), value=c(DT$y, DT$v)),
+    warning="'measure.vars' [[]y, v[]] are not all of the same type.*molten data value column will be of type 'double'.*'double'")
   test(1035.19, foo(DT), data.table(x=rep(DT$x, 2L), variable=factor(rep(c("y", "v"), each=9L), levels=c("y", "v")), value=c(DT$y, DT$v)),
-               warning=c("id.vars and measure.vars are internally guessed when both are 'NULL'",
-                         "are not all of the same type. By order of hierarchy"))
+    warning=c("id.vars and measure.vars are internally guessed.*this case are columns [[]x[]]",
+              "'measure.vars' [[]y, v[]] are not all of the same type.*'double'.*'double'"))
   # Fix for #1055; was test 1495
   DT <- data.table(A = 1:2, B = 3:4, D = 5:6, D = 7:8)
   test(1035.20, melt(DT, id.vars=1:2), data.table(A=1:2, B=3:4,
@@ -3102,7 +3103,8 @@ test(1034, as.data.table(x<-as.character(sample(letters, 5))), data.table(V1=x))
     R.utils::decompressFile(testDir("melt_1754.R.gz"), tt<-tempfile(), remove=FALSE, FUN=gzfile, ext=NULL)
     source(tt, local=TRUE) # creates DT
     test(1036.01, dim(DT), INT(1,327))
-    test(1036.02, dim(ans<-melt(DT, 1:2)), INT(325,4), warning="All measure variables not of type 'character' will be coerced")
+    test(1036.02, dim(ans<-melt(DT, 1:2)), INT(325,4),
+      warning="'measure.vars' [[]Geography, Estimate; SEX AND AGE - Total population, Margin of Error; SEX AND AGE - Total population, Percent; SEX AND AGE - Total population, [.][.][.][]] are not all of the same type.*the molten data value column will be of type 'character'.*not of type 'character' will be coerced too")
     test(1036.03, length(levels(ans$variable)), 317L)
     test(1036.04, levels(ans$variable)[c(1,2,316,317)],
       tt <- c("Geography",
@@ -3112,7 +3114,8 @@ test(1034, as.data.table(x<-as.character(sample(letters, 5))), data.table(V1=x))
     test(1036.05, range(as.integer(ans$variable)), INT(1,317))
     test(1036.06, as.vector(table(table(as.integer(ans$variable)))), INT(309,8))
     test(1036.07, sapply(ans, class), c(Id="character",Id2="integer",variable="factor",value="character"))
-    test(1036.08, dim(ans<-melt(DT, 1:2, variable.factor=FALSE)), INT(325,4), warning="All measure variables not of type 'character' will be coerced")
+    test(1036.08, dim(ans<-melt(DT, 1:2, variable.factor=FALSE)), INT(325,4),
+      warning="'measure.vars' [[]Geography, Estimate;.*[.][.][.][]].*'character'.*'character'")
     test(1036.09, sapply(ans, class), c(Id="character",Id2="integer",variable="character",value="character"))
     test(1036.10, ans$variable[c(1,2,324,325)], tt)
 
@@ -3147,7 +3150,7 @@ Jun,34.5,23.7,19.3,14.9,1.1,87.5,87.5,0,13.8,13.8,0,250.1
 Jul,36.1,26.6,22.3,17.9,7.8,106.2,106.2,0,12.3,12.3,0,271.6
 Aug,35.6,24.8,20.8,16.7,6.1,100.6,100.6,0,13.4,13.4,0,230.7
 Sep,33.5,19.4,15.7,11.9,0,100.8,100.8,0,12.7,12.7,0,174.1")
-  test(1037.301, print(melt(DT, id.vars="month", verbose=TRUE)), output="'measure.vars' is missing.*Assigned.*are.*Record high.*1:.*Jan.*Record high.*12.8.*108:.*Sep.*sunshine hours.*174.1")
+  test(1037.301, print(melt(DT, id.vars="month", verbose=TRUE)), output="'measure.vars' is missing.*Assigned 'measure.vars' are [[]Record high, Average high, Daily mean, Average low, ...[]].*1:.*Jan.*Record high.*12.8.*108:.*Sep.*sunshine hours.*174.1")
 
   # coverage of reworked fmelt.c:getvarcols, #1754; was test 1574
   # missing id satisfies data->lvalues!=1 at C level to test those branches


### PR DESCRIPTION
Closes #4628 
Confirmed that all parts of test 1036 now pass full strength gctorture(TRUE) with latest R-devel compiled strictly.
concat was marked as a hack anyway so needed attention. If I was forced to guess I'd guess it was that `SETCAR(t, mkString(", "));` doesn't protect the result of `mkString` but I'd be surprised if it doesn't. Initially I protected the result of concat before it was passed on to warning/Rprintf which definitely needed doing, but it wasn't just that (it still failed torture). Not sure what else it could be as I don't see anything else missing protection. The dev cycle time to resolve this one was significant due to the slowness of torture so I just went for the rework approach which needed doing anyway.   The new approach for concat is simpler and cleaner, but we need to make sure not to use it twice in the same warning/Rprintf call (comment added).
Several of the fmelt tests weren't checking the dynamic parts of their messages; i.e. the result of concat being correct, so I expanded those tests too. I checked that the expanded fmelt tests also pass v1.12.8 to ensure the reworked concat returns the same string as before. concat is only used in warning and verbose messages, and only in fmelt, so the risk of this code rework at this stage in release is limited. Reran rchk just to make sure nothing new introduced, and all fine.