### PR TITLE
copy altrep refs to specials too

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -17164,6 +17164,7 @@ for (i in 0:4) test(2155+i/10,
 # length(value)>=64, R creates an ALTREP REF wrapper. Which dogroups.c now catches.
 # Hence this test needs to be at least 128 rows, 2 groups of 64 each.
 DT = data.table(series=c("ts1","ts2"), value=rnorm(128))
-test(2156, DT[,list(list({attr(value,"class")<-"newclass";value})),by=series]$V1[[1L]][1L],
-           DT[1,value])
+test(2156.1, DT[,list(list({attr(value,"class")<-"newclass";value})),by=series]$V1[[1L]][1L],
+             DT[1,value])
+test(2156.2, truelength(DT[,list(list(value)),by=series]$V1[[1L]])>=0L)  # not -64 carried over by duplicate() of the .SD column
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -17158,7 +17158,7 @@ for (i in 0:4) test(2155+i/10,
   data.table(A=1:7, V1=42)
 )
 
-# dogroups.c eval(j) could create list columns containing altrep references to the specials, #PRNUM
+# dogroups.c eval(j) could create list columns containing altrep references to the specials, #4759
 # thanks to revdep testing of 1.13.2 where package tstools revealed this via ts() creating ALTREP, #4758
 # the attr(value,"class")<-"newclass" lines mimics a line at the end of stats::ts(). When the 
 # length(value)>=64, R creates an ALTREP REF wrapper. Which dogroups.c now catches.

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -17158,3 +17158,12 @@ for (i in 0:4) test(2155+i/10,
   data.table(A=1:7, V1=42)
 )
 
+# dogroups.c eval(j) could create list columns containing altrep references to the specials, #PRNUM
+# thanks to revdep testing of 1.13.2 where package tstools revealed this via ts() creating ALTREP, #4758
+# the attr(value,"class")<-"newclass" lines mimics a line at the end of stats::ts(). When the 
+# length(value)>=64, R creates an ALTREP REF wrapper. Which dogroups.c now catches.
+# Hence this test needs to be at least 128 rows, 2 groups of 64 each.
+DT = data.table(series=c("ts1","ts2"), value=rnorm(128))
+test(2156, DT[,list(list({attr(value,"class")<-"newclass";value})),by=series]$V1[[1L]][1L],
+           DT[1,value])
+

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -17167,4 +17167,7 @@ DT = data.table(series=c("ts1","ts2"), value=rnorm(128))
 test(2156.1, DT[,list(list({attr(value,"class")<-"newclass";value})),by=series]$V1[[1L]][1L],
              DT[1,value])
 test(2156.2, truelength(DT[,list(list(value)),by=series]$V1[[1L]])>=0L)  # not -64 carried over by duplicate() of the .SD column
+# cover NULL case in copyAsPlain by putting a NULL alongside a dogroups .SD column. The 'if(.GRP==1L)' is just for fun.
+test(2156.3, sapply(DT[, list(if (.GRP==1L) list(value,NULL) else list(NULL,value)), by=series]$V1, length),
+             INT(64,0,0,64))
 

--- a/src/dogroups.c
+++ b/src/dogroups.c
@@ -3,7 +3,7 @@
 #include <fcntl.h>
 #include <time.h>
 
-static SEXP copySpecialStaticAndAltrep(SEXP x) {
+static bool anySpecialStatic(SEXP x) {
   // Special refers to special symbols .BY, .I, .N, and .GRP; see special-symbols.Rd
   // Static because these are like C static arrays which are the same memory for each group; e.g., dogroups
   // creates .SD for the largest group once up front, overwriting the contents for each group. Their
@@ -42,16 +42,15 @@ static SEXP copySpecialStaticAndAltrep(SEXP x) {
   const int n = length(x);
   // use length() not LENGTH() because LENGTH() on NULL is segfault in R<3.5 where we still define USE_RINTERNALS
   // (see data.table.h), and isNewList() is true for NULL
-  if ((isVectorAtomic(x) && n>0 && TRUELENGTH(x)<0) || ALTREP(x))
-    return copyAsPlain(x);
-  if (isNewList(x)) for (int i=0; i<n; ++i) {
-    SEXP item = VECTOR_ELT(x,i);
-    SEXP newx = PROTECT(copySpecialStaticAndAltrep(item));
-    if (newx!=item)
-      SET_VECTOR_ELT(x,i,newx);
-    UNPROTECT(1);
+  if (n==0)
+    return false;
+  if (isVectorAtomic(x))
+    return TRUELENGTH(x)<0 || ALTREP(x);
+  if (isNewList(x)) for (int i=0; i<n; ++i) {  
+    if (anySpecialStatic(VECTOR_ELT(x,i)))
+      return true;
   }
-  return x;
+  return false;
 }
 
 SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEXP xjiscols, SEXP grporder, SEXP order, SEXP starts, SEXP lens, SEXP jexp, SEXP env, SEXP lhs, SEXP newnames, SEXP on, SEXP verboseArg)
@@ -297,14 +296,14 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
           SET_STRING_ELT(dtnames, colj, STRING_ELT(newnames, colj-origncol));
           copyMostAttrib(RHS, target); // attributes of first group dominate; e.g. initial factor levels come from first group
         }
-        bool prot = false;
-        if (isNewList(target)) {
-          RHS = PROTECT(copySpecialStaticAndAltrep(RHS));
-          prot = true;
+        bool copied = false;
+        if (isNewList(target) && anySpecialStatic(RHS)) {  // see comments in anySpecialStatic()
+          RHS = PROTECT(duplicate(RHS));
+          copied = true;
         }
         const char *warn = memrecycle(target, order, INTEGER(starts)[i]-1, grpn, RHS, 0, -1, 0, "");
         // can't error here because length mismatch already checked for all jval columns before starting to add any new columns
-        if (prot) UNPROTECT(1);
+        if (copied) UNPROTECT(1);
         if (warn)
           warning(_("Group %d column '%s': %s"), i+1, CHAR(STRING_ELT(dtnames, colj)), warn);
       }
@@ -402,14 +401,13 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
         if (thislen>1 && thislen!=maxn && grpn>0) {  // grpn>0 for grouping empty tables; test 1986
           error(_("Supplied %d items for column %d of group %d which has %d rows. The RHS length must either be 1 (single values are ok) or match the LHS length exactly. If you wish to 'recycle' the RHS please use rep() explicitly to make this intent clear to readers of your code."), thislen, j+1, i+1, maxn);
         }
-        bool prot = false;
-        if (isNewList(target)) {
-          source = PROTECT(copySpecialStaticAndAltrep(source));
-          // mostly this protect will be unnecessary as the components will be changed; see its comments
-          prot = true;
+        bool copied = false;
+        if (isNewList(target) && anySpecialStatic(source)) {  // see comments in anySpecialStatic()
+          source = PROTECT(duplicate(source));
+          copied = true;
         }
         memrecycle(target, R_NilValue, thisansloc, maxn, source, 0, -1, 0, "");
-        if (prot) UNPROTECT(1);
+        if (copied) UNPROTECT(1);
       }
     }
     ansloc += maxn;
@@ -429,7 +427,7 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
     }
   } else ans = R_NilValue;
   // Now reset length of .SD columns and .I to length of largest group, otherwise leak if the last group is smaller (often is).
