### PR TITLE
extend g[ to work for tail queries like x[.N]

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 ## NEW FEATURES
 
+1. Group-wise queries like `x[.N]` or `.SD[.N-1L]` (i.e. an offset of `k>=0` from the end of the group at index `.N`) are now optimized, [#4809](https://github.com/Rdatatable/data.table/issues/4809) and part of [#735](https://github.com/Rdatatable/data.table/issues/4809). Previously only fixed positive offsets like `x[1L]` or `.SD[2L]` were optimized. Thanks to @matthewgson for the report.
+
 ## BUG FIXES
 
 1. `as.matrix(<empty DT>)` now retains the column type for the empty matrix result, [#4762](https://github.com/Rdatatable/data.table/issues/4762). Thus, for example, `min(DT[0])` where DT's columns are numeric, is now consistent with non-empty all-NA input and returns `Inf` with R's warning `no non-missing arguments to min; returning Inf` rather than R's error `only defined on a data frame with all numeric[-alike] variables`. Thanks to @mb706 for reporting.

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -8114,6 +8114,33 @@ fun = function (DT, tag = c("A", "B")) DT[, var := tag[[.GRP]], by = "id"]
 fun(DT)
 test(1581.19, DT, DT0[ , var := c('A', 'A', 'B')])
 
+# #4809 g[ with fromLast=TRUE (i.e. on queries like x[.N-k])
+DT = data.table(id = c(1, 1, 2), value = c(FALSE, TRUE, FALSE))
+options(datatable.optimize=1L)
+test(1581.20, ans1 <- DT[ , value[.N], by=id, verbose=TRUE], output="GForce FALSE")
+test(1581.21, ans2 <- DT[ , value[.N-1L], by=id, verbose=TRUE], output="GForce FALSE")
+options(datatable.optimize=Inf)
+test(1581.22, ans3 <- DT[ , value[.N], by=id, verbose=TRUE], output="GForce TRUE")
+test(1581.23, ans4 <- DT[ , value[.N-1L], by=id, verbose=TRUE], output="GForce TRUE")
+test(1581.24, ans1, ans3)
+#test(1581.25, ans2, ans4)
+
+idx = c(2L, 3L)
+DT[ , value := 0:2]
+test(1581.26, DT[ , value[.N], by=id], DT[idx, .(id, V1 = value)])
+
+DT[ , value := value + .1]
+test(1581.27, DT[ , value[.N], by=id], DT[idx, .(id, V1 = value)])
+
+DT[ , value := value + 1i]
+test(1581.28, DT[ , value[.N], by=id], DT[idx, .(id, V1 = value)])
+
+DT[ , value := letters[1:3]]
+test(1581.29, DT[ , value[.N], by=id], DT[idx, .(id, V1 = value)])
+
+DT[ , value := .(list(1, 1:2, 1:3))]
+test(1581.30, DT[ , value[.N], by=id], DT[idx, .(id, V1 = value)])
+
 # handle NULL value correctly #1429
 test(1582, uniqueN(NULL), 0L)
 


### PR DESCRIPTION
Closes #4809 

The idea is to detect `x[.N - k]` cases and send them to `g[`, which gets a new argument `fromLast` (default `FALSE`), so `x[1L]` becomes `"g["(x, 1L, FALSE)` and `x[.N-2L]` becomes `"g["(x, 2L, TRUE)`. Logic for `x[.N]` is basically the same as for `glast`.

Two things for feedback:

 - Any suggestions for improvement of the R implementation? In particular the part where we edit `jsub` feels somewhat redundant (running roughly same somewhat long list of checks on `jsub` a second time)
 - The edge case here has different semantics than for the old `fromLast=FALSE` cases -- in particular `DT[,x[0],id]` behaves differently than `DT[,x[.N+1],id]` -- any suggestions for how to implement this cleanly? Maybe it should be an error instead of allowing it and returning `NA`? That's not very nice (e.g. the workaround of suggesting the `base::` alternative is quite clunky for `[`) & would probably break some code.