### PR TITLE
Add inline to function definition

### DIFF
--- a/inst/include/datatableAPI.h
+++ b/inst/include/datatableAPI.h
@@ -21,7 +21,7 @@ extern "C" {
 /* provided the interface for the function exported in
    ../src/init.c via R_RegisterCCallable()		*/
 
-SEXP attribute_hidden DT_subsetDT(SEXP x, SEXP rows, SEXP cols) {
+inline SEXP attribute_hidden DT_subsetDT(SEXP x, SEXP rows, SEXP cols) {
      static SEXP(*fun)(SEXP, SEXP, SEXP) =
        (SEXP(*)(SEXP,SEXP,SEXP)) R_GetCCallable("data.table", "CsubsetDT");
      return fun(x,rows,cols);


### PR DESCRIPTION
This is something I should have picked up ages but didn't because most often these API include headers are used only in one file / compilation unit.

And when for once it is not, we get duplicate symbols :-/

So this just adds a missing `inline` that should have been present in the original PR.  