### PR TITLE
Add new template functions for internal error/warning/message to ease translation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,6 @@ vignettes/plots/figures
 .Renviron
 lib
 library
-*.R
 *.csv
 *.csvy
 *.RDS

--- a/R/as.data.table.R
+++ b/R/as.data.table.R
@@ -105,7 +105,7 @@ as.data.table.array = function(x, keep.rownames=FALSE, key=NULL, sorted=TRUE, va
   if (is.null(names(val)) || !any(nzchar(names(val))))
     setattr(val, 'names', paste0("V", rev(seq_along(val))))
   if (value.name %chin% names(val))
-    stop("Argument 'value.name' should not overlap with column names in result: ", brackify(rev(names(val))))
+    stopf("Argument 'value.name' should not overlap with column names in result: %s", brackify(rev(names(val))))
   N = NULL
   ans = data.table(do.call(CJ, c(val, sorted=FALSE)), N=as.vector(x))
   if (isTRUE(na.rm))
@@ -178,7 +178,7 @@ as.data.table.list = function(x,
     xi = x[[i]]
     if (is.null(xi)) { n_null = n_null+1L; next }
     if (eachnrow[i]>1L && nrow%%eachnrow[i]!=0L)   # in future: eachnrow[i]!=nrow
-      warning("Item ", i, " has ", eachnrow[i], " rows but longest item has ", nrow, "; recycled with remainder.")
+      warningf("Item %d has %d rows but longest item has %d; recycled with remainder.", i, eachnrow[i], nrow)
     if (is.data.table(xi)) {   # matrix and data.frame were coerced to data.table above
       prefix = if (!isFALSE(.named[i]) && isTRUE(nchar(names(x)[i])>0L)) paste0(names(x)[i],".") else ""  # test 2058.12
       for (j in seq_along(xi)) {

--- a/R/between.R
+++ b/R/between.R
@@ -9,10 +9,10 @@ between = function(x, lower, upper, incbounds=TRUE, NAbounds=TRUE, check=FALSE) 
   if (is.px(x) && (is.character(lower) || is.character(upper))) {
     tz = attr(x, "tzone", exact=TRUE)
     if (is.null(tz)) tz = ""
-    if (is.character(lower)) lower = tryCatch(as.POSIXct(lower, tz=tz), error=function(e)stop(
-      "'between' function the 'x' argument is a POSIX class while 'lower' was not, coercion to POSIX failed with: ", e$message))
-    if (is.character(upper)) upper = tryCatch(as.POSIXct(upper, tz=tz), error=function(e)stop(
-      "'between' function the 'x' argument is a POSIX class while 'upper' was not, coercion to POSIX failed with: ", e$message))
+    if (is.character(lower)) lower = tryCatch(as.POSIXct(lower, tz=tz), error=function(e)stopf(
+      "'between' function the 'x' argument is a POSIX class while '%s' was not, coercion to POSIX failed with: %s", 'lower', e$message))
+    if (is.character(upper)) upper = tryCatch(as.POSIXct(upper, tz=tz), error=function(e)stopf(
+      "'between' function the 'x' argument is a POSIX class while '%s' was not, coercion to POSIX failed with: %s", 'upper', e$message))
     stopifnot(is.px(x), is.px(lower), is.px(upper)) # nocov # internal
   }
   # POSIX check timezone match
@@ -24,11 +24,11 @@ between = function(x, lower, upper, incbounds=TRUE, NAbounds=TRUE, check=FALSE) 
     # lower/upper should be more tightly linked than x/lower, so error
     #   if the former don't match but only inform if they latter don't
     if (tzs[2L]!=tzs[3L]) {
-      stop("'between' lower= and upper= are both POSIXct but have different tzone attributes: ", brackify(tzs[2:3],quote=TRUE), ". Please align their time zones.")
+      stopf("'between' lower= and upper= are both POSIXct but have different tzone attributes: %s. Please align their time zones.", brackify(tzs[2:3], quote=TRUE))
       # otherwise the check in between.c that lower<=upper can (correctly) fail for this reason
     }
     if (tzs[1L]!=tzs[2L]) {
-      message("'between' arguments are all POSIXct but have mismatched tzone attributes: ", brackify(tzs,quote=TRUE),". The UTC times will be compared.")
+      messagef("'between' arguments are all POSIXct but have mismatched tzone attributes: %s. The UTC times will be compared.", brackify(tzs, quote=TRUE))
       # the underlying numeric is always UTC anyway in POSIXct so no coerce is needed; just compare as-is. As done by CoSMoS::example(analyzeTS), #3581
     }
   }
@@ -60,12 +60,8 @@ between = function(x, lower, upper, incbounds=TRUE, NAbounds=TRUE, check=FALSE) 
     y = eval.parent(ysub)
   }
   if ((l <- length(y)) != 2L) {
-    stop("RHS has length() ", l, "; expecting length 2. ",
-         if (ysub %iscall% 'c')
-           sprintf("Perhaps you meant %s? ",
-                   capture.output(print(`[[<-`(ysub, 1L, quote(list))))),
-         "The first element should be the lower bound(s); ",
-         "the second element should be the upper bound(s).")
+    suggestion <- if (ysub %iscall% 'c') gettextf("Perhaps you meant %s? ", capture.output(print(`[[<-`(ysub, 1L, quote(list))))) else ""
+    stopf("RHS has length() %d; expecting length 2. %sThe first element should be the lower bound(s); the second element should be the upper bound(s).", l, suggestion)
   }
   between(x, y[[1L]], y[[2L]], incbounds=TRUE)
 }

--- a/R/bmerge.R
+++ b/R/bmerge.R
@@ -45,11 +45,11 @@ bmerge = function(i, x, icols, xcols, roll, rollends, nomatch, mult, ops, verbos
     iclass = getClass(i[[ic]])
     xname = paste0("x.", names(x)[xc])
     iname = paste0("i.", names(i)[ic])
-    if (!xclass %chin% supported) stop("x.", names(x)[xc]," is type ", xclass, " which is not supported by data.table join")
-    if (!iclass %chin% supported) stop("i.", names(i)[ic]," is type ", iclass, " which is not supported by data.table join")
+    if (!xclass %chin% supported) stopf("%s is type %s which is not supported by data.table join", xname, xclass)
+    if (!iclass %chin% supported) stopf("%s is type %s which is not supported by data.table join", iname, iclass)
     if (xclass=="factor" || iclass=="factor") {
       if (roll!=0.0 && a==length(icols))
-        stop("Attempting roll join on factor column when joining x.",names(x)[xc]," to i.",names(i)[ic],". Only integer, double or character columns may be roll joined.")
+        stopf("Attempting roll join on factor column when joining %s to %s. Only integer, double or character columns may be roll joined.", xname, iname)
       if (xclass=="factor" && iclass=="factor") {
         if (verbose) catf("Matching %s factor levels to %s factor levels.\n", iname, xname)
         set(i, j=ic, value=chmatch(levels(i[[ic]]), levels(x[[xc]]), nomatch=0L)[i[[ic]]])  # nomatch=0L otherwise a level that is missing would match to NA values
@@ -68,7 +68,7 @@ bmerge = function(i, x, icols, xcols, roll, rollends, nomatch, mult, ops, verbos
           next
         }
       }
-      stop("Incompatible join types: x.", names(x)[xc], " (",xclass,") and i.", names(i)[ic], " (",iclass,"). Factor columns must join to factor or character columns.")
+      stopf("Incompatible join types: %s (%s) and %s (%s). Factor columns must join to factor or character columns.", xname, xclass, iname, iclass)
     }
     if (xclass == iclass) {
       if (verbose) catf("%s has same type (%s) as %s. No coercion needed.\n", iname, xclass, xname)
@@ -87,7 +87,7 @@ bmerge = function(i, x, icols, xcols, roll, rollends, nomatch, mult, ops, verbos
         set(x, j=xc, value=match.fun(paste0("as.", iclass))(x[[xc]]))
         next
       }
-      stop("Incompatible join types: x.", names(x)[xc], " (",xclass,") and i.", names(i)[ic], " (",iclass,")")
+      stopf("Incompatible join types: %s (%s) and %s (%s)", xname, xclass, iname, iclass)
     }
     if (xclass=="integer64" || iclass=="integer64") {
       nm = c(iname, xname)
@@ -95,7 +95,7 @@ bmerge = function(i, x, icols, xcols, roll, rollends, nomatch, mult, ops, verbos
       if (wclass=="integer" || (wclass=="double" && !isReallyReal(w[[wc]]))) {
         if (verbose) catf("Coercing %s column %s%s to type integer64 to match type of %s.\n", wclass, nm[1L], if (wclass=="double") " (which contains no fractions)" else "", nm[2L])
         set(w, j=wc, value=bit64::as.integer64(w[[wc]]))
-      } else stop("Incompatible join types: ", nm[2L], " is type integer64 but ", nm[1L], " is type double and contains fractions")
+      } else stopf("Incompatible join types: %s is type integer64 but %s is type double and contains fractions", nm[2L], nm[1L])
     } else {
       # just integer and double left
       if (iclass=="double") {

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -284,7 +284,7 @@ replace_dot_alias = function(e) {
     } else if (is.name(jsub)) {
       if (startsWith(as.character(jsub), "..")) stop("Internal error:  DT[, ..var] should be dealt with by the branch above now.") # nocov
       if (!with && !exists(as.character(jsub), where=parent.frame()))
-        stopf("Variable '%s' is not found in calling scope. Looking in calling scope because you set with=FALSE. Also, please use .. symbol prefix and remove with=FALSE.", jsub)
+        stopf("Variable '%s' is not found in calling scope. Looking in calling scope because you set with=FALSE. Also, please use .. symbol prefix and remove with=FALSE.", as.character(jsub))
     }
     if (root=="{") {
       if (length(jsub) == 2L) {
@@ -866,7 +866,7 @@ replace_dot_alias = function(e) {
         } else bynames = names(byval)
         if (is.atomic(byval)) {
           if (is.character(byval) && length(byval)<=ncol(x) && !(is.name(bysub) && bysub %chin% names_x) ) {
-            stopf("'by' appears to evaluate to column names but isn't c() or key(). Use by=list(...) if you can. Otherwise, by=eval(%s) should work. This is for efficiency so data.table can detect which columns are needed.", deparse(bysub))
+            stopf("'by' appears to evaluate to column names but isn't c() or key(). Use by=list(...) if you can. Otherwise, by=eval%s should work. This is for efficiency so data.table can detect which columns are needed.", deparse(bysub))
           } else {
             # by may be a single unquoted column name but it must evaluate to list so this is a convenience to users. Could also be a single expression here such as DT[,sum(v),by=colA%%2]
             byval = list(byval)
@@ -2568,7 +2568,7 @@ setnames = function(x,old,new,skip_absent=FALSE) {
     if (anyDuplicated(old)) stopf("Some duplicates exist in 'old': %s", brackify(old[duplicated(old)]))
     if (is.numeric(old)) i = old = seq_along(x)[old]  # leave it to standard R to manipulate bounds and negative numbers
     else if (!is.character(old)) stopf("'old' is type %s but should be integer, double or character", typeof(old))
-    if (length(new)!=length(old)) stopf("'old' is length %d but 'new' is length ", length(old), length(new))
+    if (length(new)!=length(old)) stopf("'old' is length %d but 'new' is length %d", length(old), length(new))
     if (anyNA(old)) stopf("NA (or out of bounds) in 'old' at positions %s", brackify(which(is.na(old))))
     if (is.character(old)) {
       i = chmatchdup(c(old,old), names(x))  # chmatchdup returns the second of any duplicates matched to in names(x) (if any)
@@ -2743,7 +2743,7 @@ setDF = function(x, rownames=NULL) {
       rn = .set_row_names(mn)
     } else {
       if (length(rownames) != mn)
-      stopf("rownames incorrect length; expected %d names, got %d", nm, length(rownames))
+      stopf("rownames incorrect length; expected %d names, got %d", mn, length(rownames))
       rn = rownames
     }
     setattr(x,"row.names", rn)

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -885,7 +885,7 @@ replace_dot_alias = function(e) {
           }
         }
         tt = vapply_1i(byval,length)
-        if (any(tt!=xnrow)) stop(domain=NA, gettextf("The items in the 'by' or 'keyby' list are length(s) (%s). Each must be length %d; the same length as there are rows in x (after subsetting if i is provided).", paste(tt, collapse=","), xnrow))
+        if (any(tt!=xnrow)) stopf("The items in the 'by' or 'keyby' list are length(s) (%s). Each must be length %d; the same length as there are rows in x (after subsetting if i is provided).", brackify(tt), xnrow)
         if (is.null(bynames)) bynames = rep.int("",length(byval))
         if (length(idx <- which(!nzchar(bynames))) && !bynull) {
           # TODO: improve this and unify auto-naming of jsub and bysub
@@ -938,7 +938,7 @@ replace_dot_alias = function(e) {
             # attempt to auto-name unnamed columns
             for (jj in which(nm=="")) {
               thisq = q[[jj + 1L]]
-              if (missing(thisq)) stop(domain=NA, gettextf("Item %d of the .() or list() passed to j is missing", jj)) #3507
+              if (missing(thisq)) stopf("Item %d of the .() or list() passed to j is missing", jj) #3507
               if (is.name(thisq)) nm[jj] = drop_dot(thisq)
               # TO DO: if call to a[1] for example, then call it 'a' too
             }
@@ -2995,7 +2995,7 @@ isReallyReal = function(x) {
     RHS = eval(stub[[3L]], x, enclos)
     if (is.list(RHS)) RHS = as.character(RHS)  # fix for #961
     if (length(RHS) != 1L && !operator %chin% c("%in%", "%chin%")){
-      if (length(RHS) != nrow(x)) stop(domain=NA, gettextf("RHS of %s is length %d which is not 1 or nrow (%d). For robustness, no recycling is allowed (other than of length 1 RHS). Consider %%in%% instead.", operator, length(RHS), nrow(x)))
+      if (length(RHS) != nrow(x)) stopf("RHS of %s is length %d which is not 1 or nrow (%d). For robustness, no recycling is allowed (other than of length 1 RHS). Consider %%in%% instead.", operator, length(RHS), nrow(x))
       return(NULL) # DT[colA == colB] regular element-wise vector scan
     }
     if ( mode(x[[col]]) != mode(RHS) ||                # mode() so that doubleLHS/integerRHS and integerLHS/doubleRHS!isReallyReal are optimized (both sides mode 'numeric')

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -408,13 +408,13 @@ replace_dot_alias = function(e) {
         # must be "not found" since isub is a mere symbol
         col = try(eval(isub, x), silent=TRUE)  # is it a column name?
         msg = if (inherits(col, "try-error")) gettextf(
-          "'%s' is not found in calling scope and it is not a column name either. ",
+          "'%s' is not found in calling scope and it is not a column name either",
           as.character(isub)
         ) else gettextf(
-          "'%s' is not found in calling scope, but it is a column of type %s. If you wish to select rows where that column contains TRUE, or perhaps that column contains row numbers of itself to select, try DT[(col)], DT[DT$col], or DT[col==TRUE} is particularly clear and is optimized. ",
+          "'%s' is not found in calling scope, but it is a column of type %s. If you wish to select rows where that column contains TRUE, or perhaps that column contains row numbers of itself to select, try DT[(col)], DT[DT$col], or DT[col==TRUE} is particularly clear and is optimized",
           as.character(isub), typeof(col)
         )
-        stopf("%sWhen the first argument inside DT[...] is a single symbol (e.g. DT[var]), data.table looks for var in calling scope.", msg)
+        stopf("%s. When the first argument inside DT[...] is a single symbol (e.g. DT[var]), data.table looks for var in calling scope.", msg)
       }
     }
     if (restore.N) {
@@ -1227,7 +1227,7 @@ replace_dot_alias = function(e) {
           if (any(w2na <- is.na(w2))) {
             ivars[leftcols] = paste0("i.",ivars[leftcols])
             w2[w2na] = chmatch(ansvars[wna][w2na], ivars)
-            if (any(w2na <- is.na(w2))) stopf("Internal error -- column(s) not found: %s", paste(ansvars[wna][w2na],sep=", ")) # nocov
+            if (any(w2na <- is.na(w2))) stopf("Internal error -- column(s) not found: %s", brackify(ansvars[wna][w2na])) # nocov
           }
         }
         icols = w2
@@ -2176,7 +2176,7 @@ dimnames.data.table = function(x) {
   if (!cedta()) return(`dimnames<-.data.frame`(x,value))  # nocov ; will drop key but names<-.data.table (below) is more common usage and does retain the key
   if (!is.list(value) || length(value) != 2L) stop("attempting to assign invalid object to dimnames of a data.table")
   if (!is.null(value[[1L]])) stop("data.tables do not have rownames")
-  if (ncol(x) != length(value[[2L]])) stopf("Can't assign %d colnames to a %d-column data.table", length(value[[2L]]), ncol(x))
+  if (ncol(x) != length(value[[2L]])) stopf("Can't assign %d names to a %d-column data.table", length(value[[2L]]), ncol(x))
   setnames(x,as.character(value[[2L]]))
   x  # this returned value is now shallow copied by R 3.1.0 via *tmp*. A very welcome change.
 }

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -885,7 +885,7 @@ replace_dot_alias = function(e) {
           }
         }
         tt = vapply_1i(byval,length)
-        if (any(tt!=xnrow)) stopf("The items in the 'by' or 'keyby' list are length(s) (%s). Each must be length %d; the same length as there are rows in x (after subsetting if i is provided).", brackify(tt), xnrow)
+        if (any(tt!=xnrow)) stopf("The items in the 'by' or 'keyby' list are length(s) %s. Each must be length %d; the same length as there are rows in x (after subsetting if i is provided).", brackify(tt), xnrow)
         if (is.null(bynames)) bynames = rep.int("",length(byval))
         if (length(idx <- which(!nzchar(bynames))) && !bynull) {
           # TODO: improve this and unify auto-naming of jsub and bysub

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -129,9 +129,9 @@ replace_dot_alias = function(e) {
     )
     found = agrep(used, ref, value=TRUE, ignore.case=TRUE, fixed=TRUE)
     if (length(found)) {
-      stop("Object '", used, "' not found. Perhaps you intended ", brackify(found))
+      stopf("Object '%s' not found. Perhaps you intended %s", used, brackify(found))
     } else {
-      stop("Object '", used, "' not found amongst ", brackify(ref))
+      stopf("Object '%s' not found amongst %s", used, brackify(ref))
     }
   } else {
     stop(err$message, call.=FALSE)
@@ -180,7 +180,7 @@ replace_dot_alias = function(e) {
         stop("When by and keyby are both provided, keyby must be TRUE or FALSE")
     }
     if (missing(by)) { missingby=TRUE; by=bysub=NULL }  # possible when env is used, PR#4304
-    else if (verbose) cat("Argument 'by' after substitute: ", paste(deparse(bysub, width.cutoff=500L), collapse=" "), "\n", sep="")
+    else if (verbose) catf("Argument '%s' after substitute: %s\n", "by", paste(deparse(bysub, width.cutoff=500L), collapse=" "))
   }
   bynull = !missingby && is.null(by) #3530
   byjoin = !is.null(by) && is.symbol(bysub) && bysub==".EACHI"
@@ -189,7 +189,7 @@ replace_dot_alias = function(e) {
   if (missing(i) && !missing(on)) {
     tt = eval.parent(.massagei(substitute(on)))
     if (!is.list(tt) || !length(names(tt))) {
-      warning("When on= is provided but not i=, on= must be a named list or data.table|frame, and a natural join (i.e. join on common names) is invoked. Ignoring on= which is '",class(tt)[1L],"'.")
+      warningf("When on= is provided but not i=, on= must be a named list or data.table|frame, and a natural join (i.e. join on common names) is invoked. Ignoring on= which is '%s'.", class(tt)[1L])
       on = NULL
     } else {
       i = tt
@@ -210,7 +210,7 @@ replace_dot_alias = function(e) {
   missingroll = missing(roll)
   if (length(roll)!=1L || is.na(roll)) stop("roll must be a single TRUE, FALSE, positive/negative integer/double including +Inf and -Inf or 'nearest'")
   if (is.character(roll)) {
-    if (roll!="nearest") stop("roll is '",roll,"' (type character). Only valid character value is 'nearest'.")
+    if (roll!="nearest") stopf("roll is '%s' (type character). Only valid character value is 'nearest'.", roll)
   } else {
     roll = if (isTRUE(roll)) +Inf else as.double(roll)
   }
@@ -225,7 +225,7 @@ replace_dot_alias = function(e) {
   if (!is.na(nomatch) && nomatch!=0L) stop("nomatch= must be either NA or NULL (or 0 for backwards compatibility which is the same as NULL)")
   nomatch = as.integer(nomatch)
   if (!is.logical(which) || length(which)>1L) stop("which= must be a logical vector length 1. Either FALSE, TRUE or NA.")
-  if ((isTRUE(which)||is.na(which)) && !missing(j)) stop("which==",which," (meaning return row numbers) but j is also supplied. Either you need row numbers or the result of j, but only one type of result can be returned.")
+  if ((isTRUE(which)||is.na(which)) && !missing(j)) stopf("which==%s (meaning return row numbers) but j is also supplied. Either you need row numbers or the result of j, but only one type of result can be returned.", which)
   if (!is.na(nomatch) && is.na(which)) stop("which=NA with nomatch=0 would always return an empty vector. Please change or remove either which or nomatch.")
   if (!with && missing(j)) stop("j must be provided when with=FALSE")
   irows = NULL  # Meaning all rows. We avoid creating 1:nrow(x) for efficiency.
@@ -241,7 +241,7 @@ replace_dot_alias = function(e) {
         substitute2(.j, env),
         list(.j = substitute(j))
       ))
-      if (missing(jsub)) {j = substitute(); jsub=NULL} else if (verbose) cat("Argument 'j'  after substitute: ", paste(deparse(jsub, width.cutoff=500L), collapse=" "), "\n", sep="")
+      if (missing(jsub)) {j = substitute(); jsub=NULL} else if (verbose) catf("Argument '%s' after substitute: %s\n", "j", paste(deparse(jsub, width.cutoff=500L), collapse=" "))
     }
   }
   if (!missing(j)) {
@@ -269,15 +269,14 @@ replace_dot_alias = function(e) {
           name = substr(..name, 3L, nchar(..name))
           if (!nzchar(name)) stop("The symbol .. is invalid. The .. prefix must be followed by at least one character.")
           if (!exists(name, where=parent.frame())) {
-            stop("Variable '",name,"' is not found in calling scope. Looking in calling scope because you used the .. prefix.",
-              if (exists(..name, where=parent.frame()))
-                paste0(" Variable '..",name,"' does exist in calling scope though, so please just removed the .. prefix from that variable name in calling scope.")
-                # We have recommended 'manual' .. prefix in the past, so try to be helpful
-              else
-                ""
-            )
+            suggested = if (exists(..name, where=parent.frame()))
+              gettextf(" Variable '..%s' does exist in calling scope though, so please just removed the .. prefix from that variable name in calling scope.", name)
+            # We have recommended 'manual' .. prefix in the past, so try to be helpful
+            else
+              ""
+            stopf("Variable '%s' is not found in calling scope. Looking in calling scope because you used the .. prefix.%s", name, suggested)
           } else if (exists(..name, where=parent.frame())) {
-            warning("Both '",name,"' and '..", name, "' exist in calling scope. Please remove the '..", name,"' variable in calling scope for clarity.")
+            warningf("Both '%1$s' and '..%1$s' exist in calling scope. Please remove the '..%1$s' variable in calling scope for clarity.", name)
           }
         }
         ..syms = av
@@ -285,7 +284,7 @@ replace_dot_alias = function(e) {
     } else if (is.name(jsub)) {
       if (startsWith(as.character(jsub), "..")) stop("Internal error:  DT[, ..var] should be dealt with by the branch above now.") # nocov
       if (!with && !exists(as.character(jsub), where=parent.frame()))
-        stop("Variable '",jsub,"' is not found in calling scope. Looking in calling scope because you set with=FALSE. Also, please use .. symbol prefix and remove with=FALSE.")
+        stopf("Variable '%s' is not found in calling scope. Looking in calling scope because you set with=FALSE. Also, please use .. symbol prefix and remove with=FALSE.", jsub)
     }
     if (root=="{") {
       if (length(jsub) == 2L) {
@@ -328,7 +327,7 @@ replace_dot_alias = function(e) {
         substitute2(.i, env),
         list(.i = substitute(i))
       ))
-      if (missing(isub)) {i = substitute(); isub=NULL} else if (verbose) cat("Argument 'i'  after substitute: ", paste(deparse(isub, width.cutoff=500L), collapse=" "), "\n", sep="")
+      if (missing(isub)) {i = substitute(); isub=NULL} else if (verbose) catf("Argument '%s' after substitute: %s\n", "i", paste(deparse(isub, width.cutoff=500L), collapse=" "))
     }
   }
   if (!missing(i)) {
@@ -415,7 +414,7 @@ replace_dot_alias = function(e) {
           "'%s' is not found in calling scope, but it is a column of type %s. If you wish to select rows where that column contains TRUE, or perhaps that column contains row numbers of itself to select, try DT[(col)], DT[DT$col], or DT[col==TRUE} is particularly clear and is optimized. ",
           as.character(isub), typeof(col)
         )
-        stop(msg, "When the first argument inside DT[...] is a single symbol (e.g. DT[var]), data.table looks for var in calling scope.")
+        stopf("%sWhen the first argument inside DT[...] is a single symbol (e.g. DT[var]), data.table looks for var in calling scope.", msg)
       }
     }
     if (restore.N) {
@@ -595,7 +594,7 @@ replace_dot_alias = function(e) {
       }
       # TO DO: TODO: Incorporate which_ here on DT[!i] where i is logical. Should avoid i = !i (above) - inefficient.
       # i is not a data.table
-      if (!is.logical(i) && !is.numeric(i)) stop("i has evaluated to type ", typeof(i), ". Expecting logical, integer or double.")
+      if (!is.logical(i) && !is.numeric(i)) stopf("i has evaluated to type %s. Expecting logical, integer or double.", typeof(i))
       if (is.logical(i)) {
         if (is.na(which)) { # #4411 i filter not optimized to join: DT[A > 1, which = NA]
           ## we need this branch here, not below next to which=TRUE because irows=i=which(i) will filter out NAs: DT[A > 10, which = NA] will be incorrect
@@ -617,7 +616,7 @@ replace_dot_alias = function(e) {
         # Also this which() is for consistency of DT[colA>3,which=TRUE] and which(DT[,colA>3])
         # Assigning to 'i' here as well to save memory, #926.
 
-        else stop("i evaluates to a logical vector length ", length(i), " but there are ", nrow(x), " rows. Recycling of logical i is no longer allowed as it hides more bugs than is worth the rare convenience. Explicitly use rep(...,length=.N) if you really need to recycle.")
+        else stopf("i evaluates to a logical vector length %d but there are %d rows. Recycling of logical i is no longer allowed as it hides more bugs than is worth the rare convenience. Explicitly use rep(...,length=.N) if you really need to recycle.", length(i), nrow(x))
       } else {
         irows = as.integer(i)  # e.g. DT[c(1,3)] and DT[c(-1,-3)] ok but not DT[c(1,-3)] (caught as error)
         irows = .Call(CconvertNegAndZeroIdx, irows, nrow(x), is.null(jsub) || root!=":=")  # last argument is allowOverMax (NA when selecting, error when assigning)
@@ -716,7 +715,7 @@ replace_dot_alias = function(e) {
       if (is.factor(j)) j = as.character(j)  # fix for FR: #358
       if (is.character(j)) {
         if (notj) {
-          if (anyNA(idx <- chmatch(j, names_x))) warning("column(s) not removed because not found: ", brackify(j[is.na(idx)]))
+          if (anyNA(idx <- chmatch(j, names_x))) warningf("column(s) not removed because not found: %s", brackify(j[is.na(idx)]))
           # all duplicates of the name in names(x) must be removed; e.g. data.table(x=1, y=2, x=3)[, !"x"] should just output 'y'.
           w = !names_x %chin% j
           ansvars = names_x[w]
@@ -730,13 +729,13 @@ replace_dot_alias = function(e) {
         if (!length(ansvals)) return(null.data.table())
         if (!length(leftcols)) {
           if (!anyNA(ansvals)) return(.Call(CsubsetDT, x, irows, ansvals))
-          else stop("column(s) not found: ", brackify(ansvars[is.na(ansvals)]))
+          else stopf("column(s) not found: %s", brackify(ansvars[is.na(ansvals)]))
         }
         # else the NA in ansvals are for join inherited scope (test 1973), and NA could be in irows from join and data in i should be returned (test 1977)
         #   in both cases leave to the R-level subsetting of i and x together further below
       } else if (is.numeric(j)) {
         j = as.integer(j)
-        if (any(w<-(j>ncol(x)))) stop("Item ",which.first(w)," of j is ",j[which.first(w)]," which is outside the column number range [1,ncol=", ncol(x),"]")
+        if (any(w <- (j>ncol(x)))) stopf("Item %d of j is %d which is outside the column number range [1,ncol=%d]", idx <- which.first(w), j[idx], ncol(x))
         j = j[j!=0L]
         if (any(j<0L)) {
           if (any(j>0L)) stop("j mixes positives and negatives")
@@ -789,7 +788,7 @@ replace_dot_alias = function(e) {
 
         if (mode(bysub) == "character") {
           if (length(grep(",", bysub, fixed = TRUE))) {
-            if (length(bysub)>1L) stop("'by' is a character vector length ",length(bysub)," but one or more items include a comma. Either pass a vector of column names (which can contain spaces, but no commas), or pass a vector length 1 containing comma separated column names. See ?data.table for other possibilities.")
+            if (length(bysub)>1L) stopf("'by' is a character vector length %d but one or more items include a comma. Either pass a vector of column names (which can contain spaces, but no commas), or pass a vector length 1 containing comma separated column names. See ?data.table for other possibilities.", length(bysub))
             bysub = strsplit(bysub,split=",")[[1L]]
           }
           backtick_idx = grep("^[^`]+$",bysub)
@@ -867,7 +866,7 @@ replace_dot_alias = function(e) {
         } else bynames = names(byval)
         if (is.atomic(byval)) {
           if (is.character(byval) && length(byval)<=ncol(x) && !(is.name(bysub) && bysub %chin% names_x) ) {
-            stop("'by' appears to evaluate to column names but isn't c() or key(). Use by=list(...) if you can. Otherwise, by=eval",deparse(bysub)," should work. This is for efficiency so data.table can detect which columns are needed.")
+            stopf("'by' appears to evaluate to column names but isn't c() or key(). Use by=list(...) if you can. Otherwise, by=eval(%s) should work. This is for efficiency so data.table can detect which columns are needed.", deparse(bysub))
           } else {
             # by may be a single unquoted column name but it must evaluate to list so this is a convenience to users. Could also be a single expression here such as DT[,sum(v),by=colA%%2]
             byval = list(byval)
@@ -920,7 +919,7 @@ replace_dot_alias = function(e) {
 
       jvnames = NULL
       drop_dot = function(x) {
-        if (length(x)!=1L) stop("Internal error: drop_dot passed ",length(x)," items")  # nocov
+        if (length(x)!=1L) stopf("Internal error: drop_dot passed %d items", length(x))  # nocov
         if (startsWith(x<-as.character(x), ".") && x %chin% c(".N", ".I", ".GRP", ".NGRP", ".BY"))
           substr(x, 2L, nchar(x))
         else
@@ -947,7 +946,7 @@ replace_dot_alias = function(e) {
               if (length(nm) != length(jvnames))
                 warning("j may not evaluate to the same number of columns for each group; if you're sure this warning is in error, please put the branching logic outside of [ for efficiency")
               else if (any(idx <- nm != jvnames))
-                warning("Different branches of j expression produced different auto-named columns: ", brackify(sprintf('%s!=%s', nm[idx], jvnames[idx])), '; using the most "last" names. If this was intentional (e.g., you know only one branch will ever be used in a given query because the branch is controlled by a function argument), please (1) pull this branch out of the call; (2) explicitly provide missing defaults for each branch in all cases; or (3) use the same name for each branch and re-name it in a follow-up call.', call. = FALSE)
+                warningf('Different branches of j expression produced different auto-named columns: %s; using the most "last" names. If this was intentional (e.g., you know only one branch will ever be used in a given query because the branch is controlled by a function argument), please (1) pull this branch out of the call; (2) explicitly provide missing defaults for each branch in all cases; or (3) use the same name for each branch and re-name it in a follow-up call.',  brackify(sprintf('%s!=%s', nm[idx], jvnames[idx])))
             }
             jvnames <<- nm # TODO: handle if() list(a, b) else list(b, a) better
             setattr(q, "names", NULL)  # drops the names from the list so it's faster to eval the j for each group; reinstated at the end on the result.
@@ -1010,15 +1009,15 @@ replace_dot_alias = function(e) {
               if (is.function(.SDcols)) {
                 .SDcols = lapply(x, .SDcols)
                 if (any(idx <- vapply_1i(.SDcols, length) > 1L | vapply_1c(.SDcols, typeof) != 'logical' | vapply_1b(.SDcols, anyNA)))
-                  stop("When .SDcols is a function, it is applied to each column; the output of this function must be a non-missing boolean scalar signalling inclusion/exclusion of the column. However, these conditions were not met for: ", brackify(names(x)[idx]))
+                  stopf("When .SDcols is a function, it is applied to each column; the output of this function must be a non-missing boolean scalar signalling inclusion/exclusion of the column. However, these conditions were not met for: %s", brackify(names(x)[idx]))
                 .SDcols = unlist(.SDcols, use.names = FALSE)
               }
             }
           }
           if (anyNA(.SDcols))
-            stop(".SDcols missing at the following indices: ", brackify(which(is.na(.SDcols))))
+            stopf(".SDcols missing at the following indices: %s", brackify(which(is.na(.SDcols))))
           if (is.logical(.SDcols)) {
-            if (length(.SDcols)!=length(x)) stop(gettextf(".SDcols is a logical vector length %d but there are %d columns", length(.SDcols), length(x)))
+            if (length(.SDcols)!=length(x)) stopf(".SDcols is a logical vector length %d but there are %d columns", length(.SDcols), length(x))
             ansvals = which_(.SDcols, !negate_sdcols)
             ansvars = sdvars = names_x[ansvals]
           } else if (is.numeric(.SDcols)) {
@@ -1026,13 +1025,13 @@ replace_dot_alias = function(e) {
             # if .SDcols is numeric, use 'dupdiff' instead of 'setdiff'
             if (length(unique(sign(.SDcols))) > 1L) stop(".SDcols is numeric but has both +ve and -ve indices")
             if (any(idx <- abs(.SDcols)>ncol(x) | abs(.SDcols)<1L))
-              stop(".SDcols is numeric but out of bounds [1, ", ncol(x), "] at: ", brackify(which(idx)))
+              stopf(".SDcols is numeric but out of bounds [1, %d] at: %s", ncol(x), brackify(which(idx)))
             ansvars = sdvars = if (negate_sdcols) dupdiff(names_x[-.SDcols], bynames) else names_x[.SDcols]
             ansvals = if (negate_sdcols) setdiff(seq_along(names(x)), c(.SDcols, which(names(x) %chin% bynames))) else .SDcols
           } else {
             if (!is.character(.SDcols)) stop(".SDcols should be column numbers or names")
             if (!all(idx <- .SDcols %chin% names_x))
-              stop("Some items of .SDcols are not column names: ", brackify(.SDcols[!idx]))
+              stopf("Some items of .SDcols are not column names: %s", brackify(.SDcols[!idx]))
             ansvars = sdvars = if (negate_sdcols) setdiff(names_x, c(.SDcols, bynames)) else .SDcols
             # dups = FALSE here. DT[, .SD, .SDcols=c("x", "x")] again doesn't really help with which 'x' to keep (and if '-' which x to remove)
             ansvals = chmatch(ansvars, names_x)
@@ -1184,9 +1183,9 @@ replace_dot_alias = function(e) {
               if (is.list(k)) {
                 origj = j = if (name[[1L]] == "$") as.character(name[[3L]]) else eval(name[[3L]], parent.frame(), parent.frame())
                 if (is.character(j)) {
-                  if (length(j)!=1L) stop("Cannot assign to an under-allocated recursively indexed list -- L[[i]][,:=] syntax is only valid when i is length 1, but its length is ", length(j))
+                  if (length(j)!=1L) stopf("Cannot assign to an under-allocated recursively indexed list -- L[[i]][,:=] syntax is only valid when i is length 1, but its length is %d", length(j))
                   j = match(j, names(k))
-                  if (is.na(j)) stop("Internal error -- item '", origj, "' not found in names of list") # nocov
+                  if (is.na(j)) stopf("Internal error -- item '%s' not found in names of list", origj) # nocov
                 }
                 .Call(Csetlistelt,k,as.integer(j), x)
               } else if (is.environment(k) && exists(as.character(name[[3L]]), k)) {
@@ -1215,7 +1214,7 @@ replace_dot_alias = function(e) {
         xcolsAns = seq_along(ansvars)
         icols = icolsAns = integer()
       } else {
-        if (!length(leftcols)) stop("Internal error -- column(s) not found: ", brackify(ansvars[wna])) # nocov
+        if (!length(leftcols)) stopf("Internal error -- column(s) not found: %s", brackify(ansvars[wna])) # nocov
         xcols = w[!wna]
         xcolsAns = which(!wna)
         map = c(seq_along(i), leftcols)   # this map is to handle dups in leftcols, #3635
@@ -1228,7 +1227,7 @@ replace_dot_alias = function(e) {
           if (any(w2na <- is.na(w2))) {
             ivars[leftcols] = paste0("i.",ivars[leftcols])
             w2[w2na] = chmatch(ansvars[wna][w2na], ivars)
-            if (any(w2na <- is.na(w2))) stop("Internal error -- column(s) not found: ", paste(ansvars[wna][w2na],sep=", ")) # nocov
+            if (any(w2na <- is.na(w2))) stopf("Internal error -- column(s) not found: %s", paste(ansvars[wna][w2na],sep=", ")) # nocov
           }
         }
         icols = w2
@@ -1257,7 +1256,7 @@ replace_dot_alias = function(e) {
     getName = substr(sym, 3L, nchar(sym))
     if (!exists(getName, parent.frame())) {
       if (exists(sym, parent.frame())) next  # user did 'manual' prefix; i.e. variable in calling scope has .. prefix
-      stop("Variable '",getName,"' is not found in calling scope. Looking in calling scope because this symbol was prefixed with .. in the j= parameter.")
+      stopf("Variable '%s' is not found in calling scope. Looking in calling scope because this symbol was prefixed with .. in the j= parameter.", getName)
     }
     assign(sym, get(getName, parent.frame()), SDenv)
   }
@@ -1269,7 +1268,7 @@ replace_dot_alias = function(e) {
       if (!(length(i) && length(icols))) {
         # new in v1.12.0 to redirect to CsubsetDT in this case
         if (!identical(xcolsAns, seq_along(xcolsAns)) || length(xcols)!=length(xcolsAns) || length(ansvars)!=length(xcolsAns)) {
-          stop("Internal error: xcolAns does not pass checks: ", length(xcolsAns), length(ansvars), length(xcols), paste(xcolsAns,collapse=","))   # nocov
+          stopf("Internal error: xcolAns does not pass checks: %d/%d/%d/%s", length(xcolsAns), length(ansvars), length(xcols), brackify(xcolsAns))   # nocov
         }
         # Retained from old R way below (test 1542.01 checks shallow at this point)
         # ' Temp fix for #921 - skip COPY until after evaluating 'jval' (scroll down).
@@ -1354,7 +1353,7 @@ replace_dot_alias = function(e) {
     # There isn't a copy of the columns here, the xvar symbols point to the SD columns (copy-on-write).
 
     if (is.name(jsub) && is.null(lhs) && !exists(jsubChar<-as.character(jsub), SDenv, inherits=FALSE)) {
-      stop("j (the 2nd argument inside [...]) is a single symbol but column name '",jsubChar,"' is not found. If you intended to select columns using a variable in calling scope, please try DT[, ..",jsubChar,"]. The .. prefix conveys one-level-up similar to a file system path.")
+      stopf("j (the 2nd argument inside [...]) is a single symbol but column name '%1$s' is not found. If you intended to select columns using a variable in calling scope, please try DT[, ..%1$s]. The .. prefix conveys one-level-up similar to a file system path.", jsubChar)
     }
 
     jval = eval(jsub, SDenv, parent.frame())
@@ -1890,7 +1889,7 @@ replace_dot_alias = function(e) {
     # Efficiency gain of dropping names has been successful. Ordinarily this will run.
     if (is.null(jvnames)) jvnames = character(length(ans)-length(bynames))
     if (length(bynames)+length(jvnames)!=length(ans))
-      stop("Internal error: jvnames is length ",length(jvnames), " but ans is ",length(ans)," and bynames is ", length(bynames)) # nocov
+      stopf("Internal error: jvnames is length %d but ans is %d and bynames is %d", length(jvnames), length(ans), length(bynames)) # nocov
     ww = which(jvnames=="")
     if (any(ww)) jvnames[ww] = paste0("V",ww)
     setattr(ans, "names", c(bynames, jvnames))
@@ -1949,8 +1948,7 @@ as.matrix.data.table = function(x, rownames=NULL, rownames.value=NULL, ...) {
       # TODO in future as warned in NEWS for 1.11.6:
       #   warning("length(rownames)>1 is deprecated. Please use rownames.value= instead")
       if (length(rownames)!=nrow(x))
-        stop("length(rownames)==", length(rownames), " but nrow(DT)==", nrow(x),
-             ". The rownames argument specifies a single column name or number. Consider rownames.value= instead.")
+        stopf("length(rownames)==%d but nrow(DT)==%d. The rownames argument specifies a single column name or number. Consider rownames.value= instead.", length(rownames), nrow(x))
       rownames.value = rownames
       rownames = NULL
     } else if (length(rownames)==0L) {
@@ -1958,8 +1956,7 @@ as.matrix.data.table = function(x, rownames=NULL, rownames.value=NULL, ...) {
     } else {
       if (isTRUE(rownames)) {
         if (length(key(x))>1L) {
-          warning("rownames is TRUE but key has multiple columns ",
-                  brackify(key(x)), "; taking first column x[,1] as rownames")
+          warningf("rownames is TRUE but key has multiple columns %s; taking first column x[,1] as rownames", brackify(key(x)))
         }
         rownames = if (length(key(x))==1L) chmatch(key(x),names(x)) else 1L
       }
@@ -1969,20 +1966,18 @@ as.matrix.data.table = function(x, rownames=NULL, rownames.value=NULL, ...) {
       }
       else if (is.character(rownames)) {
         w = chmatch(rownames, names(x))
-        if (is.na(w)) stop("'", rownames, "' is not a column of x")
+        if (is.na(w)) stopf("'%s' is not a column of x", rownames)
         rownames = w
       }
       else { # rownames is a column number already
         rownames = as.integer(rownames)
         if (is.na(rownames) || rownames<1L || rownames>ncol(x))
-          stop("as.integer(rownames)==", rownames,
-               " which is outside the column number range [1,ncol=", ncol(x), "].")
+          stopf("as.integer(rownames)==%d which is outside the column number range [1,ncol=%d].", rownames, ncol(x))
       }
     }
   } else if (!is.null(rownames.value)) {
     if (length(rownames.value)!=nrow(x))
-      stop("length(rownames.value)==", length(rownames.value),
-           " but should be nrow(x)==", nrow(x))
+      stopf("length(rownames.value)==%d but should be nrow(x)==%d", length(rownames.value), nrow(x))
   }
   if (!is.null(rownames)) {
     # extract that column and drop it.
@@ -2044,7 +2039,7 @@ as.matrix.data.table = function(x, rownames=NULL, rownames.value=NULL, ...) {
   if (any(dm==0L)) {
     # retain highest type of input for empty output, #4762
     if (length(X)!=0L)
-      stop("Internal error: as.matrix.data.table length(X)==", length(X), " but a dimension is zero")  # nocov
+      stopf("Internal error: as.matrix.data.table length(X)==%d but a dimension is zero", length(X))  # nocov
     return(array(if (is.null(X)) NA else X, dim = dm, dimnames = list(rownames.value, cn)))
   }
   dim(X) <- c(n, length(X)/n)
@@ -2181,7 +2176,7 @@ dimnames.data.table = function(x) {
   if (!cedta()) return(`dimnames<-.data.frame`(x,value))  # nocov ; will drop key but names<-.data.table (below) is more common usage and does retain the key
   if (!is.list(value) || length(value) != 2L) stop("attempting to assign invalid object to dimnames of a data.table")
   if (!is.null(value[[1L]])) stop("data.tables do not have rownames")
-  if (ncol(x) != length(value[[2L]])) stop("Can't assign ", length(value[[2L]]), " colnames to a ", ncol(x), "-column data.table")
+  if (ncol(x) != length(value[[2L]])) stopf("Can't assign %d colnames to a %d-column data.table", length(value[[2L]]), ncol(x))
   setnames(x,as.character(value[[2L]]))
   x  # this returned value is now shallow copied by R 3.1.0 via *tmp*. A very welcome change.
 }
@@ -2358,7 +2353,7 @@ split.data.table = function(x, f, drop = FALSE, by, sorted = FALSE, keep.by = TR
   if (".ll.tech.split" %chin% names(x)) stop("Column '.ll.tech.split' is reserved for split.data.table processing")
   if (".nm.tech.split" %chin% by) stop("Column '.nm.tech.split' is reserved for split.data.table processing")
   if (!all(by %chin% names(x))) stop("Argument 'by' must refer to column names in x")
-  if (!all(by.atomic <- vapply_1b(by, function(.by) is.atomic(x[[.by]])))) stop("Argument 'by' must refer only to atomic-type columns, but the following columns are non-atomic: ", brackify(by[!by.atomic]))
+  if (!all(by.atomic <- vapply_1b(by, function(.by) is.atomic(x[[.by]])))) stopf("Argument 'by' must refer only to atomic-type columns, but the following columns are non-atomic: %s", brackify(by[!by.atomic]))
   # list of data.tables (flatten) or list of lists of ... data.tables
   make.levels = function(x, cols, sorted) {
     by.order = if (!sorted) x[, funique(.SD), .SDcols=cols] # remember order of data, only when not sorted=FALSE
@@ -2547,15 +2542,15 @@ setnames = function(x,old,new,skip_absent=FALSE) {
   # duplicates are permitted to be created without warning; e.g. in revdeps and for example, and setting spacer columns all with ""
   if (!is.data.frame(x)) stop("x is not a data.table or data.frame")
   ncol = length(x)
-  if (length(names(x)) != ncol) stop("x has ",ncol," columns but its names are length ",length(names(x)))
+  if (length(names(x)) != ncol) stopf("x has %d columns but its names are length %d", ncol, length(names(x)))
   stopifnot(isTRUEorFALSE(skip_absent))
   if (missing(new) || missing(old)) {
     # usage: setnames(DT, new = letters[1:n])
     if (missing(old)) { old = new; new = NULL }
     # for setnames(DT,new); e.g., setnames(DT,c("A","B")) where ncol(DT)==2
     if (is.function(old)) old = old(names(x))
-    if (!is.character(old)) stop("Passed a vector of type '",typeof(old),"'. Needs to be type 'character'.")
-    if (length(old) != ncol) stop("Can't assign ",length(old)," names to a ",ncol," column data.table")
+    if (!is.character(old)) stopf("Passed a vector of type '%s'. Needs to be type 'character'.", typeof(old))
+    if (length(old) != ncol) stopf("Can't assign %d names to a %d-column data.table", length(old), ncol)
     if (anyNA(names(x))) {
       # if x somehow has some NA names, which() needs help to return them, #2475
       w = which((names(x) != old) | (Encoding(names(x)) != Encoding(old)) | (is.na(names(x)) & !is.na(old)))
@@ -2569,15 +2564,15 @@ setnames = function(x,old,new,skip_absent=FALSE) {
     if (is.function(new)) new = if (is.numeric(old)) new(names(x)[old]) else new(old)
     if (!is.character(new)) stop("'new' is not a character vector or a function")
     #  if (anyDuplicated(new)) warning("Some duplicates exist in 'new': ", brackify(new[duplicated(new)]))  # dups allowed without warning; warn if and when the dup causes an ambiguity
-    if (anyNA(new)) stop("NA in 'new' at positions ", brackify(which(is.na(new))))
-    if (anyDuplicated(old)) stop("Some duplicates exist in 'old': ", brackify(old[duplicated(old)]))
+    if (anyNA(new)) stopf("NA in 'new' at positions %s", brackify(which(is.na(new))))
+    if (anyDuplicated(old)) stopf("Some duplicates exist in 'old': %s", brackify(old[duplicated(old)]))
     if (is.numeric(old)) i = old = seq_along(x)[old]  # leave it to standard R to manipulate bounds and negative numbers
-    else if (!is.character(old)) stop("'old' is type ",typeof(old)," but should be integer, double or character")
-    if (length(new)!=length(old)) stop("'old' is length ",length(old)," but 'new' is length ",length(new))
-    if (anyNA(old)) stop("NA (or out of bounds) in 'old' at positions ", brackify(which(is.na(old))))
+    else if (!is.character(old)) stopf("'old' is type %s but should be integer, double or character", typeof(old))
+    if (length(new)!=length(old)) stopf("'old' is length %d but 'new' is length ", length(old), length(new))
+    if (anyNA(old)) stopf("NA (or out of bounds) in 'old' at positions %s", brackify(which(is.na(old))))
     if (is.character(old)) {
       i = chmatchdup(c(old,old), names(x))  # chmatchdup returns the second of any duplicates matched to in names(x) (if any)
-      if (!all(tt<-is.na(tail(i,length(old))))) warning("Item ",w<-which.first(!tt)," of 'old' is '", old[w],"' which appears several times in column names. Just the first will be changed. There are ", sum(!tt)-1L," other items in old that are also duplicated in column names.")
+      if (!all(tt<-is.na(tail(i,length(old))))) warningf("Item %d of 'old' is '%s' which appears several times in column names. Just the first will be changed. There are %d other items in 'old' that are also duplicated in column names.", w <- which.first(!tt), old[w], sum(!tt)-1L)
       i = head(i,length(old))
       if (anyNA(i)) {
         if (isTRUE(skip_absent)) {
@@ -2585,7 +2580,7 @@ setnames = function(x,old,new,skip_absent=FALSE) {
           new = new[w]
           i = i[w]
         } else {
-          stop("Items of 'old' not found in column names: ", brackify(old[is.na(i)]), ". Consider skip_absent=TRUE.")
+          stopf("Items of 'old' not found in column names: %s. Consider skip_absent=TRUE.", brackify(old[is.na(i)]))
         }
       }
     }
@@ -2624,7 +2619,7 @@ setnames = function(x,old,new,skip_absent=FALSE) {
 setcolorder = function(x, neworder=key(x))
 {
   if (is.character(neworder) && anyDuplicated(names(x)))
-    stop("x has some duplicated column name(s): ", paste(names(x)[duplicated(names(x))], collapse=","), ". Please remove or rename the duplicate(s) and try again.")
+    stopf("x has some duplicated column name(s): %s. Please remove or rename the duplicate(s) and try again.", brackify(unique(names(x)[duplicated(names(x))])))
   # if (!is.data.table(x)) stop("x is not a data.table")
   neworder = colnamesInt(x, neworder, check_dups=FALSE)  # dups are now checked inside Csetcolorder below
   if (length(neworder) != length(x)) {
@@ -2677,7 +2672,7 @@ cbind.data.table = data.table
 
 rbindlist = function(l, use.names="check", fill=FALSE, idcol=NULL) {
   if (is.null(l)) return(null.data.table())
-  if (!is.list(l) || is.data.frame(l)) stop("Input is ", class(l)[1L]," but should be a plain list of items to be stacked")
+  if (!is.list(l) || is.data.frame(l)) stopf("Input is %s but should be a plain list of items to be stacked", class(l)[1L])
   if (isFALSE(idcol)) { idcol = NULL }
   else if (!is.null(idcol)) {
     if (isTRUE(idcol)) idcol = ".id"
@@ -2715,7 +2710,7 @@ setDF = function(x, rownames=NULL) {
       rn = .set_row_names(nrow(x))
     } else {
       if (length(rownames) != nrow(x))
-        stop("rownames incorrect length; expected ", nrow(x), " names, got ", length(rownames))
+        stopf("rownames incorrect length; expected %d names, got %d", nrow(x), length(rownames))
       rn = rownames
     }
     setattr(x, "row.names", rn)
@@ -2725,7 +2720,7 @@ setDF = function(x, rownames=NULL) {
   } else if (is.data.frame(x)) {
     if (!is.null(rownames)) {
       if (length(rownames) != nrow(x))
-        stop("rownames incorrect length; expected ", nrow(x), " names, got ", length(rownames))
+        stopf("rownames incorrect length; expected %d names, got %d", nrow(x), length(rownames))
       setattr(x, "row.names", rownames)
     }
     x
@@ -2748,7 +2743,7 @@ setDF = function(x, rownames=NULL) {
       rn = .set_row_names(mn)
     } else {
       if (length(rownames) != mn)
-      stop("rownames incorrect length; expected ", mn, " names, got ", length(rownames))
+      stopf("rownames incorrect length; expected %d names, got %d", nm, length(rownames))
       rn = rownames
     }
     setattr(x,"row.names", rn)
@@ -2762,21 +2757,21 @@ setDT = function(x, keep.rownames=FALSE, key=NULL, check.names=FALSE) {
   if (is.name(name)) {
     home = function(x, env) {
       if (identical(env, emptyenv()))
-        stop("Cannot find symbol ", cname, call. = FALSE)
+        stopf("Cannot find symbol %s", cname)
       else if (exists(x, env, inherits=FALSE)) env
       else home(x, parent.env(env))
     }
     cname = as.character(name)
     envir = home(cname, parent.frame())
     if (bindingIsLocked(cname, envir)) {
-      stop("Cannot convert '", cname, "' to data.table by reference because binding is locked. It is very likely that '", cname, "' resides within a package (or an environment) that is locked to prevent modifying its variable bindings. Try copying the object to your current environment, ex: var <- copy(var) and then using setDT again.")
+      stopf("Cannot convert '%1$s' to data.table by reference because binding is locked. It is very likely that '%1$s' resides within a package (or an environment) that is locked to prevent modifying its variable bindings. Try copying the object to your current environment, ex: var <- copy(var) and then using setDT again.", cname)
     }
   }
   # check no matrix-like columns, #3760. Other than a single list(matrix) is unambiguous and depended on by some revdeps, #3581
   if (length(x)>1L) {
     idx = vapply_1i(x, function(xi) length(dim(xi)))>1L
     if (any(idx))
-      warning("Some columns are a multi-column type (such as a matrix column): ", brackify(which(idx)),". setDT will retain these columns as-is but subsequent operations like grouping and joining may fail. Please consider as.data.table() instead which will create a new column for each embedded column.")
+      warningf("Some columns are a multi-column type (such as a matrix column): %s. setDT will retain these columns as-is but subsequent operations like grouping and joining may fail. Please consider as.data.table() instead which will create a new column for each embedded column.", brackify(which(idx)))
   }
   if (is.data.table(x)) {
     # fix for #1078 and #1128, see .resetclass() for explanation.
@@ -2808,14 +2803,13 @@ setDT = function(x, keep.rownames=FALSE, key=NULL, check.names=FALSE) {
                                   # many operations still work in the presence of NULL columns and it might be convenient
                                   # e.g. in package eplusr which calls setDT on a list when parsing JSON. Operations which
                                   # fail for NULL columns will give helpful error at that point, #3480 and #3471
-      if (inherits(x[[i]], "POSIXlt")) stop("Column ", i, " is of POSIXlt type. Please convert it to POSIXct using as.POSIXct and run setDT again. We do not recommend use of POSIXlt at all because it uses 40 bytes to store one date.")
+      if (inherits(x[[i]], "POSIXlt")) stopf("Column %d is of POSIXlt type. Please convert it to POSIXct using as.POSIXct and run setDT again. We do not recommend use of POSIXlt at all because it uses 40 bytes to store one date.", i)
     }
     n = vapply_1i(x, length)
     n_range = range(n)
     if (n_range[1L] != n_range[2L]) {
       tbl = sort(table(n))
-      stop("All elements in argument 'x' to 'setDT' must be of same length, but the profile of input lengths (length:frequency) is: ",
-           brackify(sprintf('%s:%d', names(tbl), tbl)), "\nThe first entry with fewer than ", n_range[2L], " entries is ", which.max(n<n_range[2L]))
+      stopf("All elements in argument 'x' to 'setDT' must be of same length, but the profile of input lengths (length:frequency) is: %s\nThe first entry with fewer than %d entries is %d.", brackify(sprintf('%s:%d', names(tbl), tbl)), n_range[2L], which.max(n<n_range[2L]))
     }
     xn = names(x)
     if (is.null(xn)) {
@@ -2847,7 +2841,7 @@ setDT = function(x, keep.rownames=FALSE, key=NULL, check.names=FALSE) {
         if (is.character(j)) {
           j = match(j, names(k))
           if (is.na(j))
-            stop("Item '", origj, "' not found in names of input list")
+            stopf("Item '%s' not found in names of input list", origj)
         }
       }
       .Call(Csetlistelt,k,as.integer(j), x)
@@ -3157,7 +3151,7 @@ isReallyReal = function(x) {
       operators[i] = thisOperators
     } else {
       ## multiple operators found in one 'on' part. Something is wrong.
-      stop("Found more than one operator in one 'on' statement: ", on[i], ". Please specify a single operator.")
+      stopf("Found more than one operator in one 'on' statement: %s. Please specify a single operator.", on[i])
     }
     if (length(thisCols) == 2L){
       ## two column names found, first is xCol, second is iCol for sure
@@ -3180,14 +3174,14 @@ isReallyReal = function(x) {
         iCols[i] = thisCols[1L]
       }
     } else if (length(thisCols) == 0L){
-      stop("'on' contains no column name: ", on[i], ". Each 'on' clause must contain one or two column names.")
+      stopf("'on' contains no column name: %s. Each 'on' clause must contain one or two column names.", on[i])
     } else {
-      stop("'on' contains more than 2 column names: ", on[i], ". Each 'on' clause must contain one or two column names.")
+      stopf("'on' contains more than 2 column names: %s. Each 'on' clause must contain one or two column names.", on[i])
     }
   }
   idx_op = match(operators, ops, nomatch=0L)
   if (any(idx_op %in% c(0L, 6L)))
-    stop(domain=NA, gettextf("Invalid join operators %s. Only allowed operators are %s.", brackify(operators[idx_op %in% c(0L, 6L)]), brackify(ops[1:5])))
+    stopf("Invalid join operators %s. Only allowed operators are %s.", brackify(operators[idx_op %in% c(0L, 6L)]), brackify(ops[1:5]))
   ## the final on will contain the xCol as name, the iCol as value
   on = iCols
   names(on) = xCols

--- a/R/devel.R
+++ b/R/devel.R
@@ -13,7 +13,7 @@ dcf.repo = function(pkg, repo, field, type) {
   idx = file(file.path(contrib.url(repo, type=type),"PACKAGES"))
   on.exit(close(idx))
   dcf = read.dcf(idx, fields=c("Package",field))
-  if (!pkg %in% dcf[,"Package"]) stop(domain=NA, gettextf("There is no package %s in provided repository.", pkg))
+  if (!pkg %in% dcf[,"Package"]) stopf("There is no package %s in provided repository.", pkg)
   dcf[dcf[,"Package"]==pkg, field][[1L]]
 }
 

--- a/R/fcast.R
+++ b/R/fcast.R
@@ -4,7 +4,7 @@ guess = function(x) {
   if ("(all)" %chin% names(x))
     return("(all)")
   var = names(x)[ncol(x)]
-  message("Using '", var, "' as value column. Use 'value.var' to override")
+  messagef("Using '%s' as value column. Use 'value.var' to override", var)
   return(var)
 }
 
@@ -17,8 +17,8 @@ dcast <- function(
   else {
     data_name = deparse(substitute(data))
     ns = tryCatch(getNamespace("reshape2"), error=function(e)
-      stop("The dcast generic in data.table has been passed a ",class(data)[1L],", but data.table::dcast currently only has a method for data.tables. Please confirm your input is a data.table, with setDT(", data_name, ") or as.data.table(", data_name, "). If you intend to use a reshape2::dcast, try installing that package first, but do note that reshape2 is superseded and is no longer actively developed."))
-    warning("The dcast generic in data.table has been passed a ", class(data)[1L], " and will attempt to redirect to the reshape2::dcast; please note that reshape2 is superseded and is no longer actively developed, and this redirection is now deprecated. Please do this redirection yourself like reshape2::dcast(", data_name, "). In the next version, this warning will become an error.")
+      stopf("The %1$s generic in data.table has been passed a %2$s, but data.table::%1$s currently only has a method for data.tables. Please confirm your input is a data.table, with setDT(%3$s) or as.data.table(%3$s). If you intend to use a method from reshape2, try installing that package first, but do note that reshape2 is superseded and is no longer actively developed.", "dcast", class(data)[1L], data_name))
+    warningf("The %1$s generic in data.table has been passed a %2$s and will attempt to redirect to the relevant reshape2 method; please note that reshape2 is superseded and is no longer actively developed, and this redirection is now deprecated. Please do this redirection yourself like reshape2::%1$s(%3$s). In the next version, this warning will become an error.", "dcast", class(data)[1L], data_name)
     ns$dcast(data, formula, fun.aggregate = fun.aggregate, ..., margins = margins,
              subset = subset, fill = fill, value.var = value.var)
   }
@@ -57,7 +57,7 @@ value_vars = function(value.var, varnames) {
   valnames = unique(unlist(value.var))
   iswrong = which(!valnames %chin% varnames)
   if (length(iswrong))
-    stop("value.var values ", brackify(value.var[iswrong]), " are not found in 'data'.")
+    stopf("value.var values %s are not found in 'data'.", brackify(value.var[iswrong]))
   value.var
 }
 
@@ -125,7 +125,7 @@ dcast.data.table = function(data, formula, fun.aggregate = NULL, sep = "_", ...,
     x = allcols[[i]]
     dat[[i]] = if (identical(x, quote(`.`))) rep(".", nrow(data)) else eval(x, data, parent.frame())
     if (is.function(dat[[i]]))
-      stop("Column [", deparse(x), "] not found or of unknown type.")
+      stopf("Column [%s] not found or of unknown type.", deparse(x))
   }
   setattr(lvars, 'names', c("lhs", "rhs"))
   # Have to take care of duplicate names, and provide names for expression columns properly.

--- a/R/fmelt.R
+++ b/R/fmelt.R
@@ -12,8 +12,8 @@ melt = function(data, ..., na.rm = FALSE, value.name = "value") {
   } else {
     data_name = deparse(substitute(data))
     ns = tryCatch(getNamespace("reshape2"), error=function(e)
-      stop("The melt generic in data.table has been passed a ",class(data)[1L],", but data.table::melt currently only has a method for data.tables. Please confirm your input is a data.table, with setDT(", data_name, ") or as.data.table(", data_name, "). If you intend to use a method from reshape2, try installing that package first, but do note that reshape2 is superseded and is no longer actively developed."))
-    warning("The melt generic in data.table has been passed a ", class(data)[1L], " and will attempt to redirect to the relevant reshape2 method; please note that reshape2 is superseded and is no longer actively developed, and this redirection is now deprecated. To continue using melt methods from reshape2 while both libraries are attached, e.g. melt.list, you can prepend the namespace like reshape2::melt(", data_name, "). In the next version, this warning will become an error.")
+      stopf("The %1$s generic in data.table has been passed a %2$s, but data.table::%1$s currently only has a method for data.tables. Please confirm your input is a data.table, with setDT(%3$s) or as.data.table(%3$s). If you intend to use a method from reshape2, try installing that package first, but do note that reshape2 is superseded and is no longer actively developed.", "melt", class(data)[1L], data_name))
+    warningf("The %1$s generic in data.table has been passed a %2$s and will attempt to redirect to the relevant reshape2 method; please note that reshape2 is superseded and is no longer actively developed, and this redirection is now deprecated. Please do this redirection yourself like reshape2::%1$s(%3$s). In the next version, this warning will become an error.", "melt", class(data)[1L], data_name)
     ns$melt(data, ..., na.rm=na.rm, value.name=value.name)
   }
   # nocov end
@@ -29,8 +29,7 @@ patterns = function(..., cols=character(0L)) {
   matched = lapply(p, grep, cols)
   # replace with lengths when R 3.2.0 dependency arrives
   if (length(idx <- which(sapply(matched, length) == 0L)))
-    stop('Pattern', if (length(idx) > 1L) 's', ' not found: [',
-         paste(p[idx], collapse = ', '), ']')
+    stop(domain = NA, sprintf(ngettext(length(idx), 'Pattern not found: [%s]', 'Patterns not found: [%s]'), brackify(p[idx])))
   matched
 }
 
@@ -44,7 +43,7 @@ measure = function(..., sep="_", pattern, cols, multiple.keyword="value.name") {
   is.symb = sapply(fun.list, is.symbol)
   bad.i = which((!user.named) & (!is.symb))
   if (length(bad.i)) {
-    stop("each ... argument to measure must be either a symbol without argument name, or a function with argument name, problems: ", paste(bad.i, collapse=","))
+    stopf("each ... argument to measure must be either a symbol without argument name, or a function with argument name, problems: %s", brackify(bad.i))
   }
   names(fun.list)[!user.named] = sapply(fun.list[!user.named], paste)
   fun.list[!user.named] = list(NULL)
@@ -52,13 +51,13 @@ measure = function(..., sep="_", pattern, cols, multiple.keyword="value.name") {
   group.is.formal = names(fun.list) %in% formal.names
   if (any(group.is.formal)) {
     bad.names = names(fun.list)[group.is.formal]
-    stop("group names specified in ... conflict with measure argument names; please fix by changing group names: ", paste(bad.names, collapse=","))
+    stopf("group names specified in ... conflict with measure argument names; please fix by changing group names: %s", brackify(bad.names))
   }
   # evaluate each value in ... and stop if not function.
   for (fun.i in which(user.named)) {
     fun = eval(fun.list[[fun.i]], parent.frame(1L))
     if (!is.function(fun) || length(formals(args(fun)))==0) {
-      stop("each ... argument to measure must be a function with at least one argument, problem: ", names(fun.list)[[fun.i]])
+      stopf("each ... argument to measure must be a function with at least one argument, problem: %s", names(fun.list)[[fun.i]])
     }
     fun.list[[fun.i]] = fun
   }  
@@ -86,18 +85,18 @@ measurev = function(fun.list, sep="_", pattern, cols, multiple.keyword="value.na
     which(names(fun.list) == "")
   }
   if (length(prob.i)) {
-    stop("in measurev, ", group.desc, " must be named, problems: ", paste(prob.i, collapse=","))
+    stopf("in measurev, %s must be named, problems: %s", group.desc, brackify(prob.i))
   }
   err.names.unique = function(err.what, name.vec) {
     name.tab = table(name.vec)
     bad.counts = name.tab[1 < name.tab]
     if (length(bad.counts)) {
-      stop(err.what, " should be uniquely named, problems: ", paste(names(bad.counts), collapse=","))
+      stopf("%s should be uniquely named, problems: %s", err.what, brackify(names(bad.counts)))
     }
   }
   err.args.groups = function(type, N){
     if (N != length(fun.list)) {
-      stop("number of ", group.desc, " =", length(fun.list), " must be same as ", type, " =", N)
+      stopf("number of %s = %d must be same as %s = %s", length(fun.list), type, N)
     }
   }
   err.names.unique(group.desc, names(fun.list))
@@ -136,7 +135,7 @@ measurev = function(fun.list, sep="_", pattern, cols, multiple.keyword="value.na
   err.names.unique("measured columns", cols[measure.vec])
   uniq.mat = unique(group.mat)
   if (nrow(uniq.mat) < nrow(group.mat)) {
-    stop("number of unique column IDs =", nrow(uniq.mat), " is less than number of melted columns =", nrow(group.mat), "; fix by changing pattern/sep")
+    stopf("number of unique column IDs = %d is less than number of melted columns = %d; fix by changing pattern/sep", nrow(uniq.mat), nrow(group.mat))
   }
   colnames(group.mat) = names(fun.list)
   group.dt = data.table(group.mat)
@@ -146,14 +145,14 @@ measurev = function(fun.list, sep="_", pattern, cols, multiple.keyword="value.na
     group.name = names(fun.list)[[group.i]]
     fun = fun.list[[group.i]]
     if (!is.function(fun) || length(formals(args(fun)))==0) {
-      stop("in the measurev fun.list, each non-NULL element must be a function with at least one argument, problem: ", group.name)
+      stopf("in the measurev fun.list, each non-NULL element must be a function with at least one argument, problem: %s", group.name)
     }
     group.val = fun(group.dt[[group.name]])
     if (!(is.atomic(group.val) && length(group.val)==nrow(group.dt))) {
-      stop("each conversion function must return an atomic vector with same length as its first argument, problem: ", group.name)
+      stopf("each conversion function must return an atomic vector with same length as its first argument, problem: %s", group.name)
     }
     if (all(is.na(group.val))) {
-      stop(group.name, " conversion function returned vector of all NA")
+      stopf("%s conversion function returned vector of all NA", group.name)
     }
     set(group.dt, j=group.name, value=group.val)
   }
@@ -164,11 +163,11 @@ measurev = function(fun.list, sep="_", pattern, cols, multiple.keyword="value.na
   # 4. compute measure.vars list or vector.
   if (multiple.keyword %in% names(fun.list)) {# multiple output columns.
     if (!is.character(group.dt[[multiple.keyword]])) {
-      stop(multiple.keyword, " column class=", class(group.dt[[multiple.keyword]])[[1L]], " after applying conversion function, but must be character")
+      stopf("%s column class=%s after applying conversion function, but must be character", multiple.keyword, class(group.dt[[multiple.keyword]])[1L])
     }
     is.other = names(group.dt) != multiple.keyword
     if (!any(is.other)) {
-      stop(multiple.keyword, " is the only group; fix by creating at least one more group")
+      stopf("%s is the only group; fix by creating at least one more group", multiple.keyword)
     }
     other.values = lapply(group.dt[, is.other, with=FALSE], unique)
     other.values$stringsAsFactors = FALSE
@@ -210,9 +209,7 @@ melt.data.table = function(data, id.vars, measure.vars, variable.name = "variabl
       }
     } else {
       if (length(value.name) > 1L) {
-        warning("'value.name' provided in both 'measure.vars'",
-                "and 'value.name argument'; value provided in",
-                "'measure.vars' is given precedence.")
+        warning("'value.name' provided in both 'measure.vars' and 'value.name argument'; value provided in 'measure.vars' is given precedence.")
       }
       if (anyNA(meas.nm) || !all(nzchar(meas.nm))) {
         stop("Please provide a name to each element of 'measure.vars'.")

--- a/R/fmelt.R
+++ b/R/fmelt.R
@@ -96,7 +96,7 @@ measurev = function(fun.list, sep="_", pattern, cols, multiple.keyword="value.na
   }
   err.args.groups = function(type, N){
     if (N != length(fun.list)) {
-      stopf("number of %s = %d must be same as %s = %s", length(fun.list), type, N)
+      stopf("number of %s =%d must be same as %s =%d", group.desc, length(fun.list), type, N)
     }
   }
   err.names.unique(group.desc, names(fun.list))
@@ -135,7 +135,7 @@ measurev = function(fun.list, sep="_", pattern, cols, multiple.keyword="value.na
   err.names.unique("measured columns", cols[measure.vec])
   uniq.mat = unique(group.mat)
   if (nrow(uniq.mat) < nrow(group.mat)) {
-    stopf("number of unique column IDs = %d is less than number of melted columns = %d; fix by changing pattern/sep", nrow(uniq.mat), nrow(group.mat))
+    stopf("number of unique column IDs =%d is less than number of melted columns =%d; fix by changing pattern/sep", nrow(uniq.mat), nrow(group.mat))
   }
   colnames(group.mat) = names(fun.list)
   group.dt = data.table(group.mat)

--- a/R/foverlaps.R
+++ b/R/foverlaps.R
@@ -37,7 +37,7 @@ foverlaps = function(x, y, by.x=if (!is.null(key(x))) key(x) else key(y), by.y=k
   if (!is.character(by.y))
     stop("A non-empty vector of column names or numbers is required for by.y")
   if (!identical(by.y, key(y)[seq_along(by.y)]))
-    stop("The first ", length(by.y), " columns of y's key must be identical to the columns specified in by.y.")
+    stopf("The first %d columns of y's key must be identical to the columns specified in by.y.", length(by.y))
   if (anyNA(chmatch(by.x, names(x))))
     stop("Elements listed in 'by.x' must be valid names in data.table 'x'")
   if (anyDuplicated(by.x) || anyDuplicated(by.y))
@@ -45,9 +45,9 @@ foverlaps = function(x, y, by.x=if (!is.null(key(x))) key(x) else key(y), by.y=k
   if (length(by.x) != length(by.y))
     stop("length(by.x) != length(by.y). Columns specified in by.x should correspond to columns specified in by.y and should be of same lengths.")
   if (any(dup.x<-duplicated(names(x)))) #1730 - handling join possible but would require workarounds on setcolorder further, it is really better just to rename dup column
-    stop("x has some duplicated column name(s): ",paste(unique(names(x)[dup.x]),collapse=","),". Please remove or rename the duplicate(s) and try again.")
+    stopf("%s has some duplicated column name(s): %s. Please remove or rename the duplicate(s) and try again.", "x", brackify(unique(names(x)[dup.x])))
   if (any(dup.y<-duplicated(names(y))))
-    stop("y has some duplicated column name(s): ",paste(unique(names(y)[dup.y]),collapse=","),". Please remove or rename the duplicate(s) and try again.")
+    stopf("%s has some duplicated column name(s): %s. Please remove or rename the duplicate(s) and try again.", "y", unique(names(y)[dup.y]))
   xnames = by.x; xintervals = tail(xnames, 2L)
   ynames = by.y; yintervals = tail(ynames, 2L)
   xval1 = x[[xintervals[1L]]]; xval2 = x[[xintervals[2L]]]
@@ -57,19 +57,19 @@ foverlaps = function(x, y, by.x=if (!is.null(key(x))) key(x) else key(y), by.y=k
   if ( isTRUEorNA(any(xval2 - xval1 < 0L)) ) {
     # better error messages as suggested by @msummersgill in #3007. Thanks for the code too. Placing this inside so that it only runs if the general condition is satisfied. Should error anyway here.. So doesn't matter even if runs all if-statements; takes about 0.2s for anyNA check on 200 million elements .. acceptable speed for stoppage, I think, at least for now.
     if ( anyNA(xval1) ) {
-      stop("NA values in data.table 'x' start column: '", xintervals[1L],"'. All rows with NA values in the range columns must be removed for foverlaps() to work.")
+      stopf("NA values in data.table '%s' '%s' column: '%s'. All rows with NA values in the range columns must be removed for foverlaps() to work.", "x", "start", xintervals[1L])
     } else if ( anyNA(xval2) ) {
-      stop("NA values in data.table 'x' end column: '", xintervals[2L],"'. All rows with NA values in the range columns must be removed for foverlaps() to work.")
-    } else stop("All entries in column ", xintervals[1L], " should be <= corresponding entries in column ", xintervals[2L], " in data.table 'x'.")
+      stopf("NA values in data.table '%s' '%s' column: '%s'. All rows with NA values in the range columns must be removed for foverlaps() to work.", "x", "end", xintervals[2L])
+    } else stopf("All entries in column '%s' should be <= corresponding entries in column '%s' in data.table 'x'.", xintervals[1L], xintervals[2L])
   }
   if (!storage.mode(yval1) %chin% c("double", "integer") || !storage.mode(yval2) %chin% c("double", "integer") || is.factor(yval1) || is.factor(yval2)) # adding factors to the bunch, #2645
     stop("The last two columns in by.y should correspond to the 'start' and 'end' intervals in data.table 'y' and must be integer/numeric type.")
   if ( isTRUEorNA(any(yval2 - yval1 < 0L) )) {
     if ( anyNA(yval1) ) {
-      stop("NA values in data.table 'y' start column: '", yintervals[1L],"'. All rows with NA values in the range columns must be removed for foverlaps() to work.")
+      stopf("NA values in data.table '%s' '%s' column: '%s'. All rows with NA values in the range columns must be removed for foverlaps() to work.", "y", "start", yintervals[1L])
     } else if ( anyNA(yval2) ) {
-      stop("NA values in data.table 'y' end column: '", yintervals[2L],"'. All rows with NA values in the range columns must be removed for foverlaps() to work.")
-    } else stop("All entries in column ", yintervals[1L], " should be <= corresponding entries in column ", yintervals[2L], " in data.table 'y'.")
+      stopf("NA values in data.table '%s' '%s' column: '%s'. All rows with NA values in the range columns must be removed for foverlaps() to work.", "y", "end", yintervals[2L])
+    } else stopf("All entries in column '%s' should be <= corresponding entries in column '%s' in data.table 'y'.", yintervals[1L], yintervals[2L])
   }
   # POSIXct interval cols error check
   posx_chk = sapply(list(xval1, xval2, yval1, yval2), inherits, 'POSIXct')

--- a/R/foverlaps.R
+++ b/R/foverlaps.R
@@ -19,7 +19,7 @@ foverlaps = function(x, y, by.x=if (!is.null(key(x))) key(x) else key(y), by.y=k
   if (maxgap != 0L || minoverlap != 1L)
     stop("maxgap and minoverlap arguments are not yet implemented.")
   if (is.null(by.y))
-    stop("'y' must be keyed (i.e., sorted, and, marked as sorted). Call setkey(y, ...) first, see ?setkey. Also check the examples in ?foverlaps.")
+    stop("y must be keyed (i.e., sorted, and, marked as sorted). Call setkey(y, ...) first, see ?setkey. Also check the examples in ?foverlaps.")
   if (length(by.x) < 2L || length(by.y) < 2L)
     stop("'by.x' and 'by.y' should contain at least two column names (or numbers) each - corresponding to 'start' and 'end' points of intervals. Please see ?foverlaps and examples for more info.")
   if (is.numeric(by.x)) {
@@ -39,7 +39,7 @@ foverlaps = function(x, y, by.x=if (!is.null(key(x))) key(x) else key(y), by.y=k
   if (!identical(by.y, key(y)[seq_along(by.y)]))
     stopf("The first %d columns of y's key must be identical to the columns specified in by.y.", length(by.y))
   if (anyNA(chmatch(by.x, names(x))))
-    stop("Elements listed in 'by.x' must be valid names in data.table 'x'")
+    stop("Elements listed in 'by.x' must be valid names in data.table x")
   if (anyDuplicated(by.x) || anyDuplicated(by.y))
     stop("Duplicate columns are not allowed in overlap joins. This may change in the future.")
   if (length(by.x) != length(by.y))
@@ -53,23 +53,23 @@ foverlaps = function(x, y, by.x=if (!is.null(key(x))) key(x) else key(y), by.y=k
   xval1 = x[[xintervals[1L]]]; xval2 = x[[xintervals[2L]]]
   yval1 = y[[yintervals[1L]]]; yval2 = y[[yintervals[2L]]]
   if (!storage.mode(xval1) %chin% c("double", "integer") || !storage.mode(xval2) %chin% c("double", "integer") || is.factor(xval1) || is.factor(xval2)) # adding factors to the bunch, #2645
-    stop("The last two columns in by.x should correspond to the 'start' and 'end' intervals in data.table 'x' and must be integer/numeric type.")
+    stop("The last two columns in by.x should correspond to the 'start' and 'end' intervals in data.table x and must be integer/numeric type.")
   if ( isTRUEorNA(any(xval2 - xval1 < 0L)) ) {
     # better error messages as suggested by @msummersgill in #3007. Thanks for the code too. Placing this inside so that it only runs if the general condition is satisfied. Should error anyway here.. So doesn't matter even if runs all if-statements; takes about 0.2s for anyNA check on 200 million elements .. acceptable speed for stoppage, I think, at least for now.
     if ( anyNA(xval1) ) {
-      stopf("NA values in data.table '%s' '%s' column: '%s'. All rows with NA values in the range columns must be removed for foverlaps() to work.", "x", "start", xintervals[1L])
+      stopf("NA values in data.table %s '%s' column: '%s'. All rows with NA values in the range columns must be removed for foverlaps() to work.", "x", "start", xintervals[1L])
     } else if ( anyNA(xval2) ) {
-      stopf("NA values in data.table '%s' '%s' column: '%s'. All rows with NA values in the range columns must be removed for foverlaps() to work.", "x", "end", xintervals[2L])
-    } else stopf("All entries in column '%s' should be <= corresponding entries in column '%s' in data.table 'x'.", xintervals[1L], xintervals[2L])
+      stopf("NA values in data.table %s '%s' column: '%s'. All rows with NA values in the range columns must be removed for foverlaps() to work.", "x", "end", xintervals[2L])
+    } else stopf("All entries in column '%s' should be <= corresponding entries in column '%s' in data.table x.", xintervals[1L], xintervals[2L])
   }
   if (!storage.mode(yval1) %chin% c("double", "integer") || !storage.mode(yval2) %chin% c("double", "integer") || is.factor(yval1) || is.factor(yval2)) # adding factors to the bunch, #2645
-    stop("The last two columns in by.y should correspond to the 'start' and 'end' intervals in data.table 'y' and must be integer/numeric type.")
+    stop("The last two columns in by.y should correspond to the 'start' and 'end' intervals in data.table y and must be integer/numeric type.")
   if ( isTRUEorNA(any(yval2 - yval1 < 0L) )) {
     if ( anyNA(yval1) ) {
-      stopf("NA values in data.table '%s' '%s' column: '%s'. All rows with NA values in the range columns must be removed for foverlaps() to work.", "y", "start", yintervals[1L])
+      stopf("NA values in data.table %s '%s' column: '%s'. All rows with NA values in the range columns must be removed for foverlaps() to work.", "y", "start", yintervals[1L])
     } else if ( anyNA(yval2) ) {
-      stopf("NA values in data.table '%s' '%s' column: '%s'. All rows with NA values in the range columns must be removed for foverlaps() to work.", "y", "end", yintervals[2L])
-    } else stopf("All entries in column '%s' should be <= corresponding entries in column '%s' in data.table 'y'.", yintervals[1L], yintervals[2L])
+      stopf("NA values in data.table %s '%s' column: '%s'. All rows with NA values in the range columns must be removed for foverlaps() to work.", "y", "end", yintervals[2L])
+    } else stopf("All entries in column '%s' should be <= corresponding entries in column '%s' in data.table y.", yintervals[1L], yintervals[2L])
   }
   # POSIXct interval cols error check
   posx_chk = sapply(list(xval1, xval2, yval1, yval2), inherits, 'POSIXct')

--- a/R/foverlaps.R
+++ b/R/foverlaps.R
@@ -47,7 +47,7 @@ foverlaps = function(x, y, by.x=if (!is.null(key(x))) key(x) else key(y), by.y=k
   if (any(dup.x<-duplicated(names(x)))) #1730 - handling join possible but would require workarounds on setcolorder further, it is really better just to rename dup column
     stopf("%s has some duplicated column name(s): %s. Please remove or rename the duplicate(s) and try again.", "x", brackify(unique(names(x)[dup.x])))
   if (any(dup.y<-duplicated(names(y))))
-    stopf("%s has some duplicated column name(s): %s. Please remove or rename the duplicate(s) and try again.", "y", unique(names(y)[dup.y]))
+    stopf("%s has some duplicated column name(s): %s. Please remove or rename the duplicate(s) and try again.", "y", brackify(unique(names(y)[dup.y])))
   xnames = by.x; xintervals = tail(xnames, 2L)
   ynames = by.y; yintervals = tail(ynames, 2L)
   xval1 = x[[xintervals[1L]]]; xval2 = x[[xintervals[2L]]]

--- a/R/fread.R
+++ b/R/fread.R
@@ -221,15 +221,8 @@ yaml=FALSE, autostart=NA, tmpdir=tempdir(), tz="UTC")
           if (!all(idx_type <- sapply(matched_name_idx, function(ii) {
             new_names[ii] %chin% colClasses[[ new_types[ii] ]]
           }))) {
-            plural = sum(idx_type) > 1L
-            message(domain = NA, sprintf(
-              ngettext(
-                sum(idx_type),
-                'colClasses dictated by user input and those read from YAML header are in conflict (specifically, for column [%s]); the proceeding assumes the user input was an intentional override and will ignore the types implied by the YAML header; please exclude this column from colClasses if this was unintentional.',
-                'colClasses dictated by user input and those read from YAML header are in conflict (specifically, for columns [%s]); the proceeding assumes the user input was an intentional override and will ignore the types implied by the YAML header; please exclude these columns from colClasses if this was unintentional.'
-              ),
-              brackify(new_names[matched_name_idx[!idx_type]])
-            ))
+            messagef('colClasses dictated by user input and those read from YAML header are in conflict (specifically, for column(s) [%s]); the proceeding assumes the user input was an intentional override and will ignore the type(s) implied by the YAML header; please exclude the column(s) from colClasses if this was unintentional.',
+              brackify(new_names[matched_name_idx[!idx_type]]))
           }
         }
         # only add unmentioned columns

--- a/R/fread.R
+++ b/R/fread.R
@@ -222,17 +222,14 @@ yaml=FALSE, autostart=NA, tmpdir=tempdir(), tz="UTC")
             new_names[ii] %chin% colClasses[[ new_types[ii] ]]
           }))) {
             plural = sum(idx_type) > 1L
-            message(
-              domain = NA,
-              sprintf(
-                ngettext(
-                  sum(idx_type),
-                  'colClasses dictated by user input and those read from YAML header are in conflict (specifically, for column [%s]); the proceeding assumes the user input was an intentional override and will ignore the types implied by the YAML header; please exclude this column from colClasses if this was unintentional.',
-                  'colClasses dictated by user input and those read from YAML header are in conflict (specifically, for columns [%s]); the proceeding assumes the user input was an intentional override and will ignore the types implied by the YAML header; please exclude these columns from colClasses if this was unintentional.'
-                ),
-                brackify(new_names[matched_name_idx[!idx_type]])
-              )
-            )
+            message(domain = NA, sprintf(
+              ngettext(
+                sum(idx_type),
+                'colClasses dictated by user input and those read from YAML header are in conflict (specifically, for column [%s]); the proceeding assumes the user input was an intentional override and will ignore the types implied by the YAML header; please exclude this column from colClasses if this was unintentional.',
+                'colClasses dictated by user input and those read from YAML header are in conflict (specifically, for columns [%s]); the proceeding assumes the user input was an intentional override and will ignore the types implied by the YAML header; please exclude these columns from colClasses if this was unintentional.'
+              ),
+              brackify(new_names[matched_name_idx[!idx_type]])
+            ))
           }
         }
         # only add unmentioned columns

--- a/R/fread.R
+++ b/R/fread.R
@@ -37,7 +37,7 @@ yaml=FALSE, autostart=NA, tmpdir=tempdir(), tz="UTC")
   nThread=as.integer(nThread)
   stopifnot(nThread>=1L)
   if (!is.null(text)) {
-    if (!is.character(text)) stop("'text=' is type ", typeof(text), " but must be character.")
+    if (!is.character(text)) stopf("'text=' is type %s but must be character.", typeof(text))
     if (!length(text)) return(data.table())
     if (length(text) > 1L) {
       writeLines(text, tmpFile<-tempfile(tmpdir=tmpdir))  # avoid paste0() which could create a new very long single string in R's memory
@@ -83,7 +83,7 @@ yaml=FALSE, autostart=NA, tmpdir=tempdir(), tz="UTC")
       else if (length(grep(' ', input, fixed = TRUE)) && !file.exists(input)) {  # file name or path containing spaces is not a command
         cmd = input
         if (input_has_vars && getOption("datatable.fread.input.cmd.message", TRUE)) {
-          message("Taking input= as a system command because it contains a space ('",cmd,"'). If it's a filename please remove the space, or use file= explicitly. A variable is being passed to input= and when this is taken as a system command there is a security concern if you are creating an app, the app could have a malicious user, and the app is not running in a secure environment; e.g. the app is running as root. Please read item 5 in the NEWS file for v1.11.6 for more information and for the option to suppress this message.")
+          messagef("Taking input= as a system command because it contains a space ('%s'). If it's a filename please remove the space, or use file= explicitly. A variable is being passed to input= and when this is taken as a system command there is a security concern if you are creating an app, the app could have a malicious user, and the app is not running in a secure environment; e.g. the app is running as root. Please read item 5 in the NEWS file for v1.11.6 for more information and for the option to suppress this message.", cmd)
         }
       }
       else {
@@ -98,11 +98,10 @@ yaml=FALSE, autostart=NA, tmpdir=tempdir(), tz="UTC")
   }
   if (!is.null(file)) {
     file_info = file.info(file)
-    if (is.na(file_info$size)) stop("File '",file,"' does not exist or is non-readable. getwd()=='", getwd(), "'")
-    if (isTRUE(file_info$isdir)) stop("File '",file,"' is a directory. Not yet implemented.") # dir.exists() requires R v3.2+, #989
+    if (is.na(file_info$size)) stopf("File '%s' does not exist or is non-readable. getwd()=='%s'", file, getwd())
+    if (isTRUE(file_info$isdir)) stopf("File '%s' is a directory. Not yet implemented.", file) # dir.exists() requires R v3.2+, #989
     if (!file_info$size) {
-      warning("File '", file, "' has size 0. Returning a NULL ",
-              if (data.table) 'data.table' else 'data.frame', ".")
+      warningf("File '%s' has size 0. Returning a NULL %s.", file, if (data.table) 'data.table' else 'data.frame')
       return(if (data.table) data.table(NULL) else data.frame(NULL))
     }
     if ((is_gz <- endsWith(file, ".gz")) || endsWith(file, ".bz2")) {
@@ -140,16 +139,16 @@ yaml=FALSE, autostart=NA, tmpdir=tempdir(), tz="UTC")
   stopifnot(is.null(na.strings) || is.character(na.strings))
   tt = grep("^\\s+$", na.strings)
   if (length(tt)) {
-    msg = paste0('na.strings[', tt[1L], ']=="',na.strings[tt[1L]],'" consists only of whitespace, ignoring. ')
+    msg = gettextf('na.strings[%d]=="%s" consists only of whitespace, ignoring', tt[1L], na.strings[tt[1L]])
     if (strip.white) {
       if (any(na.strings=="")) {
-        warning(msg, 'strip.white==TRUE (default) and "" is present in na.strings, so any number of spaces in string columns will already be read as <NA>.')
+        warningf('%s. strip.white==TRUE (default) and "" is present in na.strings, so any number of spaces in string columns will already be read as <NA>.', msg)
       } else {
-        warning(msg, 'Since strip.white=TRUE (default), use na.strings="" to specify that any number of spaces in a string column should be read as <NA>.')
+        warningf('%s. Since strip.white=TRUE (default), use na.strings="" to specify that any number of spaces in a string column should be read as <NA>.', msg)
       }
       na.strings = na.strings[-tt]
     } else {
-      stop(msg, 'But strip.white=FALSE. Use strip.white=TRUE (default) together with na.strings="" to turn any number of spaces in string columns into <NA>')
+      stopf('%s. But strip.white=FALSE. Use strip.white=TRUE (default) together with na.strings="" to turn any number of spaces in string columns into <NA>', msg)
     }
     # whitespace at the beginning or end of na.strings is checked at C level and is an error there; test 1804
   }
@@ -159,9 +158,7 @@ yaml=FALSE, autostart=NA, tmpdir=tempdir(), tz="UTC")
     # for tracking which YAML elements may be overridden by being declared explicitly
     call_args = names(match.call())
     if (is.character(skip))
-      warning("Combining a search string as 'skip' and reading a YAML header may not work as expected -- currently, ",
-              "reading will proceed to search for 'skip' from the beginning of the file, NOT from the end of ",
-              "the metadata; please file an issue on GitHub if you'd like to see more intuitive behavior supported.")
+      warning("Combining a search string as 'skip' and reading a YAML header may not work as expected -- currently, reading will proceed to search for 'skip' from the beginning of the file, NOT from the end of the metadata; please file an issue on GitHub if you'd like to see more intuitive behavior supported.")
     # create connection to stream header lines from file:
     #   https://stackoverflow.com/questions/9871307
     f = base::file(input, 'r')
@@ -170,10 +167,10 @@ yaml=FALSE, autostart=NA, tmpdir=tempdir(), tz="UTC")
     yaml_border_re = '^#?---'
     if (!grepl(yaml_border_re, first_line)) {
       close(f)
-      stop(gettextf(
+      stopf(
         'Encountered <%s%s> at the first unskipped line (%d), which does not constitute the start to a valid YAML header (expecting something matching regex "%s"); please check your input and try again.',
         substr(first_line, 1L, 50L), if (nchar(first_line) > 50L) '...' else '', 1L+skip, yaml_border_re
-      ))
+      )
     }
 
     yaml_comment_re = '^#'
@@ -183,8 +180,7 @@ yaml=FALSE, autostart=NA, tmpdir=tempdir(), tz="UTC")
       n_read = n_read + 1L
       if (!length(this_line)){
         close(f)
-        stop('Reached the end of the file before finding a completion to the YAML header. A valid YAML header is bookended by lines matching ',
-             'the regex "', yaml_border_re, '". Please double check the input file is a valid csvy.')
+        stopf('Reached the end of the file before finding a completion to the YAML header. A valid YAML header is bookended by lines matching the regex "%s". Please double check the input file is a valid csvy.', yaml_border_re)
       }
       if (grepl(yaml_border_re, this_line)) break
       if (grepl(yaml_comment_re, this_line))
@@ -226,10 +222,17 @@ yaml=FALSE, autostart=NA, tmpdir=tempdir(), tz="UTC")
             new_names[ii] %chin% colClasses[[ new_types[ii] ]]
           }))) {
             plural = sum(idx_type) > 1L
-            message('colClasses dictated by user input and those read from YAML header are in conflict (specifically, for column', if (plural) 's',
-                    ' [', paste(new_names[matched_name_idx[!idx_type]], collapse = ','), ']); the proceeding assumes the user input was ',
-                    'an intentional override and will ignore the types implied by the YAML header; please exclude ',
-                    if (plural) 'these columns' else 'this column from colClasses if this was unintentional.')
+            message(
+              domain = NA,
+              sprintf(
+                ngettext(
+                  sum(idx_type),
+                  'colClasses dictated by user input and those read from YAML header are in conflict (specifically, for column [%s]); the proceeding assumes the user input was an intentional override and will ignore the types implied by the YAML header; please exclude this column from colClasses if this was unintentional.',
+                  'colClasses dictated by user input and those read from YAML header are in conflict (specifically, for columns [%s]); the proceeding assumes the user input was an intentional override and will ignore the types implied by the YAML header; please exclude these columns from colClasses if this was unintentional.'
+                ),
+                brackify(new_names[matched_name_idx[!idx_type]])
+              )
+            )
           }
         }
         # only add unmentioned columns
@@ -311,8 +314,7 @@ yaml=FALSE, autostart=NA, tmpdir=tempdir(), tz="UTC")
              methods::as(v, new_class))
       },
       warning = fun <- function(e) {
-        warning("Column '", names(ans)[j], "' was requested to be '", new_class, "' but fread encountered the following ",
-                if (inherits(e, "error")) "error" else "warning", ":\n\t", e$message, "\nso the column has been left as type '", typeof(v), "'", call.=FALSE)
+        warningf("Column '%s' was requested to be '%s' but fread encountered the following %s:\n\t%s\nso the column has been left as type '%s'", names(ans)[j], new_class, if (inherits(e, "error")) "error" else "warning", e$message, typeof(v))
         return(v)
       },
       error = fun)

--- a/R/fwrite.R
+++ b/R/fwrite.R
@@ -76,13 +76,11 @@ fwrite = function(x, file="", append=FALSE, quote="auto",
   }
   if (NCOL(x)==0L && file!="") {
     if (file.exists(file)) {
-      warning("Input has no columns; doing nothing.",
-              if (!append)
-                paste("\nIf you intended to overwrite the file at",
-                      file, "with an empty one, please use file.remove first."))
+      suggested <- if (append) "" else gettextf("\nIf you intended to overwrite the file at %s with an empty one, please use file.remove first.", file)
+      warningf("Input has no columns; doing nothing.%s", suggested)
       return(invisible())
     } else {
-      warning("Input has no columns; creating an empty file at '", file, "' and exiting.")
+      warningf("Input has no columns; creating an empty file at '%s' and exiting.", file)
       file.create(file)
       return(invisible())
     }

--- a/R/groupingsets.R
+++ b/R/groupingsets.R
@@ -59,13 +59,13 @@ groupingsets.data.table = function(x, j, by, sets, .SDcols, id = FALSE, jj, ...)
     stop("Argument 'id' must be a logical scalar.")
   # logic constraints validation
   if (!all((sets.all.by <- unique(unlist(sets))) %chin% by))
-    stop("All columns used in 'sets' argument must be in 'by' too. Columns used in 'sets' but not present in 'by': ", brackify(setdiff(sets.all.by, by)))
+    stopf("All columns used in 'sets' argument must be in 'by' too. Columns used in 'sets' but not present in 'by': %s", brackify(setdiff(sets.all.by, by)))
   if (id && "grouping" %chin% names(x))
     stop("When using `id=TRUE` the 'x' data.table must not have a column named 'grouping'.")
   if (any(vapply_1i(sets, anyDuplicated)))  # anyDuplicated returns index of first duplicate, otherwise 0L
     stop("Character vectors in 'sets' list must not have duplicated column names within a single grouping set.")
   if (length(sets) > 1L && (idx<-anyDuplicated(lapply(sets, sort))))
-    warning("'sets' contains a duplicate (i.e., equivalent up to sorting) element at index ", idx, "; as such, there will be duplicate rows in the output -- note that grouping by A,B and B,A will produce the same aggregations. Use `sets=unique(lapply(sets, sort))` to eliminate duplicates.")
+    warningf("'sets' contains a duplicate (i.e., equivalent up to sorting) element at index %d; as such, there will be duplicate rows in the output -- note that grouping by A,B and B,A will produce the same aggregations. Use `sets=unique(lapply(sets, sort))` to eliminate duplicates.", idx)
   # input arguments handling
   jj = if (!missing(jj)) jj else substitute(j)
   av = all.vars(jj, TRUE)

--- a/R/last.R
+++ b/R/last.R
@@ -35,7 +35,7 @@ last = function(x, n=1L, ...) {
     }
   } else {
     if (!requireNamespace("xts", quietly=TRUE))
-      stop(domain=NA, gettextf("'xts' class passed to %s function but 'xts' is not available, you should have 'xts' installed already", "data.table::last")) # nocov
+      stopf("'xts' class passed to %s function but 'xts' is not available, you should have 'xts' installed already", "data.table::last") # nocov
     if (verbose)
       catf("%s: using %s: %s\n", "last", "xts::last", "is.xts(x)")
     xts::last(x, n=n, ...)
@@ -76,7 +76,7 @@ first = function(x, n=1L, ...) {
     }
   } else {
     if (!requireNamespace("xts", quietly=TRUE))
-      stop(domain=NA, gettextf("'xts' class passed to %s function but 'xts' is not available, you should have 'xts' installed already", "data.table::first")) # nocov
+      stopf("'xts' class passed to %s function but 'xts' is not available, you should have 'xts' installed already", "data.table::first") # nocov
     if (verbose)
       catf("%s: using %s: %s\n", "first", "xts::first", "is.xts(x)")
     xts::first(x, n=n, ...)

--- a/R/merge.R
+++ b/R/merge.R
@@ -13,9 +13,12 @@ merge.data.table = function(x, y, by = NULL, by.x = NULL, by.y = NULL, all = FAL
   }
   x0 = length(x)==0L
   y0 = length(y)==0L
-  if (x0 || y0) warning(sprintf(ngettext(x0+y0,
-    "You are trying to join data.tables where %s has 0 columns.",
-    "You are trying to join data.tables where %s have 0 columns."),
+  if (x0 || y0) warning(domain=NA, sprintf(
+    ngettext(
+      x0+y0,
+      "You are trying to join data.tables where %s has 0 columns.",
+      "You are trying to join data.tables where %s have 0 columns."
+    ),
     if (x0 && y0) "'x' and 'y'" else if (x0) "'x'" else "'y'"
   ))
   nm_x = names(x)

--- a/R/merge.R
+++ b/R/merge.R
@@ -100,8 +100,7 @@ merge.data.table = function(x, y, by = NULL, by.x = NULL, by.y = NULL, all = FAL
   # `suffixes=c("","")`, to match behaviour in base:::merge.data.frame)
   resultdupnames = names(dt)[duplicated(names(dt))]
   if (length(resultdupnames)) {
-    warning("column names ", paste0("'", resultdupnames, "'", collapse=", "),
-            " are duplicated in the result")
+    warningf("column names %s are duplicated in the result", brackify(resultdupnames))
   }
 
   # retain custom classes of first argument that resulted in dispatch to this method, #1378

--- a/R/onAttach.R
+++ b/R/onAttach.R
@@ -18,21 +18,24 @@
   }
   dev = as.integer(v[1L, 3L]) %% 2L == 1L  # version number odd => dev
   if (!isTRUE(getOption("datatable.quiet"))) {   # new option in v1.12.4, #3489
-    packageStartupMessage("data.table ", v, if(dev)paste0(" IN DEVELOPMENT built ",d,g),
-                          " using ", getDTthreads(verbose=FALSE), " threads (see ?getDTthreads).  Latest news: r-datatable.com", domain="R-data.table")
+    # NB: we need to supply domain= for translation below since the below is technically not run in the data.table namespace
+    nth = getDTthreads(verbose=FALSE)
+    if (dev)
+      packageStartupMessagef(domain="R-data.table", "data.table %s IN DEVELOPMENT built %s%s using %d threads (see ?getDTthreads).  ", v, d, g, nth, appendLF=FALSE)
+    else 
+      packageStartupMessagef(domain="R-data.table", "data.table %s using %d threads (see ?getDTthreads).  ", v, nth, appendLF=FALSE)
+    packageStartupMessage(domain="R-data.table", "Latest news: r-datatable.com")
     # NB: domain= is necessary in .onAttach and .onLoad, see ?gettext and https://bugs.r-project.org/bugzilla/show_bug.cgi?id=18092.
     if (gettext(domain="R-data.table", "TRANSLATION CHECK") != "TRANSLATION CHECK")
       packageStartupMessage(domain="R-data.table", "**********\nRunning data.table in English; package support is available in English only. When searching for online help, be sure to also check for the English error message. This can be obtained by looking at the po/R-<locale>.po and po/<locale>.po files in the package source, where the native language and English error messages can be found side-by-side\n**********")
     if (dev && (Sys.Date() - as.Date(d))>28L)
       packageStartupMessage(domain="R-data.table", "**********\nThis development version of data.table was built more than 4 weeks ago. Please update: data.table::update.dev.pkg()\n**********")
     if (!.Call(ChasOpenMP))
-      packageStartupMessage(domain="R-data.table", "**********\n",
-        "This installation of data.table has not detected OpenMP support. It should still work but in single-threaded mode.\n",
-        if (Sys.info()["sysname"]=="Darwin")
-          "This is a Mac. Please read https://mac.r-project.org/openmp/. Please engage with Apple and ask them for support. Check r-datatable.com for updates, and our Mac instructions here: https://github.com/Rdatatable/data.table/wiki/Installation. After several years of many reports of installation problems on Mac, it's time to gingerly point out that there have been no similar problems on Windows or Linux."
-        else
-          paste0("This is ", Sys.info()["sysname"], ". This warning should not normally occur on Windows or Linux where OpenMP is turned on by data.table's configure script by passing -fopenmp to the compiler. If you see this warning on Windows or Linux, please file a GitHub issue."),
-        "\n**********")
+      packageStartupMessage(domain="R-data.table", "**********\nThis installation of data.table has not detected OpenMP support. It should still work but in single-threaded mode.\n", appendLF=FALSE)
+      if (Sys.info()["sysname"] == "Darwin")
+        packageStartupMessage(domain="R-data.table", "This is a Mac. Please read https://mac.r-project.org/openmp/. Please engage with Apple and ask them for support. Check r-datatable.com for updates, and our Mac instructions here: https://github.com/Rdatatable/data.table/wiki/Installation. After several years of many reports of installation problems on Mac, it's time to gingerly point out that there have been no similar problems on Windows or Linux.\n**********")
+    else
+      packageStartupMessagef(domain="R-data.table", "This is %s. This warning should not normally occur on Windows or Linux where OpenMP is turned on by data.table's configure script by passing -fopenmp to the compiler. If you see this warning on Windows or Linux, please file a GitHub issue.\n**********", Sys.info()["sysname"])
   }
 }
 

--- a/R/onAttach.R
+++ b/R/onAttach.R
@@ -30,12 +30,13 @@
       packageStartupMessage(domain="R-data.table", "**********\nRunning data.table in English; package support is available in English only. When searching for online help, be sure to also check for the English error message. This can be obtained by looking at the po/R-<locale>.po and po/<locale>.po files in the package source, where the native language and English error messages can be found side-by-side\n**********")
     if (dev && (Sys.Date() - as.Date(d))>28L)
       packageStartupMessage(domain="R-data.table", "**********\nThis development version of data.table was built more than 4 weeks ago. Please update: data.table::update.dev.pkg()\n**********")
-    if (!.Call(ChasOpenMP))
+    if (!.Call(ChasOpenMP)) {
       packageStartupMessage(domain="R-data.table", "**********\nThis installation of data.table has not detected OpenMP support. It should still work but in single-threaded mode.\n", appendLF=FALSE)
       if (Sys.info()["sysname"] == "Darwin")
         packageStartupMessage(domain="R-data.table", "This is a Mac. Please read https://mac.r-project.org/openmp/. Please engage with Apple and ask them for support. Check r-datatable.com for updates, and our Mac instructions here: https://github.com/Rdatatable/data.table/wiki/Installation. After several years of many reports of installation problems on Mac, it's time to gingerly point out that there have been no similar problems on Windows or Linux.\n**********")
-    else
-      packageStartupMessagef(domain="R-data.table", "This is %s. This warning should not normally occur on Windows or Linux where OpenMP is turned on by data.table's configure script by passing -fopenmp to the compiler. If you see this warning on Windows or Linux, please file a GitHub issue.\n**********", Sys.info()["sysname"])
+      else
+        packageStartupMessagef(domain="R-data.table", "This is %s. This warning should not normally occur on Windows or Linux where OpenMP is turned on by data.table's configure script by passing -fopenmp to the compiler. If you see this warning on Windows or Linux, please file a GitHub issue.\n**********", Sys.info()["sysname"])
+    }
   }
 }
 

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -26,11 +26,11 @@
       dll = if (.Platform$OS.type=="windows") "dll" else "so"
       # https://bugs.r-project.org/bugzilla/show_bug.cgi?id=17478
       # NB: domain= is necessary in .onAttach and .onLoad, see ?gettext and https://bugs.r-project.org/bugzilla/show_bug.cgi?id=18092.
-      stop(domain="R-data.table", "The datatable.",dll," version (",dllV,") does not match the package (",RV,"). Please close all R sessions to release the old ",toupper(dll)," and reinstall data.table in a fresh R session. The root cause is that R's package installer can in some unconfirmed circumstances leave a package in a state that is apparently functional but where new R code is calling old C code silently: https://bugs.r-project.org/bugzilla/show_bug.cgi?id=17478. Once a package is in this mismatch state it may produce wrong results silently until you next upgrade the package. Please help by adding precise circumstances to 17478 to move the status to confirmed. This mismatch between R and C code can happen with any package not just data.table. It is just that data.table has added this check.")
+      stopf(domain="R-data.table", "The datatable.%s version (%s) does not match the package (%s). Please close all R sessions to release the old %s and reinstall data.table in a fresh R session. The root cause is that R's package installer can in some unconfirmed circumstances leave a package in a state that is apparently functional but where new R code is calling old C code silently: https://bugs.r-project.org/bugzilla/show_bug.cgi?id=17478. Once a package is in this mismatch state it may produce wrong results silently until you next upgrade the package. Please help by adding precise circumstances to 17478 to move the status to confirmed. This mismatch between R and C code can happen with any package not just data.table. It is just that data.table has added this check.", dll, dllV, Rv, toupper(dll))
     }
     builtUsing = readRDS(system.file("Meta/package.rds",package="data.table"))$Built$R
     if (!identical(base::getRversion()>="4.0.0", builtUsing>="4.0.0")) {
-      stop(domain="R-data.table", "This is R ", base::getRversion(), " but data.table has been installed using R ",builtUsing,". The major version must match. Please reinstall data.table.")
+      stopf(domain="R-data.table", "This is R %s but data.table has been installed using R %s. The major version must match. Please reinstall data.table.", base::getRversion(), builtUsing)
       # the if(R>=4.0.0) in NAMESPACE when registering S3 methods rbind.data.table and cbind.data.table happens on install; #3968
     }
   }

--- a/R/openmp-utils.R
+++ b/R/openmp-utils.R
@@ -1,9 +1,9 @@
 setDTthreads = function(threads=NULL, restore_after_fork=NULL, percent=NULL, throttle=NULL) {
   if (!missing(percent)) {
     if (!missing(threads)) stop("Provide either threads= or percent= but not both")
-    if (length(percent)!=1) stop("percent= is provided but is length ", length(percent))
+    if (length(percent)!=1) stopf("percent= is provided but is length %d", length(percent))
     percent=as.integer(percent)
-    if (is.na(percent) || percent<2L || percent>100L) stop("percent==",percent," but should be a number between 2 and 100")
+    if (is.na(percent) || percent<2L || percent>100L) stopf("percent==%d but should be a number between 2 and 100", percent)
     invisible(.Call(CsetDTthreads, percent, restore_after_fork, TRUE, as.integer(throttle)))
   } else {
     invisible(.Call(CsetDTthreads, as.integer(threads), restore_after_fork, FALSE, as.integer(throttle)))

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -235,9 +235,7 @@ trunc_cols_message = function(not_printed, abbs, class, col.names){
   n = length(not_printed)
   if (class && col.names != "none") classes = paste0(" ", tail(abbs, n)) else classes = ""
   cat(sprintf(
-    ngettext(n,
-             "%d variable not shown: %s\n",
-             "%d variables not shown: %s\n"),
+    ngettext(n, "%d variable not shown: %s\n", "%d variables not shown: %s\n"),
     n, brackify(paste0(not_printed, classes))
   ))
 }

--- a/R/programming.R
+++ b/R/programming.R
@@ -16,8 +16,7 @@ list2lang = function(x) {
   to.name = !asis & char
   if (any(to.name)) { ## turns "my_name" character scalar into `my_name` symbol, for convenience
     if (any(non.scalar.char <- vapply(x[to.name], length, 0L)!=1L)) {
-      stop("Character objects provided in the input are not scalar objects, if you need them as character vector rather than a name, then wrap each into 'I' call: ",
-           paste(names(non.scalar.char)[non.scalar.char], collapse=", "))
+      stopf("Character objects provided in the input are not scalar objects, if you need them as character vector rather than a name, then wrap each into 'I' call: %s", brackify(names(non.scalar.char)[non.scalar.char]))
     }
     x[to.name] = lapply(x[to.name], as.name)
   }

--- a/R/setkey.R
+++ b/R/setkey.R
@@ -54,7 +54,7 @@ setkeyv = function(x, cols, verbose=getOption("datatable.verbose"), physical=TRU
   if (!all(nzchar(cols))) stop("cols contains some blanks.")
   cols = gsub("`", "", cols, fixed = TRUE)
   miss = !(cols %chin% colnames(x))
-  if (any(miss)) stop("some columns are not in the data.table: ", paste(cols[miss], collapse=","))
+  if (any(miss)) stopf("some columns are not in the data.table: %s", brackify(cols[miss]))
 
   ## determine, whether key is already present:
   if (identical(key(x),cols)) {
@@ -79,7 +79,7 @@ setkeyv = function(x, cols, verbose=getOption("datatable.verbose"), physical=TRU
   if (".xi" %chin% names(x)) stop("x contains a column called '.xi'. Conflicts with internal use by data.table.")
   for (i in cols) {
     .xi = x[[i]]  # [[ is copy on write, otherwise checking type would be copying each column
-    if (!typeof(.xi) %chin% ORDERING_TYPES) stop("Column '",i,"' is type '",typeof(.xi),"' which is not supported as a key column type, currently.")
+    if (!typeof(.xi) %chin% ORDERING_TYPES) stopf("Column '%s' is type '%s' which is not supported as a key column type, currently.", i, typeof(.xi))
   }
   if (!is.character(cols) || length(cols)<1L) stop("Internal error. 'cols' should be character at this point in setkey; please report.") # nocov
 
@@ -128,7 +128,7 @@ getindex = function(x, name) {
   # name can be "col", or "col1__col2", or c("col1","col2")
   ans = attr(attr(x, 'index', exact=TRUE), paste0("__",name,collapse=""), exact=TRUE)
   if (!is.null(ans) && (!is.integer(ans) || (length(ans)!=nrow(x) && length(ans)!=0L))) {
-    stop("Internal error: index '",name,"' exists but is invalid")   # nocov
+    stopf("Internal error: index '%s' exists but is invalid", name)   # nocov
   }
   ans
 }
@@ -284,11 +284,11 @@ setorderv = function(x, cols = colnames(x), order=1L, na.last=FALSE)
   # remove backticks from cols
   cols = gsub("`", "", cols, fixed = TRUE)
   miss = !(cols %chin% colnames(x))
-  if (any(miss)) stop("some columns are not in the data.table: ", paste(cols[miss], collapse=","))
+  if (any(miss)) stopf("some columns are not in the data.table: %s", brackify(cols[miss]))
   if (".xi" %chin% colnames(x)) stop("x contains a column called '.xi'. Conflicts with internal use by data.table.")
   for (i in cols) {
     .xi = x[[i]]  # [[ is copy on write, otherwise checking type would be copying each column
-    if (!typeof(.xi) %chin% ORDERING_TYPES) stop("Column '",i,"' is type '",typeof(.xi),"' which is not supported for ordering currently.")
+    if (!typeof(.xi) %chin% ORDERING_TYPES) stopf("Column '%s' is type '%s' which is not supported for ordering currently.", i, typeof(.xi))
   }
   if (!is.character(cols) || length(cols)<1L) stop("Internal error. 'cols' should be character at this point in setkey; please report.") # nocov
 
@@ -337,7 +337,7 @@ CJ = function(..., sorted = TRUE, unique = FALSE)
     y = l[[i]]
     if (!length(y)) next
     if (sorted) {
-      if (!is.atomic(y)) stop("'sorted' is TRUE but element ", i, " is non-atomic, which can't be sorted; try setting sorted = FALSE")
+      if (!is.atomic(y)) stopf("'sorted' is TRUE but element %d is non-atomic, which can't be sorted; try setting sorted = FALSE", i)
       o = forderv(y, retGrp=TRUE)
       thisdups = attr(o, 'maxgrpn', exact=TRUE)>1L
       if (thisdups) {

--- a/R/setkey.R
+++ b/R/setkey.R
@@ -352,7 +352,7 @@ CJ = function(..., sorted = TRUE, unique = FALSE)
     }
   }
   nrow = prod( vapply_1i(l, length) )  # lengths(l) will work from R 3.2.0
-  if (nrow > .Machine$integer.max) stop(domain=NA, gettextf("Cross product of elements provided to CJ() would result in %.0f rows which exceeds .Machine$integer.max == %d", nrow, .Machine$integer.max))
+  if (nrow > .Machine$integer.max) stopf("Cross product of elements provided to CJ() would result in %.0f rows which exceeds .Machine$integer.max == %d", nrow, .Machine$integer.max)
   l = .Call(Ccj, l)
   setDT(l)
   l = setalloccol(l)  # a tiny bit wasteful to over-allocate a fixed join table (column slots only), doing it anyway for consistency since

--- a/R/setops.R
+++ b/R/setops.R
@@ -14,11 +14,11 @@ setdiff_ = function(x, y, by.x=seq_along(x), by.y=seq_along(y), use.names=FALSE)
     icnam = names(y)[lc]
     xcnam = names(x)[rc]
     if ( is.character(x[[rc]]) && !(is.character(y[[lc]]) || is.factor(y[[lc]])) ) {
-      stop("When x's column ('",xcnam,"') is character, the corresponding column in y ('",icnam,"') should be factor or character, but found incompatible type '",typeof(y[[lc]]),"'.")
+      stopf("When x's column ('%s') is character, the corresponding column in y ('%s') should be factor or character, but found incompatible type '%s'.", xcnam, icnam, typeof(y[[lc]]))
     } else if ( is.factor(x[[rc]]) && !(is.character(y[[lc]]) || is.factor(y[[lc]])) ) {
-      stop("When x's column ('",xcnam,"') is factor, the corresponding column in y ('",icnam,"') should be character or factor, but found incompatible type '",typeof(y[[lc]]),"'.")
+      stopf("When x's column ('%s') is factor, the corresponding column in y ('%s') should be character or factor, but found incompatible type '%s'.", xcnam, icnam, typeof(y[[lc]]))
     } else if ( (is.integer(x[[rc]]) || is.double(x[[rc]])) && (is.logical(y[[lc]]) || is.character(y[[lc]])) ) {
-      stop("When x's column ('",xcnam,"') is integer or numeric, the corresponding column in y ('",icnam,"') can not be character or logical types, but found incompatible type '",typeof(y[[lc]]),"'.")
+      stopf("When x's column ('%s') is integer or numeric, the corresponding column in y ('%s') can not be character or logical types, but found incompatible type '%s'.", xcnam, icnam, typeof(y[[lc]]))
     }
   }
   ux = unique(shallow(x, by.x))
@@ -42,8 +42,7 @@ funique = function(x) {
   if (!identical(names(x), names(y))) stop("x and y must have the same column order")
   bad_types = c("raw", "complex", if (block_list) "list")
   found = bad_types %chin% c(vapply_1c(x, typeof), vapply_1c(y, typeof))
-  if (any(found)) stop("unsupported column type", if (sum(found) > 1L) "s" else "",
-                       " found in x or y: ", brackify(bad_types[found]))
+  if (any(found)) stop(domain=NA, sprintf(ngettext(sum(found), "unsupported column type found in x or y: %s", "unsupported column types found in x or y: %s"), brackify(bad_types[found])))
   super = function(x) {
     # allow character->factor and integer->numeric because from v1.12.4 i's type is retained by joins, #3820
     ans = class(x)[1L]
@@ -51,7 +50,7 @@ funique = function(x) {
   }
   if (!identical(sx<-sapply(x, super), sy<-sapply(y, super))) {
     w = which.first(sx!=sy)
-    stop("Item ",w," of x is '",class(x[[w]])[1L],"' but the corresponding item of y is '", class(y[[w]])[1L], "'.")
+    stopf("Item %d of x is '%s' but the corresponding item of y is '%s'.", w, class(x[[w]])[1L], class(y[[w]])[1L])
   }
   if (.seqn && ".seqn" %chin% names(x)) stop("None of the datasets should contain a column named '.seqn'")
 }
@@ -189,9 +188,9 @@ all.equal.data.table = function(target, current, trim.levels=TRUE, check.attribu
       stop("None of the datasets to compare should contain a column named '.seqn'")
     bad.type = setNames(c("raw","complex","list") %chin% c(vapply_1c(current, typeof), vapply_1c(target, typeof)), c("raw","complex","list"))
     if (any(bad.type))
-      stop("Datasets to compare with 'ignore.row.order' must not have unsupported column types: ", brackify(names(bad.type)[bad.type]))
+      stopf("Datasets to compare with 'ignore.row.order' must not have unsupported column types: %s", brackify(names(bad.type)[bad.type]))
     if (between(tolerance, 0, sqrt(.Machine$double.eps), incbounds=FALSE)) {
-      warning("Argument 'tolerance' was forced to lowest accepted value `sqrt(.Machine$double.eps)` from provided ", format(tolerance, scientific=FALSE))
+      warningf("Argument 'tolerance' was forced to lowest accepted value `sqrt(.Machine$double.eps)` from provided %s", format(tolerance, scientific=FALSE))
       tolerance = sqrt(.Machine$double.eps)
     }
     target_dup = as.logical(anyDuplicated(target))

--- a/R/tables.R
+++ b/R/tables.R
@@ -23,7 +23,7 @@ tables = function(mb=TRUE, order.col="NAME", width=80,
       KEY = list(key(DT)),
       INDICES = if (index) list(indices(DT)))
   }))
-  if (!order.col %chin% names(info)) stop("order.col='",order.col,"' not a column name of info")
+  if (!order.col %chin% names(info)) stopf("order.col='%s' not a column name of info", order.col)
   info = info[base::order(info[[order.col]])]  # base::order to maintain locale ordering of table names
   if (!silent) {
     # prettier printing on console

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -46,7 +46,7 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
     # nocov start
     fn2 = paste0(fn,".bz2")
     if (!file.exists(file.path(fulldir, fn2)))
-      stop(domain=NA, gettextf("Neither %s nor %s exist in %s",fn, fn2, fulldir))
+      stopf("Neither %s nor %s exist in %s",fn, fn2, fulldir)
     fn = fn2
     # nocov end
     # sys.source() below accepts .bz2 directly.
@@ -166,7 +166,8 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
         nfail,
         "%d error out of %d. Search %s for test number %s",
         "%d errors out of %d. Search %s for test numbers %s"
-      ), nfail, ntest, names(fn), paste(env$whichfail, collapse=", ")
+      ),
+      nfail, ntest, names(fn), toString(env$whichfail)
     ))
     # important to stop() here, so that 'R CMD check' fails
     # nocov end

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -151,7 +151,7 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
   if (inherits(err,"try-error")) {
     # nocov start
     if (silent) return(FALSE)
-    stop("Failed after test ", env$prevtest, " before the next test() call in ",fn)
+    stopf("Failed after test %s before the next test() call in %s", env$prevtest, fn)
     # the try() above with silent=FALSE will have already printed the error itself
     # nocov end
   }
@@ -176,7 +176,7 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
   timings = env$timings
   DT = head(timings[-1L][order(-time)], 10L)   # exclude id 1 as in dev that includes JIT
   if ((x<-sum(timings[["nTest"]])) != ntest) {
-    warning("Timings count mismatch: ",x," vs ",ntest)  # nocov
+    warningf("Timings count mismatch: %d vs %d", x, ntest)  # nocov
   }
   catf("10 longest running tests took %ds (%d%% of %ds)\n", as.integer(tt<-DT[, sum(time)]), as.integer(100*tt/(ss<-timings[,sum(time)])), as.integer(ss))
   print(DT, class=FALSE)
@@ -305,7 +305,7 @@ test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,no
     showProgress = FALSE     # nocov
   }
   if (!missing(error) && !missing(y))
-    stop("Test ",numStr," is invalid: when error= is provided it does not make sense to pass y as well")  # nocov
+    stopf("Test %s is invalid: when error= is provided it does not make sense to pass y as well", numStr)  # nocov
 
   string_match = function(x, y, ignore.case=FALSE) {
     length(grep(x, y, fixed=TRUE)) ||  # try treating x as literal first; useful for most messages containing ()[]+ characters

--- a/R/translation.R
+++ b/R/translation.R
@@ -1,0 +1,21 @@
+# templated warning/error functions to smooth translation & development
+
+catf = function(fmt, ..., sep=" ", domain=NULL) {
+  cat(gettextf(fmt, ..., domain=domain), sep=sep)
+}
+
+stopf = function(fmt, ..., domain=NULL) {
+  stop(gettextf(fmt, ..., domain=domain), domain=NA, call. = FALSE)
+}
+
+warningf = function(fmt, ..., immediate.=FALSE, noBreaks.=FALSE, domain=NULL) {
+  warning(gettextf(fmt, ..., domain=domain), domain=NA, call.=FALSE, immediate.=immediate., noBreaks.=noBreaks.)
+}
+
+messagef = function(fmt, ..., appendLF=TRUE, domain=NULL) {
+  message(gettextf(fmt, ..., domain=domain), domain=NA, appendLF=appendLF)
+}
+
+packageStartupMessagef = function(fmt, ..., appendLF=TRUE, domain=NULL) {
+  packageStartupMessage(gettextf(fmt, ..., domain=domain), domain=NA, appendLF=appendLF)
+}

--- a/R/transpose.R
+++ b/R/transpose.R
@@ -4,12 +4,12 @@ transpose = function(l, fill=NA, ignore.empty=FALSE, keep.names=NULL, make.names
     if (is.character(make.names)) {
       m = chmatch(make.names, names(l))
       if (is.na(m))
-        stop("make.names='",make.names,"' not found in names of input")
+        stopf("make.names='%s' not found in names of input", make.names)
       make.names = m
     } else {
       make.names = as.integer(make.names)
       if (is.na(make.names) || make.names<1L || make.names>length(l))
-        stop("make.names=",make.names," is out of range [1,ncol=",length(l),"]")
+        stopf("make.names=%d is out of range [1,ncol=%d]", make.names, length(l))
     }
     colnames = as.character(l[[make.names]])
     l = if (is.data.table(l)) l[,-make.names,with=FALSE] else l[-make.names]
@@ -31,8 +31,7 @@ tstrsplit = function(x, ..., fill=NA, type.convert=FALSE, keep, names=FALSE) {
     keep = suppressWarnings(as.integer(keep))
     chk = min(keep) >= min(1L, length(ans)) & max(keep) <= length(ans)
     if (!isTRUE(chk)) # handles NA case too
-      stop("'keep' should contain integer values between ",
-        min(1L, length(ans)), " and ", length(ans), ".")
+      stopf("'keep' should contain integer values between %d and %d.", min(1L, length(ans)), length(ans))
     ans = ans[keep]
   }
   # Implementing #1094, but default FALSE
@@ -41,8 +40,7 @@ tstrsplit = function(x, ..., fill=NA, type.convert=FALSE, keep, names=FALSE) {
   else if (isTRUE(names)) names = paste0("V", seq_along(ans))
   if (length(names) != length(ans)) {
     str = if (missing(keep)) "ans" else "keep"
-    stop("length(names) (= ", length(names),
-      ") is not equal to length(", str, ") (= ", length(ans), ").")
+    stopf("length(names) (= %d) is not equal to length(%s) (= %d).", length(names), str, length(ans))
   }
   setattr(ans, 'names', names)
   ans

--- a/R/utils.R
+++ b/R/utils.R
@@ -152,8 +152,3 @@ edit.data.table = function(name, ...) {
   setDT(NextMethod('edit', name))[]
 }
 # nocov end
-
-catf = function(fmt, ...) {
-  cat(gettextf(fmt, ...))
-}
-

--- a/R/xts.R
+++ b/R/xts.R
@@ -19,7 +19,7 @@ as.xts.data.table = function(x, ...) {
   stopifnot(requireNamespace("xts"), !missing(x), is.data.table(x))
   if (!xts::is.timeBased(x[[1L]])) stop("data.table must have a time based column in first position, use `setcolorder` function to change the order, or see ?timeBased for supported types")
   colsNumeric = vapply_1b(x, is.numeric)[-1L] # exclude first col, xts index
-  if (!all(colsNumeric)) warning("Following columns are not numeric and will be omitted: ", brackify(names(colsNumeric)[!colsNumeric]))
+  if (!all(colsNumeric)) warningf("Following columns are not numeric and will be omitted: %s", brackify(names(colsNumeric)[!colsNumeric]))
   r = setDF(x[, .SD, .SDcols = names(colsNumeric)[colsNumeric]])
   return(xts::as.xts(r, order.by = if ("IDate" %chin% class(x[[1L]])) as.Date(x[[1L]]) else x[[1L]]))
 }

--- a/R/xts.R
+++ b/R/xts.R
@@ -7,7 +7,7 @@ as.data.table.xts = function(x, keep.rownames = TRUE, key=NULL, ...) {
   r = setDT(as.data.frame(x, row.names=NULL))
   if (identical(keep.rownames, FALSE)) return(r[])
   index_nm = if (is.character(keep.rownames)) keep.rownames else "index"
-  if (index_nm %chin% names(x)) stop(domain=NA, gettextf("Input xts object should not have '%s' column because it would result in duplicate column names. Rename '%s' column in xts or use `keep.rownames` to change the index column name.", index_nm, index_nm))
+  if (index_nm %chin% names(x)) stopf("Input xts object should not have '%s' column because it would result in duplicate column names. Rename '%s' column in xts or use `keep.rownames` to change the index column name.", index_nm, index_nm)
   r[, c(index_nm) := zoo::index(x), env=list(x=x)]
   setcolorder(r, c(index_nm, setdiff(names(r), index_nm)))
   # save to end to allow for key=index_nm

--- a/inst/tests/programming.Rraw
+++ b/inst/tests/programming.Rraw
@@ -251,7 +251,7 @@ test(7.12, f(list(var1 = var2), list(var1 = "c1", var2 = 5L)), quote(list(c1 = 5
 d = data.table(a = 2:1, b = 1:4)
 test(11.01, d[var3%in%values, .(var1 = f(var2)), by=var3,
   env=list(var1="res", var2="b", f="sum", var3="a", values=0:3),
-  verbose=TRUE], data.table(a=c(2L,1L), res=c(4L,6L)), output=c("Argument 'by' after substitute: a","Argument 'j'  after substitute: .(res = sum(b))","Argument 'i'  after substitute: a %in% 0:3"))
+  verbose=TRUE], data.table(a=c(2L,1L), res=c(4L,6L)), output=c("Argument 'by' after substitute: a","Argument 'j' after substitute: .(res = sum(b))","Argument 'i' after substitute: a %in% 0:3"))
 # data.table symbols and chars
 d = data.table(a = c("b","a"), b = 1:4)
 out = capture.output(ans <- d[var3%in%values, .(var1 = f(var2)), keyby=var3,
@@ -261,8 +261,8 @@ test(11.02, ans, data.table(a=c("a","b"), res=c(6L,4L), key="a"))
 out = grep("Argument.*substitute", out, value=TRUE)
 test(11.021, length(out), 3L) # we expect i, j, by only here, ensure about that
 test(11.022, "Argument 'by' after substitute: a" %in% out, TRUE)
-test(11.023, "Argument 'j'  after substitute: .(res = sum(b))" %in% out, TRUE)
-test(11.024, "Argument 'i'  after substitute: a %in% c(\"a\", \"b\", \"c\")" %in% out, TRUE)
+test(11.023, "Argument 'j' after substitute: .(res = sum(b))" %in% out, TRUE)
+test(11.024, "Argument 'i' after substitute: a %in% c(\"a\", \"b\", \"c\")" %in% out, TRUE)
 out = capture.output(ans <- d[var3%in%values, .(var1 = f(var2)), keyby=var3,
   env=I(list(var1=as.name("res"), var2=as.name("b"), f=as.name("sum"), var3=as.name("a"), values=c("b","c"))),
   verbose=TRUE])
@@ -270,8 +270,8 @@ test(11.03, ans, data.table(a=c("b"), res=c(4L), key="a"))
 out = grep("Argument.*substitute", out, value=TRUE)
 test(11.031, length(out), 3L)
 test(11.032, "Argument 'by' after substitute: a" %in% out, TRUE)
-test(11.033, "Argument 'j'  after substitute: .(res = sum(b))" %in% out, TRUE)
-test(11.034, "Argument 'i'  after substitute: a %in% c(\"b\", \"c\")" %in% out, TRUE)
+test(11.033, "Argument 'j' after substitute: .(res = sum(b))" %in% out, TRUE)
+test(11.034, "Argument 'i' after substitute: a %in% c(\"b\", \"c\")" %in% out, TRUE)
 # substitute2 during join
 d1 = data.table(id1=1:4, v1=5)
 d2 = data.table(id1=c(0L,2:3), v1=6)
@@ -279,7 +279,7 @@ out = capture.output(ans <- d1[d2, on="id1<=id1", .(c1, c2, c3, c4), env=list(c1
 test(11.041, ans, data.table(x.id1=c(NA,1:2,1:3), i.id1=c(0L,2L,2L,3L,3L,3L), x.v1=c(NA,rep(5,5)), i.v1=rep(6,6)))
 out = grep("Argument.*substitute", out, value=TRUE)
 test(11.042, length(out), 2L) ## 2L because i is non-missing attempt to substitute is made
-test(11.043, "Argument 'j'  after substitute: .(x.id1, i.id1, x.v1, i.v1)" %in% out, TRUE)
+test(11.043, "Argument 'j' after substitute: .(x.id1, i.id1, x.v1, i.v1)" %in% out, TRUE)
 d1 = data.table(id1=c(2L,4L,2L,4L), v1=5)
 d2 = data.table(id1=c(0L,2:3), v1=6)
 out = capture.output(ans <- d1[dd, on="id1<=id1", .(sum(c3), sum(c4)), by=by, env=list(dd="d2", c3="x.v1", c4="i.v1", by=".EACHI"), verbose=TRUE])
@@ -287,8 +287,8 @@ test(11.044, ans, data.table(id1=c(0L,2L,3L), V1=c(NA,10,10), V2=c(6,6,6)))
 out = grep("Argument.*substitute", out, value=TRUE)
 test(11.045, length(out), 3L)
 test(11.046, "Argument 'by' after substitute: .EACHI" %in% out, TRUE)
-test(11.047, "Argument 'j'  after substitute: .(sum(x.v1), sum(i.v1))" %in% out, TRUE)
-test(11.048, "Argument 'i'  after substitute: d2" %in% out, TRUE)
+test(11.047, "Argument 'j' after substitute: .(sum(x.v1), sum(i.v1))" %in% out, TRUE)
+test(11.048, "Argument 'i' after substitute: d2" %in% out, TRUE)
 dt1 = data.table(x = letters[1:5], y = 1:5)
 dt2 = data.table(x = letters[1:3], y = 11:13)
 target_v = "y"
@@ -326,9 +326,9 @@ f = function(x, i, j, by) {
   x[.i, .j, .by, env=list(.i=substitute(i), .j=substitute(j), .by=substitute(by)), verbose=TRUE]
 }
 test(11.083, f(d), d)
-test(11.084, f(d, 1), d[1], output="Argument 'i'  after substitute", notOutput="Argument 'j'  after substitute")
-test(11.085, f(d,, 1), d[,1], output="Argument 'j'  after substitute", notOutput="Argument 'i'  after substitute")
-test(11.086, f(d, 1, 1), d[1, 1], output="Argument 'j'  after substitute.*Argument 'i'  after substitute")
+test(11.084, f(d, 1), d[1], output="Argument 'i' after substitute", notOutput="Argument 'j' after substitute")
+test(11.085, f(d,, 1), d[,1], output="Argument 'j' after substitute", notOutput="Argument 'i' after substitute")
+test(11.086, f(d, 1, 1), d[1, 1], output="Argument 'j' after substitute.*Argument 'i' after substitute")
 
 #1985 weird exception when by contains get
 tb = data.table(x=c(1,2), y=c(3,4), z=c(5,6), w=c("a","b"))
@@ -362,7 +362,7 @@ test(11.107, ans, data.table(Type=factor(c("Quebec","Mississippi"), levels=c("Qu
 out = grep("Argument.*substitute", out, value=TRUE)
 test(11.108, length(out), 2L)
 test(11.109, "Argument 'by' after substitute: Type" %in% out, TRUE)
-test(11.110, "Argument 'j'  after substitute: list(max(conc), round(mean(conc)))" %in% out, TRUE)
+test(11.110, "Argument 'j' after substitute: list(max(conc), round(mean(conc)))" %in% out, TRUE)
 #628 Change j=list(xout=eval(...))'s eval to eval within scope of DT
 dat = data.table(x_one=1:10, x_two=1:10, y_one=1:10, y_two=1:10)
 f = function(vars) as.call(c(quote(list), lapply(setNames(vars, paste(vars,"out",sep="_")), function(var) substitute2(one-two, list(one=paste(var,"one",sep="_"), two=paste(var,"two",sep="_"))))))
@@ -488,8 +488,8 @@ test(101.01, dt$x_ratio, x_rat)
 test(101.02, dt$y_ratio, y_rat)
 test(101.03, length(grep("Argument.*substitute", out[["x"]], value=TRUE)), 1L)
 test(101.04, length(grep("Argument.*substitute", out[["y"]], value=TRUE)), 1L)
-test(101.05, "Argument 'j'  after substitute: `:=`(x_ratio, (x3 - x2) * (x2 - x1) * (x3 - x1)/sqrt(x1^2 + x2^2 + x3^2))" %in% out[["x"]], TRUE)
-test(101.06, "Argument 'j'  after substitute: `:=`(y_ratio, (y3 - y2) * (y2 - y1) * (y3 - y1)/sqrt(y1^2 + y2^2 + y3^2))" %in% out[["y"]], TRUE)
+test(101.05, "Argument 'j' after substitute: `:=`(x_ratio, (x3 - x2) * (x2 - x1) * (x3 - x1)/sqrt(x1^2 + x2^2 + x3^2))" %in% out[["x"]], TRUE)
+test(101.06, "Argument 'j' after substitute: `:=`(y_ratio, (y3 - y2) * (y2 - y1) * (y3 - y1)/sqrt(y1^2 + y2^2 + y3^2))" %in% out[["y"]], TRUE)
 daily_cor = function(data, x, y) { ## daily correlation of user input features
   data[, .(cor = cor(x, y)),
     keyby = date,
@@ -499,7 +499,7 @@ daily_cor = function(data, x, y) { ## daily correlation of user input features
 out = capture.output(ans <- daily_cor(dt, "x0", "y2"))
 test(101.07, length(grep("Argument.*substitute", out, value=TRUE)), 2L) ## 'by' (or 'keyby') is not substituted here but it still goes via substitute2 because it is non-missing
 test(101.08, "Argument 'by' after substitute: date" %in% out, TRUE)
-test(101.09, "Argument 'j'  after substitute: .(cor = cor(x0, y2))" %in% out, TRUE)
+test(101.09, "Argument 'j' after substitute: .(cor = cor(x0, y2))" %in% out, TRUE)
 group_cor = function(data, x, y, g) { ## group cor comparison of user input features
   cor_dt = data[, lapply(.SD, function(x) cor(x, Y)),
     keyby = .(group = GROUP),
@@ -511,11 +511,11 @@ group_cor = function(data, x, y, g) { ## group cor comparison of user input feat
 out = capture.output(dt1 <- group_cor(dt, c("x0", "x1", "x2"), "y1", "grp1"))
 test(101.10, length(grep("Argument.*substitute", out, value=TRUE)), 2L)
 test(101.11, "Argument 'by' after substitute: .(group = grp1)" %in% out, TRUE)
-test(101.12, "Argument 'j'  after substitute: lapply(.SD, function(x) cor(x, y1))" %in% out, TRUE)
+test(101.12, "Argument 'j' after substitute: lapply(.SD, function(x) cor(x, y1))" %in% out, TRUE)
 out = capture.output(dt2 <- group_cor(dt, c("x0", "x1", "x2"), "y1", "grp2"))
 test(101.13, length(grep("Argument.*substitute", out, value=TRUE)), 2L)
 test(101.14, "Argument 'by' after substitute: .(group = grp2)" %in% out, TRUE)
-test(101.15, "Argument 'j'  after substitute: lapply(.SD, function(x) cor(x, y1))" %in% out, TRUE)
+test(101.15, "Argument 'j' after substitute: lapply(.SD, function(x) cor(x, y1))" %in% out, TRUE)
 stats_dt1 = as.data.table(list(
   x = c("x0", "x1", "x2"),
   min = c(-0.325967794724422, -0.126026585686073, -0.398950077203113),
@@ -551,8 +551,8 @@ out = capture.output(ans <- cor_xy(xdt, ydt, c("x1", "x2"), "y10"))
 exp = as.data.table(list(symbol = 1:2, x1 = c(0.529292252112253, 0.0301956035638738), x2 = c(0.287076866252898, -0.335969587268599)), key="symbol")
 test(102.01, ans, exp)
 test(102.02, length(grep("Argument.*substitute", out, value=TRUE)), 2L)
-test(102.03, "Argument 'j'  after substitute: `:=`(y, y10)" %in% out, TRUE)
-test(102.04, "Argument 'i'  after substitute: ydt" %in% out, TRUE)
+test(102.03, "Argument 'j' after substitute: `:=`(y, y10)" %in% out, TRUE)
+test(102.04, "Argument 'i' after substitute: ydt" %in% out, TRUE)
 cor_xy2 = function(xdt, ydt, x, y) { ## cor between each pair of x and y
   rbindlist(lapply(y, function(yi) {
     xdt[ydt, y := Y, on = .(symbol, date),

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -2362,7 +2362,7 @@ test(827.1, names(a[b]), c("User ID","Blah Blah","Yadda Yadda"))
 
 # setcolorder and merge check for dup column names, #2193(ii)
 setnames(DT2,"b","a")
-test(828, setcolorder(DT2,c("a","b")), error="x has some duplicated column name(s): a. Please remove or rename")
+test(828, setcolorder(DT2,c("a","b")), error="x has some duplicated column name(s): [a]. Please remove or rename")
 test(829, merge(DT1,DT2), error="y has some duplicated column name(s): [a]. Please remove or rename")
 test(830, merge(DT2,DT1), error="x has some duplicated column name(s): [a]. Please remove or rename")
 
@@ -5678,7 +5678,7 @@ for (i in seq_along(dt)) {
 x = data.table(chr=c("Chr1", "Chr1", "Chr2", "Chr2", "Chr2"), start=c(5,10, 1, 25, 50), end=c(11,20,4,52,60))
 y = data.table(chr=c("Chr1", "Chr1", "Chr2"), start=c(1, 15,1), end=c(4, 18, 55), val=1:3)
 # no by.x and by.y error
-test(1371.1, foverlaps(x, y, type="any"), error="'y' must be keyed (i.e., sorted, and, marked as sorted).")
+test(1371.1, foverlaps(x, y, type="any"), error="y must be keyed (i.e., sorted, and, marked as sorted).")
 setkey(y, chr, end, start)
 test(1371.2, foverlaps(x, y, by.y=1:3, type="any"), error="The first 3 columns of y's key must be identical to the columns specified in by.y.")
 setkey(y, chr, start, end)
@@ -13827,7 +13827,7 @@ test(1967.30, foverlaps(x, y),
      error = 'must be integer/numeric type')
 x[ , end := as.integer(end)]
 test(1967.31, foverlaps(x, y, by.x = c('end', 'start')),
-     error = 'All entries in column end should be <= corresponding entries')
+     error = "All entries in column 'end' should be <= corresponding entries")
 y[ , end := as.character(end)]
 setkey(y, start, end)
 test(1967.32, foverlaps(x, y),
@@ -13835,7 +13835,7 @@ test(1967.32, foverlaps(x, y),
 y[ , end := as.integer(end)]
 setkey(y, end, start)
 test(1967.33, foverlaps(x, y, by.x = c('start', 'end'), by.y = c('end', 'start')),
-     error = 'All entries in column end should be <= corresponding entries')
+     error = "All entries in column 'end' should be <= corresponding entries")
 
 ## data.table.R
 test(1967.34, data.table(1:5, NULL), data.table(V1=1:5))
@@ -16058,12 +16058,12 @@ test(2074.23, capture.output(print(DT2, topn=1L, col.names='none')),
 # foverlaps
 x = data.table(start=NA_integer_, end=1L, key='start,end')
 y = copy(x)
-test(2074.24, foverlaps(x, y), error="NA values in data.table 'x' start column")
+test(2074.24, foverlaps(x, y), error="NA values in data.table x 'start' column")
 x[ , start := 0L]
 setkey(x, start, end)
-test(2074.25, foverlaps(x, y), error="NA values in data.table 'y' start column")
+test(2074.25, foverlaps(x, y), error="NA values in data.table y 'start' column")
 setkey(y, end, start)
-test(2074.26, foverlaps(x, y), error="NA values in data.table 'y' end column")
+test(2074.26, foverlaps(x, y), error="NA values in data.table y 'end' column")
 
 # cube
 test(2074.27, cube(DT, by=1L), error="Argument 'by' must be a character")
@@ -17563,15 +17563,15 @@ test(2183.00004, melt(DTid, measure.vars=measurev(list(value.name=NULL, istr=NUL
 test(2183.00005, melt(DTid, measure.vars=measurev(list(column=NULL, istr=NULL), pattern="([ab])([12])", multiple.keyword="column"))[order(b)], data.table(id=1, istr=paste(c(1,2)), a=c(NA, 2), b=c(1,2)))#same computation but different multiple.keyword
 iris.dt = data.table(datasets::iris)
 test(2183.00020, melt(iris.dt, measure.vars=measurev(value.name, dim, sep=".", pattern="foo")), error="both sep and pattern arguments used; must use either sep or pattern (not both)")
-test(2183.000201, melt(iris.dt, measure.vars=measurev(list(NULL, dim=NULL), sep=".")), error="in measurev, elements of fun.list must be named, problems: 1")
-test(2183.000202, melt(iris.dt, measure.vars=measurev(list(NULL, NULL), sep=".")), error="in measurev, elements of fun.list must be named, problems: 1,2")
+test(2183.000201, melt(iris.dt, measure.vars=measurev(list(NULL, dim=NULL), sep=".")), error="in measurev, elements of fun.list must be named, problems: [1]")
+test(2183.000202, melt(iris.dt, measure.vars=measurev(list(NULL, NULL), sep=".")), error="in measurev, elements of fun.list must be named, problems: [1, 2]")
 test(2183.00027, melt(iris.dt, measure.vars=measurev(list(value.name=NULL, dim="bar"), sep=".")), error="in the measurev fun.list, each non-NULL element must be a function with at least one argument, problem: dim")
 test(2183.00028, melt(iris.dt, measure.vars=measurev(list(value.name=NULL, dim=NULL, baz=NULL), sep=".")), error="number of elements of fun.list =3 must be same as max number of items after splitting column names =2")
 test(2183.00042, melt(DTid, measure.vars=measurev(list(value.name=NULL, istr=function()1), pattern="([ab])([12])")), error="in the measurev fun.list, each non-NULL element must be a function with at least one argument, problem: istr")
 test(2183.00043, melt(DTid, measure.vars=measurev(list(value.name=NULL, istr=interactive), pattern="([ab])([12])")), error="in the measurev fun.list, each non-NULL element must be a function with at least one argument, problem: istr")
 test(2183.00044, melt(DTid, measure.vars=measurev(list(value.name=NULL, istr=function(x)1), pattern="([ab])([12])")), error="each conversion function must return an atomic vector with same length as its first argument, problem: istr")
 test(2183.00045, melt(iris.dt, measure.vars=measurev(list(value.name=NULL, dim=NULL, baz=NULL), pattern="(.*)[.](.*)")), error="number of elements of fun.list =3 must be same as number of capture groups in pattern =2")
-test(2183.00048, melt(iris.dt, measure.vars=measurev(list(value.name=NULL, value.name=NULL), sep=".")), error="elements of fun.list should be uniquely named, problems: value.name")
+test(2183.00048, melt(iris.dt, measure.vars=measurev(list(value.name=NULL, value.name=NULL), sep=".")), error="elements of fun.list should be uniquely named, problems: [value.name]")
 # measure with factor conversion.
 myfac = function(x)factor(x)#user-defined conversion function.
 test(2183.00060, melt(DTid, measure.vars=measurev(list(letter=myfac, value.name=NULL), pattern="([ab])([12])")), data.table(id=1, letter=factor(c("a","b")), "2"=c(2,2), "1"=c(NA,1)))
@@ -17623,9 +17623,9 @@ test(2183.42, melt(DTid, measure.vars=measure(value.name, istr=function()1, patt
 test(2183.43, melt(DTid, measure.vars=measure(value.name, istr=interactive, pattern="([ab])([12])")), error="each ... argument to measure must be a function with at least one argument, problem: istr")
 test(2183.44, melt(DTid, measure.vars=measure(value.name, istr=function(x)1, pattern="([ab])([12])")), error="each conversion function must return an atomic vector with same length as its first argument, problem: istr")
 test(2183.45, melt(iris.dt, measure.vars=measure(value.name, dim, baz, pattern="(.*)[.](.*)")), error="number of ... arguments to measure =3 must be same as number of capture groups in pattern =2")
-test(2183.46, melt(iris.dt, measure.vars=measure(function(x)factor(x), dim, pattern="(.*)[.](.*)")), error="each ... argument to measure must be either a symbol without argument name, or a function with argument name, problems: 1")
-test(2183.47, melt(iris.dt, measure.vars=measure(function(x)factor(x), pattern="(.*)[.](.*)")), error="each ... argument to measure must be either a symbol without argument name, or a function with argument name, problems: 1")
-test(2183.48, melt(iris.dt, measure.vars=measure(value.name, value.name, sep=".")), error="... arguments to measure should be uniquely named, problems: value.name")
+test(2183.46, melt(iris.dt, measure.vars=measure(function(x)factor(x), dim, pattern="(.*)[.](.*)")), error="each ... argument to measure must be either a symbol without argument name, or a function with argument name, problems: [1]")
+test(2183.47, melt(iris.dt, measure.vars=measure(function(x)factor(x), pattern="(.*)[.](.*)")), error="each ... argument to measure must be either a symbol without argument name, or a function with argument name, problems: [1]")
+test(2183.48, melt(iris.dt, measure.vars=measure(value.name, value.name, sep=".")), error="... arguments to measure should be uniquely named, problems: [value.name]")
 # measure with factor conversion.
 myfac = function(x)factor(x)#user-defined conversion function.
 test(2183.60, melt(DTid, measure.vars=measure(letter=myfac, value.name, pattern="([ab])([12])")), data.table(id=1, letter=factor(c("a","b")), "2"=c(2,2), "1"=c(NA,1)))
@@ -17642,15 +17642,15 @@ test(2183.65, melt(iris.days, measure.vars=measure(pattern="day")), error="patte
 test(2183.66, melt(iris.days, measure.vars=measure(value.name, pattern="(.*)")), error="value.name is the only group; fix by creating at least one more group")
 test(2183.67, melt(iris.days, measure.vars=measure(foo, bar, pattern="(foo)(bar)")), error="pattern did not match any cols, so nothing would be melted; fix by changing pattern")
 test(2183.68, melt(iris.days, measure.vars=measure(value.name, bar, pattern="(foo)(bar)")), error="pattern did not match any cols, so nothing would be melted; fix by changing pattern")
-test(2183.69, melt(data.table(ff=1, ff=2), measure.vars=measure(letter, number, pattern="(.)(.)")), error="measured columns should be uniquely named, problems: ff")
-test(2183.70, melt(data.table(f_f=1, f_f=2), measure.vars=measure(letter, number)), error="measured columns should be uniquely named, problems: f_f")
+test(2183.69, melt(data.table(ff=1, ff=2), measure.vars=measure(letter, number, pattern="(.)(.)")), error="measured columns should be uniquely named, problems: [ff]")
+test(2183.70, melt(data.table(f_f=1, f_f=2), measure.vars=measure(letter, number)), error="measured columns should be uniquely named, problems: [f_f]")
 test(2183.71, melt(iris.days, measure.vars=measure(value.name=as.integer, variable, pattern="day(.)[.](.*)")), error="value.name column class=integer after applying conversion function, but must be character")
 test(2183.72, melt(data.table(ff=1, ff=2, a=3, b=4), measure.vars=measure(letter, pattern="([ab])"), id.vars="ff"), data.table(ff=1, letter=c("a","b"), value=c(3,4)))#duplicate column names are fine if they are not matched by pattern.
-test(2183.73, melt(DTid, measure.vars=measure(letter, multiple.keyword, pattern="([ab])([12])")), error="group names specified in ... conflict with measure argument names; please fix by changing group names: multiple.keyword")
+test(2183.73, melt(DTid, measure.vars=measure(letter, multiple.keyword, pattern="([ab])([12])")), error="group names specified in ... conflict with measure argument names; please fix by changing group names: [multiple.keyword]")
 test(2183.74, melt(DTid, measure.vars=measure(letter, number, multiple.keyword=as.integer, pattern="([ab])([12])")), error="multiple.keyword must be a character string")
 test(2183.75, melt(DTid, measure.vars=measure(letter, number, multiple.keyword=NA_character_, pattern="([ab])([12])")), error="multiple.keyword must be a character string")
 test(2183.76, melt(DTid, measure.vars=measure(letter, number, multiple.keyword="", pattern="([ab])([12])")), error="multiple.keyword must be a character string with nchar>0")
-test(2183.77, melt(DTid, measure.vars=measure(letter, cols, pattern="([ab])([12])")), error="group names specified in ... conflict with measure argument names; please fix by changing group names: cols")
+test(2183.77, melt(DTid, measure.vars=measure(letter, cols, pattern="([ab])([12])")), error="group names specified in ... conflict with measure argument names; please fix by changing group names: [cols]")
 test(2183.78, melt(DTid, measure.vars=measure(letter, cols=as.integer, pattern="([ab])([12])")), error="cols must be a character vector of column names")
 test(2183.79, melt(DTid, measure.vars=measure(letter, number, pattern=as.integer)), error="pattern must be character string")
 test(2183.80, melt(DTid, measure.vars=measure(letter, number, sep=as.integer)), error="sep must be character string")

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -14109,7 +14109,7 @@ test(1984.07, DT[, sum(a), by=call('sin',pi)], error='must evaluate to a vector 
 test(1984.081, DT[, sum(a), by=as.raw(0)],     error="Column or expression.*1.*type 'raw'.*not.*supported")
 test(1984.082, data.table(A=1:4, L=list(1, 1:2, 1, 1:3), V=1:4)[, sum(V), by=.(A,L)],  # better error message, 4308
                error="Column or expression.*2.*type 'list'.*not.*supported")
-test(1984.09, DT[, sum(a), by=.(1,1:2)],       error='The items.*list are length[(]s[)] [(]1,2[)].*Each must be length 10; .*rows in x.*after subsetting')
+test(1984.09, DT[, sum(a), by=.(1,1:2)],       error="The items in the 'by' or 'keyby' list are length(s) [1, 2]. Each must be length 10; the same length as there are rows in x (after subsetting if i is provided).")
 options('datatable.optimize' = Inf)
 test(1984.10, DT[ , 1, by = .(a %% 2), verbose = TRUE],
      data.table(a = c(1, 0), V1 = c(1, 1)),
@@ -14124,7 +14124,7 @@ test(1984.16, DT[1, 1+3i] <- 4, error='j must be vector of')
 test(1984.17, dimnames(DT) <- 5, error = 'attempting to assign invalid object')
 test(1984.18, dimnames(DT) <- list(5, 5, 5), error = 'attempting to assign invalid object')
 test(1984.19, dimnames(DT) <- list(5, 5), error = 'data.tables do not have rownames')
-test(1984.20, dimnames(DT) <- list(NULL, 5), error = "Can't assign 1 colnames")
+test(1984.20, dimnames(DT) <- list(NULL, 5), error = "Can't assign 1 names")
 dimnames(DT) <- list(NULL, 1:5)
 test(1984.21, names(DT), paste0(1:5))
 DT = data.table(a = 1:10)


### PR DESCRIPTION
`potools` invocation helping us out here (I'll write this in CRAN_release once `potools` itself lands on CRAN):

```
potools::translate_package(custom_translation_functions = list(
  R = c("stopf:fmt|1", "warningf:fmt|1", "messagef:fmt|1", "packageStartupMessagef:fmt|1"),
  src = c("STOP:1", "DTWARN:1", "Error:1", "DTPRINT:1")
))
```

A few thoughts

 1. We could just replace all stop/warning/message usages with stopf/warningf/messagef to keep a consistent interface & not worry about switching between stop/stopf based on if there are templates.
 2. We could consider another function (`nstopf()`?) to wrap the somewhat ugly `stop(domain=NA, sprintf(ngettext(n, msg1, msg2), ...))` case (and of course nwarningf/nmessagef)
 3. (for another day) there's definitely a lot of inconsistency internally with punctuation... whether we wrap columns/types/data.table names with single/double/no quotes, etc. could consider a pass over messages to come up with a consistent taxonomy there. `potools::get_message_data()` will facilitate this by getting a data set of messages.