### PR TITLE
Remove tracing of zlib/fwrite for Solaris

### DIFF
--- a/src/fwrite.c
+++ b/src/fwrite.c
@@ -564,50 +564,13 @@ int init_stream(z_stream *stream) {
   return err;  // # nocov
 }
 
-void print_z_stream(const z_stream *s)   // temporary tracing function for #4099
-{
-  const char *byte = (char *)s;
-  DTPRINT("sizeof(z_stream)==%d: ", sizeof(z_stream));
-  for (int i=0; i<sizeof(z_stream); ++i) {
-    DTPRINT("%02x ", *(unsigned char *)byte++);  // not byte[i] is attempt to avoid valgrind's use-of-uninitialized, #4639, and z_stream={0} now too
-  }
-  // e.g. sizeof(z_stream)==56 on CRAN Solaris, 88 on Windows 64bit, and 112 on 64bit Linux
-  // trace z_stream->state->status which zlib:deflateStateCheck checks, #4826
-  // this structure is not exposed, so we'll get to it via memory offsets using the trace output we put in to show on CRAN's Solaris output
-  const char *pos = (char *)&s->msg + sizeof(char *); // the field after *msg (exposed) is internal_state *state (not exposed)
-  byte = *(char **)pos;  // byte now at start of internal_state pointed to by s->state
-  char *strm = *(char **)byte; // first 8 bytes (or 4 on 32bit) is strm labeled 'pointer back to this zlib stream'
-  DTPRINT("state: ");
-  for (int i=0; i<(sizeof(char *) + sizeof(int)); ++i) {
-    DTPRINT("%02x ", *(unsigned char *)byte++);
-  }
-  int status = *(int *)(byte-sizeof(int));
-  DTPRINT("strm==%p state->strm==%p state->status==%d", s, strm, status);  // two pointer values should be the same
-  DTPRINT(" zalloc==%p zfree==%p", s->zalloc, s->zfree); // checked to be !=0 by deflate.c:deflateStateCheck
-  DTPRINT(" (s->strm==strm)==%d", (char *)s==strm);     // mimics the s->strm==strm check in deflate.c:deflateStateCheck
-  DTPRINT(" s->next_out==%p s->avail_in=%d s->next_in=%p", s->next_out, s->avail_in, s->next_in); // top of deflate.c:deflate() after the call to deflateStateCheck
-  DTPRINT(" deflates()'s checks (excluding status) would %s here",
-    (s->zalloc==(alloc_func)0 || s->zfree==(free_func)0 || s==Z_NULL || (char *)s!=strm ||
-      s->next_out==Z_NULL || (s->avail_in!=0 && s->next_in==Z_NULL)) ?
-    "return -2" : "be ok");
-  DTPRINT("\n");
-}
-
 int compressbuff(z_stream *stream, void* dest, size_t *destLen, const void* source, size_t sourceLen)
 {
   stream->next_out = dest;
   stream->avail_out = *destLen;
   stream->next_in = (Bytef *)source; // don't use z_const anywhere; #3939
   stream->avail_in = sourceLen;
-  if (verbose) {
-    DTPRINT(_("deflate input stream: %p %d %p %d z_stream: "), stream->next_out, (int)(stream->avail_out), stream->next_in, (int)(stream->avail_in));
-    print_z_stream(stream);
-  }
   int err = deflate(stream, Z_FINISH);
-  if (verbose) {
-    DTPRINT(_("deflate returned %d with stream->total_out==%d; Z_FINISH==%d, Z_OK==%d, Z_STREAM_END==%d z_stream: "), err, (int)(stream->total_out), Z_FINISH, Z_OK, Z_STREAM_END);
-    print_z_stream(stream);
-  }
   if (err == Z_OK) {
     // with Z_FINISH, deflate must return Z_STREAM_END if correct, otherwise it's an error and we shouldn't return Z_OK (0)
     err = -9;  // # nocov
@@ -766,7 +729,6 @@ void fwriteMain(fwriteMainArgs args)
           free(buff);                                    // # nocov
           STOP(_("Can't allocate gzip stream structure"));  // # nocov
         }
-        if (verbose) {DTPRINT(_("z_stream for header (%d): "), 1); print_z_stream(&stream);}
         size_t zbuffSize = deflateBound(&stream, headerLen);
         char *zbuff = malloc(zbuffSize);
         if (!zbuff) {
@@ -775,7 +737,6 @@ void fwriteMain(fwriteMainArgs args)
         }
         size_t zbuffUsed = zbuffSize;
         ret1 = compressbuff(&stream, zbuff, &zbuffUsed, buff, (size_t)(ch-buff));
-        if (verbose) {DTPRINT(_("z_stream for header (%d): "), 2); print_z_stream(&stream);}
         if (ret1==Z_OK) ret2 = WRITE(f, zbuff, (int)zbuffUsed);
         deflateEnd(&stream);
         free(zbuff);
@@ -881,13 +842,11 @@ void fwriteMain(fwriteMainArgs args)
         failed = true;              // # nocov
         my_failed_compress = -998;  // # nocov
       }
-      if (verbose) {DTPRINT(_("z_stream for data (%d): "), 1); print_z_stream(mystream);}
     }
 
     #pragma omp for ordered schedule(dynamic)
     for(int64_t start=0; start<args.nrow; start+=rowsPerBatch) {
       if (failed) continue;  // Not break. Because we don't use #omp cancel yet.
-      if (verbose && args.is_gzip) {DTPRINT(_("z_stream for data (%d): "), 2); print_z_stream(mystream);}  // extra trace point referred to in #4099
       int64_t end = ((args.nrow - start)<rowsPerBatch) ? args.nrow : start + rowsPerBatch;
       for (int64_t i=start; i<end; i++) {
         // Tepid starts here (once at beginning of each per line)
@@ -914,9 +873,7 @@ void fwriteMain(fwriteMainArgs args)
       // compress buffer if gzip
       if (args.is_gzip && !failed) {
         myzbuffUsed = zbuffSize;
-        if (verbose) {DTPRINT(_("z_stream for data (%d): "), 3); print_z_stream(mystream);}
         int ret = compressbuff(mystream, myzBuff, &myzbuffUsed, myBuff, (size_t)(ch-myBuff));
-        if (verbose) {DTPRINT(_("z_stream for data (%d): "), 4); print_z_stream(mystream);}
         if (ret) { failed=true; my_failed_compress=ret; }
         else deflateReset(mystream);
       }


### PR DESCRIPTION
Follow up to #4845 and #4099 to remove the tracing now it is passing on CRAN's Solaris.
Can always fetch this code from the history should we need it again.
