### PR TITLE
added markdown as well as rmarkdown to Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,7 +64,7 @@ Authors@R: c(
   person("Ben","Schwen",           role="ctb"))
 Depends: R (>= 3.1.0)
 Imports: methods
-Suggests: bit64 (>= 4.0.0), bit (>= 4.0.4), curl, R.utils, xts, nanotime, zoo (>= 1.8-1), yaml, knitr, rmarkdown
+Suggests: bit64 (>= 4.0.0), bit (>= 4.0.4), curl, R.utils, xts, nanotime, zoo (>= 1.8-1), yaml, knitr, rmarkdown, markdown
 SystemRequirements: zlib
 Description: Fast aggregation of large data (e.g. 100GB in RAM), fast ordered joins, fast add/modify/delete of columns by group using no copies at all, list columns, friendly and fast character-separated-value read/write. Offers a natural and flexible syntax, for faster development.
 License: MPL-2.0 | file LICENSE


### PR DESCRIPTION
GLCI build started to fail today.
Passes locally ok under --as-cran, and passes appveyor and travis.  Maybe there's been a package update somewhere upstream or something.
In #4605 we already added `rmarkdown` to Suggests as per yihui/knitr#1864. I wrote a comment in #4605 explaining that I had read the full text of the 1864 issue and reached conclusion that we should add `rmarkdown` and not `markdown`. That has worked since then until now.
Now adding `markdown` as well as `rmarkdown` to see if that solves GLCI build before trying to understand.

```
$ Rscript -e 'install.packages("knitr", repos=file.path("file:",normalizePath("bus/mirror-packages/cran")), quiet=TRUE)'
30also installing the dependencies ‘mime’, ‘glue’, ‘magrittr’, ‘stringi’, ‘evaluate’, ‘highr’, ‘markdown’, ‘stringr’, ‘yaml’, ‘xfun’
31$ rm -r bus
32$ echo "Revision:" $CI_BUILD_REF >> ./DESCRIPTION
33$ R CMD build .
34* checking for file ‘./DESCRIPTION’ ... OK
35* preparing ‘data.table’:
36* checking DESCRIPTION meta-information ... OK
37* cleaning src
38* running ‘cleanup’
39* installing the package to build vignettes
40* creating vignettes ... ERROR
41--- re-building ‘datatable-benchmarking.Rmd’ using rmarkdown
42Error: processing vignette 'datatable-benchmarking.Rmd' failed with diagnostics:
43The 'markdown' package should be declared as a dependency of the 'data.table' package (e.g., in the  'Suggests' field of DESCRIPTION), because the latter contains vignette(s) built with the 'markdown' package. Please see https://github.com/yihui/knitr/issues/1864 for more information.
44--- failed re-building ‘datatable-benchmarking.Rmd’
45--- re-building ‘datatable-faq.Rmd’ using rmarkdown
46Error: processing vignette 'datatable-faq.Rmd' failed with diagnostics:
47The 'markdown' package should be declared as a dependency of the 'data.table' package (e.g., in the  'Suggests' field of DESCRIPTION), because the latter contains vignette(s) built with the 'markdown' package. Please see https://github.com/yihui/knitr/issues/1864 for more information.
48--- failed re-building ‘datatable-faq.Rmd’
49--- re-building ‘datatable-importing.Rmd’ using rmarkdown
50Error: processing vignette 'datatable-importing.Rmd' failed with diagnostics:
51The 'markdown' package should be declared as a dependency of the 'data.table' package (e.g., in the  'Suggests' field of DESCRIPTION), because the latter contains vignette(s) built with the 'markdown' package. Please see https://github.com/yihui/knitr/issues/1864 for more information.
52--- failed re-building ‘datatable-importing.Rmd’
53--- re-building ‘datatable-intro.Rmd’ using rmarkdown
54Error: processing vignette 'datatable-intro.Rmd' failed with diagnostics:
55The 'markdown' package should be declared as a dependency of the 'data.table' package (e.g., in the  'Suggests' field of DESCRIPTION), because the latter contains vignette(s) built with the 'markdown' package. Please see https://github.com/yihui/knitr/issues/1864 for more information.
56--- failed re-building ‘datatable-intro.Rmd’
57--- re-building ‘datatable-keys-fast-subset.Rmd’ using rmarkdown
58Error: processing vignette 'datatable-keys-fast-subset.Rmd' failed with diagnostics:
59The 'markdown' package should be declared as a dependency of the 'data.table' package (e.g., in the  'Suggests' field of DESCRIPTION), because the latter contains vignette(s) built with the 'markdown' package. Please see https://github.com/yihui/knitr/issues/1864 for more information.
60--- failed re-building ‘datatable-keys-fast-subset.Rmd’
61--- re-building ‘datatable-reference-semantics.Rmd’ using rmarkdown
62Error: processing vignette 'datatable-reference-semantics.Rmd' failed with diagnostics:
63The 'markdown' package should be declared as a dependency of the 'data.table' package (e.g., in the  'Suggests' field of DESCRIPTION), because the latter contains vignette(s) built with the 'markdown' package. Please see https://github.com/yihui/knitr/issues/1864 for more information.
64--- failed re-building ‘datatable-reference-semantics.Rmd’
65--- re-building ‘datatable-reshape.Rmd’ using rmarkdown
66Error: processing vignette 'datatable-reshape.Rmd' failed with diagnostics:
67The 'markdown' package should be declared as a dependency of the 'data.table' package (e.g., in the  'Suggests' field of DESCRIPTION), because the latter contains vignette(s) built with the 'markdown' package. Please see https://github.com/yihui/knitr/issues/1864 for more information.
68--- failed re-building ‘datatable-reshape.Rmd’
69--- re-building ‘datatable-sd-usage.Rmd’ using rmarkdown
70Error: processing vignette 'datatable-sd-usage.Rmd' failed with diagnostics:
71The 'markdown' package should be declared as a dependency of the 'data.table' package (e.g., in the  'Suggests' field of DESCRIPTION), because the latter contains vignette(s) built with the 'markdown' package. Please see https://github.com/yihui/knitr/issues/1864 for more information.
72--- failed re-building ‘datatable-sd-usage.Rmd’
73--- re-building ‘datatable-secondary-indices-and-auto-indexing.Rmd’ using rmarkdown
74Error: processing vignette 'datatable-secondary-indices-and-auto-indexing.Rmd' failed with diagnostics:
75The 'markdown' package should be declared as a dependency of the 'data.table' package (e.g., in the  'Suggests' field of DESCRIPTION), because the latter contains vignette(s) built with the 'markdown' package. Please see https://github.com/yihui/knitr/issues/1864 for more information.
76--- failed re-building ‘datatable-secondary-indices-and-auto-indexing.Rmd’
77rm -rf *.tex *.bbl *.blg *.aux *.out *.toc *.log *.spl *tikzDictionary *.md figure/
78rm -rf *.tex *.bbl *.blg *.aux *.out *.toc *.log *.spl *tikzDictionary *.md figure/
79SUMMARY: processing the following files failed:
80  ‘datatable-benchmarking.Rmd’ ‘datatable-faq.Rmd’
81  ‘datatable-importing.Rmd’ ‘datatable-intro.Rmd’
82  ‘datatable-keys-fast-subset.Rmd’ ‘datatable-reference-semantics.Rmd’
83  ‘datatable-reshape.Rmd’ ‘datatable-sd-usage.Rmd’
84  ‘datatable-secondary-indices-and-auto-indexing.Rmd’
85Error: Vignette re-building failed.
86Execution halted
```