### PR TITLE
Localize remaining loop variables

### DIFF
--- a/src/assign.c
+++ b/src/assign.c
@@ -149,7 +149,6 @@ static SEXP shallow(SEXP dt, SEXP cols, R_len_t n)
   // NEW: cols argument to specify the columns to shallow copy on. If NULL, all columns.
   // called from alloccol where n is checked carefully, or from shallow() at R level
   // where n is set to truelength (i.e. a shallow copy only with no size change)
-  R_len_t i,l;
   int protecti=0;
   SEXP newdt = PROTECT(allocVector(VECSXP, n)); protecti++;   // to do, use growVector here?
   SET_ATTRIB(newdt, shallow_duplicate(ATTRIB(dt)));
@@ -173,21 +172,20 @@ static SEXP shallow(SEXP dt, SEXP cols, R_len_t n)
 
   SEXP names = PROTECT(getAttrib(dt, R_NamesSymbol)); protecti++;
   SEXP newnames = PROTECT(allocVector(STRSXP, n)); protecti++;
+  const int l = isNull(cols) ? LENGTH(dt) : length(cols);
   if (isNull(cols)) {
-    l = LENGTH(dt);
-    for (i=0; i<l; i++) SET_VECTOR_ELT(newdt, i, VECTOR_ELT(dt,i));
+    for (int i=0; i<l; ++i) SET_VECTOR_ELT(newdt, i, VECTOR_ELT(dt,i));
     if (length(names)) {
       if (length(names) < l) error(_("Internal error: length(names)>0 but <length(dt)")); // # nocov
-      for (i=0; i<l; i++) SET_STRING_ELT(newnames, i, STRING_ELT(names,i));
+      for (int i=0; i<l; ++i) SET_STRING_ELT(newnames, i, STRING_ELT(names,i));
     }
     // else an unnamed data.table is valid e.g. unname(DT) done by ggplot2, and .SD may have its names cleared in dogroups, but shallow will always create names for data.table(NULL) which has 100 slots all empty so you can add to an empty data.table by reference ok.
   } else {
-    l = length(cols);
-    for (i=0; i<l; i++) SET_VECTOR_ELT(newdt, i, VECTOR_ELT(dt,INTEGER(cols)[i]-1));
+    for (int i=0; i<l; ++i) SET_VECTOR_ELT(newdt, i, VECTOR_ELT(dt,INTEGER(cols)[i]-1));
     if (length(names)) {
       // no need to check length(names) < l here. R-level checks if all value
       // in 'cols' are valid - in the range of 1:length(names(x))
-      for (i=0; i<l; i++) SET_STRING_ELT( newnames, i, STRING_ELT(names,INTEGER(cols)[i]-1) );
+      for (int i=0; i<l; ++i) SET_STRING_ELT( newnames, i, STRING_ELT(names,INTEGER(cols)[i]-1) );
     }
   }
   setAttrib(newdt, R_NamesSymbol, newnames);
@@ -290,12 +288,12 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values)
   // newcolnames : add these columns (if any)
   // cols : column names or numbers corresponding to the values to set
   // rows : row numbers to assign
-  R_len_t i, j, numToDo, targetlen, vlen, oldncol, oldtncol, coln, protecti=0, newcolnum, indexLength;
+  R_len_t numToDo, targetlen, vlen, oldncol, oldtncol, coln, protecti=0, newcolnum, indexLength;
   SEXP targetcol, nullint, s, colnam, tmp, key, index, a, assignedNames, indexNames;
   bool verbose=GetVerbose();
   int ndelete=0;  // how many columns are being deleted
   const char *c1, *tc1, *tc2;
-  int *buf, newKeyLength, indexNo;
+  int *buf, indexNo;
   if (isNull(dt)) error(_("assign has been passed a NULL dt"));
   if (TYPEOF(dt) != VECSXP) error(_("dt passed to assign isn't type VECSXP"));
   if (islocked(dt))
@@ -336,7 +334,7 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values)
     targetlen = length(rows);
     numToDo = 0;
     const int *rowsd = INTEGER(rows);
-    for (i=0; i<targetlen; i++) {
+    for (int i=0; i<targetlen; ++i) {
       if ((rowsd[i]<0 && rowsd[i]!=NA_INTEGER) || rowsd[i]>nrow)
         error(_("i[%d] is %d which is out of range [1,nrow=%d]."),i+1,rowsd[i],nrow);  // set() reaches here (test 2005.2); := reaches the same error in subset.c first
       if (rowsd[i]>=1) numToDo++;
@@ -364,13 +362,13 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values)
     PROTECT(tmp = chmatch(cols, names, 0)); protecti++;
     buf = (int *) R_alloc(length(cols), sizeof(int));
     int k=0;
-    for (i=0; i<length(cols); i++) {
+    for (int i=0; i<length(cols); ++i) {
       if (INTEGER(tmp)[i] == 0) buf[k++] = i;
     }
     if (k>0) {
       if (!isDataTable) error(_("set() on a data.frame is for changing existing columns, not adding new ones. Please use a data.table for that. data.table's are over-allocated and don't shallow copy."));
       newcolnames = PROTECT(allocVector(STRSXP, k)); protecti++;
-      for (i=0; i<k; i++) {
+      for (int i=0; i<k; ++i) {
         SET_STRING_ELT(newcolnames, i, STRING_ELT(cols, buf[i]));
         INTEGER(tmp)[buf[i]] = oldncol+i+1;
       }
@@ -409,7 +407,7 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values)
     }
   }
   // Check all inputs :
-  for (i=0; i<length(cols); i++) {
+  for (int i=0; i<length(cols); ++i) {
     coln = INTEGER(cols)[i];
     if (coln<1 || coln>oldncol+length(newcolnames)) {
       if (!isDataTable) error(_("Item %d of column numbers in j is %d which is outside range [1,ncol=%d]. set() on a data.frame is for changing existing columns, not adding new ones. Please use a data.table for that."), i+1, coln, oldncol);
@@ -436,8 +434,11 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values)
       }
       // RHS of assignment to new column is zero length but we'll use its type to create all-NA column of that type
     }
-    if (isMatrix(thisvalue) && (j=INTEGER(getAttrib(thisvalue, R_DimSymbol))[1]) > 1)  // matrix passes above (considered atomic vector)
-      warning(_("%d column matrix RHS of := will be treated as one vector"), j);
+    { 
+      int j;
+      if (isMatrix(thisvalue) && (j=INTEGER(getAttrib(thisvalue, R_DimSymbol))[1]) > 1)  // matrix passes above (considered atomic vector)
+        warning(_("%d column matrix RHS of := will be treated as one vector"), j);
+    }
     const SEXP existing = (coln+1)<=oldncol ? VECTOR_ELT(dt,coln) : R_NilValue;
     if (isFactor(existing) &&
       !isString(thisvalue) && TYPEOF(thisvalue)!=INTSXP && TYPEOF(thisvalue)!=LGLSXP && !isReal(thisvalue) && !isNewList(thisvalue)) {  // !=INTSXP includes factor
@@ -470,7 +471,7 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values)
       error(_("Internal error: selfrefnames is ok but tl names [%d] != tl [%d]"), TRUELENGTH(names), oldtncol);  // # nocov
     SETLENGTH(dt, oldncol+LENGTH(newcolnames));
     SETLENGTH(names, oldncol+LENGTH(newcolnames));
-    for (i=0; i<LENGTH(newcolnames); i++)
+    for (int i=0; i<LENGTH(newcolnames); ++i)
       SET_STRING_ELT(names,oldncol+i,STRING_ELT(newcolnames,i));
     // truelengths of both already set by alloccol
     if (oldncol==0) {
@@ -482,7 +483,7 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values)
       setAttrib(dt, R_RowNamesSymbol, rn);
     }
   }
