### PR TITLE
simplify checking for untranslated messages

### DIFF
--- a/.dev/CRAN_Release.cmd
+++ b/.dev/CRAN_Release.cmd
@@ -7,36 +7,9 @@
 ##     ideally, we are including _() wrapping in
 ##     new PRs throughout dev cycle, and this step
 ##     becomes about tying up loose ends
-## Appending _() char array wrapping to all messages
-##   that might be shown to the user. This step is slightly
-##   too greedy, as it includes too many msg, some of which
-##   need not be translated [more work to do here to make
-##   this less manual] some things to watch out for:
-##     * quote embedded (and escaped) within message [could be fixed with smarter regex]
-##     * multi-line implicit-concat arrays (in C, `"a" "b"` is the same as `"ab"`) should be wrapped "on the outside" not individually
-##     * `data.table` shares some of its `src` with `pydatatable`, so the requirement to `#include <R.h>` before the `#define _` macro meant we need to be careful about including this macro only in the R headers for these files (hence I created `po.h`)
-##     * Can't use `_()` _inside_ another functional macro. Only wrap the string passed to the macro later.
-for MSG in error warning DTWARN DTPRINT Rprintf STOP Error;
-  do for SRC_FILE in src/*.c;
-    # no inplace -i in default mac sed
-    do sed -E "s/$MSG[(](\"[^\"]*\")/$MSG(_(\1)/g" $SRC_FILE > out;
-    mv out $SRC_FILE;
-  done
-done
-
-## checking for other lines calling these that didn't get _()-wrapped
-for MSG in error warning DTWARN DTPRINT Rprintf STOP Error;
-  do grep -Er "\b$MSG[(]" src --include=*.c | grep -v _ | grep -Ev "(?:\s*//|[*]).*$MSG[(]"
-done
-
-## similar, but a bit more manual to check snprintf usage
-
-## look for char array that haven't been covered yet
-grep -Er '"[^"]+"' src --include=*.c | grep -Fv '_("' | \
-  grep -Ev '#include|//.*".*"|strcmp|COERCE_ERROR|install\("|\{"'
-
-## look for lines starting with a char array (likely continued from prev line & can be combined)
-grep -Er '^\s*"' src/*.c
+## Check the output here for translatable messages
+xgettext -o /dev/stdout ./*.c \
+  --keyword=Rprintf --keyword=error --keyword=warning --keyword=STOP --keyword=DTWARN --keyword=Error --keyword=DTPRINT --keyword=snprintf:3
 
 ## (b) Update R template file: src/R-data.table.pot
 ##  NB: this relies on R >= 4.0 to remove a bug in update_pkg_po

--- a/src/fwrite.c
+++ b/src/fwrite.c
@@ -800,7 +800,7 @@ void fwriteMain(fwriteMainArgs args)
     if(init_stream(&stream))
       STOP(_("Can't allocate gzip stream structure")); // # nocov
     zbuffSize = deflateBound(&stream, buffSize);
-    if (verbose) DTPRINT("zbuffSize=%d returned from deflateBound\n", (int)zbuffSize);
+    if (verbose) DTPRINT(_("zbuffSize=%d returned from deflateBound\n"), (int)zbuffSize);
     deflateEnd(&stream);
 #endif
   }

--- a/src/init.c
+++ b/src/init.c
@@ -395,7 +395,7 @@ int GetVerbose() {
   // don't call repetitively; save first in that case
   SEXP opt = GetOption(sym_verbose, R_NilValue);
   if ((!isLogical(opt) && !isInteger(opt)) || LENGTH(opt)!=1 || INTEGER(opt)[0]==NA_INTEGER)
-    error("verbose option must be length 1 non-NA logical or integer");
+    error(_("verbose option must be length 1 non-NA logical or integer"));
   return INTEGER(opt)[0];
 }
 

--- a/src/nafill.c
+++ b/src/nafill.c
@@ -84,7 +84,7 @@ void nafillInteger64(int64_t *x, uint_fast64_t nx, unsigned int type, int64_t fi
     }
   }
   if (verbose)
-    snprintf(ans->message[0], 500, "%s: took %.3fs\n", __func__, omp_get_wtime()-tic);
+    snprintf(ans->message[0], 500, _("%s: took %.3fs\n"), __func__, omp_get_wtime()-tic);
 }
 
 SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP nan_is_na_arg, SEXP inplace, SEXP cols) {
@@ -100,7 +100,7 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP nan_is_na_arg, SEXP inplace, S
 
   bool binplace = LOGICAL(inplace)[0];
   if (!IS_TRUE_OR_FALSE(nan_is_na_arg))
-    error("nan_is_na must be TRUE or FALSE"); // # nocov
+    error(_("nan_is_na must be TRUE or FALSE")); // # nocov
   bool nan_is_na = LOGICAL(nan_is_na_arg)[0];
 
   SEXP x = R_NilValue;
@@ -184,7 +184,7 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP nan_is_na_arg, SEXP inplace, S
         SET_VECTOR_ELT(fill, i, fill1);
     }
     if (!isNewList(fill))
-      error("internal error: 'fill' should be recycled as list already"); // # nocov
+      error(_("internal error: 'fill' should be recycled as list already")); // # nocov
     for (R_len_t i=0; i<nx; i++) {
       SET_VECTOR_ELT(fill, i, coerceAs(VECTOR_ELT(fill, i), VECTOR_ELT(x, i), ScalarLogical(TRUE)));
       fillp[i] = SEXPPTR_RO(VECTOR_ELT(fill, i)); // do like this so we can use in parallel region

--- a/src/programming.c
+++ b/src/programming.c
@@ -13,7 +13,7 @@ static void substitute_call_arg_names(SEXP expr, SEXP env) {
         if (imatches[i]) {
           SEXP sym = env_sub[imatches[i]-1];
           if (!isSymbol(sym))
-            error("Attempting to substitute '%s' element with object of type '%s' but it has to be 'symbol' type when substituting name of the call argument, functions 'as.name' and 'I' can be used to work out proper substitution, see ?substitute2 examples.", CHAR(STRING_ELT(arg_names, i)), type2char(TYPEOF(sym)));
+            error(_("Attempting to substitute '%s' element with object of type '%s' but it has to be 'symbol' type when substituting name of the call argument, functions 'as.name' and 'I' can be used to work out proper substitution, see ?substitute2 examples."), CHAR(STRING_ELT(arg_names, i)), type2char(TYPEOF(sym)));
           SET_TAG(tmp, sym);
         }
       }

--- a/src/utils.c
+++ b/src/utils.c
@@ -352,24 +352,24 @@ const char *class1(SEXP x) {
 SEXP coerceAs(SEXP x, SEXP as, SEXP copyArg) {
   // copyArg does not update in place, but only IF an object is of the same type-class as class to be coerced, it will return with no copy
   if (!isVectorAtomic(x))
-    error("'x' is not atomic");
+    error(_("'x' is not atomic"));
   if (!isVectorAtomic(as))
-    error("'as' is not atomic");
+    error(_("'as' is not atomic"));
   if (!isNull(getAttrib(x, R_DimSymbol)))
-    error("'x' must not be matrix or array");
+    error(_("'x' must not be matrix or array"));
   if (!isNull(getAttrib(as, R_DimSymbol)))
-    error("'as' must not be matrix or array");
+    error(_("'as' must not be matrix or array"));
   bool verbose = GetVerbose()>=2; // verbose level 2 required
   if (!LOGICAL(copyArg)[0] && TYPEOF(x)==TYPEOF(as) && class1(x)==class1(as)) {
     if (verbose)
-      Rprintf("copy=false and input already of expected type and class %s[%s]\n", type2char(TYPEOF(x)), class1(x));
+      Rprintf(_("copy=false and input already of expected type and class %s[%s]\n"), type2char(TYPEOF(x)), class1(x));
     copyMostAttrib(as, x); // so attrs like factor levels are same for copy=T|F
     return(x);
   }
   int len = LENGTH(x);
   SEXP ans = PROTECT(allocNAVectorLike(as, len));
   if (verbose)
-    Rprintf("Coercing %s[%s] into %s[%s]\n", type2char(TYPEOF(x)), class1(x), type2char(TYPEOF(as)), class1(as));
+    Rprintf(_("Coercing %s[%s] into %s[%s]\n"), type2char(TYPEOF(x)), class1(x), type2char(TYPEOF(as)), class1(as));
   const char *ret = memrecycle(/*target=*/ans, /*where=*/R_NilValue, /*start=*/0, /*len=*/LENGTH(x), /*source=*/x, /*sourceStart=*/0, /*sourceLen=*/-1, /*colnum=*/0, /*colname=*/"");
   if (ret)
     warning(_("%s"), ret);
@@ -385,7 +385,7 @@ SEXP dt_zlib_version() {
 #ifndef NOZLIB
   snprintf(out, 50, "zlibVersion()==%s ZLIB_VERSION==%s", zlibVersion(), ZLIB_VERSION);
 #else
-  snprintf(out, 50, "zlib header files were not found when data.table was compiled");
+  snprintf(out, 50, _("zlib header files were not found when data.table was compiled"));
 #endif
   return ScalarString(mkChar(out));
 }


### PR DESCRIPTION
Just learned `xgettext` can really outclass the `grep` approach that was used before. Soon we'll be able to replace it all with some `potools` things, but we can simplify right away with this one command.

Also marked a few messages for translation that came out of running this, while we're at it, just to demonstrate utility.