### PR TITLE
extra print in test summary

### DIFF
--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -177,7 +177,7 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
   cat("10 longest running tests took ", as.integer(tt<-DT[, sum(time)]), "s (", as.integer(100*tt/(ss<-timings[,sum(time)])), "% of ", as.integer(ss), "s)\n", sep="")
   print(DT, class=FALSE)
 
-  cat("All ",ntest," tests in ",names(fn)," completed ok in ",timetaken(env$started.at),"\n",sep="")
+  cat("All ",ntest," tests (last ",env$prevtest,") in ",names(fn)," completed ok in ",timetaken(env$started.at),"\n",sep="")
 
   ## this chunk requires to include new suggested deps: graphics, grDevices
   #memtest.plot = function(.inittime) {

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -12899,7 +12899,7 @@ for (col in c('b', 'c')) {
 #
 # tests-S4.R (S4 Compatability)
 #
-suppressWarnings(setClass("Data.Table", contains="data.table"))  # suppress 'Created a package name, ‘2018-05-26 06:14:43.444’, when none found'
+suppressWarnings(setClass("Data.Table", contains="data.table"))  # suppress "Created a package name, '2018-05-26 06:14:43.444', when none found"
 suppressWarnings(setClass("S4Composition", representation(data="data.table")))
 # data.table can be a parent class
 ids <- sample(letters[1:3], 10, replace=TRUE)


### PR DESCRIPTION
Output I am getting after first commit in this PR.
```
All 8259 tests (last 1913.24) in tests/tests.Rraw completed ok in 57.3s elapsed (00:01:12 cpu)
```
and after fixing the problem, in second commit.
```
All 9993 tests (last 2161.2) in inst/tests/tests.Rraw completed ok in 00:01:32 elapsed (00:01:49 cpu)
```
