### PR TITLE
added anchor as new parameter for setcolorder, now user can move some…

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2548,18 +2548,52 @@ setnames = function(x,old,new,skip_absent=FALSE) {
   invisible(x)
 }
 
-setcolorder = function(x, neworder=key(x))
+# in anchor mode user should provide a length 1 named vector: anchor = c(before/after = anchor_col_name/index)
+setcolorder = function(x, neworder=key(x), anchor = NULL)
 {
   if (is.character(neworder) && anyDuplicated(names(x)))
     stop("x has some duplicated column name(s): ", paste(names(x)[duplicated(names(x))], collapse=","), ". Please remove or rename the duplicate(s) and try again.")
   # if (!is.data.table(x)) stop("x is not a data.table")
   neworder = colnamesInt(x, neworder, check_dups=FALSE)  # dups are now checked inside Csetcolorder below
-  if (length(neworder) != length(x)) {
-    #if shorter than length(x), pad by the missing
-    #  elements (checks below will catch other mistakes)
-    neworder = c(neworder, setdiff(seq_along(x), neworder))
+  # original mode without anchor
+  if (is.null(anchor)) {
+    if (length(neworder) != length(x)) {
+      #if shorter than length(x), pad by the missing
+      #  elements (checks below will catch other mistakes)
+      final_order = c(neworder, setdiff(seq_along(x), neworder))
+    }
+  } else {
+    if (!(names(anchor) %in% c("before", "after"))) {
+      stop("anchor need to be named with 'before' or 'after'")
+    }
+    if (!(class(anchor) %in% c("character", "numeric", "integer"))) {
+      stop("anchor need to be either column name or index")
+    }
+    # always operating in index mode, consistent with original mode
+    oldorder <- seq_along(x)
+    if (class(anchor) == "character") {
+      anchor_location <- which(names(x) == anchor)
+    } else {
+      anchor_location <- which(oldorder == anchor)
+    }
+    if (length(anchor_location) == 0) {
+      stop("anchor not matching any column")
+    }
+    if (anchor_location %in% neworder) {
+      stop("anchor cannot be part of neworder")
+    }
+    # we always split columns without the moving subset into left, anchor, right, then insert the moving subset before or after anchor.
+    # : in R is seq, always return a seqence even for 1:0, or 11:10 of length 10 vector, this is not what we want.
+    slice <- function(vec, from, to) {
+      if (from > to) return(NULL) else vec[from:to]
+    }
+    left_cols <- setdiff(slice(oldorder, 1, anchor_location - 1), neworder)
+    right_cols <- setdiff(slice(oldorder, anchor_location + 1, length(oldorder)), neworder)
+    final_order <- switch(names(anchor),
+                       before = c(left_cols, neworder, anchor_location, right_cols),
+                       after =  c(left_cols, anchor_location, neworder, right_cols))
   }
-  .Call(Csetcolorder, x, neworder)
+  .Call(Csetcolorder, x, final_order)
   invisible(x)
 }
 

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2561,6 +2561,8 @@ setcolorder = function(x, neworder=key(x), anchor = NULL)
       #if shorter than length(x), pad by the missing
       #  elements (checks below will catch other mistakes)
       final_order = c(neworder, setdiff(seq_along(x), neworder))
+    } else {
+      final_order <- neworder
     }
   } else {
     if (!(names(anchor) %in% c("before", "after"))) {

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -1489,6 +1489,16 @@ test(498.3, setcolorder(DT, 1:4), error = "specify non existing column*.*4")
 # Test where neworder=NULL, thus ordered by key and index columns
 DT = data.table(a = 1:3, b = 2:4, c = 3:5, d = 4:6, key="b")
 test(498.4, names(setcolorder(DT)), c("b", "a", "c", "d"))
+# Test setcolorder with parameter of anchor
+DT = data.table(a=1,b=2,c=3)
+test(498.5, setcolorder(copy(DT), "c", c(after="a")), data.table(a=1,c=3,b=2))
+test(498.6, setcolorder(copy(DT), "a", c(after="c")), data.table(b=2,c=3,a=1))
+test(498.7, setcolorder(copy(DT), "a", c(after=2)), data.table(b=2,a=1,c=3))
+test(498.8, setcolorder(copy(DT), "a", c(after=2L)), data.table(b=2,a=1,c=3))
+test(498.9, setcolorder(copy(DT), "a", c(after=4L)), error = "anchor not matching any column")
+test(498.10, setcolorder(copy(DT), "a", c(before="c")), data.table(b=2,a=1,c=3))
+test(498.11, setcolorder(copy(DT), "c", c(before="a")), data.table(c=3,a=1,b=2))
+test(498.12, setcolorder(copy(DT), "c", c(before=1)), data.table(c=3,a=1,b=2))
 
 # test first group listens to nomatch when j uses join inherited scope.
 x <- data.table(x=c(1,3,8),x1=10:12, key="x")


### PR DESCRIPTION
… columns before or after an anchor column

This is per #4668  and #4358.

- I added the new parameter as a length 1 named vector `anchor = c(before = 1)`. Another option is adding two parameters `before = NULL, after = NULL`. If more people prefer the 2nd interface I can switch to that.
- anchor need to be named as either `before` or `after`, value as numeric, integer or character. There are some checks if any of this failed.

If this got accepted, I can further draft the updated help for the function.