### PR TITLE
Fix 4783 - by adding an allow.assign.inplace attribute

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -62,7 +62,8 @@ Authors@R: c(
   person("Kevin","Ushey",          role="ctb"),
   person("Dirk","Eddelbuettel",    role="ctb"),
   person("Ben","Schwen",           role="ctb"),
-  person("Tony","Fischetti",       role="ctb"))
+  person("Tony","Fischetti",       role="ctb"),
+  person("Ofek","Shilon",          role="ctb"))
 Depends: R (>= 3.1.0)
 Imports: methods
 Suggests: bit64 (>= 4.0.0), bit (>= 4.0.4), curl, R.utils, xts, nanotime, zoo (>= 1.8-1), yaml, knitr, rmarkdown, markdown

--- a/NEWS.md
+++ b/NEWS.md
@@ -76,6 +76,8 @@
 
 10. `X[Y, .SD, by=]` (joining and grouping in the same query) could segfault if i) `by=` is supplied custom data (i.e. not simple expressions of columns), and ii) some rows of `Y` do not match to any rows in `X`, [#4892](https://github.com/Rdatatable/data.table/issues/4892). Thanks to @Kodiologist for reporting, @ColeMiller1 for investigating, and @tlapak for the PR.
 
+11. If a data.table was generated from an existing data.frame, as in `df2 <- df1; dt <- setDT(df1)`, some (but not all!) modifications to `dt` would leak to `df2`,  [#4783](https://github.com/Rdatatable/data.table/issues/4783). Thanks to @OfekShilon for investigating and the PR.
+
 ## NOTES
 
 1. New feature 29 in v1.12.4 (Oct 2019) introduced zero-copy coercion. Our thinking is that requiring you to get the type right in the case of `0` (type double) vs `0L` (type integer) is too inconvenient for you the user. So such coercions happen in `data.table` automatically without warning. Thanks to zero-copy coercion there is no speed penalty, even when calling `set()` many times in a loop, so there's no speed penalty to warn you about either. However, we believe that assigning a character value such as `"2"` into an integer column is more likely to be a user mistake that you would like to be warned about. The type difference (character vs integer) may be the only clue that you have selected the wrong column, or typed the wrong variable to be assigned to that column. For this reason we view character to numeric-like coercion differently and will warn about it. If it is correct, then the warning is intended to nudge you to wrap the RHS with `as.<type>()` so that it is clear to readers of your code that a coercion from character to that type is intended. For example :

--- a/R/as.data.table.R
+++ b/R/as.data.table.R
@@ -64,7 +64,7 @@ as.data.table.matrix = function(x, keep.rownames=FALSE, key=NULL, ...) {
     for (i in ic) value[[i]] <- as.vector(x[, i])       # to drop any row.names that would otherwise be retained inside every column of the data.table
   }
   col_labels = dimnames(x)[[2L]]
-  setDT(value)
+  setDT(value, set.allow.inplace.attrib=FALSE)
   if (length(col_labels) == ncols) {
     if (any(empty <- !nzchar(col_labels)))
       col_labels[empty] = paste0("V", ic[empty])
@@ -194,7 +194,7 @@ as.data.table.list = function(x,
   if (any(vnames==".SD")) stop("A column may not be called .SD. That has special meaning.")
   if (check.names) vnames = make.names(vnames, unique=TRUE)
   setattr(ans, "names", vnames)
-  setDT(ans, key=key) # copy ensured above; also, setDT handles naming
+  setDT(ans, key=key, set.allow.inplace.attrib=FALSE) # copy ensured above; also, setDT handles naming
   if (length(origListNames)==length(ans)) setattr(ans, "names", origListNames)  # PR 3854 and tests 2058.15-17
   ans
 }

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2086,6 +2086,7 @@ as.data.frame.data.table = function(x, ...)
   setattr(ans,"class","data.frame")
   setattr(ans,"sorted",NULL)  # remove so if you convert to df, do something, and convert back, it is not sorted
   setattr(ans,".internal.selfref",NULL)
+  setattr(ans, "allow.assign.inplace", NULL)
   # leave tl intact, no harm,
   ans
 }
@@ -2102,6 +2103,7 @@ as.list.data.table = function(x, ...) {
   setattr(ans, "row.names", NULL)
   setattr(ans, "sorted", NULL)
   setattr(ans,".internal.selfref", NULL)   # needed to pass S4 tests for example
+  setattr(ans, "allow.assign.inplace", NULL)
   ans
 }
 
@@ -2663,6 +2665,7 @@ setDF = function(x, rownames=NULL) {
     setattr(x, "class", "data.frame")
     setattr(x, "sorted", NULL)
     setattr(x, ".internal.selfref", NULL)
+    setattr(x, "allow.assign.inplace", NULL)
   } else if (is.data.frame(x)) {
     if (!is.null(rownames)) {
       if (length(rownames) != nrow(x))
@@ -2698,7 +2701,8 @@ setDF = function(x, rownames=NULL) {
   invisible(x)
 }
 
-setDT = function(x, keep.rownames=FALSE, key=NULL, check.names=FALSE) {
+setDT = function(x, keep.rownames=FALSE, key=NULL, check.names=FALSE,
+                 set.allow.inplace.attrib=TRUE) {
   name = substitute(x)
   if (is.name(name)) {
     home = function(x, env) {
@@ -2737,6 +2741,8 @@ setDT = function(x, keep.rownames=FALSE, key=NULL, check.names=FALSE) {
       x[, (nm[1L]) := rn]
       setcolorder(x, nm)
     }
+    if(set.allow.inplace.attrib)
+      setattr(x, "allow.assign.inplace", FALSE)
   } else if (is.list(x) && length(x)==1L && is.matrix(x[[1L]])) {
     # a single list(matrix) is unambiguous and depended on by some revdeps, #3581
     x = as.data.table.matrix(x[[1L]])
@@ -2772,6 +2778,8 @@ setDT = function(x, keep.rownames=FALSE, key=NULL, check.names=FALSE) {
     setattr(x,"row.names",.set_row_names(n_range[2L]))
     setattr(x,"class",c("data.table","data.frame"))
     setalloccol(x)
+    if(set.allow.inplace.attrib)
+      setattr(x, "allow.assign.inplace", FALSE)
   } else {
     stop("Argument 'x' to 'setDT' should be a 'list', 'data.frame' or 'data.table'")
   }

--- a/R/setops.R
+++ b/R/setops.R
@@ -177,7 +177,7 @@ all.equal.data.table = function(target, current, trim.levels=TRUE, check.attribu
 
     # Trim any extra row.names attributes that came from some inheritance
     # Trim ".internal.selfref" as long as there is no `all.equal.externalptr` method
-    exclude.attrs = function(x, attrs = c("row.names",".internal.selfref")) x[!names(x) %chin% attrs]
+    exclude.attrs = function(x, attrs = c("row.names",".internal.selfref", "allow.assign.inplace")) x[!names(x) %chin% attrs]
     a1 = exclude.attrs(attributes(target))
     a2 = exclude.attrs(attributes(current))
     if (length(a1) != length(a2)) return(sprintf("Datasets has different number of (non-excluded) attributes: target %s, current %s", length(a1), length(a2)))

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -7491,12 +7491,12 @@ test(1542.06, DT1, data.table(id=1:5, newCol=6:10, key="id"))
 DT1[3, id:=6L]
 test(1542.07, DT1, data.table(id=INT(1,2,6,4,5), newCol=6:10))
 
-# current wrong behaviour (invalid key, #3215); root cause is the shallow exposed uniquely via DT[TRUE]
-test(1542.08, DT$id, INT(1,2,6,4,5))
-test(1542.09, key(DT), "id")
-# future correct behaviour :
-# test(1542.10, DT$id, 1:5)
-# test(1542.11, key(DT), "id")
+# past wrong behaviour (invalid key, #3215); root cause is the shallow exposed uniquely via DT[TRUE]
+# test(1542.08, DT$id, INT(1,2,6,4,5))
+# test(1542.09, key(DT), "id")
+# current correct behaviour :
+test(1542.10, DT$id, 1:5)
+test(1542.11, key(DT), "id")
 
 # rest of #1130 - merge doesn't copy, instead uses joins without keys.
 set.seed(1L)
@@ -9003,18 +9003,19 @@ set.seed(123)
 dt = data.table(x1 = rep(letters[1:2], 6), x2 = rep(letters[3:5], 4), x3 = rep(letters[5:8], 3), y = rnorm(12))
 dt = dt[sample(.N)]
 df = as.data.frame(dt)
+setDT_noattr = function(x) setDT(x, set.allow.inplace.attrib=FALSE)
 # - [x] split by factor the same as `split.data.frame` - `f` argument ----
-test(1639.001, lapply(split(df, as.factor(1:2)), setDT), split(dt, as.factor(1:2))) # drop=FALSE on same factor
-test(1639.002, lapply(split(df, as.factor(1:2), drop=TRUE), setDT), split(dt, as.factor(1:2), drop=TRUE)) # drop=TRUE on same factor
-test(1639.003, lapply(split(df, as.factor(1:4)[3:2]), setDT), split(dt, as.factor(1:4)[3:2])) # drop=FALSE on same factor with empty levels
-test(1639.004, lapply(split(df, as.factor(1:4)[3:2], drop=TRUE), setDT), split(dt, as.factor(1:4)[3:2], drop=TRUE)) # drop=TRUE on same factor with empty levels
-test(1639.005, lapply(split(df, as.factor(1:12)), setDT), split(dt, as.factor(1:12))) # drop=FALSE factor length of nrow
-test(1639.006, lapply(split(df, as.factor(1:12), drop=TRUE), setDT), split(dt, as.factor(1:12), drop=TRUE)) # drop=TRUE factor length of nrow
+test(1639.001, lapply(split(df, as.factor(1:2)), setDT_noattr), split(dt, as.factor(1:2))) # drop=FALSE on same factor
+test(1639.002, lapply(split(df, as.factor(1:2), drop=TRUE), setDT_noattr), split(dt, as.factor(1:2), drop=TRUE)) # drop=TRUE on same factor
+test(1639.003, lapply(split(df, as.factor(1:4)[3:2]), setDT_noattr), split(dt, as.factor(1:4)[3:2])) # drop=FALSE on same factor with empty levels
+test(1639.004, lapply(split(df, as.factor(1:4)[3:2], drop=TRUE), setDT_noattr), split(dt, as.factor(1:4)[3:2], drop=TRUE)) # drop=TRUE on same factor with empty levels
+test(1639.005, lapply(split(df, as.factor(1:12)), setDT_noattr), split(dt, as.factor(1:12))) # drop=FALSE factor length of nrow
+test(1639.006, lapply(split(df, as.factor(1:12), drop=TRUE), setDT_noattr), split(dt, as.factor(1:12), drop=TRUE)) # drop=TRUE factor length of nrow
 ord = sample(2:13)
-test(1639.007, lapply(split(df, as.factor(1:14)[ord]), setDT), split(dt, as.factor(1:14)[ord])) # drop=FALSE factor length of nrow with empty levels
-test(1639.008, lapply(split(df, as.factor(1:14)[ord], drop=TRUE), setDT), split(dt, as.factor(1:14)[ord], drop=TRUE)) # drop=TRUE factor length of nrow with empty levels
-test(1639.009, lapply(split(df, list(as.factor(1:2), as.factor(3:2))), setDT), split(dt, list(as.factor(1:2), as.factor(3:2)))) # `f` list object drop=FALSE
-test(1639.010, lapply(split(df, list(as.factor(1:2), as.factor(3:2)), drop=TRUE), setDT), split(dt, list(as.factor(1:2), as.factor(3:2)), drop=TRUE)) # `f` list object drop=TRUE
+test(1639.007, lapply(split(df, as.factor(1:14)[ord]), setDT_noattr), split(dt, as.factor(1:14)[ord])) # drop=FALSE factor length of nrow with empty levels
+test(1639.008, lapply(split(df, as.factor(1:14)[ord], drop=TRUE), setDT_noattr), split(dt, as.factor(1:14)[ord], drop=TRUE)) # drop=TRUE factor length of nrow with empty levels
+test(1639.009, lapply(split(df, list(as.factor(1:2), as.factor(3:2))), setDT_noattr), split(dt, list(as.factor(1:2), as.factor(3:2)))) # `f` list object drop=FALSE
+test(1639.010, lapply(split(df, list(as.factor(1:2), as.factor(3:2)), drop=TRUE), setDT_noattr), split(dt, list(as.factor(1:2), as.factor(3:2)), drop=TRUE)) # `f` list object drop=TRUE
 test(1639.011, split(dt, as.factor(integer())), error = "group length is 0 but data nrow > 0") # factor length 0L
 test(1639.012, split(dt, as.factor(integer()), drop=TRUE), error = "group length is 0 but data nrow > 0")
 test(1639.013, split(dt, as.factor(1:2)[0L]), error = "group length is 0 but data nrow > 0") # factor length 0L with empty levels
@@ -9022,40 +9023,40 @@ test(1639.014, split(dt, as.factor(1:2)[0L], drop=TRUE), error = "group length i
 # - [x] edge cases for `f` argument ----
 test(1639.015, split(df, as.factor(NA)), split(dt, as.factor(NA))) # factor NA
 test(1639.016, split(df, as.factor(NA), drop=TRUE), split(dt, as.factor(NA), drop=TRUE))
-test(1639.017, lapply(split(df, as.factor(1:2)[0L][1L]), setDT), split(dt, as.factor(1:2)[0L][1L])) # factor NA with empty levels
+test(1639.017, lapply(split(df, as.factor(1:2)[0L][1L]), setDT_noattr), split(dt, as.factor(1:2)[0L][1L])) # factor NA with empty levels
 test(1639.018, split(df, as.factor(1:2)[0L][1L], drop=TRUE), split(dt, as.factor(1:2)[0L][1L], drop=TRUE))
-test(1639.019, lapply(split(df, as.factor(c(1L,NA,2L))), setDT), split(dt, as.factor(c(1L,NA,2L)))) # factor has NA
-test(1639.020, lapply(split(df, as.factor(c(1L,NA,2L)), drop=TRUE), setDT), split(dt, as.factor(c(1L,NA,2L)), drop=TRUE))
-test(1639.021, lapply(split(df, as.factor(c(1L,NA,2:4))[1:3]), setDT), split(dt, as.factor(c(1L,NA,2:4))[1:3])) # factor has NA with empty levels
-test(1639.022, lapply(split(df, as.factor(c(1L,NA,2:4))[1:3], drop=TRUE), setDT), split(dt, as.factor(c(1L,NA,2:4))[1:3], drop=TRUE))
-test(1639.023, lapply(split(df, letters[c(1L,NA,2L)]), setDT), split(dt, letters[c(1L,NA,2L)])) # character as `f` arg
-test(1639.024, lapply(split(df, letters[c(1L,NA,2L)], drop=TRUE), setDT), split(dt, letters[c(1L,NA,2L)], drop=TRUE))
-test(1639.025, lapply(split(df, "z"), setDT), split(dt, "z")) # character as `f` arg, length 1L
-test(1639.026, lapply(split(df, "z", drop=TRUE), setDT), split(dt, "z", drop=TRUE))
-test(1639.027, lapply(split(df, letters[c(1L,NA)]), setDT), split(dt, letters[c(1L,NA)])) # character as `f` arg, length 1L of non-NA
-test(1639.028, lapply(split(df, letters[c(1L,NA)], drop=TRUE), setDT), split(dt, letters[c(1L,NA)], drop=TRUE))
-test(1639.029, lapply(split(df[0L,], "z"), setDT), split(dt[0L], "z")) # nrow 0, f length 1-2
-test(1639.030, lapply(split(df[0L,], c("z1","z2")), setDT), split(dt[0L], c("z1","z2")))
-test(1639.031, lapply(split(df[0L,], "z", drop=TRUE), setDT), split(dt[0L], "z", drop=TRUE))
-test(1639.032, lapply(split(df[0L,], c("z1","z2"), drop=TRUE), setDT), split(dt[0L], c("z1","z2"), drop=TRUE))
-test(1639.033, lapply(split(df[1L,], "z"), setDT), split(dt[1L], "z")) # nrow 1, f length 1-2
-test(1639.034, lapply(suppressWarnings(split(df[1L,], c("z1","z2"))), setDT), suppressWarnings(split(dt[1L], c("z1","z2"))))
-test(1639.035, lapply(split(df[1L,], "z", drop=TRUE), setDT), split(dt[1L], "z", drop=TRUE) )
-test(1639.036, lapply(suppressWarnings(split(df[1L,], c("z1","z2"), drop=TRUE)), setDT), suppressWarnings(split(dt[1L], c("z1","z2"), drop=TRUE)))
-test(1639.037, lapply(split(df[0L,], as.factor(NA_character_)), setDT), split(dt[0L], as.factor(NA_character_))) # nrow 0, f factor length 1L NA
-test(1639.038, lapply(split(df[0L,], as.factor(NA_character_), drop=TRUE), setDT), split(dt[0L], as.factor(NA_character_), drop=TRUE))
-test(1639.039, lapply(split(df[0L,], as.factor(1:2)[0L][1L]), setDT), split(dt[0L], as.factor(1:2)[0L][1L])) # nrow 0, f factor length 1L NA with empty levels
-test(1639.040, lapply(split(df[0L,], as.factor(1:2)[0L][1L], drop=TRUE), setDT), split(dt[0L], as.factor(1:2)[0L][1L], drop=TRUE))
-test(1639.041, lapply(split(df[0L,], as.factor(integer())), setDT), split(dt[0L], as.factor(integer()))) # nrow 0, f factor length 0L
-test(1639.042, lapply(split(df[0L,], as.factor(integer()), drop=TRUE), setDT), split(dt[0L], as.factor(integer()), drop=TRUE))
-test(1639.043, lapply(split(df[0L,], as.factor(1:2)[0L]), setDT), split(dt[0L], as.factor(1:2)[0L])) # nrow 0, f factor length 0L with empty levels
-test(1639.044, lapply(split(df[0L,], as.factor(1:2)[0L], drop=TRUE), setDT), split(dt[0L], as.factor(1:2)[0L], drop=TRUE))
-test(1639.045, lapply(split(df[0L,], as.factor(1:3)[c(2L,NA,3L)]), setDT), split(dt[0L], as.factor(1:3)[c(2L,NA,3L)])) # nrow 0, f factor with empty levels and NA
-test(1639.046, lapply(split(df[0L,], as.factor(1:3)[c(2L,NA,3L)], drop=TRUE), setDT), split(dt[0L], as.factor(1:3)[c(2L,NA,3L)], drop=TRUE)) # nrow 0, f character length 1L NA
-test(1639.047, lapply(split(df[0L,], NA_character_), setDT), split(dt[0L], NA_character_))
-test(1639.048, lapply(split(df[0L,], NA_character_, drop=TRUE), setDT), split(dt[0L], NA_character_, drop=TRUE))
-test(1639.049, lapply(split(df[0L,], letters[c(NA,1:3)]), setDT), split(dt[0L], letters[c(NA,1:3)])) # nrow 0, f length > 1L, with NA
-test(1639.050, lapply(split(df[0L,], letters[c(NA,1:3)], drop=TRUE), setDT), split(dt[0L], letters[c(NA,1:3)], drop=TRUE))
+test(1639.019, lapply(split(df, as.factor(c(1L,NA,2L))), setDT_noattr), split(dt, as.factor(c(1L,NA,2L)))) # factor has NA
+test(1639.020, lapply(split(df, as.factor(c(1L,NA,2L)), drop=TRUE), setDT_noattr), split(dt, as.factor(c(1L,NA,2L)), drop=TRUE))
+test(1639.021, lapply(split(df, as.factor(c(1L,NA,2:4))[1:3]), setDT_noattr), split(dt, as.factor(c(1L,NA,2:4))[1:3])) # factor has NA with empty levels
+test(1639.022, lapply(split(df, as.factor(c(1L,NA,2:4))[1:3], drop=TRUE), setDT_noattr), split(dt, as.factor(c(1L,NA,2:4))[1:3], drop=TRUE))
+test(1639.023, lapply(split(df, letters[c(1L,NA,2L)]), setDT_noattr), split(dt, letters[c(1L,NA,2L)])) # character as `f` arg
+test(1639.024, lapply(split(df, letters[c(1L,NA,2L)], drop=TRUE), setDT_noattr), split(dt, letters[c(1L,NA,2L)], drop=TRUE))
+test(1639.025, lapply(split(df, "z"), setDT_noattr), split(dt, "z")) # character as `f` arg, length 1L
+test(1639.026, lapply(split(df, "z", drop=TRUE), setDT_noattr), split(dt, "z", drop=TRUE))
+test(1639.027, lapply(split(df, letters[c(1L,NA)]), setDT_noattr), split(dt, letters[c(1L,NA)])) # character as `f` arg, length 1L of non-NA
+test(1639.028, lapply(split(df, letters[c(1L,NA)], drop=TRUE), setDT_noattr), split(dt, letters[c(1L,NA)], drop=TRUE))
+test(1639.029, lapply(split(df[0L,], "z"), setDT_noattr), split(dt[0L], "z")) # nrow 0, f length 1-2
+test(1639.030, lapply(split(df[0L,], c("z1","z2")), setDT_noattr), split(dt[0L], c("z1","z2")))
+test(1639.031, lapply(split(df[0L,], "z", drop=TRUE), setDT_noattr), split(dt[0L], "z", drop=TRUE))
+test(1639.032, lapply(split(df[0L,], c("z1","z2"), drop=TRUE), setDT_noattr), split(dt[0L], c("z1","z2"), drop=TRUE))
+test(1639.033, lapply(split(df[1L,], "z"), setDT_noattr), split(dt[1L], "z")) # nrow 1, f length 1-2
+test(1639.034, lapply(suppressWarnings(split(df[1L,], c("z1","z2"))), setDT_noattr), suppressWarnings(split(dt[1L], c("z1","z2"))))
+test(1639.035, lapply(split(df[1L,], "z", drop=TRUE), setDT_noattr), split(dt[1L], "z", drop=TRUE) )
+test(1639.036, lapply(suppressWarnings(split(df[1L,], c("z1","z2"), drop=TRUE)), setDT_noattr), suppressWarnings(split(dt[1L], c("z1","z2"), drop=TRUE)))
+test(1639.037, lapply(split(df[0L,], as.factor(NA_character_)), setDT_noattr), split(dt[0L], as.factor(NA_character_))) # nrow 0, f factor length 1L NA
+test(1639.038, lapply(split(df[0L,], as.factor(NA_character_), drop=TRUE), setDT_noattr), split(dt[0L], as.factor(NA_character_), drop=TRUE))
+test(1639.039, lapply(split(df[0L,], as.factor(1:2)[0L][1L]), setDT_noattr), split(dt[0L], as.factor(1:2)[0L][1L])) # nrow 0, f factor length 1L NA with empty levels
+test(1639.040, lapply(split(df[0L,], as.factor(1:2)[0L][1L], drop=TRUE), setDT_noattr), split(dt[0L], as.factor(1:2)[0L][1L], drop=TRUE))
+test(1639.041, lapply(split(df[0L,], as.factor(integer())), setDT_noattr), split(dt[0L], as.factor(integer()))) # nrow 0, f factor length 0L
+test(1639.042, lapply(split(df[0L,], as.factor(integer()), drop=TRUE), setDT_noattr), split(dt[0L], as.factor(integer()), drop=TRUE))
+test(1639.043, lapply(split(df[0L,], as.factor(1:2)[0L]), setDT_noattr), split(dt[0L], as.factor(1:2)[0L])) # nrow 0, f factor length 0L with empty levels
+test(1639.044, lapply(split(df[0L,], as.factor(1:2)[0L], drop=TRUE), setDT_noattr), split(dt[0L], as.factor(1:2)[0L], drop=TRUE))
+test(1639.045, lapply(split(df[0L,], as.factor(1:3)[c(2L,NA,3L)]), setDT_noattr), split(dt[0L], as.factor(1:3)[c(2L,NA,3L)])) # nrow 0, f factor with empty levels and NA
+test(1639.046, lapply(split(df[0L,], as.factor(1:3)[c(2L,NA,3L)], drop=TRUE), setDT_noattr), split(dt[0L], as.factor(1:3)[c(2L,NA,3L)], drop=TRUE)) # nrow 0, f character length 1L NA
+test(1639.047, lapply(split(df[0L,], NA_character_), setDT_noattr), split(dt[0L], NA_character_))
+test(1639.048, lapply(split(df[0L,], NA_character_, drop=TRUE), setDT_noattr), split(dt[0L], NA_character_, drop=TRUE))
+test(1639.049, lapply(split(df[0L,], letters[c(NA,1:3)]), setDT_noattr), split(dt[0L], letters[c(NA,1:3)])) # nrow 0, f length > 1L, with NA
+test(1639.050, lapply(split(df[0L,], letters[c(NA,1:3)], drop=TRUE), setDT_noattr), split(dt[0L], letters[c(NA,1:3)], drop=TRUE))
 # - [x] split by reference to column names - `by` - for factor column ----
 fdt = dt[, c(lapply(.SD, as.factor), list(y=y)), .SDcols=x1:x3]
 l = split(fdt, by = "x1", flatten=FALSE) # single col
@@ -9123,9 +9124,9 @@ test(1639.060, TRUE, all(
   sapply(l, sapply, sapply, ncol) == rep(4L, 12)
 ))
 sdf = split(as.data.frame(fdt), f=list(fdt$x1, fdt$x3)) # split.data.frame match
-test(1639.061, unlist(split(fdt, by = c("x1","x3"), sorted = TRUE, flatten=FALSE), recursive = FALSE), lapply(sdf[sort(names(sdf))], setDT)) # vs split.data.frame by 2L drop=FALSE
+test(1639.061, unlist(split(fdt, by = c("x1","x3"), sorted = TRUE, flatten=FALSE), recursive = FALSE), lapply(sdf[sort(names(sdf))], setDT_noattr)) # vs split.data.frame by 2L drop=FALSE
 sdf = split(as.data.frame(fdt), f=list(fdt$x1, fdt$x3), drop=TRUE)
-test(1639.062, unlist(split(fdt, by = c("x1","x3"), sorted = TRUE, drop=TRUE, flatten=FALSE), recursive = FALSE), lapply(sdf[sort(names(sdf))], setDT)) # vs split.data.frame by 2L drop=TRUE
+test(1639.062, unlist(split(fdt, by = c("x1","x3"), sorted = TRUE, drop=TRUE, flatten=FALSE), recursive = FALSE), lapply(sdf[sort(names(sdf))], setDT_noattr)) # vs split.data.frame by 2L drop=TRUE
 fdt = dt[, .(x1 = as.factor(c(as.character(x1), "c"))[-13L], # empty levels in factor and drop=FALSE
              x2 = as.factor(c("a", as.character(x2)))[-1L],
              x3 = as.factor(c("a", as.character(x3), "z"))[c(-1L,-14L)],
@@ -9171,9 +9172,9 @@ test(1639.070, TRUE, all(
   sapply(l, sapply, ncol) == rep(4L, 4)
 ))
 sdf = split(as.data.frame(fdt), list(fdt$x3, fdt$x1)) # split.data.frame match on by = 2L and empty levels, drop=FALSE
-test(1639.071, unlist(split(fdt, by = c("x3","x1"), sorted=TRUE, flatten=FALSE), recursive = FALSE), lapply(sdf[sort(names(sdf))], setDT))
+test(1639.071, unlist(split(fdt, by = c("x3","x1"), sorted=TRUE, flatten=FALSE), recursive = FALSE), lapply(sdf[sort(names(sdf))], setDT_noattr))
 sdf = split(as.data.frame(fdt), list(fdt$x3, fdt$x1), drop=TRUE) # split.data.frame match on by = 2L and empty levels, drop=TRUE
-test(1639.072, unlist(split(fdt, by = c("x3","x1"), sorted=TRUE, drop=TRUE, flatten=FALSE), recursive = FALSE), lapply(sdf[sort(names(sdf))], setDT))
+test(1639.072, unlist(split(fdt, by = c("x3","x1"), sorted=TRUE, drop=TRUE, flatten=FALSE), recursive = FALSE), lapply(sdf[sort(names(sdf))], setDT_noattr))
 # - [x] split by reference to column names - `by` - factor and character column ----
 fdt = dt[, .(x1 = x1,
              x2 = x2,
@@ -9386,47 +9387,47 @@ test(1639.107, unlist(split(fdt, by = c("x1","x2"), sorted = TRUE, flatten = FAL
 test(1639.108, unlist(split(fdt, by = c("x1","x2"), sorted = FALSE, flatten = FALSE), recursive = FALSE), split(fdt, by = c("x1","x2"), sorted = FALSE)) # sorted=FALSE
 test(1639.109, unlist(split(fdt, by = c("x1","x2"), sorted = TRUE, keep.by = FALSE, flatten = FALSE), recursive = FALSE), split(fdt, by = c("x1","x2"), sorted = TRUE, keep.by = FALSE)) # drop.by=TRUE
 sdf = split(as.data.frame(fdt), f=list(fdt$x1, fdt$x2)) # vs split.data.frame by 2L # this will dispatch to `interaction(x1, x2)` which results into different order, see: levels(interaction(1:2,1:2)) vs CJ(1:2,1:2)
-test(1639.110, split(fdt, by = c("x1","x2"), sorted = TRUE), lapply(sdf[sort(names(sdf))], setDT))# vs split.data.frame by 2L drop=FALSE
-test(1639.111, unlist(split(fdt, by = c("x1","x2"), flatten = FALSE, sorted = TRUE), recursive = FALSE), lapply(sdf[sort(names(sdf))], setDT))# vs split.data.frame by 2L drop=FALSE, flatten=FALSE + unlist
+test(1639.110, split(fdt, by = c("x1","x2"), sorted = TRUE), lapply(sdf[sort(names(sdf))], setDT_noattr))# vs split.data.frame by 2L drop=FALSE
+test(1639.111, unlist(split(fdt, by = c("x1","x2"), flatten = FALSE, sorted = TRUE), recursive = FALSE), lapply(sdf[sort(names(sdf))], setDT_noattr))# vs split.data.frame by 2L drop=FALSE, flatten=FALSE + unlist
 sdf = split(as.data.frame(fdt), f=list(fdt$x1, fdt$x2), drop=TRUE)
-test(1639.112, split(fdt, by = c("x1","x2"), sorted = TRUE, drop=TRUE), lapply(sdf[sort(names(sdf))], setDT)) # vs split.data.frame by 2L drop=TRUE
+test(1639.112, split(fdt, by = c("x1","x2"), sorted = TRUE, drop=TRUE), lapply(sdf[sort(names(sdf))], setDT_noattr)) # vs split.data.frame by 2L drop=TRUE
 sdf = split(as.data.frame(fdt), f=list(fdt$x1, fdt$x2, fdt$x3)) # vs split.data.frame by 3L
-test(1639.113, split(fdt, by = c("x1","x2","x3"), flatten = TRUE, sorted = TRUE), lapply(sdf[sort(names(sdf))], setDT)) # vs split.data.frame by 3L drop=FALSE
+test(1639.113, split(fdt, by = c("x1","x2","x3"), flatten = TRUE, sorted = TRUE), lapply(sdf[sort(names(sdf))], setDT_noattr)) # vs split.data.frame by 3L drop=FALSE
 sdf = split(as.data.frame(fdt), f=list(fdt$x1, fdt$x2, fdt$x3), drop=TRUE)
-test(1639.114, split(fdt, by = c("x1","x2","x3"), flatten = TRUE, sorted = TRUE, drop=TRUE), lapply(sdf[sort(names(sdf))], setDT)) # vs split.data.frame by 3L drop=TRUE
+test(1639.114, split(fdt, by = c("x1","x2","x3"), flatten = TRUE, sorted = TRUE, drop=TRUE), lapply(sdf[sort(names(sdf))], setDT_noattr)) # vs split.data.frame by 3L drop=TRUE
 fdt = dt[, .(x1 = as.factor(c(as.character(x1), "c"))[-13L], # empty levels in factors
              x2 = as.factor(c("a", as.character(x2)))[-1L],
              x3 = as.factor(c("a", as.character(x3), "z"))[c(-1L,-14L)],
              y = y)]
 sdf = split(as.data.frame(fdt), f=list(fdt$x1, fdt$x2)) # vs split.data.frame by 2L # this will dispatch to `interaction(x1, x2)` which results into different order, see: levels(interaction(1:2,1:2)) vs CJ(1:2,1:2)
-test(1639.115, split(fdt, by = c("x1","x2"), sorted = TRUE), lapply(sdf[sort(names(sdf))], setDT)) # vs split.data.frame by 2L drop=FALSE
-test(1639.116, unlist(split(fdt, by = c("x1","x2"), flatten = FALSE, sorted = TRUE), recursive = FALSE), lapply(sdf[sort(names(sdf))], setDT)) # vs split.data.frame by 2L drop=FALSE, flatten=FALSE + unlist
+test(1639.115, split(fdt, by = c("x1","x2"), sorted = TRUE), lapply(sdf[sort(names(sdf))], setDT_noattr)) # vs split.data.frame by 2L drop=FALSE
+test(1639.116, unlist(split(fdt, by = c("x1","x2"), flatten = FALSE, sorted = TRUE), recursive = FALSE), lapply(sdf[sort(names(sdf))], setDT_noattr)) # vs split.data.frame by 2L drop=FALSE, flatten=FALSE + unlist
 sdf = split(as.data.frame(fdt), f=list(fdt$x1, fdt$x2), drop=TRUE)
-test(1639.117, split(fdt, by = c("x1","x2"), sorted = TRUE, drop=TRUE), lapply(sdf[sort(names(sdf))], setDT)) # vs split.data.frame by 2L drop=TRUE
+test(1639.117, split(fdt, by = c("x1","x2"), sorted = TRUE, drop=TRUE), lapply(sdf[sort(names(sdf))], setDT_noattr)) # vs split.data.frame by 2L drop=TRUE
 sdf = split(as.data.frame(fdt), f=list(fdt$x1, fdt$x2, fdt$x3)) # vs split.data.frame by 3L
-test(1639.118, split(fdt, by = c("x1","x2","x3"), flatten = TRUE, sorted = TRUE), lapply(sdf[sort(names(sdf))], setDT)) # vs split.data.frame by 3L drop=FALSE
+test(1639.118, split(fdt, by = c("x1","x2","x3"), flatten = TRUE, sorted = TRUE), lapply(sdf[sort(names(sdf))], setDT_noattr)) # vs split.data.frame by 3L drop=FALSE
 sdf = split(as.data.frame(fdt), f=list(fdt$x1, fdt$x2, fdt$x3), drop=TRUE)
-test(1639.119, split(fdt, by = c("x1","x2","x3"), flatten = TRUE, sorted = TRUE, drop=TRUE), lapply(sdf[sort(names(sdf))], setDT)) # vs split.data.frame by 3L drop=TRUE
+test(1639.119, split(fdt, by = c("x1","x2","x3"), flatten = TRUE, sorted = TRUE, drop=TRUE), lapply(sdf[sort(names(sdf))], setDT_noattr)) # vs split.data.frame by 3L drop=TRUE
 sdf = split(as.data.frame(fdt[, .SD, .SDcols=c("x3","y")]), f=list(fdt$x1, fdt$x2)) # flatten drop.by and empty lists # this will dispatch to `interaction(x1, x2)` which results into different order, see: levels(interaction(1:2,1:2)) vs CJ(1:2,1:2)
-test(1639.120, split(fdt, by = c("x1","x2"), sorted = TRUE, keep.by = FALSE), lapply(sdf[sort(names(sdf))], setDT)) # vs split.data.frame by 2L drop=FALSE
-test(1639.121, unlist(split(fdt, by = c("x1","x2"), flatten = FALSE, sorted = TRUE, keep.by = FALSE), recursive = FALSE), lapply(sdf[sort(names(sdf))], setDT)) # vs split.data.frame by 2L drop=FALSE, flatten=FALSE + unlist
+test(1639.120, split(fdt, by = c("x1","x2"), sorted = TRUE, keep.by = FALSE), lapply(sdf[sort(names(sdf))], setDT_noattr)) # vs split.data.frame by 2L drop=FALSE
+test(1639.121, unlist(split(fdt, by = c("x1","x2"), flatten = FALSE, sorted = TRUE, keep.by = FALSE), recursive = FALSE), lapply(sdf[sort(names(sdf))], setDT_noattr)) # vs split.data.frame by 2L drop=FALSE, flatten=FALSE + unlist
 sdf = split(as.data.frame(fdt[, .SD, .SDcols=c("x3","y")]), f=list(fdt$x1, fdt$x2), drop=TRUE)
-test(1639.122, split(fdt, by = c("x1","x2"), sorted = TRUE, drop=TRUE, keep.by = FALSE), lapply(sdf[sort(names(sdf))], setDT)) # vs split.data.frame by 2L drop=TRUE
+test(1639.122, split(fdt, by = c("x1","x2"), sorted = TRUE, drop=TRUE, keep.by = FALSE), lapply(sdf[sort(names(sdf))], setDT_noattr)) # vs split.data.frame by 2L drop=TRUE
 # - [x] edge cases for `by` and `sorted`, 0 rows, 1 unique value in cols, drop ----
 test(1639.123, length(split(dt[0L], by = "x1")), 0L) # drop=FALSE vs split.data.frame expand list with empty levels won't work on characters, use factor with defined levels, included those unused.
 test(1639.124, length(split(as.data.frame(dt[0L]), df$x1)), 2L) # unlike data.frame because character != factor
 fdt = dt[, c(lapply(.SD, as.factor), list(y=y)), .SDcols=x1:x3] # factors no empty levels
 test(1639.125, length(split(fdt[0L], by = "x1")), 2L)
 test(1639.126, length(split(as.data.frame(fdt[0L]), df$x1)), 2L) # match on factors work
-test(1639.127, split(fdt[0L], by = "x1"), lapply(split(as.data.frame(fdt[0L]), df$x1), setDT)) # we match also on complete structure
+test(1639.127, split(fdt[0L], by = "x1"), lapply(split(as.data.frame(fdt[0L]), df$x1), setDT_noattr)) # we match also on complete structure
 fdt = dt[, .(x1 = as.factor(c(as.character(x1), "c"))[-13L], # factors empty levels
              x2 = as.factor(c("a", as.character(x2)))[-1L],
              x3 = as.factor(c("a", as.character(x3), "z"))[c(-1L,-14L)],
              y = y)]
 sdf = split(as.data.frame(fdt), f=list(fdt$x1, fdt$x2)) # vs split.data.frame by 2L# this will dispatch to `interaction(x1, x2)` which results into different order, see: levels(interaction(1:2,1:2)) vs CJ(1:2,1:2)
-test(1639.128, split(fdt, by = c("x1","x2"), sorted = TRUE), lapply(sdf[sort(names(sdf))], setDT)) # vs split.data.frame by 2L drop=FALSE
+test(1639.128, split(fdt, by = c("x1","x2"), sorted = TRUE), lapply(sdf[sort(names(sdf))], setDT_noattr)) # vs split.data.frame by 2L drop=FALSE
 sdf = split(as.data.frame(fdt), f=list(fdt$x1, fdt$x2), drop=TRUE)
-test(1639.129, split(fdt, by = c("x1","x2"), sorted = TRUE, drop=TRUE), lapply(sdf[sort(names(sdf))], setDT)) # vs split.data.frame by 2L drop=TRUE
+test(1639.129, split(fdt, by = c("x1","x2"), sorted = TRUE, drop=TRUE), lapply(sdf[sort(names(sdf))], setDT_noattr)) # vs split.data.frame by 2L drop=TRUE
 test(1639.130, split(dt[0L], by = "x1"), structure(list(), .Names = character(0))) # 0 nrow character/factor with empty levels # no empty levels
 test(1639.131, split(fdt[0L], by = "x1"), lapply(c(a=1L,b=2L,c=3L), function(i) data.table(x1=factor(levels = c("a","b","c")),x2=factor(levels = c("a","c","d","e")),x3=factor(levels = c("a","e","f","g","h","z")),y=numeric()))) # expand empty levels
 test(1639.132, split(dt[0L], by = "x1", sorted = TRUE), structure(list(), .Names = character(0)))
@@ -9449,7 +9450,7 @@ test(1639.135, o2, ans)
 lapply(ans, setattr, ".data.table.locked", NULL)
 sort.by.names = function(x) x[sort(names(x))]
 test(1639.136, sort.by.names(ans), sort.by.names(split(as.data.table(df), f=list(df$product, df$year))))
-test(1639.137, sort.by.names(ans), sort.by.names(unlist(split(setDT(df), by=c("product","year"), flatten = FALSE), recursive = FALSE)))
+test(1639.137, sort.by.names(ans), sort.by.names(unlist(split(setDT_noattr(df), by=c("product","year"), flatten = FALSE), recursive = FALSE)))
 test(1639.138, ans, split(as.data.table(df), by=c("product","year")))
 test(1639.139, sort.by.names(ans), sort.by.names(unlist(split(as.data.table(df), by=c("product","year"), flatten=FALSE), recursive = FALSE)))
 # test if split preallocate columns in results #1908
@@ -17410,3 +17411,11 @@ x = data.table(id = 1:4, key = 'id')
 y = data.table(id = 2:5, key = 'id')
 z = data.table(c=c(2L, 2L, 1L, 1L), id=c(2L, 4L, 3L, NA))
 test(2178, x[y, .SD, by=.(c(2L, 1L, 2L, 1L))], z)
+
+	
+# Fix: In-place assignment can leak to origin DF, #4783
+d <- data.frame(a=c(1,2), b=c(1,2))
+df <- d
+setDT(d)
+d[!is.na(a), b:=c(3, 4)]  # Change shouldn't leak to df
+test(2179, df$b[1], 1)

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -101,6 +101,7 @@ extern SEXP sym_inherits;
 extern SEXP sym_datatable_locked;
 extern SEXP sym_tzone;
 extern SEXP sym_old_fread_datetime_character;
+extern SEXP sym_allow_assign_inplace;
 extern double NA_INT64_D;
 extern long long NA_INT64_LL;
 extern Rcomplex NA_CPLX;  // initialized in init.c; see there for comments

--- a/src/init.c
+++ b/src/init.c
@@ -34,6 +34,7 @@ SEXP sym_inherits;
 SEXP sym_datatable_locked;
 SEXP sym_tzone;
 SEXP sym_old_fread_datetime_character;
+SEXP sym_allow_assign_inplace;
 double NA_INT64_D;
 long long NA_INT64_LL;
 Rcomplex NA_CPLX;
@@ -359,7 +360,8 @@ void attribute_visible R_init_datatable(DllInfo *info)
   sym_datatable_locked = install(".data.table.locked");
   sym_tzone = install("tzone");
   sym_old_fread_datetime_character = install("datatable.old.fread.datetime.character");
-
+  sym_allow_assign_inplace = install("allow.assign.inplace");
+  
   initDTthreads();
   avoid_openmp_hang_within_fork();
 }


### PR DESCRIPTION
Previous fix attempts were too general (global option) or too specific (per-column attribute). This one, I hope, hits the right balance: `setDT` adds a per-dt attribute that disables in-place assignment semantics.  It was made from a fresh fork to ease merging.
I'll close the previous PRs.