### PR TITLE
Properly handle `cols` argument of `measure()`

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -133,11 +133,14 @@ eval_with_cols = function(orig_call, all_cols) {
       if (!"cols" %in% names(named_call)) {
         named_call[["cols"]] = all_cols
       } else if (is.language(named_call[["cols"]])) {
-        named_call[["cols"]] = eval(named_call[["cols"]], parent)
+        cols = named_call[["cols"]] = eval(named_call[["cols"]], parent)
+      }
+      if (!all(cols %in% all_cols)) {
+        stop("cols must be a subset of the column names of data")
       }
       # not strictly needed when cols == all_cols, which is probably the most common case
       # but overhead is minimal and this simplifies control flow
-      offsets = which(all_cols %in% named_call[["cols"]])
+      offsets = which(all_cols %in% cols)
     }
     named_call[[1L]] = fun
     ans = eval(named_call, parent)

--- a/R/utils.R
+++ b/R/utils.R
@@ -130,6 +130,8 @@ eval_with_cols = function(orig_call, all_cols) {
     named_call = match.call(fun, orig_call)
     if ("cols" %in% names(formals(fun)) && !"cols" %in% names(named_call)) {
       named_call[["cols"]] = all_cols
+    } else if (is.call(named_call[["cols"]])) {
+      named_call[["cols"]] = eval(named_call[["cols"]], parent.frame(2L))
     }
     named_call[[1L]] = fun
     eval(named_call, parent)

--- a/R/utils.R
+++ b/R/utils.R
@@ -133,19 +133,19 @@ eval_with_cols = function(orig_call, all_cols) {
       if (!"cols" %in% names(named_call)) {
         named_call[["cols"]] = all_cols
       } else if (is.language(named_call[["cols"]])) {
-        cols = named_call[["cols"]] = eval(named_call[["cols"]], parent)
+        named_call[["cols"]] = eval(named_call[["cols"]], parent)
       }
-      if (!all(cols %in% all_cols)) {
+      if (!all(named_call[["cols"]] %in% all_cols)) {
         stop("cols must be a subset of the column names of data")
       }
-      # not strictly needed when cols == all_cols, which is probably the most common case
+      # not strictly needed when cols == all_cols, which is probably the most common case,
       # but overhead is minimal and this simplifies control flow
-      offsets = which(all_cols %in% cols)
+      offsets = which(all_cols %in% named_call[["cols"]])
     }
     named_call[[1L]] = fun
     ans = eval(named_call, parent)
     if (!is.null(offsets)) {
-      setattr(offsets[ans], "variable_table", attr(ans, "variable_table"))
+      ans = setattr(offsets[ans], "variable_table", attr(ans, "variable_table"))
     }
     return(ans)
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -131,7 +131,7 @@ eval_with_cols = function(orig_call, all_cols) {
     if ("cols" %in% names(formals(fun)) && !"cols" %in% names(named_call)) {
       named_call[["cols"]] = all_cols
     } else if (is.call(named_call[["cols"]])) {
-      named_call[["cols"]] = eval(named_call[["cols"]], parent.frame(2L))
+      named_call[["cols"]] = eval(named_call[["cols"]], parent)
     }
     named_call[[1L]] = fun
     eval(named_call, parent)

--- a/R/utils.R
+++ b/R/utils.R
@@ -135,7 +135,7 @@ eval_with_cols = function(orig_call, all_cols) {
       } else if (is.language(named_call[["cols"]])) {
         named_call[["cols"]] = eval(named_call[["cols"]], parent)
       }
-      if (!all(named_call[["cols"]] %in% all_cols)) {
+      if (!is.character(named_call[["cols"]]) & !all(named_call[["cols"]] %in% all_cols)) {
         stop("cols must be a subset of the column names of data")
       }
       # not strictly needed when cols == all_cols, which is probably the most common case,
@@ -144,8 +144,8 @@ eval_with_cols = function(orig_call, all_cols) {
     }
     named_call[[1L]] = fun
     ans = eval(named_call, parent)
-    if (!is.null(offsets)) {
-      ans = setattr(offsets[ans], "variable_table", attr(ans, "variable_table"))
+    if (fun_uneval %in% c('measure', 'measurev') & is.integer(ans)) {  # the original measure/v
+      ans = setattr(offsets[ans], "variable_table", attributes(ans)[["variable_table"]])
     }
     return(ans)
   }


### PR DESCRIPTION
Closes #5063 

There are two separate issues reported here. One results from `col` not being properly evaluated at any point. The other from the fact that measure and melt assume that measure was passed the complete list of column names. (`measure` returns an index into `cols` and `melt` applies that to `names(data)`)

The fix feels slightly hacky but seems to be the simplest way of letting `measure()` know about the full list of column names without exposing this interaction to the user. I also think we should check that `cols` is only passed a subset of column names.

Todos:

- [ ] Currently fails test 2183.00020 because that call contains two errors and I'm now checking `is.character(cols)` further up
- [ ] Also fails 2183.78 because I use a slightly different error message for the same test which is now combined with checking that `cols` is a subset of `names(data)`
- [ ] Unit tests
- [ ] News item
