### PR TITLE
Changes buffer size for writing header in fwrite

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -159,6 +159,8 @@
 
 7. Grouping by a `list` column has its error message improved stating this is unsupported, [#4308](https://github.com/Rdatatable/data.table/issues/4308). Thanks @sindribaldur for filing, and @michaelchirico for the PR. Please add your vote and especially use cases to the [#1597](https://github.com/Rdatatable/data.table/issues/1597) feature request.
 
+8. OpenBSD 6.9 released May 2021 apparently uses a an old version of zlib (v1.2.3 from 2005) which induces `Compress gzip error: -9` from `fwrite()`, [#5048](https://github.com/Rdatatable/data.table/issues/5048). Thanks to Philippe Chataignon for investigating and for the PR which attempts a solution.
+
 
 # data.table [v1.14.0](https://github.com/Rdatatable/data.table/milestone/23?closed=1)  (21 Feb 2021)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -159,7 +159,7 @@
 
 7. Grouping by a `list` column has its error message improved stating this is unsupported, [#4308](https://github.com/Rdatatable/data.table/issues/4308). Thanks @sindribaldur for filing, and @michaelchirico for the PR. Please add your vote and especially use cases to the [#1597](https://github.com/Rdatatable/data.table/issues/1597) feature request.
 
-8. OpenBSD 6.9 released May 2021 apparently uses a an old version of zlib (v1.2.3 from 2005) which induces `Compress gzip error: -9` from `fwrite()`, [#5048](https://github.com/Rdatatable/data.table/issues/5048). Thanks to Philippe Chataignon for investigating and for the PR which attempts a solution.
+8. OpenBSD 6.9 released May 2021 apparently uses a 16 year old version of zlib (v1.2.3 from 2005) which induces `Compress gzip error: -9` from `fwrite()`, [#5048](https://github.com/Rdatatable/data.table/issues/5048). Thanks to Philippe Chataignon for investigating and for the PR which attempts a solution.
 
 
 # data.table [v1.14.0](https://github.com/Rdatatable/data.table/milestone/23?closed=1)  (21 Feb 2021)

--- a/src/fwrite.c
+++ b/src/fwrite.c
@@ -738,14 +738,9 @@ void fwriteMain(fwriteMainArgs args)
           free(buff);                                    // # nocov
           STOP(_("Can't allocate gzip stream structure"));  // # nocov
         }
-        // accurate size
-        size_t zbuffSize = deflateBound(&stream, headerLen);
-        // alternate size to resolve #5048 (old openbsd zlib)
-        // this buffsize is the same used for writing rows
-        size_t alt_zbuffSize = deflateBound(&stream, buffSize);
-        // takes the max size in case of very long header
-        if (alt_zbuffSize >  zbuffSize)
-             zbuffSize = alt_zbuffSize;
+        // by default, buffsize is the same used for writing rows (#5048 old openbsd zlib)
+        // takes the max with headerLen size in case of very long header
+        size_t zbuffSize = deflateBound(&stream, headerLen > buffSize ? headerLen : buffSize);
         char *zbuff = malloc(zbuffSize);
         if (!zbuff) {
           free(buff);                                                                                   // # nocov

--- a/src/fwrite.c
+++ b/src/fwrite.c
@@ -738,7 +738,14 @@ void fwriteMain(fwriteMainArgs args)
           free(buff);                                    // # nocov
           STOP(_("Can't allocate gzip stream structure"));  // # nocov
         }
+        // accurate size
         size_t zbuffSize = deflateBound(&stream, headerLen);
+        // alternate size to resolve #5048 (old openbsd zlib)
+        // this buffsize is the same used for writing rows
+        size_t alt_zbuffSize = deflateBound(&stream, buffSize);
+        // takes the max size in case of very long header
+        if (alt_zbuffSize >  zbuffSize)
+             zbuffSize = alt_zbuffSize;
         char *zbuff = malloc(zbuffSize);
         if (!zbuff) {
           free(buff);                                                                                   // # nocov


### PR DESCRIPTION
This PR is an attempt to Resolve #5048.

Actually, buffer size for writing header only uses headerLen. headerLen is computed accurately and deflateBound returns a buffer size witch guarantees an one pass compression. But that's not true with OpenBSD which uses on old zlib version.

Here, we use by default the buffer size used for rows from the buffer size parameter (buffMB) and, if we have a very long header, we use headerLen.