### PR TITLE
Solaris const nth and added grep to CRAN_Release.cmd

### DIFF
--- a/.dev/CRAN_Release.cmd
+++ b/.dev/CRAN_Release.cmd
@@ -103,7 +103,9 @@ grep omp_set_nested ./src/*.c
 grep --exclude="./src/openmp-utils.c" omp_get_max_threads ./src/*
 
 # Ensure all #pragama omp parallel directives include a num_threads() clause
-grep "pragma omp parallel" ./src/*.c | grep -v getDTthreads
+grep -i "pragma.*omp parallel" ./src/*.c | grep -v getDTthreads
+# this will return a set of num_threads(nth) clauses; ensure that variable is not declared const for Solaris, #4638
+grep -i "const.*int.*nth" ./src/*.c
 
 # Update documented list of places where openMP parallelism is used: c.f. ?openmp
 grep -Elr "[pP]ragma.*omp" src | sort

--- a/.dev/CRAN_Release.cmd
+++ b/.dev/CRAN_Release.cmd
@@ -104,7 +104,7 @@ grep --exclude="./src/openmp-utils.c" omp_get_max_threads ./src/*
 
 # Ensure all #pragama omp parallel directives include a num_threads() clause
 grep -i "pragma.*omp parallel" ./src/*.c | grep -v getDTthreads
-# this will return a set of num_threads(nth) clauses; ensure that variable is not declared const for Solaris, #4638
+# for each num_threads(nth) above, ensure for Solaris that the variable is not declared const, #4638
 grep -i "const.*int.*nth" ./src/*.c
 
 # Update documented list of places where openMP parallelism is used: c.f. ?openmp

--- a/src/subset.c
+++ b/src/subset.c
@@ -11,7 +11,7 @@ void subsetVectorRaw(SEXP ans, SEXP source, SEXP idx, const bool anyNA)
   // negatives, zeros and out-of-bounds have already been dealt with in convertNegAndZero so we can rely
   // here on idx in range [1,length(ans)].
 
-  const int nth = getDTthreads(n, /*throttle=*/true);
+  int nth = getDTthreads(n, /*throttle=*/true);   // not const for Solaris, #4638
   // For small n such as 2,3,4 etc we had hoped OpenMP would be sensible inside it and not create a team
   // with each thread doing just one item. Otherwise, call overhead would be too high for highly iterated
   // calls on very small subsets. Timings were tested in #3175. However, the overhead does seem to add up


### PR DESCRIPTION
Closes #4638 
Removed the `const` on this instance
Expanded the grep in CRAN_Release to find _Pragma lines too
Added a grep which would have found this line in future.
No news item because nobody thinks anyone is using Solaris. If Solaris users do exist they haven't said anything in 14 years: no thanks, no reports, no nothing. Not necessarily a problem, other than Solaris uses up a lot of time to support, and it's ongoing; e.g. the zlib problem only on Solaris which still needs time to solve.
```
# Ensure all #pragama omp parallel directives include a num_threads() clause
$ grep -i "pragma.*omp parallel" ./src/*.c | grep -v getDTthreads
./src/fread.c:  #pragma omp parallel num_threads(nth)
./src/fsort.c:  #pragma omp parallel for num_threads(nth)
./src/fsort.c:  #pragma omp parallel for num_threads(nth)
./src/fwrite.c:  #pragma omp parallel num_threads(nth)
./src/subset.c:      _Pragma("omp parallel for num_threads(nth)")                \
./src/subset.c:      _Pragma("omp parallel for num_threads(nth)")                \
# for each num_threads(nth) above, ensure for Solaris that the variable is not declared const, #4638
$ grep -i "const.*int.*nth" ./src/*.c
./src/subset.c:  const int nth = getDTthreads(n, /*throttle=*/true);
$
```