### PR TITLE
add `datatable.fwrite.sep` option

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,7 +61,8 @@ Authors@R: c(
   person("Vaclav","Tlapak",        role="ctb"),
   person("Kevin","Ushey",          role="ctb"),
   person("Dirk","Eddelbuettel",    role="ctb"),
-  person("Ben","Schwen",           role="ctb"))
+  person("Ben","Schwen",           role="ctb"),
+  person("Tony","Fischetti",       role="ctb"))
 Depends: R (>= 3.1.0)
 Imports: methods
 Suggests: bit64 (>= 4.0.0), bit (>= 4.0.4), curl, R.utils, xts, nanotime, zoo (>= 1.8-1), yaml, knitr, rmarkdown, markdown

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 3. `fwrite()` now writes UTF-8 or native csv files by specifying the `encoding=` argument, [#1770](https://github.com/Rdatatable/data.table/pull/1770). Thanks to @shrektan for the request and the PR.
 
+4. `fwrite()` can now use a new `datatable.fwrite.sep` option to set a default separator. Even with this option set, the separator can still be changed by using the `sep` argument. When not set, the default separator is still ",". Thanks to Tony Fischetti for the PR.
+
 ## BUG FIXES
 
 1. `by=.EACHI` when `i` is keyed but `on=` different columns than `i`'s key could create an invalidly keyed result, [#4603](https://github.com/Rdatatable/data.table/issues/4603) [#4911](https://github.com/Rdatatable/data.table/issues/4911). Thanks to @myoung3 and @adamaltmejd for reporting, and @ColeMiller1 for the PR. An invalid key is where a `data.table` is marked as sorted by the key columns but the data is not sorted by those columns, leading to incorrect results from subsequent queries.

--- a/R/fwrite.R
+++ b/R/fwrite.R
@@ -1,5 +1,6 @@
 fwrite = function(x, file="", append=FALSE, quote="auto",
-           sep=",", sep2=c("","|",""), eol=if (.Platform$OS.type=="windows") "\r\n" else "\n",
+           sep=getOption("datatable.fwrite.sep", ","),
+           sep2=c("","|",""), eol=if (.Platform$OS.type=="windows") "\r\n" else "\n",
            na="", dec=".", row.names=FALSE, col.names=TRUE,
            qmethod=c("double","escape"),
            logical01=getOption("datatable.logical01", FALSE), # due to change to TRUE; see NEWS

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -17329,3 +17329,15 @@ test(2168.01, print(DT, trunc.cols = 5L), error=c("Valid options for trunc.cols 
 test(2168.02, print(DT, trunc.cols = NA), error=c("Valid options for trunc.cols are TRUE and FALSE"))
 test(2168.03, print(DT, trunc.cols = "thing"), error=c("Valid options for trunc.cols are TRUE and FALSE"))
 test(2168.04, print(DT, trunc.cols = c(TRUE, FALSE)), error=c("Valid options for trunc.cols are TRUE and FALSE"))
+
+# check fwrite output using new default separator option
+DT = data.table(a=1, b=2)
+options(datatable.fwrite.sep='\t')
+ans = 'a\tb\n1\t2'
+test(2169.01, fwrite(DT), output=ans)
+options(datatable.fwrite.sep=';')
+ans = 'a;b\n1;2'
+test(2169.02, fwrite(DT), output=ans)
+options(datatable.fwrite.sep=NULL)
+ans = 'a,b\n1,2'
+test(2169.03, fwrite(DT), output=ans)

--- a/man/fwrite.Rd
+++ b/man/fwrite.Rd
@@ -6,7 +6,8 @@ As \code{write.csv} but much faster (e.g. 2 seconds versus 1 minute) and just as
 }
 \usage{
 fwrite(x, file = "", append = FALSE, quote = "auto",
-  sep = ",", sep2 = c("","|",""),
+  sep=getOption("datatable.fwrite.sep", ","),
+  sep2 = c("","|",""),
   eol = if (.Platform$OS.type=="windows") "\r\n" else "\n",
   na = "", dec = ".", row.names = FALSE, col.names = TRUE,
   qmethod = c("double","escape"),


### PR DESCRIPTION
With many kind of data, particularly with data heavy in text
fields, using ";" as a default separator can cause issues
when imported with naive parsers. This commit add a new global
option to set the default fwrite separator. Even with this option set,
the separator can still be changed by using the `sep` argument. When not
set, the default separator is still ",".