-  for (i=0; i<length(cols); i++) {
+  for (int i=0; i<length(cols); ++i) {
     coln = INTEGER(cols)[i]-1;
     SEXP thisvalue = RHS_list_of_columns ? VECTOR_ELT(values, i) : values;
     if (TYPEOF(thisvalue)==NILSXP) {
@@ -528,14 +529,14 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values)
 
   *_Last_updated = numToDo;  // the updates have taken place with no error, so update .Last.updated now
   assignedNames = PROTECT(allocVector(STRSXP, LENGTH(cols))); protecti++;
-  for (i=0;i<LENGTH(cols);i++) SET_STRING_ELT(assignedNames,i,STRING_ELT(names,INTEGER(cols)[i]-1));
+  for (int i=0; i<LENGTH(cols); ++i) SET_STRING_ELT(assignedNames,i,STRING_ELT(names,INTEGER(cols)[i]-1));
   key = getAttrib(dt, sym_sorted);
   if (length(key)) {
     // if assigning to at least one key column, the key is truncated to one position before the first changed column.
     //any() and subsetVector() don't seem to be exposed by R API at C level, so this is done here long hand.
     PROTECT(tmp = chin(key, assignedNames)); protecti++;
-    newKeyLength = xlength(key);
-    for (i=0;i<LENGTH(tmp);i++) if (LOGICAL(tmp)[i]) {
+    int newKeyLength = length(key);
+    for (int i=0; i<LENGTH(tmp); ++i) if (LOGICAL(tmp)[i]) {
       // If a key column is being assigned to, set newKeyLength to the key element before since everything after that may have changed in order.
       newKeyLength = i;
       break;
@@ -543,10 +544,10 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values)
     if(newKeyLength == 0){
       // no valid key columns remain, remove the key
       setAttrib(dt, sym_sorted, R_NilValue);
-    } else if (newKeyLength < xlength(key)){
+    } else if (newKeyLength < length(key)){
       // new key is shorter than original one. Reassign
       PROTECT(tmp = allocVector(STRSXP, newKeyLength)); protecti++;
-      for (int i=0; i<newKeyLength; i++) SET_STRING_ELT(tmp, i, STRING_ELT(key, i));
+      for (int i=0; i<newKeyLength; ++i) SET_STRING_ELT(tmp, i, STRING_ELT(key, i));
       setAttrib(dt, sym_sorted, tmp);
     }
     //else: no key column changed, nothing to be done
@@ -589,7 +590,7 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values)
       memcpy(s4, c1, strlen(c1));
       memset(s4 + strlen(c1), '\0', 1);
       strcat(s4, "__"); // add trailing '__' to newKey so we can search for pattern '__colName__' also at the end of the index.
-      newKeyLength = strlen(c1);
+      int newKeyLength = strlen(c1);
       for(int i = 0; i < xlength(assignedNames); i++){
         tc2 = CHAR(STRING_ELT(assignedNames, i));
         char *s5 = (char*) malloc(strlen(tc2) + 5); //4 * '_' + \0

--- a/src/dogroups.c
+++ b/src/dogroups.c
@@ -372,7 +372,7 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
           if (verbose) Rprintf(_("The result of j is a named list. It's very inefficient to create the same names over and over again for each group. When j=list(...), any names are detected, removed and put back after grouping has completed, for efficiency. Using j=transform(), for example, prevents that speedup (consider changing to :=). This message may be upgraded to warning in future.\n"));  // e.g. test 104 has j=transform().
           // names of result come from the first group and the names of remaining groups are ignored (all that matters for them is that the number of columns (and their types) match the first group.
           SEXP names2 = PROTECT(allocVector(STRSXP,ngrpcols+njval));
-          //  for (j=0; j<ngrpcols; j++) SET_STRING_ELT(names2, j, STRING_ELT(bynames,j));  // These get set back up in R
+          //  for (int j=0; j<ngrpcols; ++j) SET_STRING_ELT(names2, j, STRING_ELT(bynames,j));  // These get set back up in R
           for (int j=0; j<njval; ++j) SET_STRING_ELT(names2, ngrpcols+j, STRING_ELT(jvalnames,j));
           setAttrib(ans, R_NamesSymbol, names2);
           UNPROTECT(1); // names2

--- a/src/fastmean.c
+++ b/src/fastmean.c
@@ -29,7 +29,7 @@ if we become out of line to base R (say if base R changed its mean).
 SEXP fastmean(SEXP args)
 {
   long double s = 0., t = 0.;
-  R_len_t i, l = 0, n = 0;
+  R_len_t l = 0, n = 0;
   SEXP x, ans, tmp;
   Rboolean narm=FALSE;
   x=CADR(args);
@@ -49,7 +49,7 @@ SEXP fastmean(SEXP args)
     switch(TYPEOF(x)) {
     case LGLSXP:
     case INTSXP:
-      for (i = 0; i<l; i++) {
+      for (int i=0; i<l; ++i) {
         if(INTEGER(x)[i] == NA_INTEGER) continue;
         s += INTEGER(x)[i];   // no under/overflow here, s is long double not integer
         n++;
@@ -60,7 +60,7 @@ SEXP fastmean(SEXP args)
         REAL(ans)[0] = R_NaN;  // consistent with base: mean(NA,na.rm=TRUE)==NaN==mean(numeric(),na.rm=TRUE)
       break;
     case REALSXP:
-      for (i = 0; i<l; i++) {
+      for (int i=0; i<l; ++i) {
         if(ISNAN(REAL(x)[i])) continue;  // TO DO: could drop this line and let NA propogate?
         s += REAL(x)[i];
         n++;
@@ -71,7 +71,7 @@ SEXP fastmean(SEXP args)
       }
       s /= n;
       if(R_FINITE((double)s)) {
-        for (i = 0; i<l; i++) {
+        for (int i=0; i<l; ++i) {
           if(ISNAN(REAL(x)[i])) continue;
           t += (REAL(x)[i] - s);
         }
@@ -86,20 +86,20 @@ SEXP fastmean(SEXP args)
     switch(TYPEOF(x)) {
     case LGLSXP:
     case INTSXP:
-      for (i = 0; i<l; i++) {
+      for (int i=0; i<l; ++i) {
         if(INTEGER(x)[i] == NA_INTEGER) {UNPROTECT(1); return(ans);}
         s += INTEGER(x)[i];
       }
       REAL(ans)[0] = (double) (s/l);
       break;
     case REALSXP:
-      for (i = 0; i<l; i++) {
+      for (int i=0; i<l; ++i) {
         if(ISNAN(REAL(x)[i])) {UNPROTECT(1); return(ans);}
         s += REAL(x)[i];
       }
       s /= l;
       if(R_FINITE((double)s)) {
-        for (i = 0; i<l; i++) {
+        for (int i=0; i<l; ++i) {
           // no NA if got this far
           t += (REAL(x)[i] - s);
         }
@@ -118,13 +118,13 @@ SEXP fastmean(SEXP args)
 /*
     case CPLXSXP:
       PROTECT(ans = allocVector(CPLXSXP, 1));
-      for (i = 0; i < n; i++) {
+      for (int i=0; i<n; ++i) {
       s += COMPLEX(x)[i].r;
       si += COMPLEX(x)[i].i;
       }
       s /= n; si /= n;
       if( R_FINITE((double)s) && R_FINITE((double)si) ) {
-      for (i = 0; i < n; i++) {
+      for (int i=0; i<n; ++i) {
         t += COMPLEX(x)[i].r - s;
         ti += COMPLEX(x)[i].i - si;
       }

--- a/src/fcast.c
+++ b/src/fcast.c
@@ -90,11 +90,10 @@ SEXP fcast(SEXP lhs, SEXP val, SEXP nrowArg, SEXP ncolArg, SEXP idxArg, SEXP fil
 // // # nocov start
 // // Note: all these functions below are internal functions and are designed specific to fcast.
 // SEXP zero_init(R_len_t n) {
-//   R_len_t i;
 //   SEXP ans;
 //   if (n < 0) error(_("Input argument 'n' to 'zero_init' must be >= 0"));
 //   ans = PROTECT(allocVector(INTSXP, n));
-//   for (i=0; i<n; i++) INTEGER(ans)[i] = 0;
+//   for (int i=0; i<n; ++i) INTEGER(ans)[i] = 0;
 //   UNPROTECT(1);
 //   return(ans);
 // }
@@ -126,11 +125,10 @@ SEXP fcast(SEXP lhs, SEXP val, SEXP nrowArg, SEXP ncolArg, SEXP idxArg, SEXP fil
 // }
 
 // SEXP diff_int(SEXP x, R_len_t n) {
-//   R_len_t i;
 //   SEXP ans;
 //   if (TYPEOF(x) != INTSXP) error(_("Argument 'x' to 'diff_int' must be an integer vector"));
 //   ans = PROTECT(allocVector(INTSXP, length(x)));
-//   for (i=1; i<length(x); i++)
+//   for (int i=1; i<length(x); ++i)
 //     INTEGER(ans)[i-1] = INTEGER(x)[i] - INTEGER(x)[i-1];
 //   INTEGER(ans)[length(x)-1] = n - INTEGER(x)[length(x)-1] + 1;
 //   UNPROTECT(1);
@@ -138,16 +136,16 @@ SEXP fcast(SEXP lhs, SEXP val, SEXP nrowArg, SEXP ncolArg, SEXP idxArg, SEXP fil
 // }
 
 // SEXP intrep(SEXP x, SEXP len) {
-//   R_len_t i,j,l=0, k=0;
+//   R_len_t l=0, k=0;
 //   SEXP ans;
 //   if (TYPEOF(x) != INTSXP || TYPEOF(len) != INTSXP) error(_("Arguments 'x' and 'len' to 'intrep' should both be integer vectors"));
 //   if (length(x) != length(len)) error(_("'x' and 'len' must be of same length"));
 //   // assuming both are of length >= 1
-//   for (i=0; i<length(len); i++)
+//   for (int i=0; i<length(len); ++i)
 //     l += INTEGER(len)[i]; // assuming positive values for len. internal use - can't bother to check.
 //   ans = PROTECT(allocVector(INTSXP, l));
-//   for (i=0; i<length(len); i++) {
-//     for (j=0; j<INTEGER(len)[i]; j++) {
+//   for (int i=0; i<length(len); ++i) {
+//     for (int j=0; j<INTEGER(len)[i]; ++j) {
 //       INTEGER(ans)[k++] = INTEGER(x)[i];
 //     }
 //   }

--- a/src/frank.c
+++ b/src/frank.c
@@ -154,7 +154,7 @@ SEXP anyNA(SEXP x, SEXP cols) {
       error(_("Item %d of 'cols' is %d which is outside 1-based range [1,ncol(x)=%d]"), i+1, elem, LENGTH(x));
     if (!n) n = length(VECTOR_ELT(x, elem-1));
   }
-  int j; // did we get to the end of the column without finding any NA in it?
+  int j=0; // did we get to the end of the column without finding any NA in it?
   for (int i=0; i<LENGTH(cols); ++i) {
     SEXP v = VECTOR_ELT(x, INTEGER(cols)[i]-1);
     if (!length(v) || isNewList(v) || isList(v)) continue; // like stats:::na.omit.data.frame, skip list/pairlist columns

--- a/src/frank.c
+++ b/src/frank.c
@@ -130,9 +130,9 @@ SEXP frank(SEXP xorderArg, SEXP xstartArg, SEXP xlenArg, SEXP ties_method) {
       }
       break;
     // case RUNLENGTH :
-    //   for (i = 0; i < length(xstartArg); i++) {
+    //   for (int i=0; i<length(xstartArg); ++i) {
     //     k=1;
-    //     for (j = xstart[i]-1; j < xstart[i]+xlen[i]-1; j++)
+    //     for (int j=xstart[i]-1; j<xstart[i]+xlen[i]-1; ++j)
     //       INTEGER(ans)[xorder[j]-1] = k++;
     //   }
     //   break;
@@ -145,19 +145,17 @@ SEXP frank(SEXP xorderArg, SEXP xstartArg, SEXP xlenArg, SEXP ties_method) {
 
 // internal version of anyNA for data.tables
 SEXP anyNA(SEXP x, SEXP cols) {
-  int i, j, n=0, elem;
-
+  int n=0;
   if (!isNewList(x)) error(_("Internal error. Argument 'x' to CanyNA is type '%s' not 'list'"), type2char(TYPEOF(x))); // #nocov
   if (!isInteger(cols)) error(_("Internal error. Argument 'cols' to CanyNA is type '%s' not 'integer'"), type2char(TYPEOF(cols))); // # nocov
-  for (i=0; i<LENGTH(cols); i++) {
-    elem = INTEGER(cols)[i];
+  for (int i=0; i<LENGTH(cols); ++i) {
+    const int elem = INTEGER(cols)[i];
     if (elem<1 || elem>LENGTH(x))
       error(_("Item %d of 'cols' is %d which is outside 1-based range [1,ncol(x)=%d]"), i+1, elem, LENGTH(x));
     if (!n) n = length(VECTOR_ELT(x, elem-1));
   }
-  SEXP ans = PROTECT(allocVector(LGLSXP, 1));
-  LOGICAL(ans)[0]=0;
-  for (i=0; i<LENGTH(cols); i++) {
+  int j; // did we get to the end of the column without finding any NA in it?
+  for (int i=0; i<LENGTH(cols); ++i) {
     SEXP v = VECTOR_ELT(x, INTEGER(cols)[i]-1);
     if (!length(v) || isNewList(v) || isList(v)) continue; // like stats:::na.omit.data.frame, skip list/pairlist columns
     if (n != length(v))
@@ -166,52 +164,38 @@ SEXP anyNA(SEXP x, SEXP cols) {
     switch (TYPEOF(v)) {
     case LGLSXP: {
       const int *iv = LOGICAL(v);
-      while(j < n && iv[j] != NA_LOGICAL) j++;
-      if (j < n) LOGICAL(ans)[0] = 1;
-    }
-      break;
+      while(j<n && iv[j]!=NA_LOGICAL) j++;
+    } break;
     case INTSXP: {
       const int *iv = INTEGER(v);
-      while(j < n && iv[j] != NA_INTEGER) j++;
-      if (j < n) LOGICAL(ans)[0] = 1;
-    }
-      break;
+      while(j<n && iv[j]!=NA_INTEGER) j++;
+    } break;
     case STRSXP: {
-      while (j < n && STRING_ELT(v, j) != NA_STRING) j++;
-      if (j < n) LOGICAL(ans)[0] = 1;
-    }
-      break;
-    case REALSXP: {
-      const double *dv = REAL(v);
+      const SEXP *sv = STRING_PTR(v);
+      while (j<n && sv[j]!=NA_STRING) j++;
+    } break;
+    case REALSXP:
       if (INHERITS(v, char_integer64)) {
-        for (j=0; j<n; j++) {
-          if (DtoLL(dv[j]) == NA_INT64_LL) {
-            LOGICAL(ans)[0] = 1;
-            break;
-          }
-        }
+        const int64_t *dv = (int64_t *)REAL(v);
+        while (j<n && dv[j]!=NA_INTEGER64) j++;
       } else {
-        while(j < n && !ISNAN(dv[j])) j++;
-        if (j < n) LOGICAL(ans)[0] = 1;
+        const double *dv = REAL(v);
+        while (j<n && !ISNAN(dv[j])) j++;
       }
-    }
       break;
-    case RAWSXP: {
-      // no such thing as a raw NA
-      // vector already initialised to all 0's
-    }
+    case RAWSXP:
+      // no such thing as a raw NA; vector already initialised to all 0's
+      j = n;
       break;
     case CPLXSXP: {
+      const Rcomplex *cv = COMPLEX(v);
       // taken from https://github.com/wch/r-source/blob/d75f39d532819ccc8251f93b8ab10d5b83aac89a/src/main/coerce.c
-      while (j < n && !ISNAN(COMPLEX(v)[j].r) && !ISNAN(COMPLEX(v)[j].i)) j++;
-      if (j < n) LOGICAL(ans)[0] = 1;
-    }
-      break;
+      while (j<n && !ISNAN(cv[j].r) && !ISNAN(cv[j].i)) j++;
+    } break;
     default:
       error(_("Unsupported column type '%s'"), type2char(TYPEOF(v)));
     }
-    if (LOGICAL(ans)[0]) break;
+    if (j<n) break; // don't look at any more columns; return true early
   }
-  UNPROTECT(1);
-  return(ans);
+  return ScalarLogical(j<n);
 }

--- a/src/gsumm.c
+++ b/src/gsumm.c
@@ -719,8 +719,7 @@ SEXP gmin(SEXP x, SEXP narm)
   if (!isLogical(narm) || LENGTH(narm)!=1 || LOGICAL(narm)[0]==NA_LOGICAL) error(_("na.rm must be TRUE or FALSE"));
   if (!isVectorAtomic(x)) error(_("GForce min can only be applied to columns, not .SD or similar. To find min of all items in a list such as .SD, either add the prefix base::min(.SD) or turn off GForce optimization using options(datatable.optimize=1). More likely, you may be looking for 'DT[,lapply(.SD,min),by=,.SDcols=]'"));
   if (inherits(x, "factor") && !inherits(x, "ordered")) error(_("min is not meaningful for factors."));
-  R_len_t i, ix, thisgrp=0;
-  int n = (irowslen == -1) ? length(x) : irowslen;
+  const int n = (irowslen == -1) ? length(x) : irowslen;
   //clock_t start = clock();
   SEXP ans;
   if (nrow != n) error(_("nrow [%d] != length(x) [%d] in %s"), nrow, n, "gmin");
@@ -729,27 +728,27 @@ SEXP gmin(SEXP x, SEXP narm)
   case LGLSXP: case INTSXP:
     ans = PROTECT(allocVector(INTSXP, ngrp)); protecti++;
     if (!LOGICAL(narm)[0]) {
-      for (i=0; i<ngrp; i++) INTEGER(ans)[i] = INT_MAX;
-      for (i=0; i<n; i++) {
-        thisgrp = grp[i];
-        ix = (irowslen == -1) ? i : irows[i]-1;
+      for (int i=0; i<ngrp; ++i) INTEGER(ans)[i] = INT_MAX;
+      for (int i=0; i<n; ++i) {
+        const int thisgrp = grp[i];
+        const int ix = (irowslen == -1) ? i : irows[i]-1;
         if (INTEGER(x)[ix] < INTEGER(ans)[thisgrp])   // NA_INTEGER==INT_MIN checked in init.c
           INTEGER(ans)[thisgrp] = INTEGER(x)[ix];
       }
     } else {
-      for (i=0; i<ngrp; i++) INTEGER(ans)[i] = NA_INTEGER;
-      for (i=0; i<n; i++) {
-        thisgrp = grp[i];
-        ix = (irowslen == -1) ? i : irows[i]-1;
+      for (int i=0; i<ngrp; ++i) INTEGER(ans)[i] = NA_INTEGER;
+      for (int i=0; i<n; ++i) {
+        const int thisgrp = grp[i];
+        const int ix = (irowslen == -1) ? i : irows[i]-1;
         if (INTEGER(x)[ix] == NA_INTEGER) continue;
         if (INTEGER(ans)[thisgrp] == NA_INTEGER || INTEGER(x)[ix] < INTEGER(ans)[thisgrp])
           INTEGER(ans)[thisgrp] = INTEGER(x)[ix];
       }
-      for (i=0; i<ngrp; i++) {
+      for (int i=0; i<ngrp; ++i) {
         if (INTEGER(ans)[i] == NA_INTEGER) {
           warning(_("No non-missing values found in at least one group. Coercing to numeric type and returning 'Inf' for such groups to be consistent with base"));
           ans = PROTECT(coerceVector(ans, REALSXP)); protecti++;
-          for (i=0; i<ngrp; i++) {
+          for (int i=0; i<ngrp; i++) {
             if (ISNA(REAL(ans)[i])) REAL(ans)[i] = R_PosInf;
           }
           break;
@@ -760,10 +759,10 @@ SEXP gmin(SEXP x, SEXP narm)
   case STRSXP:
     ans = PROTECT(allocVector(STRSXP, ngrp)); protecti++;
     if (!LOGICAL(narm)[0]) {
-      for (i=0; i<ngrp; i++) SET_STRING_ELT(ans, i, char_maxString); // char_maxString == "\xFF\xFF..." in init.c
-      for (i=0; i<n; i++) {
-        thisgrp = grp[i];
-        ix = (irowslen == -1) ? i : irows[i]-1;
+      for (int i=0; i<ngrp; ++i) SET_STRING_ELT(ans, i, char_maxString); // char_maxString == "\xFF\xFF..." in init.c
+      for (int i=0; i<n; ++i) {
+        const int thisgrp = grp[i];
+        const int ix = (irowslen == -1) ? i : irows[i]-1;
         if (STRING_ELT(x, ix) == NA_STRING) {
           SET_STRING_ELT(ans, thisgrp, NA_STRING);
         } else {
@@ -774,17 +773,17 @@ SEXP gmin(SEXP x, SEXP narm)
         }
       }
     } else {
-      for (i=0; i<ngrp; i++) SET_STRING_ELT(ans, i, NA_STRING);
-      for (i=0; i<n; i++) {
-        thisgrp = grp[i];
-        ix = (irowslen == -1) ? i : irows[i]-1;
+      for (int i=0; i<ngrp; ++i) SET_STRING_ELT(ans, i, NA_STRING);
+      for (int i=0; i<n; ++i) {
+        const int thisgrp = grp[i];
+        const int ix = (irowslen == -1) ? i : irows[i]-1;
         if (STRING_ELT(x, ix) == NA_STRING) continue;
         if (STRING_ELT(ans, thisgrp) == NA_STRING ||
           strcmp(CHAR(STRING_ELT(x, ix)), CHAR(STRING_ELT(ans, thisgrp))) < 0) {
           SET_STRING_ELT(ans, thisgrp, STRING_ELT(x, ix));
         }
       }
-      for (i=0; i<ngrp; i++) {
+      for (int i=0; i<ngrp; ++i) {
         if (STRING_ELT(ans, i)==NA_STRING) {
           warning(_("No non-missing values found in at least one group. Returning 'NA' for such groups to be consistent with base"));
           break;
@@ -795,23 +794,23 @@ SEXP gmin(SEXP x, SEXP narm)
   case REALSXP:
     ans = PROTECT(allocVector(REALSXP, ngrp)); protecti++;
     if (!LOGICAL(narm)[0]) {
-      for (i=0; i<ngrp; i++) REAL(ans)[i] = R_PosInf;
-      for (i=0; i<n; i++) {
-        thisgrp = grp[i];
-        ix = (irowslen == -1) ? i : irows[i]-1;
+      for (int i=0; i<ngrp; ++i) REAL(ans)[i] = R_PosInf;
+      for (int i=0; i<n; ++i) {
+        const int thisgrp = grp[i];
+        const int ix = (irowslen == -1) ? i : irows[i]-1;
         if (ISNAN(REAL(x)[ix]) || REAL(x)[ix] < REAL(ans)[thisgrp])
           REAL(ans)[thisgrp] = REAL(x)[ix];
       }
     } else {
-      for (i=0; i<ngrp; i++) REAL(ans)[i] = NA_REAL;
-      for (i=0; i<n; i++) {
-        thisgrp = grp[i];
-        ix = (irowslen == -1) ? i : irows[i]-1;
+      for (int i=0; i<ngrp; ++i) REAL(ans)[i] = NA_REAL;
+      for (int i=0; i<n; ++i) {
+        const int thisgrp = grp[i];
+        const int ix = (irowslen == -1) ? i : irows[i]-1;
         if (ISNAN(REAL(x)[ix])) continue;
         if (ISNAN(REAL(ans)[thisgrp]) || REAL(x)[ix] < REAL(ans)[thisgrp])
           REAL(ans)[thisgrp] = REAL(x)[ix];
       }
-      for (i=0; i<ngrp; i++) {
+      for (int i=0; i<ngrp; ++i) {
         if (ISNAN(REAL(ans)[i])) {
           warning(_("No non-missing values found in at least one group. Returning 'Inf' for such groups to be consistent with base"));
           for (; i<ngrp; i++) if (ISNAN(REAL(ans)[i])) REAL(ans)[i] = R_PosInf;
@@ -838,24 +837,23 @@ SEXP gmax(SEXP x, SEXP narm)
   if (!isLogical(narm) || LENGTH(narm)!=1 || LOGICAL(narm)[0]==NA_LOGICAL) error(_("na.rm must be TRUE or FALSE"));
   if (!isVectorAtomic(x)) error(_("GForce max can only be applied to columns, not .SD or similar. To find max of all items in a list such as .SD, either add the prefix base::max(.SD) or turn off GForce optimization using options(datatable.optimize=1). More likely, you may be looking for 'DT[,lapply(.SD,max),by=,.SDcols=]'"));
   if (inherits(x, "factor") && !inherits(x, "ordered")) error(_("max is not meaningful for factors."));
-  R_len_t i, ix, thisgrp=0;
-  int n = (irowslen == -1) ? length(x) : irowslen;
+  const int n = (irowslen == -1) ? length(x) : irowslen;
   //clock_t start = clock();
   SEXP ans;
   if (nrow != n) error(_("nrow [%d] != length(x) [%d] in %s"), nrow, n, "gmax");
 
   // TODO rework gmax in the same way as gmin and remove this *update
   char *update = (char *)R_alloc(ngrp, sizeof(char));
-  for (int i=0; i<ngrp; i++) update[i] = 0;
+  for (int i=0; i<ngrp; ++i) update[i] = 0;
   int protecti=0;
   switch(TYPEOF(x)) {
   case LGLSXP: case INTSXP:
     ans = PROTECT(allocVector(INTSXP, ngrp)); protecti++;
-    for (i=0; i<ngrp; i++) INTEGER(ans)[i] = 0;
+    for (int i=0; i<ngrp; ++i) INTEGER(ans)[i] = 0;
     if (!LOGICAL(narm)[0]) { // simple case - deal in a straightforward manner first
-      for (i=0; i<n; i++) {
-        thisgrp = grp[i];
-        ix = (irowslen == -1) ? i : irows[i]-1;
+      for (int i=0; i<n; ++i) {
+        const int thisgrp = grp[i];
+        const int ix = (irowslen == -1) ? i : irows[i]-1;
         if (INTEGER(x)[ix] != NA_INTEGER && INTEGER(ans)[thisgrp] != NA_INTEGER) {
           if ( update[thisgrp] != 1 || INTEGER(ans)[thisgrp] < INTEGER(x)[ix] ) {
             INTEGER(ans)[thisgrp] = INTEGER(x)[ix];
@@ -864,9 +862,9 @@ SEXP gmax(SEXP x, SEXP narm)
         } else  INTEGER(ans)[thisgrp] = NA_INTEGER;
       }
     } else {
-      for (i=0; i<n; i++) {
-        thisgrp = grp[i];
-        ix = (irowslen == -1) ? i : irows[i]-1;
+      for (int i=0; i<n; ++i) {
+        const int thisgrp = grp[i];
+        const int ix = (irowslen == -1) ? i : irows[i]-1;
         if (INTEGER(x)[ix] != NA_INTEGER) {
           if ( update[thisgrp] != 1 || INTEGER(ans)[thisgrp] < INTEGER(x)[ix] ) {
             INTEGER(ans)[thisgrp] = INTEGER(x)[ix];
@@ -878,11 +876,11 @@ SEXP gmax(SEXP x, SEXP narm)
           }
         }
       }
-      for (i=0; i<ngrp; i++) {
+      for (int i=0; i<ngrp; ++i) {
         if (update[i] != 1)  {// equivalent of INTEGER(ans)[thisgrp] == NA_INTEGER
           warning(_("No non-missing values found in at least one group. Coercing to numeric type and returning 'Inf' for such groups to be consistent with base"));
           ans = PROTECT(coerceVector(ans, REALSXP)); protecti++;
-          for (i=0; i<ngrp; i++) {
+          for (int i=0; i<ngrp; ++i) {
             if (update[i] != 1) REAL(ans)[i] = -R_PosInf;
           }
           break;
@@ -892,11 +890,11 @@ SEXP gmax(SEXP x, SEXP narm)
     break;
   case STRSXP:
     ans = PROTECT(allocVector(STRSXP, ngrp)); protecti++;
-    for (i=0; i<ngrp; i++) SET_STRING_ELT(ans, i, mkChar(""));
+    for (int i=0; i<ngrp; ++i) SET_STRING_ELT(ans, i, mkChar(""));
     if (!LOGICAL(narm)[0]) { // simple case - deal in a straightforward manner first
-      for (i=0; i<n; i++) {
-        thisgrp = grp[i];
-        ix = (irowslen == -1) ? i : irows[i]-1;
+      for (int i=0; i<n; ++i) {
+        const int thisgrp = grp[i];
+        const int ix = (irowslen == -1) ? i : irows[i]-1;
         if (STRING_ELT(x,ix) != NA_STRING && STRING_ELT(ans, thisgrp) != NA_STRING) {
           if ( update[thisgrp] != 1 || strcmp(CHAR(STRING_ELT(ans, thisgrp)), CHAR(STRING_ELT(x,ix))) < 0 ) {
             SET_STRING_ELT(ans, thisgrp, STRING_ELT(x, ix));
@@ -905,9 +903,9 @@ SEXP gmax(SEXP x, SEXP narm)
         } else  SET_STRING_ELT(ans, thisgrp, NA_STRING);
       }
     } else {
-      for (i=0; i<n; i++) {
-        thisgrp = grp[i];
-        ix = (irowslen == -1) ? i : irows[i]-1;
+      for (int i=0; i<n; ++i) {
+        const int thisgrp = grp[i];
+        const int ix = (irowslen == -1) ? i : irows[i]-1;
         if (STRING_ELT(x, ix) != NA_STRING) {
           if ( update[thisgrp] != 1 || strcmp(CHAR(STRING_ELT(ans, thisgrp)), CHAR(STRING_ELT(x, ix))) < 0 ) {
             SET_STRING_ELT(ans, thisgrp, STRING_ELT(x, ix));
@@ -919,7 +917,7 @@ SEXP gmax(SEXP x, SEXP narm)
           }
         }
       }
-      for (i=0; i<ngrp; i++) {
+      for (int i=0; i<ngrp; ++i) {
         if (update[i] != 1)  {// equivalent of INTEGER(ans)[thisgrp] == NA_INTEGER
           warning(_("No non-missing values found in at least one group. Returning 'NA' for such groups to be consistent with base"));
           break;
@@ -929,11 +927,11 @@ SEXP gmax(SEXP x, SEXP narm)
     break;
   case REALSXP:
     ans = PROTECT(allocVector(REALSXP, ngrp)); protecti++;
-    for (i=0; i<ngrp; i++) REAL(ans)[i] = 0;
+    for (int i=0; i<ngrp; ++i) REAL(ans)[i] = 0;
     if (!LOGICAL(narm)[0]) {
-      for (i=0; i<n; i++) {
-        thisgrp = grp[i];
-        ix = (irowslen == -1) ? i : irows[i]-1;
+      for (int i=0; i<n; ++i) {
+        const int thisgrp = grp[i];
+        const int ix = (irowslen == -1) ? i : irows[i]-1;
         if ( !ISNA(REAL(x)[ix]) && !ISNA(REAL(ans)[thisgrp]) ) {
           if ( update[thisgrp] != 1 || REAL(ans)[thisgrp] < REAL(x)[ix] ||
              (ISNAN(REAL(x)[ix]) && !ISNAN(REAL(ans)[thisgrp])) ) { // #1461
@@ -943,9 +941,9 @@ SEXP gmax(SEXP x, SEXP narm)
         } else REAL(ans)[thisgrp] = NA_REAL;
       }
     } else {
-      for (i=0; i<n; i++) {
-        thisgrp = grp[i];
-        ix = (irowslen == -1) ? i : irows[i]-1;
+      for (int i=0; i<n; ++i) {
+        const int thisgrp = grp[i];
+        const int ix = (irowslen == -1) ? i : irows[i]-1;
         if ( !ISNAN(REAL(x)[ix]) ) { // #1461
           if ( update[thisgrp] != 1 || REAL(ans)[thisgrp] < REAL(x)[ix] ) {
             REAL(ans)[thisgrp] = REAL(x)[ix];
@@ -958,7 +956,7 @@ SEXP gmax(SEXP x, SEXP narm)
         }
       }
       // everything taken care of already. Just warn if all NA groups have occurred at least once
-      for (i=0; i<ngrp; i++) {
+      for (int i=0; i<ngrp; ++i) {
         if (update[i] != 1)  { // equivalent of REAL(ans)[thisgrp] == -R_PosInf
           warning(_("No non-missing values found in at least one group. Returning '-Inf' for such groups to be consistent with base"));
           break;
@@ -984,7 +982,7 @@ SEXP gmedian(SEXP x, SEXP narmArg) {
   if (!isVectorAtomic(x)) error(_("GForce median can only be applied to columns, not .SD or similar. To find median of all items in a list such as .SD, either add the prefix stats::median(.SD) or turn off GForce optimization using options(datatable.optimize=1). More likely, you may be looking for 'DT[,lapply(.SD,median),by=,.SDcols=]'"));
   if (inherits(x, "factor")) error(_("median is not meaningful for factors."));
   const bool isInt64 = INHERITS(x, char_integer64), narm = LOGICAL(narmArg)[0];
-  int n = (irowslen == -1) ? length(x) : irowslen;
+  const int n = (irowslen == -1) ? length(x) : irowslen;
   if (nrow != n) error(_("nrow [%d] != length(x) [%d] in %s"), nrow, n, "gmedian");
   SEXP ans = PROTECT(allocVector(REALSXP, ngrp));
   double *ansd = REAL(ans);
@@ -1010,7 +1008,8 @@ SEXP gmedian(SEXP x, SEXP narmArg) {
     int *subi = INTEGER(PROTECT(allocVector(INTSXP, maxgrpn)));
     int *xi = INTEGER(x);
     for (int i=0; i<ngrp; i++) {
-      int thisgrpsize = grpsize[i], nacount=0;
+      const int thisgrpsize = grpsize[i];
+      int nacount=0;
       for (int j=0; j<thisgrpsize; ++j) {
         int k = ff[i]+j-1;
         if (isunsorted) k = oo[k]-1;
@@ -1031,9 +1030,7 @@ SEXP gmedian(SEXP x, SEXP narmArg) {
 }
 
 SEXP glast(SEXP x) {
-
-  R_len_t i,k;
-  int n = (irowslen == -1) ? length(x) : irowslen;
+  const int n = (irowslen == -1) ? length(x) : irowslen;
   SEXP ans;
   if (nrow != n) error(_("nrow [%d] != length(x) [%d] in %s"), nrow, n, "gtail");
   switch(TYPEOF(x)) {
@@ -1041,8 +1038,8 @@ SEXP glast(SEXP x) {
     const int *ix = LOGICAL(x);
     ans = PROTECT(allocVector(LGLSXP, ngrp));
     int *ians = LOGICAL(ans);
-    for (i=0; i<ngrp; i++) {
-      k = ff[i]+grpsize[i]-2;
+    for (int i=0; i<ngrp; ++i) {
+      int k = ff[i]+grpsize[i]-2;
       if (isunsorted) k = oo[k]-1;
       k = (irowslen == -1) ? k : irows[k]-1;
       ians[i] = ix[k];
@@ -1053,8 +1050,8 @@ SEXP glast(SEXP x) {
     const int *ix = INTEGER(x);
     ans = PROTECT(allocVector(INTSXP, ngrp));
     int *ians = INTEGER(ans);
-    for (i=0; i<ngrp; i++) {
-      k = ff[i]+grpsize[i]-2;
+    for (int i=0; i<ngrp; ++i) {
+      int k = ff[i]+grpsize[i]-2;
       if (isunsorted) k = oo[k]-1;
       k = (irowslen == -1) ? k : irows[k]-1;
       ians[i] = ix[k];
@@ -1065,8 +1062,8 @@ SEXP glast(SEXP x) {
     const double *dx = REAL(x);
     ans = PROTECT(allocVector(REALSXP, ngrp));
     double *dans = REAL(ans);
-    for (i=0; i<ngrp; i++) {
-      k = ff[i]+grpsize[i]-2;
+    for (int i=0; i<ngrp; ++i) {
+      int k = ff[i]+grpsize[i]-2;
       if (isunsorted) k = oo[k]-1;
       k = (irowslen == -1) ? k : irows[k]-1;
       dans[i] = dx[k];
@@ -1077,8 +1074,8 @@ SEXP glast(SEXP x) {
     const Rcomplex *dx = COMPLEX(x);
     ans = PROTECT(allocVector(CPLXSXP, ngrp));
     Rcomplex *dans = COMPLEX(ans);
-    for (i=0; i<ngrp; i++) {
-      k = ff[i]+grpsize[i]-2;
+    for (int i=0; i<ngrp; ++i) {
+      int k = ff[i]+grpsize[i]-2;
       if (isunsorted) k = oo[k]-1;
       k = (irowslen == -1) ? k : irows[k]-1;
       dans[i] = dx[k];
@@ -1086,8 +1083,8 @@ SEXP glast(SEXP x) {
   } break;
   case STRSXP:
     ans = PROTECT(allocVector(STRSXP, ngrp));
-    for (i=0; i<ngrp; i++) {
-      k = ff[i]+grpsize[i]-2;
+    for (int i=0; i<ngrp; ++i) {
+      int k = ff[i]+grpsize[i]-2;
       if (isunsorted) k = oo[k]-1;
       k = (irowslen == -1) ? k : irows[k]-1;
       SET_STRING_ELT(ans, i, STRING_ELT(x, k));
@@ -1095,8 +1092,8 @@ SEXP glast(SEXP x) {
     break;
   case VECSXP:
     ans = PROTECT(allocVector(VECSXP, ngrp));
-    for (i=0; i<ngrp; i++) {
-      k = ff[i]+grpsize[i]-2;
+    for (int i=0; i<ngrp; ++i) {
+      int k = ff[i]+grpsize[i]-2;
       if (isunsorted) k = oo[k]-1;
       k = (irowslen == -1) ? k : irows[k]-1;
       SET_VECTOR_ELT(ans, i, VECTOR_ELT(x, k));
@@ -1111,9 +1108,7 @@ SEXP glast(SEXP x) {
 }
 
 SEXP gfirst(SEXP x) {
-
-  R_len_t i,k;
-  int n = (irowslen == -1) ? length(x) : irowslen;
+  const int n = (irowslen == -1) ? length(x) : irowslen;
   SEXP ans;
   if (nrow != n) error(_("nrow [%d] != length(x) [%d] in %s"), nrow, n, "ghead");
   switch(TYPEOF(x)) {
@@ -1121,8 +1116,8 @@ SEXP gfirst(SEXP x) {
     int const *ix = LOGICAL(x);
     ans = PROTECT(allocVector(LGLSXP, ngrp));
     int *ians = LOGICAL(ans);
-    for (i=0; i<ngrp; i++) {
-      k = ff[i]-1;
+    for (int i=0; i<ngrp; ++i) {
+      int k = ff[i]-1;
       if (isunsorted) k = oo[k]-1;
       k = (irowslen == -1) ? k : irows[k]-1;
       ians[i] = ix[k];
@@ -1133,8 +1128,8 @@ SEXP gfirst(SEXP x) {
     const int *ix = INTEGER(x);
     ans = PROTECT(allocVector(INTSXP, ngrp));
     int *ians = INTEGER(ans);
-    for (i=0; i<ngrp; i++) {
-      k = ff[i]-1;
+    for (int i=0; i<ngrp; ++i) {
+      int k = ff[i]-1;
       if (isunsorted) k = oo[k]-1;
       k = (irowslen == -1) ? k : irows[k]-1;
       ians[i] = ix[k];
@@ -1145,8 +1140,8 @@ SEXP gfirst(SEXP x) {
     const double *dx = REAL(x);
     ans = PROTECT(allocVector(REALSXP, ngrp));
     double *dans = REAL(ans);
-    for (i=0; i<ngrp; i++) {
-      k = ff[i]-1;
+    for (int i=0; i<ngrp; ++i) {
+      int k = ff[i]-1;
       if (isunsorted) k = oo[k]-1;
       k = (irowslen == -1) ? k : irows[k]-1;
       dans[i] = dx[k];
@@ -1157,8 +1152,8 @@ SEXP gfirst(SEXP x) {
     const Rcomplex *dx = COMPLEX(x);
     ans = PROTECT(allocVector(CPLXSXP, ngrp));
     Rcomplex *dans = COMPLEX(ans);
-    for (i=0; i<ngrp; i++) {
-      k = ff[i]-1;
+    for (int i=0; i<ngrp; ++i) {
+      int k = ff[i]-1;
       if (isunsorted) k = oo[k]-1;
       k = (irowslen == -1) ? k : irows[k]-1;
       dans[i] = dx[k];
@@ -1166,8 +1161,8 @@ SEXP gfirst(SEXP x) {
   } break;
   case STRSXP:
     ans = PROTECT(allocVector(STRSXP, ngrp));
-    for (i=0; i<ngrp; i++) {
-      k = ff[i]-1;
+    for (int i=0; i<ngrp; ++i) {
+      int k = ff[i]-1;
       if (isunsorted) k = oo[k]-1;
       k = (irowslen == -1) ? k : irows[k]-1;
       SET_STRING_ELT(ans, i, STRING_ELT(x, k));
@@ -1175,8 +1170,8 @@ SEXP gfirst(SEXP x) {
     break;
   case VECSXP:
     ans = PROTECT(allocVector(VECSXP, ngrp));
-    for (i=0; i<ngrp; i++) {
-      k = ff[i]-1;
+    for (int i=0; i<ngrp; ++i) {
+      int k = ff[i]-1;
       if (isunsorted) k = oo[k]-1;
       k = (irowslen == -1) ? k : irows[k]-1;
       SET_VECTOR_ELT(ans, i, VECTOR_ELT(x, k));
@@ -1203,8 +1198,8 @@ SEXP ghead(SEXP x, SEXP valArg) {
 SEXP gnthvalue(SEXP x, SEXP valArg) {
 
   if (!isInteger(valArg) || LENGTH(valArg)!=1 || INTEGER(valArg)[0]<=0) error(_("Internal error, `g[` (gnthvalue) is only implemented single value subsets with positive index, e.g., .SD[2]. This should have been caught before. please report to data.table issue tracker.")); // # nocov
-  R_len_t i,k, val=INTEGER(valArg)[0];
-  int n = (irowslen == -1) ? length(x) : irowslen;
+  const int val=INTEGER(valArg)[0];
+  const int n = (irowslen == -1) ? length(x) : irowslen;
   SEXP ans;
   if (nrow != n) error(_("nrow [%d] != length(x) [%d] in %s"), nrow, n, "ghead");
   switch(TYPEOF(x)) {
@@ -1212,9 +1207,9 @@ SEXP gnthvalue(SEXP x, SEXP valArg) {
     const int *ix = LOGICAL(x);
     ans = PROTECT(allocVector(LGLSXP, ngrp));
     int *ians = LOGICAL(ans);
-    for (i=0; i<ngrp; i++) {
+    for (int i=0; i<ngrp; ++i) {
       if (val > grpsize[i]) { LOGICAL(ans)[i] = NA_LOGICAL; continue; }
-      k = ff[i]+val-2;
+      int k = ff[i]+val-2;
       if (isunsorted) k = oo[k]-1;
       k = (irowslen == -1) ? k : irows[k]-1;
       ians[i] = ix[k];
@@ -1225,9 +1220,9 @@ SEXP gnthvalue(SEXP x, SEXP valArg) {
     const int *ix = INTEGER(x);
     ans = PROTECT(allocVector(INTSXP, ngrp));
     int *ians = INTEGER(ans);
-    for (i=0; i<ngrp; i++) {
+    for (int i=0; i<ngrp; ++i) {
       if (val > grpsize[i]) { INTEGER(ans)[i] = NA_INTEGER; continue; }
-      k = ff[i]+val-2;
+      int k = ff[i]+val-2;
       if (isunsorted) k = oo[k]-1;
       k = (irowslen == -1) ? k : irows[k]-1;
       ians[i] = ix[k];
@@ -1238,9 +1233,9 @@ SEXP gnthvalue(SEXP x, SEXP valArg) {
     const double *dx = REAL(x);
     ans = PROTECT(allocVector(REALSXP, ngrp));
     double *dans = REAL(ans);
-    for (i=0; i<ngrp; i++) {
+    for (int i=0; i<ngrp; ++i) {
       if (val > grpsize[i]) { REAL(ans)[i] = NA_REAL; continue; }
-      k = ff[i]+val-2;
+      int k = ff[i]+val-2;
       if (isunsorted) k = oo[k]-1;
       k = (irowslen == -1) ? k : irows[k]-1;
       dans[i] = dx[k];
@@ -1251,9 +1246,9 @@ SEXP gnthvalue(SEXP x, SEXP valArg) {
     const Rcomplex *dx = COMPLEX(x);
     ans = PROTECT(allocVector(CPLXSXP, ngrp));
     Rcomplex *dans = COMPLEX(ans);
-    for (i=0; i<ngrp; i++) {
+    for (int i=0; i<ngrp; ++i) {
       if (val > grpsize[i]) { dans[i].r = NA_REAL; dans[i].i = NA_REAL; continue; }
-      k = ff[i]+val-2;
+      int k = ff[i]+val-2;
       if (isunsorted) k = oo[k]-1;
       k = (irowslen == -1) ? k : irows[k]-1;
       dans[i] = dx[k];
@@ -1261,9 +1256,9 @@ SEXP gnthvalue(SEXP x, SEXP valArg) {
   } break;
   case STRSXP:
     ans = PROTECT(allocVector(STRSXP, ngrp));
-    for (i=0; i<ngrp; i++) {
+    for (int i=0; i<ngrp; ++i) {
       if (val > grpsize[i]) { SET_STRING_ELT(ans, i, NA_STRING); continue; }
-      k = ff[i]+val-2;
+      int k = ff[i]+val-2;
       if (isunsorted) k = oo[k]-1;
       k = (irowslen == -1) ? k : irows[k]-1;
       SET_STRING_ELT(ans, i, STRING_ELT(x, k));
@@ -1271,9 +1266,9 @@ SEXP gnthvalue(SEXP x, SEXP valArg) {
     break;
   case VECSXP:
     ans = PROTECT(allocVector(VECSXP, ngrp));
-    for (i=0; i<ngrp; i++) {
+    for (int i=0; i<ngrp; ++i) {
       if (val > grpsize[i]) { SET_VECTOR_ELT(ans, i, R_NilValue); continue; }
-      k = ff[i]+val-2;
+      int k = ff[i]+val-2;
       if (isunsorted) k = oo[k]-1;
       k = (irowslen == -1) ? k : irows[k]-1;
       SET_VECTOR_ELT(ans, i, VECTOR_ELT(x, k));
@@ -1294,33 +1289,32 @@ SEXP gvarsd1(SEXP x, SEXP narm, Rboolean isSD)
   if (!isLogical(narm) || LENGTH(narm)!=1 || LOGICAL(narm)[0]==NA_LOGICAL) error(_("na.rm must be TRUE or FALSE"));
   if (!isVectorAtomic(x)) error(_("GForce var/sd can only be applied to columns, not .SD or similar. For the full covariance matrix of all items in a list such as .SD, either add the prefix stats::var(.SD) (or stats::sd(.SD)) or turn off GForce optimization using options(datatable.optimize=1). Alternatively, if you only need the diagonal elements, 'DT[,lapply(.SD,var),by=,.SDcols=]' is the optimized way to do this."));
   if (inherits(x, "factor")) error(_("var/sd is not meaningful for factors."));
-  long double m, s, v;
-  R_len_t i, j, ix, thisgrpsize = 0, n = (irowslen == -1) ? length(x) : irowslen;
+  const int n = (irowslen == -1) ? length(x) : irowslen;
   if (nrow != n) error(_("nrow [%d] != length(x) [%d] in %s"), nrow, n, "gvar");
   SEXP sub, ans = PROTECT(allocVector(REALSXP, ngrp));
-  Rboolean ans_na;
   switch(TYPEOF(x)) {
   case LGLSXP: case INTSXP:
     sub = PROTECT(allocVector(INTSXP, maxgrpn)); // allocate once upfront
     if (!LOGICAL(narm)[0]) {
-      for (i=0; i<ngrp; i++) {
-        m=0.; s=0.; v=0.; ans_na = FALSE;
+      for (int i=0; i<ngrp; ++i) {
+        long double m=0., s=0., v=0.;
+        bool ans_na = false;
         if (grpsize[i] != 1) {
-          thisgrpsize = grpsize[i];
+          const int thisgrpsize = grpsize[i];
           SETLENGTH(sub, thisgrpsize); // to gather this group's data
-          for (j=0; j<thisgrpsize; j++) {
-            ix = ff[i]+j-1;
+          for (int j=0; j<thisgrpsize; ++j) {
+            int ix = ff[i]+j-1;
             if (isunsorted) ix = oo[ix]-1;
             ix = (irowslen == -1) ? ix : irows[ix]-1;
-            if (INTEGER(x)[ix] == NA_INTEGER) { ans_na = TRUE; break; }
+            if (INTEGER(x)[ix] == NA_INTEGER) { ans_na=true; break; }
             INTEGER(sub)[j] = INTEGER(x)[ix];
             m += INTEGER(sub)[j]; // sum
           }
           if (ans_na) { REAL(ans)[i] = NA_REAL; continue; }
           m = m/thisgrpsize; // mean, first pass
-          for (j=0; j<thisgrpsize; j++) s += (INTEGER(sub)[j]-m); // residuals
+          for (int j=0; j<thisgrpsize; ++j) s += (INTEGER(sub)[j]-m); // residuals
           m += (s/thisgrpsize); // mean, second pass
-          for (j=0; j<thisgrpsize; j++) { // variance
+          for (int j=0; j<thisgrpsize; ++j) { // variance
             v += (INTEGER(sub)[j]-(double)m) * (INTEGER(sub)[j]-(double)m);
           }
           REAL(ans)[i] = (double)v/(thisgrpsize-1);
@@ -1328,12 +1322,13 @@ SEXP gvarsd1(SEXP x, SEXP narm, Rboolean isSD)
         } else REAL(ans)[i] = NA_REAL;
       }
     } else {
-      for (i=0; i<ngrp; i++) {
-        m=0.; s=0.; v=0.; thisgrpsize = 0;
+      for (int i=0; i<ngrp; ++i) {
+        long double m=0., s=0., v=0.;
+        int thisgrpsize = 0;
         if (grpsize[i] != 1) {
           SETLENGTH(sub, grpsize[i]); // to gather this group's data
-          for (j=0; j<grpsize[i]; j++) {
-            ix = ff[i]+j-1;
+          for (int j=0; j<grpsize[i]; ++j) {
+            int ix = ff[i]+j-1;
             if (isunsorted) ix = oo[ix]-1;
             ix = (irowslen == -1) ? ix : irows[ix]-1;
             if (INTEGER(x)[ix] == NA_INTEGER) continue;
@@ -1343,9 +1338,9 @@ SEXP gvarsd1(SEXP x, SEXP narm, Rboolean isSD)
           }
           if (thisgrpsize <= 1) { REAL(ans)[i] = NA_REAL; continue; }
           m = m/thisgrpsize; // mean, first pass
-          for (j=0; j<thisgrpsize; j++) s += (INTEGER(sub)[j]-m); // residuals
+          for (int j=0; j<thisgrpsize; ++j) s += (INTEGER(sub)[j]-m); // residuals
           m += (s/thisgrpsize); // mean, second pass
-          for (j=0; j<thisgrpsize; j++) { // variance
+          for (int j=0; j<thisgrpsize; ++j) { // variance
             v += (INTEGER(sub)[j]-(double)m) * (INTEGER(sub)[j]-(double)m);
           }
           REAL(ans)[i] = (double)v/(thisgrpsize-1);
@@ -1358,24 +1353,25 @@ SEXP gvarsd1(SEXP x, SEXP narm, Rboolean isSD)
   case REALSXP:
     sub = PROTECT(allocVector(REALSXP, maxgrpn)); // allocate once upfront
     if (!LOGICAL(narm)[0]) {
-      for (i=0; i<ngrp; i++) {
-        m=0.; s=0.; v=0.; ans_na = FALSE;
+      for (int i=0; i<ngrp; ++i) {
+        long double m=0., s=0., v=0.;
+        bool ans_na=false;
         if (grpsize[i] != 1) {
-          thisgrpsize = grpsize[i];
+          const int thisgrpsize = grpsize[i];
           SETLENGTH(sub, thisgrpsize); // to gather this group's data
-          for (j=0; j<thisgrpsize; j++) {
-            ix = ff[i]+j-1;
+          for (int j=0; j<thisgrpsize; ++j) {
+            int ix = ff[i]+j-1;
             if (isunsorted) ix = oo[ix]-1;
             ix = (irowslen == -1) ? ix : irows[ix]-1;
-            if (ISNAN(REAL(x)[ix])) { ans_na = TRUE; break; }
+            if (ISNAN(REAL(x)[ix])) { ans_na=true; break; }
             REAL(sub)[j] = REAL(x)[ix];
             m += REAL(sub)[j]; // sum
           }
           if (ans_na) { REAL(ans)[i] = NA_REAL; continue; }
           m = m/thisgrpsize; // mean, first pass
-          for (j=0; j<thisgrpsize; j++) s += (REAL(sub)[j]-m); // residuals
+          for (int j=0; j<thisgrpsize; ++j) s += (REAL(sub)[j]-m); // residuals
           m += (s/thisgrpsize); // mean, second pass
-          for (j=0; j<thisgrpsize; j++) { // variance
+          for (int j=0; j<thisgrpsize; ++j) { // variance
             v += (REAL(sub)[j]-(double)m) * (REAL(sub)[j]-(double)m);
           }
           REAL(ans)[i] = (double)v/(thisgrpsize-1);
@@ -1383,12 +1379,13 @@ SEXP gvarsd1(SEXP x, SEXP narm, Rboolean isSD)
         } else REAL(ans)[i] = NA_REAL;
       }
     } else {
-      for (i=0; i<ngrp; i++) {
-        m=0.; s=0.; v=0.; thisgrpsize = 0;
+      for (int i=0; i<ngrp; ++i) {
+        long double m=0., s=0., v=0.;
+        int thisgrpsize = 0;
         if (grpsize[i] != 1) {
           SETLENGTH(sub, grpsize[i]); // to gather this group's data
-          for (j=0; j<grpsize[i]; j++) {
-            ix = ff[i]+j-1;
+          for (int j=0; j<grpsize[i]; ++j) {
+            int ix = ff[i]+j-1;
             if (isunsorted) ix = oo[ix]-1;
             ix = (irowslen == -1) ? ix : irows[ix]-1;
             if (ISNAN(REAL(x)[ix])) continue;
@@ -1398,9 +1395,9 @@ SEXP gvarsd1(SEXP x, SEXP narm, Rboolean isSD)
           }
           if (thisgrpsize <= 1) { REAL(ans)[i] = NA_REAL; continue; }
           m = m/thisgrpsize; // mean, first pass
-          for (j=0; j<thisgrpsize; j++) s += (REAL(sub)[j]-m); // residuals
+          for (int j=0; j<thisgrpsize; ++j) s += (REAL(sub)[j]-m); // residuals
           m += (s/thisgrpsize); // mean, second pass
-          for (j=0; j<thisgrpsize; j++) { // variance
+          for (int j=0; j<thisgrpsize; ++j) { // variance
             v += (REAL(sub)[j]-(double)m) * (REAL(sub)[j]-(double)m);
           }
           REAL(ans)[i] = (double)v/(thisgrpsize-1);
@@ -1435,40 +1432,39 @@ SEXP gprod(SEXP x, SEXP narm)
   if (!isLogical(narm) || LENGTH(narm)!=1 || LOGICAL(narm)[0]==NA_LOGICAL) error(_("na.rm must be TRUE or FALSE"));
   if (!isVectorAtomic(x)) error(_("GForce prod can only be applied to columns, not .SD or similar. To multiply all items in a list such as .SD, either add the prefix base::prod(.SD) or turn off GForce optimization using options(datatable.optimize=1). More likely, you may be looking for 'DT[,lapply(.SD,prod),by=,.SDcols=]'"));
   if (inherits(x, "factor")) error(_("prod is not meaningful for factors."));
-  int i, ix, thisgrp;
-  int n = (irowslen == -1) ? length(x) : irowslen;
+  const int n = (irowslen == -1) ? length(x) : irowslen;
   //clock_t start = clock();
   SEXP ans;
   if (nrow != n) error(_("nrow [%d] != length(x) [%d] in %s"), nrow, n, "gprod");
   long double *s = malloc(ngrp * sizeof(long double));
   if (!s) error(_("Unable to allocate %d * %d bytes for gprod"), ngrp, sizeof(long double));
-  for (i=0; i<ngrp; i++) s[i] = 1.0;
+  for (int i=0; i<ngrp; ++i) s[i] = 1.0;
   ans = PROTECT(allocVector(REALSXP, ngrp));
   switch(TYPEOF(x)) {
   case LGLSXP: case INTSXP:
-    for (i=0; i<n; i++) {
-      thisgrp = grp[i];
-      ix = (irowslen == -1) ? i : irows[i]-1;
+    for (int i=0; i<n; ++i) {
+      const int thisgrp = grp[i];
+      const int ix = (irowslen == -1) ? i : irows[i]-1;
       if(INTEGER(x)[ix] == NA_INTEGER) {
         if (!LOGICAL(narm)[0]) s[thisgrp] = NA_REAL;  // Let NA_REAL propogate from here. R_NaReal is IEEE.
         continue;
       }
       s[thisgrp] *= INTEGER(x)[ix];  // no under/overflow here, s is long double (like base)
     }
-    for (i=0; i<ngrp; i++) {
+    for (int i=0; i<ngrp; ++i) {
       if (s[i] > DBL_MAX) REAL(ans)[i] = R_PosInf;
       else if (s[i] < -DBL_MAX) REAL(ans)[i] = R_NegInf;
       else REAL(ans)[i] = (double)s[i];
     }
     break;
   case REALSXP:
-    for (i=0; i<n; i++) {
-      thisgrp = grp[i];
-      ix = (irowslen == -1) ? i : irows[i]-1;
+    for (int i=0; i<n; ++i) {
+      const int thisgrp = grp[i];
+      const int ix = (irowslen == -1) ? i : irows[i]-1;
       if(ISNAN(REAL(x)[ix]) && LOGICAL(narm)[0]) continue;  // else let NA_REAL propogate from here
       s[thisgrp] *= REAL(x)[ix];  // done in long double, like base
     }
-    for (i=0; i<ngrp; i++) {
+    for (int i=0; i<ngrp; ++i) {
       if (s[i] > DBL_MAX) REAL(ans)[i] = R_PosInf;
       else if (s[i] < -DBL_MAX) REAL(ans)[i] = R_NegInf;
       else REAL(ans)[i] = (double)s[i];

--- a/src/inrange.c
+++ b/src/inrange.c
@@ -4,11 +4,12 @@
 
 SEXP inrange(SEXP ansArg, SEXP xoArg, SEXP startsArg, SEXP lenArg) {
 
-  int *ans = INTEGER(ansArg), *xo = INTEGER(xoArg);
-  int *starts = INTEGER(startsArg), *len = INTEGER(lenArg);
-  R_len_t i, j, n = length(startsArg), nxo = length(xoArg);
-  for (i = 0; i < n; i++) {
-    for (j = starts[i]-1; j < starts[i]-1+len[i]; j++) {
+  int *ans = INTEGER(ansArg);
+  const int *xo = INTEGER(xoArg);
+  const int *starts = INTEGER(startsArg), *len = INTEGER(lenArg);
+  const int n = length(startsArg), nxo = length(xoArg);
+  for (int i=0; i<n; ++i) {
+    for (int j=starts[i]-1; j<starts[i]-1+len[i]; ++j) {
       ans[nxo ? xo[j]-1 : j] = 1;
     }
   }
@@ -16,7 +17,7 @@ SEXP inrange(SEXP ansArg, SEXP xoArg, SEXP startsArg, SEXP lenArg) {
   // contains A LOT of overlapping indices.. rare in real examples.
   // so switched to simpler logic above.. retaining it commented for now.
 
-  // R_len_t i =0,j, ss,ee,new_ss,new_ee;
+  // R_len_t i=0, ss,ee,new_ss,new_ee;
   // while(i < n && starts[i] == 0) i++;
   // while (i < n) {
   //     ss = starts[i]-1;
@@ -29,7 +30,7 @@ SEXP inrange(SEXP ansArg, SEXP xoArg, SEXP startsArg, SEXP lenArg) {
   //         ee = ee > new_ee ? ee : new_ee;
   //     }
   //     // Rprintf(_("Moved to %d, start=%d, end=%d\n"), i, ss, ee);
-  //     for (j=ss; j<=ee; j++) ans[nxo ? xo[j]-1 : j] = 1;
+  //     for (int j=ss; j<=ee; j++) ans[nxo ? xo[j]-1 : j] = 1;
   // }
   return (R_NilValue);
 }


### PR DESCRIPTION
A lot were already done. This clears up the remaining. I started with :
`grep -En "for [(][^ ]+[ ]*=" src/*.c`
and went from there.  The ones remaining are intentional; e.g. they use the ending loop counter value afterwards, and now we can see that more clearly.

It's not for speed (although it might help depending on compiler and options) but for i) easier reading without needing to scroll up to the declaration, and ii) restrict variable scope to prevent accidentally using or changing a variable in other parts of the code.

Also modernized `anyNA` in `frank.c`: integer64 tidy, took `STRING_ELT()` outside loop, and saved the repeated `ans[0]=true` in each case.