### PR TITLE
Add header to declare C level API 

### DIFF
--- a/inst/include/datatableAPI.h
+++ b/inst/include/datatableAPI.h
@@ -1,0 +1,45 @@
+
+/* This header file provides the interface used by other packages,
+   and should be included once per package.                        */
+
+#ifndef _R_data_table_API_h_
+#define _R_data_table_API_h_
+
+/* number of R header files (possibly listing too many) */
+#include <R.h>
+
+#ifdef HAVE_VISIBILITY_ATTRIBUTE
+    # define attribute_hidden __attribute__ ((visibility ("hidden")))
+#else
+    # define attribute_hidden
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* provided the interface for the function exported in
+   ../src/init.c via R_RegisterCCallable()		*/
+
+SEXP attribute_hidden DT_subsetDT(SEXP x, SEXP rows, SEXP cols) {
+     static SEXP(*fun)(SEXP, SEXP, SEXP) =
+       (SEXP(*)(SEXP,SEXP,SEXP)) R_GetCCallable("data.table", "CsubsetDT");
+     return fun(x,rows,cols);
+}
+
+/* permit opt-in to redefine shorter identifiers */
+#if defined(DATATABLE_REMAP_API)
+  #define subsetDT DT_subsetDT
+#endif
+
+#ifdef __cplusplus
+}
+
+/* add a namespace for C++ use */
+namespace dt {
+  inline SEXP subsetDT(SEXP x, SEXP rows, SEXP cols) { return DT_subsetDT(x, rows, cols); }
+}
+
+#endif /* __cplusplus */
+
+#endif /* _R_data_table_API_h_ */


### PR DESCRIPTION
This PR follows the discussion in #4643 and adds a (very simply and short) file declaring a C level function to access the registered-as-callable function `subsetDT`.  But providing a function which shields the somewhat unwieldy C function pointer setup, wider use is facilitated.   It also offers a benefit for maintenance as it provides another user facing layer allowing the data.table team to redefine or rename the internal function registers as C callable and called here.

At present the function can called three ways

- "as is":  `DT_subsetDT()` with an explicit prefix (and we could consider dropping the suffix...)
- "with an additional define":  `subsetDT()` which is a little cleaner but may clash, this is an opt-in
- "from C++":  `dt::subsetDT()` where we put a simple C++ namespace around it

Please free to rename or realign as you see fit.  I have tested all three access mechanisms (in a simple Rcpp-based test).  Doing a proper unit test is likely more work but maybe something we should do.  I can help...