### PR TITLE
Extend error message for auto-naming

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -945,7 +945,7 @@ replace_dot_alias = function(e) {
               if (length(nm) != length(jvnames))
                 warning("j may not evaluate to the same number of columns for each group; if you're sure this warning is in error, please put the branching logic outside of [ for efficiency")
               else if (any(idx <- nm != jvnames))
-                warning("Different branches of j expression produced different auto-named columns: ", brackify(sprintf('%s!=%s', nm[idx], jvnames[idx])), '; using the most "last" names. If this was intentional (e.g., you know only one branch will ever be used in a given query because the branch is controlled by a function argument), please (1) pull this branch out of the call or (2) explicitly provide missing defaults for each branch in all cases.', call. = FALSE)
+                warning("Different branches of j expression produced different auto-named columns: ", brackify(sprintf('%s!=%s', nm[idx], jvnames[idx])), '; using the most "last" names. If this was intentional (e.g., you know only one branch will ever be used in a given query because the branch is controlled by a function argument), please (1) pull this branch out of the call; (2) explicitly provide missing defaults for each branch in all cases; or (3) use the same name for each branch and re-name it in a follow-up call.', call. = FALSE)
             }
             jvnames <<- nm # TODO: handle if() list(a, b) else list(b, a) better
             setattr(q, "names", NULL)  # drops the names from the list so it's faster to eval the j for each group; reinstated at the end on the result.

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -945,7 +945,7 @@ replace_dot_alias = function(e) {
               if (length(nm) != length(jvnames))
                 warning("j may not evaluate to the same number of columns for each group; if you're sure this warning is in error, please put the branching logic outside of [ for efficiency")
               else if (any(idx <- nm != jvnames))
-                warning("Different branches of j expression produced different auto-named columns: ", brackify(sprintf('%s!=%s', nm[idx], jvnames[idx])), '; using the most "last" names', call. = FALSE)
+                warning("Different branches of j expression produced different auto-named columns: ", brackify(sprintf('%s!=%s', nm[idx], jvnames[idx])), '; using the most "last" names. If this was intentional (e.g., you know only one branch will ever be used in a given query because the branch is controlled by a function argument), please (1) pull this branch out of the call or (2) explicitly provide missing defaults for each branch in all cases.', call. = FALSE)
             }
             jvnames <<- nm # TODO: handle if() list(a, b) else list(b, a) better
             setattr(q, "names", NULL)  # drops the names from the list so it's faster to eval the j for each group; reinstated at the end on the result.


### PR DESCRIPTION
Just got bit by this myself. I wrote some code like

```
foo <- function(flag) {
  DT[by = grp, if (flag) .(a = 1) else .(b = 2)]
}
```

Of course for any given evaluation of the query, either `a` or `b` will be returned. But our auto-namer can't know statically that `flag` doesn't depend on the `.BY` group, hence the issue... but the current warning message had me puzzled & trying to find how evaluation had leaked to the "wrong" branch.

Of course there are better/more efficient ways to write the above, so I am also fine not to change our behavior to warn & choose a default in this case.