### PR TITLE
Marking columns as externally-referenced - WIP

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 2. `fintersect()` now retains the order of the first argument as reasonably expected, rather than retaining the order of the second argument, [#4716](https://github.com/Rdatatable/data.table/issues/4716). Thanks to Michel Lang for reporting, and Ben Schwen for the PR.
 
+3. After setDT, some (not all) data modifications leaked to other names bound to the origin data.frame. [#4783](https://github.com/Rdatatable/data.table/issues/4783). Thanks to Ofek Shilon for the report and PR.
+
 ## NOTES
 
 1. Compiling from source no longer requires `zlib` header files to be available, [#4844](https://github.com/Rdatatable/data.table/pull/4844). The output suggests installing `zlib` headers, and how (e.g. `zlib1g-dev` on Ubuntu) as before, but now proceeds with `gzip` compression disabled in `fwrite`. Upon calling `fwrite(DT, "file.csv.gz")` at runtime, an error message suggests to reinstall `data.table` with `zlib` headers available. This does not apply to users on Windows or Mac who install the pre-compiled binary package from CRAN.

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2637,6 +2637,12 @@ address = function(x) .Call(Caddress, eval(substitute(x), parent.frame()))
   stop('Check that is.data.table(DT) == TRUE. Otherwise, := and `:=`(...) are defined for use in j, once only and in particular ways. See help(":=").')
 }
 
+mark.external.ref.cols <- function(x, val=TRUE) {
+  lapply(names(x), function(nm) {
+    setattr(x[[nm]], "referenced.externally", val)
+  })  
+}
+
 setDF = function(x, rownames=NULL) {
   if (!is.list(x)) stop("setDF only accepts data.table, data.frame or list of equal length as input")
   if (anyDuplicated(rownames)) stop("rownames contains duplicates")
@@ -2653,6 +2659,7 @@ setDF = function(x, rownames=NULL) {
     setattr(x, "class", "data.frame")
     setattr(x, "sorted", NULL)
     setattr(x, ".internal.selfref", NULL)
+    mark.external.ref.cols(x, NULL)
   } else if (is.data.frame(x)) {
     if (!is.null(rownames)) {
       if (length(rownames) != nrow(x))
@@ -2721,6 +2728,7 @@ setDT = function(x, keep.rownames=FALSE, key=NULL, check.names=FALSE) {
     if (check.names) setattr(x, "names", make.names(names(x), unique=TRUE))
     # fix for #1078 and #1128, see .resetclass() for explanation.
     setattr(x, "class", .resetclass(x, 'data.frame'))
+    mark.external.ref.cols(x)
     setalloccol(x)
     if (!is.null(rn)) {
       nm = c(if (is.character(keep.rownames)) keep.rownames[1L] else "rn", names(x))
@@ -2761,6 +2769,7 @@ setDT = function(x, keep.rownames=FALSE, key=NULL, check.names=FALSE) {
     }
     setattr(x,"row.names",.set_row_names(n_range[2L]))
     setattr(x,"class",c("data.table","data.frame"))
+    # mark.external.ref.cols(x)
     setalloccol(x)
   } else {
     stop("Argument 'x' to 'setDT' should be a 'list', 'data.frame' or 'data.table'")

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -17261,3 +17261,10 @@ if (identical(x, enc2native(x))) {
 
 # fintersect now preserves order of first argument like intersect, #4716
 test(2163, fintersect(data.table(x=c("b", "c", "a")), data.table(x=c("a","c")))$x, c("c", "a"))
+
+# Avoid leakage of data changes after setDT to origin DF, #4783
+d1 <- data.frame(a=1)
+d2 <- d1
+setDT(d2)
+d2[!is.na(a), a:=2] # used to leak into d1
+test(2164, d1[["a"]], 2)

--- a/src/assign.c
+++ b/src/assign.c
@@ -503,7 +503,9 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values)
       continue;
     }
 
-    if (coln+1 > oldncol) {  // new column
+    const bool colReferencedExternally = !isNull(getAttrib(thisvalue, sym_referenced_externally)); // Fix #4783
+//    if (coln+1 > oldncol || colReferencedExternally) {  // new column
+   if (coln+1 > oldncol) {  // new column
       SET_VECTOR_ELT(dt, coln, targetcol=allocNAVectorLike(thisvalue, nrow));
       // initialize with NAs for when 'rows' is a subset and it doesn't touch
       // do not try to save the time to NA fill (contiguous branch free assign anyway) since being

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -99,6 +99,7 @@ extern SEXP sym_verbose;
 extern SEXP SelfRefSymbol;
 extern SEXP sym_inherits;
 extern SEXP sym_datatable_locked;
+extern SEXP sym_referenced_externally;
 extern SEXP sym_tzone;
 extern SEXP sym_old_fread_datetime_character;
 extern double NA_INT64_D;

--- a/src/init.c
+++ b/src/init.c
@@ -32,6 +32,7 @@ SEXP sym_verbose;
 SEXP SelfRefSymbol;
 SEXP sym_inherits;
 SEXP sym_datatable_locked;
+SEXP sym_referenced_externally;
 SEXP sym_tzone;
 SEXP sym_old_fread_datetime_character;
 double NA_INT64_D;
@@ -355,6 +356,7 @@ void attribute_visible R_init_datatable(DllInfo *info)
   SelfRefSymbol = install(".internal.selfref");
   sym_inherits = install("inherits");
   sym_datatable_locked = install(".data.table.locked");
+  sym_referenced_externally = install("referenced.externally");
   sym_tzone = install("tzone");
   sym_old_fread_datetime_character = install("datatable.old.fread.datetime.character");
 


### PR DESCRIPTION
This PR is not mergeable yet, it is intended to start a conversation.   I hope to get your feedback on the basic approach: _marking columns with an attribute saying they are also referenced outside the DT, and then use this attribute to bypass `memrecycle`._ 
It solves the immediate issue, but:
(1) Many tests break, as the output of setDT is indeed changed (additional attribute).
(2) I'm not entirely comfortable with this invasive approach.  Perhaps it would be better to contain the change inside the DT itself (adding a list attribute to it), and not add attributes to raw data.  I'm not sure which modifications would be required to make this work - cbind? Elsewhere?  Any thoughts are welcome.
