### PR TITLE
Fix bit::copy for unit tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 ## BUG FIXES
 
+1. The new release of `bit` 4.0.0 included a new function `copy` which caused unit tests to fail. Thanks to Cole Miller for the fix. 
+
 ## NOTES
 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,9 +8,24 @@
 
 ## BUG FIXES
 
-1. The new release of `bit` 4.0.0 included a new function `copy` which caused unit tests to fail. Thanks to Cole Miller for the fix. 
-
 ## NOTES
+
+1. `bit64` v4.0.2 released on 30th July broke `data.table`'s tests. It seems that reverse dependency testing of `bit64` (i.e. testing of the packages which use `bit64`) did not include `data.table` because `data.table` merely suggests `bit64` and does not depend on it. Like other packages on our `Suggest` list, we test `data.table` works with `bit64` in our tests. In testing of our own reverse dependencies (packages which use `data.table`) we do include packages which suggest `data.table`, although it appears it is not CRAN policy to do so. We have requested that CRAN policy be changed to include suggests in reverse dependency testing.
+
+    The first break was because `all.equal` did not work in previous versions of `bit64`; e.g.,
+
+```R
+require(bit64)  
+all.equal(as.integer64(3), as.integer64(4))
+TRUE    # < v4.0.0
+FALSE   # >= v4.0.0
+```
+
+    We feel the need to explain this in detail here because the addition of the `integer64` method for `all.equal` appears as a very brief "new feature" in `bit64`'s NEWS. We like `bit64` a lot and we know users of `data.table` also use `bit64`. They may be impacted in the same way; e.g., equality tests previously passing when they should not have passed. In our case, two `fcase` tests on `integer64` and `nanotime` started to fail upon `bit64`'s update. Fortunately, the `fcase` results were correct but the tests were comparing to an incorrect result which was incorrectly passing due to `all.equal` always returning TRUE for any `integer64` input.
+
+    The second break caused by `bit64` was the addition of a `copy` function. Since `data.table::copy` is long standing we hope that `bit64` can rename its new `copy` function. Otherwise, users of `data.table` may need to prefix every occurrence of `copy` with `data.table::copy` if they use `bit64` too. Again, this impacted `data.table`'s tests which mimic a user's environment; not `data.table` itself per se.
+
+    Thanks to Cole Miller for the PR to accomodate `bit64`'s update. 
 
 
 # data.table [v1.13.0](https://github.com/Rdatatable/data.table/milestone/17?closed=1)  (24 Jul 2020)

--- a/inst/tests/nafill.Rraw
+++ b/inst/tests/nafill.Rraw
@@ -8,11 +8,12 @@ if (exists("test.data.table", .GlobalEnv, inherits=FALSE)) {
   INT = data.table:::INT
   colnamesInt = data.table:::colnamesInt
   coerceFill = data.table:::coerceFill
-  
-                                          # masked by which package?
+                                        # masked by which package?
                                         # =================================
-  copy = data.table::copy               # bit
-  setattr = data.table::setattr         # bit
+  copy = data.table::copy               # bit64;  copy is used in this file, so this line is needed
+  setattr = data.table::setattr         # bit  ;  setattr does not appear in this file, so not needed. Here in case that changes.
+                                        # use of copy and setattr within data.table's own code is not masked by other packages
+                                        # we only have to do this in test files because, like a user would, these test files run like a user
 }
 
 sugg = c(

--- a/inst/tests/nafill.Rraw
+++ b/inst/tests/nafill.Rraw
@@ -8,6 +8,11 @@ if (exists("test.data.table", .GlobalEnv, inherits=FALSE)) {
   INT = data.table:::INT
   colnamesInt = data.table:::colnamesInt
   coerceFill = data.table:::coerceFill
+  
+                                          # masked by which package?
+                                        # =================================
+  copy = data.table::copy               # bit
+  setattr = data.table::setattr         # bit
 }
 
 sugg = c(

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -16756,11 +16756,11 @@ test(2127.24, fcase(test_vec1, as.Date("2019-10-11"), test_vec2, as.Date("2019-1
 test(2127.25, fcase(test_vec1, as.Date("2019-10-11"), test_vec2, as.Date("2019-10-14"),default=123), error="Resulting value has different class than 'default'. Please make sure that both arguments have the same class.")
 if(test_bit64) {
   i=as.integer64(1:12)+3e9
-  test(2127.26, fcase(test_vec_na1, i, test_vec_na2, i+100), c(i[1L:5L], as.integer64(NA),i[7L:12L]+100))
+  test(2127.26, fcase(test_vec_na1, i, test_vec_na2, i+100), c(i[1L:5L], as.integer64(NA),i[7L:11L]+100, as.integer64(NA)))
 }
 if(test_nanotime) {
   n=nanotime(1:12)
-  test(2127.27, fcase(test_vec_na1, n, test_vec_na2, n+100), c(n[1L:5L], nanotime(NA),n[7L:12L]+100))
+  test(2127.27, fcase(test_vec_na1, n, test_vec_na2, n+100), c(n[1L:5L], nanotime(NA),n[7L:11L]+100, as.integer64(NA)))
 }
 test(2127.28, fcase(test_vec1, rep(1L,11L), test_vec2, rep(0L,11L)), as.integer(out_vec))
 test(2127.29, fcase(test_vec1, rep(1,11L), test_vec2, rep(0,11L)), out_vec)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -77,7 +77,7 @@ if (exists("test.data.table", .GlobalEnv, inherits=FALSE)) {
   melt = data.table::melt               # reshape2
   last = data.table::last               # xts
   first = data.table::first             # xts, S4Vectors
-  copy = data.table::copy               # bit64
+  copy = data.table::copy               # bit
 }
 
 # Load optional Suggests packages, which are tested by Travis for code coverage, and on CRAN

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -77,7 +77,7 @@ if (exists("test.data.table", .GlobalEnv, inherits=FALSE)) {
   melt = data.table::melt               # reshape2
   last = data.table::last               # xts
   first = data.table::first             # xts, S4Vectors
-  copy = data.table::copy               # bit
+  copy = data.table::copy               # bit64 v4; bit64 offered to rename though so this is just in case bit64 unoffers
 }
 
 # Load optional Suggests packages, which are tested by Travis for code coverage, and on CRAN

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -77,6 +77,7 @@ if (exists("test.data.table", .GlobalEnv, inherits=FALSE)) {
   melt = data.table::melt               # reshape2
   last = data.table::last               # xts
   first = data.table::first             # xts, S4Vectors
+  copy = data.table::copy               # bit64
 }
 
 # Load optional Suggests packages, which are tested by Travis for code coverage, and on CRAN


### PR DESCRIPTION
Closes #4654. 

Seems like a TODO would be to see all name conflicts between for ```Suggests``` packages for the various unit tests. 