### PR TITLE
Backport str2lang

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -746,7 +746,7 @@ replace_dot_alias = function(e) {
           if (length(backtick_idx)) bysub[backtick_idx] = paste0("`",bysub[backtick_idx],"`")
           backslash_idx = grep("\\", bysub, fixed = TRUE)
           if (length(backslash_idx)) bysub[backslash_idx] = gsub('\\', '\\\\', bysub[backslash_idx], fixed = TRUE)
-          bysub = parse(text=paste0("list(",paste(bysub,collapse=","),")"))[[1L]]
+          bysub = str2lang(paste0("list(",paste(bysub,collapse=","),")"))
           bysubl = as.list.default(bysub)
         }
         allbyvars = intersect(all.vars(bysub), names_x)

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -44,11 +44,11 @@
     # If R 3.6.2 (not yet released) includes the c|rbind S3 dispatch fix, then this workaround still works.
     tt = base::cbind.data.frame
     ss = body(tt)
-    if (class(ss)[1L]!="{") ss = as.call(c(as.name("{"), ss))
+    if (class(ss)[1L]!="{") ss = call("{", ss)
     prefix = if (!missing(pkgname)) "data.table::" else ""  # R provides the arguments when it calls .onLoad, I don't in dev/test
     if (!length(grep("data.table", ss[[2L]], fixed = TRUE))) {
       ss = ss[c(1L, NA, 2L:length(ss))]
-      ss[[2L]] = parse(text=paste0("if (!identical(class(..1),'data.frame')) for (x in list(...)) { if (inherits(x,'data.table')) return(",prefix,"data.table(...)) }"))[[1L]]
+      ss[[2L]] = str2lang(paste0("if (!identical(class(..1),'data.frame')) for (x in list(...)) { if (inherits(x,'data.table')) return(",prefix,"data.table(...)) }"))
       body(tt)=ss
       (unlockBinding)("cbind.data.frame",baseenv())
       assign("cbind.data.frame",tt,envir=asNamespace("base"),inherits=FALSE)
@@ -56,10 +56,10 @@
     }
     tt = base::rbind.data.frame
     ss = body(tt)
-    if (class(ss)[1L]!="{") ss = as.call(c(as.name("{"), ss))
+    if (class(ss)[1L]!="{") ss = call("{", ss)
     if (!length(grep("data.table", ss[[2L]], fixed = TRUE))) {
       ss = ss[c(1L, NA, 2L:length(ss))]
-      ss[[2L]] = parse(text=paste0("for (x in list(...)) { if (inherits(x,'data.table')) return(",prefix,".rbind.data.table(...)) }"))[[1L]] # fix for #89
+      ss[[2L]] = str2lang(paste0("for (x in list(...)) { if (inherits(x,'data.table')) return(",prefix,".rbind.data.table(...)) }")) # fix for #89
       body(tt)=ss
       (unlockBinding)("rbind.data.frame",baseenv())
       assign("rbind.data.frame",tt,envir=asNamespace("base"),inherits=FALSE)
@@ -89,7 +89,7 @@
        "datatable.prettyprint.char" = NULL     # FR #1091
        )
   for (i in setdiff(names(opts),names(options()))) {
-    eval(parse(text=paste0("options(",i,"=",opts[i],")")))
+    eval(str2lang(paste0("options(",i,"=",opts[i],")")))
   }
 
   if (!is.null(getOption("datatable.old.bywithoutby")))

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -97,7 +97,7 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
   assign("testDir", function(x) file.path(fulldir, x), envir=env)
 
   # are R's messages being translated to a foreign language? #3039, #630
-  txt = eval(parse(text="tryCatch(mean(not__exist__), error = function(e) e$message)"), envir=.GlobalEnv)
+  txt = eval(str2lang("tryCatch(mean(not__exist__), error = function(e) e$message)"), envir=.GlobalEnv)
   foreign = txt != "object 'not__exist__' not found"
   if (foreign) {
     # nocov start

--- a/R/utils.R
+++ b/R/utils.R
@@ -34,15 +34,6 @@ which.first = function(x)
   match(TRUE, x)
 }
 
-# which.last
-which.last = function(x)
-{
-  if (!is.logical(x)) {
-    stop("x not boolean")
-  }
-  length(x) - match(TRUE, rev(x)) + 1L
-}
-
 require_bit64_if_needed = function(DT) {
   # called in fread and print.data.table
   if (!isNamespaceLoaded("bit64") && any(sapply(DT,inherits,"integer64"))) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -34,6 +34,12 @@ which.first = function(x)
   match(TRUE, x)
 }
 
+# backport str2lang for older versions
+if (!exists('str2lang', 'package:base')) {
+  # see base/R/parse.R -- skipping the internal checks on our internal usage
+  str2lang = function(s) parse(text = s, keep.source=FALSE)[[1L]]
+}
+
 require_bit64_if_needed = function(DT) {
   # called in fread and print.data.table
   if (!isNamespaceLoaded("bit64") && any(sapply(DT,inherits,"integer64"))) {


### PR DESCRIPTION
`str2lang` is a more efficient version of `parse(text=.)` but it's only available since R 3.6.0.

We are allowed to use an object from our namespace in `.onLoad` right? If not, we should at least use `keep.source=FALSE` there.