### PR TITLE
Fix building from source on Mac OSX

### DIFF
--- a/configure
+++ b/configure
@@ -104,7 +104,7 @@ else
   sed -e "s|@openmp_cflags@|\$(SHLIB_OPENMP_CFLAGS)|" src/Makevars.in > src/Makevars
 fi
 # retain user supplied PKG_ env variables, #4664. See comments in Makevars.in too.
-sed -i "s|@PKG_CFLAGS@|$PKG_CFLAGS|" src/Makevars
-sed -i "s|@PKG_LIBS@|$PKG_LIBS|" src/Makevars
+sed -i "" "s|@PKG_CFLAGS@|$PKG_CFLAGS|" src/Makevars
+sed -i "" "s|@PKG_LIBS@|$PKG_LIBS|" src/Makevars
 
 exit 0

--- a/configure
+++ b/configure
@@ -104,7 +104,7 @@ else
   sed -e "s|@openmp_cflags@|\$(SHLIB_OPENMP_CFLAGS)|" src/Makevars.in > src/Makevars
 fi
 # retain user supplied PKG_ env variables, #4664. See comments in Makevars.in too.
-sed -e "s|@PKG_CFLAGS@|$PKG_CFLAGS|" src/Makevars > src/MakevarsTmp && mv src/MakevarsTmp src/Makevars
-sed -e "s|@PKG_LIBS@|$PKG_LIBS|" src/Makevars > src/MakevarsTmp && mv src/MakevarsTmp src/Makevars
+sed -e "s|@PKG_CFLAGS@|$PKG_CFLAGS|" src/Makevars > src/Makevars.tmp && mv src/Makevars.tmp src/Makevars
+sed -e "s|@PKG_LIBS@|$PKG_LIBS|" src/Makevars > src/Makevars.tmp && mv src/Makevars.tmp src/Makevars
 
 exit 0

--- a/configure
+++ b/configure
@@ -104,7 +104,7 @@ else
   sed -e "s|@openmp_cflags@|\$(SHLIB_OPENMP_CFLAGS)|" src/Makevars.in > src/Makevars
 fi
 # retain user supplied PKG_ env variables, #4664. See comments in Makevars.in too.
-sed -i "" "s|@PKG_CFLAGS@|$PKG_CFLAGS|" src/Makevars
-sed -i "" "s|@PKG_LIBS@|$PKG_LIBS|" src/Makevars
+sed -e "s|@PKG_CFLAGS@|$PKG_CFLAGS|" src/Makevars > src/MakevarsTmp && mv src/MakevarsTmp src/Makevars
+sed -e "s|@PKG_LIBS@|$PKG_LIBS|" src/Makevars > src/MakevarsTmp && mv src/MakevarsTmp src/Makevars
 
 exit 0


### PR DESCRIPTION
Fixes #4742 as the sed used on OSX is not the GNU version. In particular, the `sed -i` command is different.


By correcting the two lines, now I can build data.table from source on my Mac.


