### PR TITLE
WIP: vector support for fsetdiff/funion/fintersect and fsetequal

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 ## NEW FEATURES
 
+1. Set operations `fintersect`, `funion`, `fsetdiff` and `fseteuqal` now also support vectors as input. #3752(https://github.com/Rdatatable/data.table/issues/3752). Thanks to @shrektan for the request and thanks to Benjamin Schwendinger for the PR. 
+
 ## BUG FIXES
 
 1. `test.data.table()` could fail the 2nd time it is run by a user in the same R session on Windows due to not resetting locale properly after testing Chinese translation, [#4630](https://github.com/Rdatatable/data.table/pull/4630). Thanks to Cole Miller for investigating and fixing.

--- a/R/setops.R
+++ b/R/setops.R
@@ -56,7 +56,15 @@ funique = function(x) {
   if (.seqn && ".seqn" %chin% names(x)) stop("None of the datasets should contain a column named '.seqn'")
 }
 
+vec2dt = function(fun, x, y, all=FALSE){
+  fun(setDT(list(x)), setDT(list(y)), all)[[1]]
+}
+
 fintersect = function(x, y, all=FALSE) {
+  if (is.vector(x) && is.vector(y)){
+    return(vec2dt(fintersect, x, y, all))
+  }
+
   .set_ops_arg_check(x, y, all, .seqn = TRUE)
   if (!nrow(x) || !nrow(y)) return(x[0L])
   if (all) {
@@ -71,6 +79,10 @@ fintersect = function(x, y, all=FALSE) {
 }
 
 fsetdiff = function(x, y, all=FALSE) {
+  if (is.vector(x) && is.vector(y)){
+    return(vec2dt(fsetdiff, x, y, all))
+  }
+
   .set_ops_arg_check(x, y, all, .seqn = TRUE)
   if (!nrow(x)) return(x)
   if (!nrow(y)) return(if (!all) funique(x) else x)
@@ -85,6 +97,10 @@ fsetdiff = function(x, y, all=FALSE) {
 }
 
 funion = function(x, y, all=FALSE) {
+  if (is.vector(x) && is.vector(y)){
+    return(vec2dt(funion, x, y, all))
+  }
+
   .set_ops_arg_check(x, y, all, block_list = !all)
   ans = rbindlist(list(x, y))
   if (!all) ans = funique(ans)
@@ -92,6 +108,10 @@ funion = function(x, y, all=FALSE) {
 }
 
 fsetequal = function(x, y, all=TRUE) {
+  if (is.vector(x) && is.vector(y)){
+    return(vec2dt(fsetequal, x, y, all))
+  }
+
   .set_ops_arg_check(x, y, all)
   if (!all) {
     x = funique(x)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -17150,3 +17150,20 @@ test(2154.1, fread("0.0\n", colClasses="integer"), data.table(V1=0.0),
 test(2154.2, fread("A\n0.0\n", colClasses="integer"), data.table(A=0.0),
              warning="Attempt to override column 1 <<A>> of inherent type 'float64' down to 'int32' ignored.*please")
 
+x = c("a", "a", "b", "b", "c", NA)
+y = c("a", "a", "c", "d", "d", NA)
+test(2155.01, sort(fintersect(x,y), na.last=TRUE), c("a", "c", NA))
+test(2155.02, sort(fintersect(y,x), na.last=TRUE), c("a", "c", NA))
+test(2155.03, sort(fintersect(x,y, all=TRUE), na.last=TRUE), c("a", "a", "c", NA))
+test(2155.04, sort(fintersect(y,x, all=TRUE), na.last=TRUE), c("a", "a", "c", NA))
+test(2155.05, sort(funion(x,y), na.last=TRUE), c("a", "b", "c", "d", NA))
+test(2155.06, sort(funion(y,x), na.last=TRUE), c("a", "b", "c", "d", NA))
+test(2155.07, sort(funion(x,y, all=TRUE), na.last=TRUE), c("a", "a", "a", "a", "b", "b", "c", "c", "d", "d", NA, NA))
+test(2155.08, sort(funion(y,x, all=TRUE), na.last=TRUE), c("a", "a", "a", "a", "b", "b", "c", "c", "d", "d", NA, NA))
+test(2155.09, fsetdiff(x,y), c("b"))
+test(2155.10, fsetdiff(y,x), c("d"))
+test(2155.11, fsetdiff(x,y, all=TRUE), c("b", "b"))
+test(2155.12, fsetdiff(y,x, all=TRUE), c("d", "d"))
+test(2155.13, fsetequal(x,y), FALSE)
+test(2155.14, fsetequal(x,x), TRUE)
+

--- a/man/setops.Rd
+++ b/man/setops.Rd
@@ -12,7 +12,7 @@
 \alias{fsetequal}
 \title{ Set operations for data tables }
 \description{
-  Similar to base R set functions, \code{union}, \code{intersect}, \code{setdiff} and \code{setequal} but for \code{data.table}s. Additional \code{all} argument controls how duplicated rows are handled. Functions \code{fintersect}, \code{setdiff} (\code{MINUS} or \code{EXCEPT} in SQL) and \code{funion} are meant to provide functionality of corresponding SQL operators. Unlike SQL, data.table functions will retain row order.
+  Similar to base R set functions, \code{union}, \code{intersect}, \code{setdiff} and \code{setequal} but for \code{atomic vector}s and \code{data.table}s. Additional \code{all} argument controls how duplicated rows/values are handled. Functions \code{fintersect}, \code{setdiff} (\code{MINUS} or \code{EXCEPT} in SQL) and \code{funion} are meant to provide functionality of corresponding SQL operators. Unlike SQL, data.table functions will retain row/value order.
 }
 \usage{
 fintersect(x, y, all = FALSE)
@@ -22,14 +22,14 @@ fsetequal(x, y, all = TRUE)
 }
 \arguments{
 	\item{x, y}{\code{data.table}s.}
-	\item{all}{Logical. Default is \code{FALSE} and removes duplicate rows on the result. When \code{TRUE}, if there are \code{xn} copies of a particular row in \code{x} and \code{yn} copies of the same row in \code{y}, then:
+	\item{all}{Logical. Default is \code{FALSE} and removes duplicate rows/values on the result. When \code{TRUE}, if there are \code{xn} copies of a particular row/value in \code{x} and \code{yn} copies of the same row/value in \code{y}, then:
 		\itemize{
 
-			\item{\code{fintersect} will return \code{min(xn, yn)} copies of that row.}
+			\item{\code{fintersect} will return \code{min(xn, yn)} copies of that row/value.}
 
-			\item{\code{fsetdiff} will return \code{max(0, xn-yn)} copies of that row.}
+			\item{\code{fsetdiff} will return \code{max(0, xn-yn)} copies of that row/value.}
 
-			\item{\code{funion} will return \code{xn+yn} copies of that row.}
+			\item{\code{funion} will return \code{xn+yn} copies of that row/value.}
 			
 			\item{\code{fsetequal} will return \code{FALSE} unless \code{xn == yn}.}
 		}
@@ -39,7 +39,7 @@ fsetequal(x, y, all = TRUE)
   \code{bit64::integer64} columns are supported but not \code{complex} and \code{list}, except for \code{funion}.
 }
 \value{
-    A data.table in case of \code{fintersect}, \code{funion} and \code{fsetdiff}. Logical \code{TRUE} or \code{FALSE} for \code{fsetequal}.
+    A data.table or vector in case of \code{fintersect}, \code{funion} and \code{fsetdiff}. Logical \code{TRUE} or \code{FALSE} for \code{fsetequal}.
 }
 \seealso{ \code{\link{data.table}}, \code{\link{rbindlist}}, \code{\link{all.equal.data.table}}, \code{\link{unique}}, \code{\link{duplicated}}, \code{\link{uniqueN}}, \code{\link{anyDuplicated}}
 }
@@ -58,5 +58,14 @@ funion(x, y)                # union
 funion(x, y, all=TRUE)      # union all
 fsetequal(x, x2, all=FALSE) # setequal
 fsetequal(x, x2)            # setequal all
+
+x = c("a", "a", "b", "b", "c", NA)
+y = c("a", "a", "c", "d", "d", NA)
+fintersect(x, y)
+fintersect(x, y, all=TRUE)
+fsetdiff(x, y)
+fsetdiff(y, x, all=TRUE)
+funion(x, y)
+fsetequal(x, y)
 }
 \keyword{ data }


### PR DESCRIPTION
Closes #3752

Merely a wrapper for vectors to use `fintersect`, `funion`, `fsetdiff` and `fsetequal` also with vectors.

Whats interesting are the benchmarks.

```
set.seed(13)
x = round(rnorm(1e7), 4)
y = round(rnorm(1e7), 4)

microbenchmark::microbenchmark(
	base = intersect(x,y),
	dplyr = dplyr::intersect(x,y),
	dt = fintersect(x,y),
	times=10L)

Unit: milliseconds
  expr       min        lq      mean    median        uq       max neval
  base 1014.8031 1033.9171 1056.6386 1067.0683 1073.6028 1089.5941    10
 dplyr 1027.2003 1038.3417 1084.2351 1082.1406 1114.7926 1198.5054    10
    dt  732.0577  745.6789  755.5956  753.7491  765.2026  782.2758    10
```
Some speedup for reals due to threads (slower for single thread).

```
a = as.character(x)
b = as.character(y)
microbenchmark::microbenchmark(
	base = intersect(a,b),
	dplyr = dplyr::intersect(a,b),
	dt = fintersect(a,b),
	times=10L)

Unit: milliseconds
  expr      min        lq      mean    median        uq       max neval
  base 1061.917 1113.0419 1168.0659 1148.5322 1225.2934 1327.6311    10
 dplyr 1058.967 1149.0933 1152.5475 1158.7641 1184.9405 1212.4005    10
    dt  438.239  453.3726  536.0707  541.5542  592.0239  622.7527    10
```
Major speedup for characters (also faster for single thread).