### PR TITLE
configure fix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 1. `test.data.table()` could fail the 2nd time it is run by a user in the same R session on Windows due to not resetting locale properly after testing Chinese translation, [#4630](https://github.com/Rdatatable/data.table/pull/4630). Thanks to Cole Miller for investigating and fixing.
 
+2. A regression in v1.13.0 resulted in installation on Mac often failing with `shared object 'datatable.so' not found`, and FreeBSD always failing with `expr: illegal option -- l`, [#4652](https://github.com/Rdatatable/data.table/issues/4652) [#4640](https://github.com/Rdatatable/data.table/issues/4640) [#4650](https://github.com/Rdatatable/data.table/issues/4650). Thanks to many for assistance including Simon Urbanek, Brian Ripley, Wes Morgan, and @ale07alvarez. There were no installation problems on Windows or Linux.
+
 ## NOTES
 
 1. `bit64` v4.0.2 released on 30th July broke `data.table`'s tests. It seems that reverse dependency testing of `bit64` (i.e. testing of the packages which use `bit64`) did not include `data.table` because `data.table` merely suggests `bit64` and does not depend on it. Like other packages on our `Suggest` list, we test `data.table` works with `bit64` in our tests. In testing of our own reverse dependencies (packages which use `data.table`) we do include packages which suggest `data.table`, although it appears it is not CRAN policy to do so. We have requested that CRAN policy be changed to include suggests in reverse dependency testing.

--- a/configure
+++ b/configure
@@ -31,9 +31,9 @@ else
     msg=1
   else
     lib=`pkg-config --libs zlib`
-    expr "$lib" : ".*-lz$" >/dev/null
+    expr -- "$lib" : ".*-lz$" >/dev/null  # -- for FreeBSD, #4652
     if [ $? -ne 0 ]; then
-      expr "$lib" : ".*-lz " >/dev/null
+      expr -- "$lib" : ".*-lz " >/dev/null
       # would use \b in one expr but MacOS does not support \b
       if [ $? -ne 0 ]; then
         echo "*** pkg-config is installed and 'pkg-config --exists zlib' succeeds but"
@@ -45,12 +45,13 @@ else
 fi
 
 if [ $msg -ne 0 ]; then
-  echo "*** Compilation will now be attempted and if it works you can ignore this message. However,"
-  echo "*** if compilation fails, try 'locate zlib.h zconf.h' and ensure the zlib development library"
-  echo "*** is installed :"
+  echo "*** Compilation will now be attempted and if it works you can ignore this message. In"
+  echo "*** particular, this should be the case on Mac where zlib is built in."
+  echo "*** However, if compilation fails, try 'locate zlib.h zconf.h' and ensure the zlib"
+  echo "*** development library is installed :"
   echo "***   deb: zlib1g-dev (Debian, Ubuntu, ...)"
   echo "***   rpm: zlib-devel (Fedora, EPEL, ...)"
-  echo "***   brew: zlib (OSX)"
+  echo "***   There is a zlib in brew for OSX but the built in zlib should work."
   echo "*** Note that zlib is required to compile R itself so you may find the advice in the R-admin"
   echo "*** guide helpful regarding zlib. On Debian/Ubuntu, zlib1g-dev is a dependency of r-base as"
   echo "*** shown by 'apt-cache showsrc r-base | grep ^Build-Depends | grep zlib', and therefore"
@@ -59,11 +60,10 @@ if [ $msg -ne 0 ]; then
   echo "***   1) 'pkg-config --exists zlib' succeeds (i.e. \$? -eq 0)"
   echo "***   2) 'pkg-config --libs zlib' contains -lz"
   echo "*** Compilation will now be attempted ..."
-  exit 0
+else
+  version=`pkg-config --modversion zlib`
+  echo "zlib ${version} is available ok"
 fi
-
-version=`pkg-config --modversion zlib`
-echo "zlib ${version} is available ok"
 
 # Test if we have a OPENMP compatible compiler
 # Aside: ${SHLIB_OPENMP_CFLAGS} does not appear to be defined at this point according to Matt's testing on


### PR DESCRIPTION
Follow up to #3984 which renamed `Makevars` to `Makevars.in` and now requires the end of `configure` to run
Closes #4640
Closes #4650 
Closes #4652

removed the exit 0
put the zlib version output into an else (that was why the exit 0 was there because there was nothing after the zlib version output originally, i.e. before #3984)
added the `--` for FreeBSD, thanks to @wesnm 
changed wording for Mac to explain that zlib is built in there
news item