### PR TITLE
cater for latest change in R-devel today which breaks test 2022

### DIFF
--- a/.dev/CRAN_Release.cmd
+++ b/.dev/CRAN_Release.cmd
@@ -301,7 +301,7 @@ tar xvf R-devel.tar.gz
 mv R-devel R-devel-strict-clang
 tar xvf R-devel.tar.gz
 
-cd R-devel  # used for revdep testing: .dev/revdep.R.
+cd R-devel  # may be used for revdep testing: .dev/revdep.R.
 # important to change directory name before building not after because the path is baked into the build, iiuc
 ./configure CFLAGS="-O2 -Wall -pedantic"
 make

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -425,7 +425,8 @@ test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,no
         setattr(xc,"index",NULL)   # too onerous to create test RHS with the correct index as well, just check result
         setattr(yc,"index",NULL)
         if (identical(xc,yc) && identical(key(x),key(y))) return(invisible(TRUE))  # check key on original x and y because := above might have cleared it on xc or yc
-        if (isTRUE(all.equal.result<-all.equal(xc,yc)) && identical(key(x),key(y)) &&
+        if (isTRUE(all.equal.result<-all.equal(xc,yc,check.environments=FALSE)) && identical(key(x),key(y)) &&
+                                                     # ^^ to pass tests 2022.[1-4] in R-devel from 5 Dec 2020
           identical(vapply_1c(xc,typeof), vapply_1c(yc,typeof))) return(invisible(TRUE))
       }
     }

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -426,7 +426,7 @@ test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,no
         setattr(yc,"index",NULL)
         if (identical(xc,yc) && identical(key(x),key(y))) return(invisible(TRUE))  # check key on original x and y because := above might have cleared it on xc or yc
         if (isTRUE(all.equal.result<-all.equal(xc,yc,check.environments=FALSE)) && identical(key(x),key(y)) &&
-                                                     # ^^ to pass tests 2022.[1-4] in R-devel from 5 Dec 2020
+                                                     # ^^ to pass tests 2022.[1-4] in R-devel from 5 Dec 2020, #4835
           identical(vapply_1c(xc,typeof), vapply_1c(yc,typeof))) return(invisible(TRUE))
       }
     }


### PR DESCRIPTION
In tests 2022.[1-4], the function value assigned has an environment attached. That environment isn't present in the RHS y value constructed by the `data.table()` call. R-devel's `all.equal` is now checking environments, on by default. More detail in https://github.com/wch/r-source/commit/4329ff7d48dcb745028b5cc1c651e373b4e7258c by @mmaechler.

Adding `check.environments=FALSE` to the `all.equal()` call in `test()` gets passed through to `all.equal.function` and fixes it. Since `all.equal` takes an `...` input, passing the new argument in old versions of R still works.

Test 2022 ...
```
d = data.table(id=c("a","b"), f=list(function(x) x*2, function(x) x^2), key="id")
d[.("a"), f:=function(x)x^3]
y = data.table(id=c("a","b"), f=list(function(x) x^3, function(x) x^2), key="id")
d$f[[1]]
# function(x)x^3
# <environment: 0x560c268b6118>
y$f[[1]]
# function(x) x^3

# before the change in R-devel
all.equal(d$f[[1]], y$f[[1]])
# [1] TRUE

# after the change in R-devel
all.equal(d$f[[1]], y$f[[1]])
# [1] "Names: 2 string mismatches"                                  
#  [2] "Length mismatch: comparison on first 2 components"           
#  [3] "Component 1: Modes: numeric, list"                           
#  [4] "Component 1: Lengths: 1, 2"                                  
#  [5] "Component 1: names for current but not for target"           
#  [6] "Component 1: Attributes: < target is NULL, current is list >"
#  [7] "Component 1: target is numeric, current is data.table"       
#  [8] "Component 2: Modes: numeric, list"                           
#  [9] "Component 2: Lengths: 1, 2"                                  
# [10] "Component 2: names for current but not for target"           
# [11] "Component 2: Attributes: < target is NULL, current is list >"
# [12] "Component 2: target is numeric, current is data.table"       

all.equal(d$f[[1]], y$f[[1]], check.environments=FALSE)
# [1] TRUE
```
