### PR TITLE
R-devel windows allow failure due to 4.2 paths

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -262,6 +262,7 @@ test-rel-win: ## R-release on Windows, test and build binaries
 
 test-dev-win: ## R-devel on Windows
   <<: *test-win
+  allow_failure: true
   variables:
     R_VERSION: "$R_DEVEL_VERSION"
   before_script:


### PR DESCRIPTION
Does not really resolve #4960 but makes the pipeline pass on that failure. I assume it is a temporary problem that happens between major version releases.
Once R release will be 4.1 we can revert this and upgrade env vars for new version. Currently those are still
```
  R_REL_VERSION: "4.0"
  R_DEVEL_VERSION: "4.1"
  R_OLDREL_VERSION: "3.6"
```