### PR TITLE
froll partial documentation

### DIFF
--- a/man/froll.Rd
+++ b/man/froll.Rd
@@ -22,7 +22,7 @@ frollsum(x, n, fill=NA, algo=c("fast","exact"), align=c("right", "left",
 frollapply(x, n, FUN, \dots, fill=NA, align=c("right", "left", "center"))
 }
 \arguments{
-  \item{x}{ vector, list, data.frame or data.table of numeric or logical columns. }
+  \item{x}{ vector, data.frame or data.table of numeric or logical columns. May also be a list, in which case the rolling function is applied to each of its elements. }
   \item{n}{ integer vector, for adaptive rolling function also list of
     integer vectors, rolling window size. }
   \item{fill}{ numeric or logical, value to pad by. Defaults to \code{NA}. }


### PR DESCRIPTION
Closes #5013.
Reported by @pnacht, and uses exact phrasing provided by them. Minor change to highlight that elements of a list are used for rolling operations, and not the list itself.