### PR TITLE
Don't call copyMostAttrib on ScalarLogical result

### DIFF
--- a/R/duplicated.R
+++ b/R/duplicated.R
@@ -1,6 +1,6 @@
 duplicated.data.table = function(x, incomparables=FALSE, fromLast=FALSE, by=seq_along(x), ...) {
   if (!cedta()) return(NextMethod("duplicated")) #nocov
-  if (!identical(incomparables,FALSE)) {
+  if (!isFALSE(incomparables)) {
     .NotYetUsed("incomparables != FALSE")
   }
   if (nrow(x) == 0L || ncol(x) == 0L) return(logical(0L)) # fix for bug #28
@@ -25,7 +25,7 @@ duplicated.data.table = function(x, incomparables=FALSE, fromLast=FALSE, by=seq_
 
 unique.data.table = function(x, incomparables=FALSE, fromLast=FALSE, by=seq_along(x), ...) {
   if (!cedta()) return(NextMethod("unique")) # nocov
-  if (!identical(incomparables,FALSE)) {
+  if (!isFALSE(incomparables)) {
     .NotYetUsed("incomparables != FALSE")
   }
   if (nrow(x) <= 1L) return(x)

--- a/R/duplicated.R
+++ b/R/duplicated.R
@@ -1,6 +1,6 @@
 duplicated.data.table = function(x, incomparables=FALSE, fromLast=FALSE, by=seq_along(x), ...) {
   if (!cedta()) return(NextMethod("duplicated")) #nocov
-  if (!isFALSE(incomparables)) {
+  if (!identical(incomparables,FALSE)) {
     .NotYetUsed("incomparables != FALSE")
   }
   if (nrow(x) == 0L || ncol(x) == 0L) return(logical(0L)) # fix for bug #28
@@ -25,7 +25,7 @@ duplicated.data.table = function(x, incomparables=FALSE, fromLast=FALSE, by=seq_
 
 unique.data.table = function(x, incomparables=FALSE, fromLast=FALSE, by=seq_along(x), ...) {
   if (!cedta()) return(NextMethod("unique")) # nocov
-  if (!isFALSE(incomparables)) {
+  if (!identical(incomparables,FALSE)) {
     .NotYetUsed("incomparables != FALSE")
   }
   if (nrow(x) <= 1L) return(x)


### PR DESCRIPTION
Follow up to #4350

The first commit "reprex" in this PR reproduces the problem. I'm using R 4.0.3 currently. Running `R CMD check` or `test.data.table()` is necessary to make 2195.[3-8] fail because test 2190.6 needs to run first. When I ran tests 2195 at the dev prompt they always passed and I couldn't reproduce.

Test 2190.6 is subassigning a logical vector with an attribute attached to an existing list column :
```R
DT = data.table(a=list(1:2, 3, 4))
DT[1:2, a:=structure(c(TRUE, FALSE), att='t')]
```

This ended up attaching the `"att"` attribute with value `"t"` to R's internal global FALSE constant. This caused the `!identical(incomparables, FALSE)` in duplicated.R to fail. I debugged and confirmed that `print(FALSE)` showed that FALSE had indeed received the attribute whereas `incomparables` did not have the attribute. Presumably TRUE was also receiving the attribute but only FALSE was showing up so far in tests 2195.* on the FALSE value.

The error shows up as : 
```
Running test id 2195.3          Test 2195.3 produced 1 errors but expected 0
Expected: 
Observed: argument 'incomparables != FALSE' is not used (yet)
```

In #4595 I worked around the issue by changing duplicated.R to use `!isFALSE(incomparables)` instead of `!identical(incomparables, FALSE)` to ignore any attributes attached to FALSE.

This PR now fixes the root cause. `ScalarLogical(false)` returns R's internal global FALSE value; `allocVector()` has to be used to return a new allocation of a length-1 logical value and a new allocation is necessary if attributes are to be attached. After this PR, duplicated.R could use `!identical(incomparables, FALSE)` again, but having gone through this, I'm now thinking that ignoring attributes attached to FALSE is more robust anyway so will leave the `!isFALSE()` in place in duplicated.R.
