### PR TITLE
Make tests 168,2043 work for any LC_TIME

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,14 @@
 
 2. `?.NGRP` now displays the help page as intended, [#4946](https://github.com/Rdatatable/data.table/issues/4649). Thanks to @KyleHaynes for posting the issue, and Cole Miller for the fix. `.NGRP` is a symbol new in v1.13.0; see below in this file.
 
+3. Tests 163 and 2043 were failing in non-English locales such as
+   `LC_TIME=fr_FR.UTF-8` because computed values use
+   `strftime(format="%b")` which is locale-dependent e.g. `janv.`
+   whereas expected values were coded in English e.g. `Jan`,
+   [#3450](https://github.com/Rdatatable/data.table/issues/3450). Fixed
+   by changing the expected values to also be locale-dependent
+   e.g. `janv.` Thanks to @tdhock for
+   [PR#4719](https://github.com/Rdatatable/data.table/pull/4719).
 
 # data.table [v1.13.0](https://github.com/Rdatatable/data.table/milestone/17?closed=1)  (24 Jul 2020)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -35,14 +35,8 @@
 
 2. `?.NGRP` now displays the help page as intended, [#4946](https://github.com/Rdatatable/data.table/issues/4649). Thanks to @KyleHaynes for posting the issue, and Cole Miller for the fix. `.NGRP` is a symbol new in v1.13.0; see below in this file.
 
-3. Tests 163 and 2043 were failing in non-English locales such as
-   `LC_TIME=fr_FR.UTF-8` because computed values use
-   `strftime(format="%b")` which is locale-dependent e.g. `janv.`
-   whereas expected values were coded in English e.g. `Jan`,
-   [#3450](https://github.com/Rdatatable/data.table/issues/3450). Fixed
-   by changing the expected values to also be locale-dependent
-   e.g. `janv.` Thanks to @tdhock for
-   [PR#4719](https://github.com/Rdatatable/data.table/pull/4719).
+3. `test.data.table()` failed in non-English locales such as `LC_TIME=fr_FR.UTF-8` due to `Jan` vs `janv.` in tests 168 and 2042, [#3450](https://github.com/Rdatatable/data.table/issues/3450). Thanks to @shrektan for reporting, and @tdhock for making the tests locale-aware.
+
 
 # data.table [v1.13.0](https://github.com/Rdatatable/data.table/milestone/17?closed=1)  (24 Jul 2020)
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -472,7 +472,7 @@ try(graphics.off(),silent=TRUE)
 
 # IDateTime conversion methods that ggplot2 uses (it calls as.data.frame method)
 # Since %b is e.g. "nov." in LC_TIME=fr_FR.UTF-8 locale, we need to
-# have the target/y value in these tests depend on the locale as well.
+# have the target/y value in these tests depend on the locale as well, #3450.
 NOV = format(strptime("2000-11-01", "%Y-%m-%d"), "%b")
 x = c("09:29:16","10:42:40","23:47:12","01:06:01","11:35:34","11:51:09")
 datetimes = paste0("2011 ", NOV, c(18,18,18,19,19,19), " ", x)
@@ -15070,7 +15070,7 @@ test(2042.1, DT[ , as.character(mean(date)), by=g, verbose=TRUE ],
              data.table(g=c("a","b"), V1=c("2018-01-04","2018-01-21")),
      output=msg<-"GForce is on, left j unchanged.*Old mean optimization is on, left j unchanged")
 # Since %b is e.g. "janv." in LC_TIME=fr_FR.UTF-8 locale, we need to
-# have the target/y value in these tests depend on the locale as well.
+# have the target/y value in these tests depend on the locale as well, #3450.
 Jan.2018 = format(strptime("2018-01-01", "%Y-%m-%d"), "%b-%Y")
 test(2042.2, DT[ , format(mean(date),"%b-%Y")], Jan.2018)
 test(2042.3, DT[ , format(mean(date),"%b-%Y"), by=g, verbose=TRUE ],  # just this case generated the error

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -471,10 +471,13 @@ test(167.3, DT[,plot(b,f),by=.(grp)], data.table(grp=integer()))
 try(graphics.off(),silent=TRUE)
 
 # IDateTime conversion methods that ggplot2 uses (it calls as.data.frame method)
-datetimes = c("2011 NOV18 09:29:16", "2011 NOV18 10:42:40", "2011 NOV18 23:47:12",
-              "2011 NOV19 01:06:01", "2011 NOV19 11:35:34", "2011 NOV19 11:51:09")
+# Since %b is e.g. "nov." in LC_TIME=fr_FR.UTF-8 locale, we need to
+# have the target/y value in these tests depend on the locale as well.
+NOV = format(strptime("2000-11-01", "%Y-%m-%d"), "%b")
+x = c("09:29:16","10:42:40","23:47:12","01:06:01","11:35:34","11:51:09")
+datetimes = paste0("2011 ", NOV, c(18,18,18,19,19,19), " ", x)
 DT = IDateTime(strptime(datetimes,"%Y %b%d %H:%M:%S"))
-test(168.1, DT[,as.data.frame(itime)], data.frame(V1=as.ITime(x<-c("09:29:16","10:42:40","23:47:12","01:06:01","11:35:34","11:51:09"))))
+test(168.1, DT[,as.data.frame(itime)], data.frame(V1=as.ITime(x)))
 test(168.2, as.character(DT[,as.POSIXct(itime,tz="UTC")]), paste(Sys.Date(), x))
 test(168.3, as.character(DT[,as.POSIXct(idate,tz="UTC")]), c("2011-11-18","2011-11-18","2011-11-18","2011-11-19","2011-11-19","2011-11-19"))
 
@@ -15065,10 +15068,13 @@ test(2041.2, DT[, median(time), by=g], DT[c(2,5),.(g=g, V1=time)])
 # 'invalid trim argument' with optimization level 1; #1876
 test(2042.1, DT[ , as.character(mean(date)), by=g, verbose=TRUE ],
              data.table(g=c("a","b"), V1=c("2018-01-04","2018-01-21")),
-             output=msg<-"GForce is on, left j unchanged.*Old mean optimization is on, left j unchanged")
-test(2042.2, DT[ , format(mean(date),"%b-%Y")], "Jan-2018")
+     output=msg<-"GForce is on, left j unchanged.*Old mean optimization is on, left j unchanged")
+# Since %b is e.g. "janv." in LC_TIME=fr_FR.UTF-8 locale, we need to
+# have the target/y value in these tests depend on the locale as well.
+Jan.2018 = format(strptime("2018-01-01", "%Y-%m-%d"), "%b-%Y")
+test(2042.2, DT[ , format(mean(date),"%b-%Y")], Jan.2018)
 test(2042.3, DT[ , format(mean(date),"%b-%Y"), by=g, verbose=TRUE ],  # just this case generated the error
-             data.table(g=c("a","b"), V1=c("Jan-2018","Jan-2018")), output=msg)
+     data.table(g=c("a","b"), V1=c(Jan.2018, Jan.2018)), output=msg)
 
 # gforce wrongly applied to external variable; #875
 DT = data.table(x=INT(1,1,1,2,2), y=1:5)


### PR DESCRIPTION
Closes #3450
hi @jangorecki @shrektan @2005m @MichaelChirico this is a fix for #3450 which you commented on.
The problem in that issue is that some of the computed values depend on the LC_TIME locale value, whereas the expected values in the test are always English/C locale (Jan/NOV).
On my system (ubuntu 18.04) I have the following locales, the important one is `LC_TIME=fr_FR.UTF-8`
```
Fri Sep 25 16:41:56 2020  endian==little, sizeof(long double)==16, longdouble.digits==64, sizeof(pointer)==8, TZ==unset, Sys.timezone()=='America/Phoenix', Sys.getlocale()=='LC_CTYPE=en_US.UTF-8;LC_NUMERIC=C;LC_TIME=fr_FR.UTF-8;LC_COLLATE=en_US.UTF-8;LC_MONETARY=fr_FR.UTF-8;LC_MESSAGES=en_US.UTF-8;LC_PAPER=fr_FR.UTF-8;LC_NAME=C;LC_ADDRESS=C;LC_TELEPHONE=C;LC_MEASUREMENT=fr_FR.UTF-8;LC_IDENTIFICATION=C', l10n_info()=='MBCS=TRUE; UTF-8=TRUE; Latin-1=FALSE', getDTthreads()=='omp_get_num_procs()==2; R_DATATABLE_NUM_PROCS_PERCENT==unset (default 50); R_DATATABLE_NUM_THREADS==unset; R_DATATABLE_THROTTLE==unset (default 1024); omp_get_thread_limit()==2147483647; omp_get_max_threads()==2; OMP_THREAD_LIMIT==unset; OMP_NUM_THREADS==unset; RestoreAfterFork==true; data.table is using 1 threads with throttle==1024. See ?setDTthreads.'
```
with current master I get
```
(base) tdhock@maude-MacBookPro:~/R$ R CMD INSTALL data.table && R --vanilla < data.table/tests/main.R 
...
  7 errors out of 9996. Search tests/tests.Rraw.bz2 for test numbers: 168.1, 168.2, 168.3, 2042.2, 2042.3, 2127.26, 2127.27.
```
After applying the commit in this PR I get
```
All 10001 tests in tests/tests.Rraw completed ok in 00:01:50 elapsed (00:01:46 cpu)
```
I could have fixed this by just setting LC_TIME=C during the tests, but I figured it would be better to not alter the environment. So instead I just changed the expected values so that they are generated based on the current locale (e.g. "janv." and "nov." instead of "Jan" and "NOV"). Is this approach ok?