### PR TITLE
More zlib/fwrite tracing for Solaris

### DIFF
--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -147,6 +147,7 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
     ", Sys.getlocale()=='", Sys.getlocale(), "'",
     ", l10n_info()=='", paste0(names(l10n_info()), "=", l10n_info(), collapse="; "), "'",
     ", getDTthreads()=='", paste0(gsub("[ ][ ]+","==",gsub("^[ ]+","",capture.output(invisible(getDTthreads(verbose=TRUE))))), collapse="; "), "'",
+    ", ", .Call(Cdt_zlib_version),
     "\n", sep="")
 
   if (inherits(err,"try-error")) {

--- a/src/init.c
+++ b/src/init.c
@@ -124,6 +124,7 @@ SEXP unlock();
 SEXP islockedR();
 SEXP allNAR();
 SEXP test_dt_win_snprintf();
+SEXP dt_zlib_version();
 
 // .Externals
 SEXP fastmean();
@@ -217,6 +218,7 @@ R_CallMethodDef callMethods[] = {
 {"CtestMsgR", (DL_FUNC) &testMsgR, -1},
 {"C_allNAR", (DL_FUNC) &allNAR, -1},
 {"Ctest_dt_win_snprintf", (DL_FUNC)&test_dt_win_snprintf, -1},
+{"Cdt_zlib_version", (DL_FUNC)&dt_zlib_version, -1},
 {NULL, NULL, 0}
 };
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -374,3 +374,10 @@ SEXP coerceUtf8IfNeeded(SEXP x) {
   return(ans);
 }
 
+#include <zlib.h>
+SEXP dt_zlib_version() {
+  char out[51];
+  snprintf(out, 50, "zlibVersion()==%s ZLIB_VERSION==%s", zlibVersion(), ZLIB_VERSION);
+  return ScalarString(mkChar(out));
+}
+


### PR DESCRIPTION
As per https://github.com/Rdatatable/data.table/issues/4099#issuecomment-736440844
Also adds zlib version (both library and header) into `test.data.table()` output.

New output of test 1658.421 when working correctly locally. The end of the long lines has the new detail.
```
DT = data.table(a=rep(1:2,each=100), b=rep(1:4,each=25))
fwrite(DT, file=f1<-tempfile(fileext=".gz"), verbose=TRUE)
  OpenMP version (_OPENMP)       201511
  omp_get_num_procs()            12
  R_DATATABLE_NUM_PROCS_PERCENT  unset (default 50)
  R_DATATABLE_NUM_THREADS        unset
  R_DATATABLE_THROTTLE           unset (default 1024)
  omp_get_thread_limit()         2147483647
  omp_get_max_threads()          12
  OMP_THREAD_LIMIT               unset
  OMP_NUM_THREADS                unset
  RestoreAfterFork               true
  data.table is using 6 threads with throttle==1024. See ?setDTthreads.
No list columns are present. Setting sep2='' otherwise quote='auto' would quote fields containing sep2.
Column writers: 3 3 
args.doRowNames=0 args.rowNames=0 doQuote=-128 args.nrow=200 args.ncol=2 eolLen=1
maxLineLen=51. Found in 0.000s
Writing bom (false), yaml (0 characters) and column names (true) ... z_stream for header (1): 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 b0 41 5f d3 55 00 00 90 50 04 20 8e 7f 00 00 a0 50 04 20 8e 7f 00 00 00 00 00 00 00 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 state: 90 a3 ab 21 fe 7f 00 00 39 00 00 00 strm==0x7ffe21aba390 state->strm==0x7ffe21aba390 state->status==57 zalloc==0x7f8e20045090 zfree==0x7f8e200450a0 (s->strm==strm)==1 s->next_out==(nil) s->avail_in=0 s->next_in=(nil) deflates()'s checks would return -2 here
deflate input stream: 0x55d355f6c780 39 0x55d35e976760 4 z_stream: 60 67 97 5e d3 55 00 00 04 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 80 c7 f6 55 d3 55 00 00 27 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 b0 41 5f d3 55 00 00 90 50 04 20 8e 7f 00 00 a0 50 04 20 8e 7f 00 00 00 00 00 00 00 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 state: 90 a3 ab 21 fe 7f 00 00 39 00 00 00 strm==0x7ffe21aba390 state->strm==0x7ffe21aba390 state->status==57 zalloc==0x7f8e20045090 zfree==0x7f8e200450a0 (s->strm==strm)==1 s->next_out==0x55d355f6c780 s->avail_in=4 s->next_in=0x55d35e976760 deflates()'s checks would be ok here
deflate returned 1 with stream->total_out==24; Z_FINISH==4, Z_OK==0, Z_STREAM_END==1 z_stream: 64 67 97 5e d3 55 00 00 00 00 00 00 00 00 00 00 04 00 00 00 00 00 00 00 98 c7 f6 55 d3 55 00 00 0f 00 00 00 00 00 00 00 18 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 b0 41 5f d3 55 00 00 90 50 04 20 8e 7f 00 00 a0 50 04 20 8e 7f 00 00 00 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00 c5 10 97 24 00 00 00 00 00 00 00 00 00 00 00 00 state: 90 a3 ab 21 fe 7f 00 00 9a 02 00 00 strm==0x7ffe21aba390 state->strm==0x7ffe21aba390 state->status==666 zalloc==0x7f8e20045090 zfree==0x7f8e200450a0 (s->strm==strm)==1 s->next_out==0x55d355f6c798 s->avail_in=0 s->next_in=0x55d35e976764 deflates()'s checks would be ok here
z_stream for header (2): 64 67 97 5e d3 55 00 00 00 00 00 00 00 00 00 00 04 00 00 00 00 00 00 00 98 c7 f6 55 d3 55 00 00 0f 00 00 00 00 00 00 00 18 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 b0 41 5f d3 55 00 00 90 50 04 20 8e 7f 00 00 a0 50 04 20 8e 7f 00 00 00 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00 c5 10 97 24 00 00 00 00 00 00 00 00 00 00 00 00 state: 90 a3 ab 21 fe 7f 00 00 9a 02 00 00 strm==0x7ffe21aba390 state->strm==0x7ffe21aba390 state->status==666 zalloc==0x7f8e20045090 zfree==0x7f8e200450a0 (s->strm==strm)==1 s->next_out==0x55d355f6c798 s->avail_in=0 s->next_in=0x55d35e976764 deflates()'s checks would be ok here
done in 0.002s
Writing 200 rows in 1 batches of 200 rows (each buffer size 8MB, showProgress=1, nth=1)
zbuffSize=8391193 returned from deflateBound
z_stream for data (1): 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 b0 41 5f d3 55 00 00 90 50 04 20 8e 7f 00 00 a0 50 04 20 8e 7f 00 00 00 00 00 00 00 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 state: 70 a2 ab 21 fe 7f 00 00 39 00 00 00 strm==0x7ffe21aba270 state->strm==0x7ffe21aba270 state->status==57 zalloc==0x7f8e20045090 zfree==0x7f8e200450a0 (s->strm==strm)==1 s->next_out==(nil) s->avail_in=0 s->next_in=(nil) deflates()'s checks would return -2 here
z_stream for data (2): 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 b0 41 5f d3 55 00 00 90 50 04 20 8e 7f 00 00 a0 50 04 20 8e 7f 00 00 00 00 00 00 00 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 state: 70 a2 ab 21 fe 7f 00 00 39 00 00 00 strm==0x7ffe21aba270 state->strm==0x7ffe21aba270 state->status==57 zalloc==0x7f8e20045090 zfree==0x7f8e200450a0 (s->strm==strm)==1 s->next_out==(nil) s->avail_in=0 s->next_in=(nil) deflates()'s checks would return -2 here
deflate input stream: 0x55d36495bb10 8391193 0x55d363d76b80 800 z_stream: 80 6b d7 63 d3 55 00 00 20 03 00 00 00 00 00 00 00 00 00 00 00 00 00 00 10 bb 95 64 d3 55 00 00 19 0a 80 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 b0 41 5f d3 55 00 00 90 50 04 20 8e 7f 00 00 a0 50 04 20 8e 7f 00 00 00 00 00 00 00 00 00 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 state: 70 a2 ab 21 fe 7f 00 00 39 00 00 00 strm==0x7ffe21aba270 state->strm==0x7ffe21aba270 state->status==57 zalloc==0x7f8e20045090 zfree==0x7f8e200450a0 (s->strm==strm)==1 s->next_out==0x55d36495bb10 s->avail_in=800 s->next_in=0x55d363d76b80 deflates()'s checks would be ok here
deflate returned 1 with stream->total_out==50; Z_FINISH==4, Z_OK==0, Z_STREAM_END==1 z_stream: a0 6e d7 63 d3 55 00 00 00 00 00 00 00 00 00 00 20 03 00 00 00 00 00 00 42 bb 95 64 d3 55 00 00 e7 09 80 00 00 00 00 00 32 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 b0 41 5f d3 55 00 00 90 50 04 20 8e 7f 00 00 a0 50 04 20 8e 7f 00 00 00 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00 f8 f0 0e c1 00 00 00 00 00 00 00 00 00 00 00 00 state: 70 a2 ab 21 fe 7f 00 00 9a 02 00 00 strm==0x7ffe21aba270 state->strm==0x7ffe21aba270 state->status==666 zalloc==0x7f8e20045090 zfree==0x7f8e200450a0 (s->strm==strm)==1 s->next_out==0x55d36495bb42 s->avail_in=0 s->next_in=0x55d363d76ea0 deflates()'s checks would be ok here
z_stream for data (3): a0 6e d7 63 d3 55 00 00 00 00 00 00 00 00 00 00 20 03 00 00 00 00 00 00 42 bb 95 64 d3 55 00 00 e7 09 80 00 00 00 00 00 32 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 b0 41 5f d3 55 00 00 90 50 04 20 8e 7f 00 00 a0 50 04 20 8e 7f 00 00 00 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00 f8 f0 0e c1 00 00 00 00 00 00 00 00 00 00 00 00 state: 70 a2 ab 21 fe 7f 00 00 9a 02 00 00 strm==0x7ffe21aba270 state->strm==0x7ffe21aba270 state->status==666 zalloc==0x7f8e20045090 zfree==0x7f8e200450a0 (s->strm==strm)==1 s->next_out==0x55d36495bb42 s->avail_in=0 s->next_in=0x55d363d76ea0 deflates()'s checks would be ok here
> 
```