-  // Also reset truelength on specials; see comments in anySpecialStatic().    // TODO update all comments using anySpecialStatic name
+  // Also reset truelength on specials; see comments in anySpecialStatic().
   for (int j=0; j<length(SDall); ++j) {
     SEXP this = VECTOR_ELT(SDall,j);
     SETLENGTH(this, maxGrpSize);

--- a/src/dogroups.c
+++ b/src/dogroups.c
@@ -298,7 +298,7 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
         }
         bool copied = false;
         if (isNewList(target) && anySpecialStatic(RHS)) {  // see comments in anySpecialStatic()
-          RHS = PROTECT(duplicate(RHS));
+          RHS = PROTECT(copyAsPlain(RHS));
           copied = true;
         }
         const char *warn = memrecycle(target, order, INTEGER(starts)[i]-1, grpn, RHS, 0, -1, 0, "");
@@ -403,7 +403,7 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
         }
         bool copied = false;
         if (isNewList(target) && anySpecialStatic(source)) {  // see comments in anySpecialStatic()
-          source = PROTECT(duplicate(source));
+          source = PROTECT(copyAsPlain(source));
           copied = true;
         }
         memrecycle(target, R_NilValue, thisansloc, maxn, source, 0, -1, 0, "");

--- a/src/utils.c
+++ b/src/utils.c
@@ -277,7 +277,7 @@ SEXP copyAsPlain(SEXP x) {
     const SEXP *xp=SEXPPTR_RO(x);
     for (int64_t i=0; i<n; ++i) SET_VECTOR_ELT(ans, i, copyAsPlain(xp[i]));
   } break;
-  default:
+  default:                                                                                           // # nocov
     error(_("Internal error: unsupported type '%s' passed to copyAsPlain()"), type2char(TYPEOF(x))); // # nocov
   }
   DUPLICATE_ATTRIB(ans, x);

--- a/src/utils.c
+++ b/src/utils.c
@@ -243,6 +243,10 @@ SEXP copyAsPlain(SEXP x) {
   // Intended for use on columns; to either un-ALTREP them or duplicate shared memory columns; see copySharedColumns() below
   // Not intended to be called on a DT VECSXP where a concept of 'deep' might refer to whether the columns are copied
   
+  if (isNull(x)) {
+    // deal with up front because isNewList(R_NilValue) is true
+    return R_NilValue;
+  }
   if (!isVectorAtomic(x) && !isNewList(x)) {
     // e.g. defer to R the CLOSXP in test 173.3 where a list column item is the function 'mean'
     return duplicate(x);
@@ -279,7 +283,7 @@ SEXP copyAsPlain(SEXP x) {
   DUPLICATE_ATTRIB(ans, x);
   // aside: unlike R's duplicate we do not copy truelength here; important for dogroups.c which uses negative truelenth to mark its specials
   if (ALTREP(ans))
-    error(_("Internal error: copyAsPlain returning an ALTREP for type '%s'"), type2char(TYPEOF(x))); // # nocov
+    error(_("Internal error: copyAsPlain returning ALTREP for type '%s'"), type2char(TYPEOF(x))); // # nocov
   UNPROTECT(1);
   return ans;
 }


### PR DESCRIPTION
See comments on the new test.
Fixes `tstools` in #4758
Removed the `# nocov` in `copyAsPlain` too and will cover in this PR if necessary.