### PR TITLE
fully migrate to templated messages

### DIFF
--- a/R/AllS4.R
+++ b/R/AllS4.R
@@ -1,5 +1,5 @@
 ## Functions to let data.table play nicer with S4
-if ("package:data.table" %in% search()) stop("data.table package loaded. When developing don't load package")
+if ("package:data.table" %in% search()) stopf("data.table package loaded. When developing don't load package")
 
 ## Allows data.table to be defined as an object of an S4 class,
 ## or even have data.table be a super class of an S4 class.

--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -93,27 +93,27 @@ round.IDate = function (x, digits=c("weeks", "months", "quarters", "years"), ...
     return(e1)
   # TODO: investigate Ops.IDate method a la Ops.difftime
   if (inherits(e1, "difftime") || inherits(e2, "difftime"))
-    stop("Internal error -- difftime objects may not be added to IDate, but Ops dispatch should have intervened to prevent this") # nocov
+    stopf("Internal error -- difftime objects may not be added to IDate, but Ops dispatch should have intervened to prevent this") # nocov
   if (isReallyReal(e1) || isReallyReal(e2)) {
     return(`+.Date`(e1, e2))
     # IDate doesn't support fractional days; revert to base Date
   }
   if (inherits(e1, "Date") && inherits(e2, "Date"))
-    stop("binary + is not defined for \"IDate\" objects")
+    stopf("binary + is not defined for \"IDate\" objects")
   (setattr(as.integer(unclass(e1) + unclass(e2)), "class", c("IDate", "Date")))  # () wrap to return visibly
 }
 
 `-.IDate` = function (e1, e2) {
   if (!inherits(e1, "IDate")) {
     if (inherits(e1, 'Date')) return(base::`-.Date`(e1, e2))
-    stop("can only subtract from \"IDate\" objects")
+    stopf("can only subtract from \"IDate\" objects")
   }
   if (storage.mode(e1) != "integer")
-    stop("Internal error: storage mode of IDate is somehow no longer integer") # nocov
+    stopf("Internal error: storage mode of IDate is somehow no longer integer") # nocov
   if (nargs() == 1L)
-    stop("unary - is not defined for \"IDate\" objects")
+    stopf("unary - is not defined for \"IDate\" objects")
   if (inherits(e2, "difftime"))
-    stop("Internal error -- difftime objects may not be subtracted from IDate, but Ops dispatch should have intervened to prevent this") # nocov
+    stopf("Internal error -- difftime objects may not be subtracted from IDate, but Ops dispatch should have intervened to prevent this") # nocov
 
   if ( isReallyReal(e2) ) {
     # IDate deliberately doesn't support fractional days so revert to base Date
@@ -301,7 +301,7 @@ clip_msec = function(secs, action) {
      truncate = as.integer(secs),
      nearest = as.integer(round(secs)),
      ceil = as.integer(ceiling(secs)),
-     stop("Valid options for ms are 'truncate', 'nearest', and 'ceil'.")
+     stopf("Valid options for ms are 'truncate', 'nearest', and 'ceil'.")
   )
 }
                            

--- a/R/as.data.table.R
+++ b/R/as.data.table.R
@@ -83,15 +83,15 @@ as.data.table.matrix = function(x, keep.rownames=FALSE, key=NULL, ...) {
 as.data.table.array = function(x, keep.rownames=FALSE, key=NULL, sorted=TRUE, value.name="value", na.rm=TRUE, ...) {
   dx = dim(x)
   if (length(dx) <= 2L)
-    stop("as.data.table.array method should only be called for arrays with 3+ dimensions; use the matrix method for 2-dimensional arrays")
+    stopf("as.data.table.array method should only be called for arrays with 3+ dimensions; use the matrix method for 2-dimensional arrays")
   if (!is.character(value.name) || length(value.name)!=1L || is.na(value.name) || !nzchar(value.name))
-    stop("Argument 'value.name' must be scalar character, non-NA and at least one character")
+    stopf("Argument 'value.name' must be scalar character, non-NA and at least one character")
   if (!is.logical(sorted) || length(sorted)!=1L || is.na(sorted))
-    stop("Argument 'sorted' must be scalar logical and non-NA")
+    stopf("Argument 'sorted' must be scalar logical and non-NA")
   if (!is.logical(na.rm) || length(na.rm)!=1L || is.na(na.rm))
-    stop("Argument 'na.rm' must be scalar logical and non-NA")
+    stopf("Argument 'na.rm' must be scalar logical and non-NA")
   if (!missing(sorted) && !is.null(key))
-    stop("Please provide either 'key' or 'sorted', but not both.")
+    stopf("Please provide either 'key' or 'sorted', but not both.")
 
   dnx = dimnames(x)
   # NULL dimnames will create integer keys, not character as in table method
@@ -137,7 +137,7 @@ as.data.table.list = function(x,
     if (is.null(xi)) next    # eachncol already initialized to 0 by integer() above
     if (!is.null(dim(xi)) && missing.check.names) check.names=TRUE
     if ("POSIXlt" %chin% class(xi)) {
-      warning("POSIXlt column type detected and converted to POSIXct. We do not recommend use of POSIXlt at all because it uses 40 bytes to store one date.")
+      warningf("POSIXlt column type detected and converted to POSIXct. We do not recommend use of POSIXlt at all because it uses 40 bytes to store one date.")
       xi = x[[i]] = as.POSIXct(xi)
     } else if (is.matrix(xi) || is.data.frame(xi)) {
       if (!is.data.table(xi)) {
@@ -193,7 +193,7 @@ as.data.table.list = function(x,
       k = k+1L
     }
   }
-  if (any(vnames==".SD")) stop("A column may not be called .SD. That has special meaning.")
+  if (any(vnames==".SD")) stopf("A column may not be called .SD. That has special meaning.")
   if (check.names) vnames = make.names(vnames, unique=TRUE)
   setattr(ans, "names", vnames)
   setDT(ans, key=key) # copy ensured above; also, setDT handles naming
@@ -207,7 +207,7 @@ as.data.table.list = function(x,
 # for now. This addresses #1078 and #1128
 .resetclass = function(x, class) {
   if (length(class)!=1L)
-    stop("class must be length 1") # nocov
+    stopf("class must be length 1") # nocov
   cx = class(x)
   n  = chmatch(class, cx)   # chmatch accepts length(class)>1 but next line requires length(n)==1
   unique( c("data.table", "data.frame", tail(cx, length(cx)-n)) )

--- a/R/between.R
+++ b/R/between.R
@@ -1,6 +1,6 @@
 # is x[i] in between lower[i] and upper[i] ?
 between = function(x, lower, upper, incbounds=TRUE, NAbounds=TRUE, check=FALSE) {
-  if (is.logical(x)) stop("between has been passed an argument x of type logical")
+  if (is.logical(x)) stopf("between has been passed an argument x of type logical")
   if (is.logical(lower)) lower = as.integer(lower)   # typically NA (which is logical type)
   if (is.logical(upper)) upper = as.integer(upper)   # typically NA (which is logical type)
   is.px = function(x) inherits(x, "POSIXct")
@@ -33,7 +33,7 @@ between = function(x, lower, upper, incbounds=TRUE, NAbounds=TRUE, check=FALSE) 
     }
   }
   if (is.i64(x)) {
-    if (!requireNamespace("bit64", quietly=TRUE)) stop("trying to use integer64 class when 'bit64' package is not installed") # nocov
+    if (!requireNamespace("bit64", quietly=TRUE)) stopf("trying to use integer64 class when 'bit64' package is not installed") # nocov
     if (!is.i64(lower) && is.numeric(lower)) lower = bit64::as.integer64(lower)
     if (!is.i64(upper) && is.numeric(upper)) upper = bit64::as.integer64(upper)
   }
@@ -45,8 +45,8 @@ between = function(x, lower, upper, incbounds=TRUE, NAbounds=TRUE, check=FALSE) 
     .Call(Cbetween, x, lower, upper, incbounds, NAbounds, check)
   } else {
     if (isTRUE(getOption("datatable.verbose"))) catf("optimised between not available for this data type, fallback to slow R routine\n")
-    if (isTRUE(NAbounds) && (anyNA(lower) || anyNA(upper))) stop("Not yet implemented NAbounds=TRUE for this non-numeric and non-character type")
-    if (check && any(lower>upper, na.rm=TRUE)) stop("Some lower>upper for this non-numeric and non-character type")
+    if (isTRUE(NAbounds) && (anyNA(lower) || anyNA(upper))) stopf("Not yet implemented NAbounds=TRUE for this non-numeric and non-character type")
+    if (check && any(lower>upper, na.rm=TRUE)) stopf("Some lower>upper for this non-numeric and non-character type")
     if (incbounds) x>=lower & x<=upper  # this & is correct not &&
     else           x> lower & x< upper
   }

--- a/R/bmerge.R
+++ b/R/bmerge.R
@@ -150,7 +150,7 @@ bmerge = function(i, x, icols, xcols, roll, rollends, nomatch, mult, ops, verbos
     nqgrp = integer(0L)
     nqmaxgrp = 1L
     if (verbose) catf("Non-equi join operators detected ... \n")
-    if (roll != FALSE) stop("roll is not implemented for non-equi joins yet.")
+    if (roll != FALSE) stopf("roll is not implemented for non-equi joins yet.")
     if (verbose) {last.started.at=proc.time();catf("  forder took ... ");flush.console()}
     # TODO: could check/reuse secondary indices, but we need 'starts' attribute as well!
     xo = forderv(x, xcols, retGrp=TRUE)
@@ -170,7 +170,7 @@ bmerge = function(i, x, icols, xcols, roll, rollends, nomatch, mult, ops, verbos
     if (verbose) {catf("done in %s\n",timetaken(last.started.at)); flush.console()}
     if (length(nqgrp)) nqmaxgrp = max(nqgrp) # fix for #1986, when 'x' is 0-row table max(.) returns -Inf.
     if (nqmaxgrp > 1L) { # got some non-equi join work to do
-      if ("_nqgrp_" %in% names(x)) stop("Column name '_nqgrp_' is reserved for non-equi joins.")
+      if ("_nqgrp_" %in% names(x)) stopf("Column name '_nqgrp_' is reserved for non-equi joins.")
       if (verbose) {last.started.at=proc.time();catf("  Recomputing forder with non-equi ids ... ");flush.console()}
       set(nqx<-shallow(x), j="_nqgrp_", value=nqgrp)
       xo = forderv(nqx, c(ncol(nqx), xcols))

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -134,7 +134,7 @@ replace_dot_alias = function(e) {
       stopf("Object '%s' not found amongst %s", used, brackify(ref))
     }
   } else {
-    stopf(err$message, call.=FALSE)
+    stopf(err$message)
   }
 }
 

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -38,7 +38,7 @@ is.ff = function(x) inherits(x, "ff")  # define this in data.table so that we do
 #}
 #NROW = function(x) {
 #    if (is.data.frame(x) || is.data.table(x)) return(nrow(x))
-#    if (is.list(x) && !is.ff(x)) stop("List is not a data.frame or data.table. Convert first before using NROW")   # list may have different length elements, which data.table and data.frame's resolve.
+#    if (is.list(x) && !is.ff(x)) stopf("List is not a data.frame or data.table. Convert first before using NROW")   # list may have different length elements, which data.table and data.frame's resolve.
 #    if (is.array(x)) nrow(x) else length(x)
 #}
 
@@ -60,7 +60,7 @@ data.table = function(..., keep.rownames=FALSE, check.names=FALSE, key=NULL, str
   if (length(x)==1L && (is.null(x[[1L]]) || (is.list(x[[1L]]) && length(x[[1L]])==0L))) return( null.data.table() ) #48
   ans = as.data.table.list(x, keep.rownames=keep.rownames, check.names=check.names, .named=nd$.named)  # see comments inside as.data.table.list re copies
   if (!is.null(key)) {
-    if (!is.character(key)) stop("key argument of data.table() must be character")
+    if (!is.character(key)) stopf("key argument of data.table() must be character")
     if (length(key)==1L) {
       key = strsplit(key,split=",")[[1L]]
       # eg key="A,B"; a syntax only useful in key argument to data.table(), really.
@@ -134,7 +134,7 @@ replace_dot_alias = function(e) {
       stopf("Object '%s' not found amongst %s", used, brackify(ref))
     }
   } else {
-    stop(err$message, call.=FALSE)
+    stopf(err$message, call.=FALSE)
   }
 }
 
@@ -154,8 +154,8 @@ replace_dot_alias = function(e) {
     return(ans)
   }
   if (!missing(verbose)) {
-    if (!is.integer(verbose) && !is.logical(verbose)) stop("verbose must be logical or integer")
-    if (length(verbose)!=1 || anyNA(verbose)) stop("verbose must be length 1 non-NA")
+    if (!is.integer(verbose) && !is.logical(verbose)) stopf("verbose must be logical or integer")
+    if (length(verbose)!=1 || anyNA(verbose)) stopf("verbose must be length 1 non-NA")
     # set the global verbose option because that is fetched from C code without having to pass it through
     oldverbose = options(datatable.verbose=verbose)
     on.exit(options(oldverbose))
@@ -163,7 +163,7 @@ replace_dot_alias = function(e) {
   .global$print=""
   missingby = missing(by) && missing(keyby)  # for tests 359 & 590 where passing by=NULL results in data.table not vector
   if (missingby || missing(j)) {
-    if (!missingby) warning("Ignoring by/keyby because 'j' is not supplied")
+    if (!missingby) warningf("Ignoring by/keyby because 'j' is not supplied")
     by = bysub = NULL
     keyby = FALSE
   } else {
@@ -177,7 +177,7 @@ replace_dot_alias = function(e) {
       if (missing(keyby))
         keyby = FALSE
       else if (!isTRUEorFALSE(keyby))
-        stop("When by and keyby are both provided, keyby must be TRUE or FALSE")
+        stopf("When by and keyby are both provided, keyby must be TRUE or FALSE")
     }
     if (missing(by)) { missingby=TRUE; by=bysub=NULL }  # possible when env is used, PR#4304
     else if (verbose) catf("Argument '%s' after substitute: %s\n", "by", paste(deparse(bysub, width.cutoff=500L), collapse=" "))
@@ -202,32 +202,32 @@ replace_dot_alias = function(e) {
     if (!is.null(names(sys.call())) &&  # not relying on nargs() as it considers DT[,] to have 3 arguments, #3163
         tryCatch(!is.symbol(tt_isub), error=function(e)TRUE) &&   # a symbol that inherits missingness from caller isn't missing for our purpose; test 1974
         tryCatch(!is.symbol(tt_jsub), error=function(e)TRUE)) {
-      warning("i and j are both missing so ignoring the other arguments. This warning will be upgraded to error in future.")
+      warningf("i and j are both missing so ignoring the other arguments. This warning will be upgraded to error in future.")
     }
     return(x)
   }
-  if (!mult %chin% c("first","last","all")) stop("mult argument can only be 'first', 'last' or 'all'")
+  if (!mult %chin% c("first","last","all")) stopf("mult argument can only be 'first', 'last' or 'all'")
   missingroll = missing(roll)
-  if (length(roll)!=1L || is.na(roll)) stop("roll must be a single TRUE, FALSE, positive/negative integer/double including +Inf and -Inf or 'nearest'")
+  if (length(roll)!=1L || is.na(roll)) stopf("roll must be a single TRUE, FALSE, positive/negative integer/double including +Inf and -Inf or 'nearest'")
   if (is.character(roll)) {
     if (roll!="nearest") stopf("roll is '%s' (type character). Only valid character value is 'nearest'.", roll)
   } else {
     roll = if (isTRUE(roll)) +Inf else as.double(roll)
   }
   force(rollends)
-  if (!is.logical(rollends)) stop("rollends must be a logical vector")
-  if (length(rollends)>2L) stop("rollends must be length 1 or 2")
+  if (!is.logical(rollends)) stopf("rollends must be a logical vector")
+  if (length(rollends)>2L) stopf("rollends must be length 1 or 2")
   if (length(rollends)==1L) rollends=rep.int(rollends,2L)
   # TO DO (document/faq/example). Removed for now ... if ((roll || rolltolast) && missing(mult)) mult="last" # for when there is exact match to mult. This does not control cases where the roll is mult, that is always the last one.
   .unsafe.opt() #3585
   missingnomatch = missing(nomatch)
   if (is.null(nomatch)) nomatch = 0L # allow nomatch=NULL API already now, part of: https://github.com/Rdatatable/data.table/issues/857
-  if (!is.na(nomatch) && nomatch!=0L) stop("nomatch= must be either NA or NULL (or 0 for backwards compatibility which is the same as NULL)")
+  if (!is.na(nomatch) && nomatch!=0L) stopf("nomatch= must be either NA or NULL (or 0 for backwards compatibility which is the same as NULL)")
   nomatch = as.integer(nomatch)
-  if (!is.logical(which) || length(which)>1L) stop("which= must be a logical vector length 1. Either FALSE, TRUE or NA.")
+  if (!is.logical(which) || length(which)>1L) stopf("which= must be a logical vector length 1. Either FALSE, TRUE or NA.")
   if ((isTRUE(which)||is.na(which)) && !missing(j)) stopf("which==%s (meaning return row numbers) but j is also supplied. Either you need row numbers or the result of j, but only one type of result can be returned.", which)
-  if (!is.na(nomatch) && is.na(which)) stop("which=NA with nomatch=0 would always return an empty vector. Please change or remove either which or nomatch.")
-  if (!with && missing(j)) stop("j must be provided when with=FALSE")
+  if (!is.na(nomatch) && is.na(which)) stopf("which=NA with nomatch=0 would always return an empty vector. Please change or remove either which or nomatch.")
+  if (!with && missing(j)) stopf("j must be provided when with=FALSE")
   irows = NULL  # Meaning all rows. We avoid creating 1:nrow(x) for efficiency.
   notjoin = FALSE
   rightcols = leftcols = integer()
@@ -267,7 +267,7 @@ replace_dot_alias = function(e) {
       if (length(av)) {
         for (..name in av) {
           name = substr(..name, 3L, nchar(..name))
-          if (!nzchar(name)) stop("The symbol .. is invalid. The .. prefix must be followed by at least one character.")
+          if (!nzchar(name)) stopf("The symbol .. is invalid. The .. prefix must be followed by at least one character.")
           if (!exists(name, where=parent.frame())) {
             suggested = if (exists(..name, where=parent.frame()))
               gettextf(" Variable '..%s' does exist in calling scope though, so please just removed the .. prefix from that variable name in calling scope.", name)
@@ -282,7 +282,7 @@ replace_dot_alias = function(e) {
         ..syms = av
       }
     } else if (is.name(jsub)) {
-      if (startsWith(as.character(jsub), "..")) stop("Internal error:  DT[, ..var] should be dealt with by the branch above now.") # nocov
+      if (startsWith(as.character(jsub), "..")) stopf("Internal error:  DT[, ..var] should be dealt with by the branch above now.") # nocov
       if (!with && !exists(as.character(jsub), where=parent.frame()))
         stopf("Variable '%s' is not found in calling scope. Looking in calling scope because you set with=FALSE. Also, please use .. symbol prefix and remove with=FALSE.", as.character(jsub))
     }
@@ -292,7 +292,7 @@ replace_dot_alias = function(e) {
         root = if (is.call(jsub)) as.character(jsub[[1L]])[1L] else ""
       } else if (length(jsub) > 2L && jsub[[2L]] %iscall% ":=") {
         #2142 -- j can be {} and have length 1
-        stop("You have wrapped := with {} which is ok but then := must be the only thing inside {}. You have something else inside {} as well. Consider placing the {} on the RHS of := instead; e.g. DT[,someCol:={tmpVar1<-...;tmpVar2<-...;tmpVar1*tmpVar2}")
+        stopf("You have wrapped := with {} which is ok but then := must be the only thing inside {}. You have something else inside {} as well. Consider placing the {} on the RHS of := instead; e.g. DT[,someCol:={tmpVar1<-...;tmpVar2<-...;tmpVar1*tmpVar2}")
       }
     }
     if (root=="eval" && !any(all.vars(jsub[[2L]]) %chin% names_x)) {
@@ -310,9 +310,9 @@ replace_dot_alias = function(e) {
     if (root == ":=") {
       allow.cartesian=TRUE   # (see #800)
       if (!missing(i) && keyby)
-        stop(":= with keyby is only possible when i is not supplied since you can't setkey on a subset of rows. Either change keyby to by or remove i")
+        stopf(":= with keyby is only possible when i is not supplied since you can't setkey on a subset of rows. Either change keyby to by or remove i")
       if (!missingnomatch) {
-        warning("nomatch isn't relevant together with :=, ignoring nomatch")
+        warningf("nomatch isn't relevant together with :=, ignoring nomatch")
         nomatch=0L
       }
     }
@@ -368,7 +368,7 @@ replace_dot_alias = function(e) {
     }
     if (isub %iscall% "!") {
       notjoin = TRUE
-      if (!missingnomatch) stop("not-join '!' prefix is present on i but nomatch is provided. Please remove nomatch.");
+      if (!missingnomatch) stopf("not-join '!' prefix is present on i but nomatch is provided. Please remove nomatch.");
       nomatch = 0L
       isub = isub[[2L]]
       # #932 related so that !(v1 == 1) becomes v1 == 1 instead of (v1 == 1) after removing "!"
@@ -397,7 +397,7 @@ replace_dot_alias = function(e) {
       if (getOption("datatable.optimize")>=1L) assign("order", forder, ienv)
       i = tryCatch(eval(.massagei(isub), x, ienv), error=function(e) {
         if (grepl(":=.*defined for use in j.*only", e$message))
-          stop("Operator := detected in i, the first argument inside DT[...], but is only valid in the second argument, j. Most often, this happens when forgetting the first comma (e.g. DT[newvar := 5] instead of DT[ , new_var := 5]). Please double-check the syntax. Run traceback(), and debugger() to get a line number.")
+          stopf("Operator := detected in i, the first argument inside DT[...], but is only valid in the second argument, j. Most often, this happens when forgetting the first comma (e.g. DT[newvar := 5] instead of DT[ , new_var := 5]). Please double-check the syntax. Run traceback(), and debugger() to get a line number.")
         else
           .checkTypos(e, names_x)
       })
@@ -426,7 +426,7 @@ replace_dot_alias = function(e) {
       if (is.numeric(i) && ncol(i)==1L) { # #826 - subset DT on single integer vector stored as matrix
         i = as.integer(i)
       } else {
-        stop("i is invalid type (matrix). Perhaps in future a 2 column matrix could return a list of elements of DT (in the spirit of A[B] in FAQ 2.14). Please report to data.table issue tracker if you'd like this, or add your comments to FR #657.")
+        stopf("i is invalid type (matrix). Perhaps in future a 2 column matrix could return a list of elements of DT (in the spirit of A[B] in FAQ 2.14). Please report to data.table issue tracker if you'd like this, or add your comments to FR #657.")
       }
     }
     if (is.logical(i)) {
@@ -449,7 +449,7 @@ replace_dot_alias = function(e) {
     if (is.data.table(i)) {
       if (missing(on)) {
         if (!haskey(x)) {
-          stop("When i is a data.table (or character vector), the columns to join by must be specified using 'on=' argument (see ?data.table), by keying x (i.e. sorted, and, marked as sorted, see ?setkey), or by sharing column names between x and i (i.e., a natural join). Keyed joins might have further speed benefits on very large data due to x being sorted in RAM.")
+          stopf("When i is a data.table (or character vector), the columns to join by must be specified using 'on=' argument (see ?data.table), by keying x (i.e. sorted, and, marked as sorted, see ?setkey), or by sharing column names between x and i (i.e., a natural join). Keyed joins might have further speed benefits on very large data due to x being sorted in RAM.")
         }
       } else if (identical(substitute(on), as.name(".NATURAL"))) {
         naturaljoin = TRUE
@@ -457,7 +457,7 @@ replace_dot_alias = function(e) {
       if (naturaljoin) { # natural join #629
         common_names = intersect(names_x, names(i))
         len_common_names = length(common_names)
-        if (!len_common_names) stop("Attempting to do natural join but no common columns in provided tables")
+        if (!len_common_names) stopf("Attempting to do natural join but no common columns in provided tables")
         if (verbose) {
           which_cols_msg = if (len_common_names == length(x)) {
             catf("Joining but 'x' has no key, natural join using all 'x' columns")
@@ -536,10 +536,10 @@ replace_dot_alias = function(e) {
           if (identical(nomatch, 0L) && allLen1) irows = irows[irows != 0L]
         } else {
           if (length(xo) && missing(on))
-            stop("Internal error. Cannot by=.EACHI when joining to an index, yet") # nocov
+            stopf("Internal error. Cannot by=.EACHI when joining to an index, yet") # nocov
           # since f__ refers to xo later in grouping, so xo needs to be passed through to dogroups too.
           if (length(irows))
-            stop("Internal error. irows has length in by=.EACHI") # nocov
+            stopf("Internal error. irows has length in by=.EACHI") # nocov
         }
         if (nqbyjoin) {
           irows = if (length(xo)) xo[irows] else irows
@@ -590,7 +590,7 @@ replace_dot_alias = function(e) {
     }
     else {
       if (!missing(on)) {
-        stop("logical error. i is not a data.table, but 'on' argument is provided.")
+        stopf("logical error. i is not a data.table, but 'on' argument is provided.")
       }
       # TO DO: TODO: Incorporate which_ here on DT[!i] where i is logical. Should avoid i = !i (above) - inefficient.
       # i is not a data.table
@@ -598,7 +598,7 @@ replace_dot_alias = function(e) {
       if (is.logical(i)) {
         if (is.na(which)) { # #4411 i filter not optimized to join: DT[A > 1, which = NA]
           ## we need this branch here, not below next to which=TRUE because irows=i=which(i) will filter out NAs: DT[A > 10, which = NA] will be incorrect
-          if (notjoin) stop("internal error: notjoin and which=NA (non-matches), huh? please provide reproducible example to issue tracker") # nocov
+          if (notjoin) stopf("internal error: notjoin and which=NA (non-matches), huh? please provide reproducible example to issue tracker") # nocov
           return(which(is.na(i) | !i))
         }
         if (length(i)==1L  # to avoid unname copy when length(i)==nrow (normal case we don't want to slow down)
@@ -628,7 +628,7 @@ replace_dot_alias = function(e) {
       }
     }
     if (notjoin) {
-      if (byjoin || !is.integer(irows) || is.na(nomatch)) stop("Internal error: notjoin but byjoin or !integer or nomatch==NA") # nocov
+      if (byjoin || !is.integer(irows) || is.na(nomatch)) stopf("Internal error: notjoin but byjoin or !integer or nomatch==NA") # nocov
       irows = irows[irows!=0L]
       if (verbose) {last.started.at=proc.time();catf("Inverting irows for notjoin done in ... ");flush.console()}
       i = irows = if (length(irows)) seq_len(nrow(x))[-irows] else NULL  # NULL meaning all rows i.e. seq_len(nrow(x))
@@ -688,10 +688,10 @@ replace_dot_alias = function(e) {
       # TODO: make these both errors (or single long error in both cases) in next release.
       # i.e. using with=FALSE together with := at all will become an error. Eventually with will be removed.
       if (is.null(names(jsub)) && is.name(jsub[[2L]])) {
-        warning("with=FALSE together with := was deprecated in v1.9.4 released Oct 2014. Please wrap the LHS of := with parentheses; e.g., DT[,(myVar):=sum(b),by=a] to assign to column name(s) held in variable myVar. See ?':=' for other examples. As warned in 2014, this is now a warning.")
+        warningf("with=FALSE together with := was deprecated in v1.9.4 released Oct 2014. Please wrap the LHS of := with parentheses; e.g., DT[,(myVar):=sum(b),by=a] to assign to column name(s) held in variable myVar. See ?':=' for other examples. As warned in 2014, this is now a warning.")
         jsub[[2L]] = eval(jsub[[2L]], parent.frame(), parent.frame())
       } else {
-        warning("with=FALSE ignored, it isn't needed when using :=. See ?':=' for examples.")
+        warningf("with=FALSE ignored, it isn't needed when using :=. See ?':=' for examples.")
       }
       with = TRUE
     }
@@ -738,7 +738,7 @@ replace_dot_alias = function(e) {
         if (any(w <- (j>ncol(x)))) stopf("Item %d of j is %d which is outside the column number range [1,ncol=%d]", idx <- which.first(w), j[idx], ncol(x))
         j = j[j!=0L]
         if (any(j<0L)) {
-          if (any(j>0L)) stop("j mixes positives and negatives")
+          if (any(j>0L)) stopf("j mixes positives and negatives")
           j = seq_along(x)[j]  # all j are <0 here
         }
         # 3013 -- handle !FALSE in column subset in j via logical+with
@@ -746,7 +746,7 @@ replace_dot_alias = function(e) {
         if (!length(j)) return(null.data.table())
         return(.Call(CsubsetDT, x, irows, j))
       } else {
-        stop("When with=FALSE, j-argument should be of type logical/character/integer indicating the columns to select.") # fix for #1440.
+        stopf("When with=FALSE, j-argument should be of type logical/character/integer indicating the columns to select.") # fix for #1440.
       }
     } else {   # with=TRUE and byjoin could be TRUE
       bynames = NULL
@@ -778,7 +778,7 @@ replace_dot_alias = function(e) {
           # or look for column names used in this by (since if none it wouldn't find column names anyway
           # when evaled within full x[irows]).  Trouble is that colA%%2L is a call and should be within frame.
           tt = eval(bysub, parent.frame(), parent.frame())
-          if (!is.character(tt)) stop("by=c(...), key(...) or names(...) must evaluate to 'character'")
+          if (!is.character(tt)) stopf("by=c(...), key(...) or names(...) must evaluate to 'character'")
           bysub=tt
         } else if (is.call(bysub) && !(bysub[[1L]] %chin% c("list", "as.list", "{", ".", ":"))) {
           # potential use of function, ex: by=month(date). catch it and wrap with "(", because we need to set "bysameorder" to FALSE as we don't know if the function will return ordered results just because "date" is ordered. Fixes #2670.
@@ -832,7 +832,7 @@ replace_dot_alias = function(e) {
           } else byval = eval(bysub, x, parent.frame())
         } else {
           # length 0 when i returns no rows
-          if (!is.integer(irows)) stop("Internal error: irows isn't integer") # nocov
+          if (!is.integer(irows)) stopf("Internal error: irows isn't integer") # nocov
           # Passing irows as i to x[] below has been troublesome in a rare edge case.
           # irows may contain NA, 0, negatives and >nrow(x) here. That's all ok.
           # But we may need i join column values to be retained (where those rows have no match), hence we tried eval(isub)
@@ -877,11 +877,11 @@ replace_dot_alias = function(e) {
               bynames = names(byval)
           }
         }
-        if (!is.list(byval)) stop("'by' or 'keyby' must evaluate to a vector or a list of vectors (where 'list' includes data.table and data.frame which are lists, too)")
+        if (!is.list(byval)) stopf("'by' or 'keyby' must evaluate to a vector or a list of vectors (where 'list' includes data.table and data.frame which are lists, too)")
         if (length(byval)==1L && is.null(byval[[1L]])) bynull=TRUE #3530 when by=(function()NULL)()
         if (!bynull) for (jj in seq_len(length(byval))) {
           if (!(this_type <- typeof(byval[[jj]])) %chin% ORDERING_TYPES) {
-            stop(gettextf("Column or expression %d of 'by' or 'keyby' is type '%s' which is not currently supported. If you have a compelling use case, please add it to https://github.com/Rdatatable/data.table/issues/1597. As a workaround, consider converting the column to a supported type, e.g. by=sapply(list_col, toString), whilst taking care to maintain distinctness in the process.", jj, this_type))
+            stopf("Column or expression %d of 'by' or 'keyby' is type '%s' which is not currently supported. If you have a compelling use case, please add it to https://github.com/Rdatatable/data.table/issues/1597. As a workaround, consider converting the column to a supported type, e.g. by=sapply(list_col, toString), whilst taking care to maintain distinctness in the process.", jj, this_type)
           }
         }
         tt = vapply_1i(byval,length)
@@ -944,7 +944,7 @@ replace_dot_alias = function(e) {
             }
             if (!is.null(jvnames)) {
               if (length(nm) != length(jvnames))
-                warning("j may not evaluate to the same number of columns for each group; if you're sure this warning is in error, please put the branching logic outside of [ for efficiency")
+                warningf("j may not evaluate to the same number of columns for each group; if you're sure this warning is in error, please put the branching logic outside of [ for efficiency")
               else if (any(idx <- nm != jvnames))
                 warningf('Different branches of j expression produced different auto-named columns: %s; using the most "last" names. If this was intentional (e.g., you know only one branch will ever be used in a given query because the branch is controlled by a function argument), please (1) pull this branch out of the call; (2) explicitly provide missing defaults for each branch in all cases; or (3) use the same name for each branch and re-name it in a follow-up call.',  brackify(sprintf('%s!=%s', nm[idx], jvnames[idx])))
             }
@@ -1023,13 +1023,13 @@ replace_dot_alias = function(e) {
           } else if (is.numeric(.SDcols)) {
             .SDcols = as.integer(.SDcols)
             # if .SDcols is numeric, use 'dupdiff' instead of 'setdiff'
-            if (length(unique(sign(.SDcols))) > 1L) stop(".SDcols is numeric but has both +ve and -ve indices")
+            if (length(unique(sign(.SDcols))) > 1L) stopf(".SDcols is numeric but has both +ve and -ve indices")
             if (any(idx <- abs(.SDcols)>ncol(x) | abs(.SDcols)<1L))
               stopf(".SDcols is numeric but out of bounds [1, %d] at: %s", ncol(x), brackify(which(idx)))
             ansvars = sdvars = if (negate_sdcols) dupdiff(names_x[-.SDcols], bynames) else names_x[.SDcols]
             ansvals = if (negate_sdcols) setdiff(seq_along(names(x)), c(.SDcols, which(names(x) %chin% bynames))) else .SDcols
           } else {
-            if (!is.character(.SDcols)) stop(".SDcols should be column numbers or names")
+            if (!is.character(.SDcols)) stopf(".SDcols should be column numbers or names")
             if (!all(idx <- .SDcols %chin% names_x))
               stopf("Some items of .SDcols are not column names: %s", brackify(.SDcols[!idx]))
             ansvars = sdvars = if (negate_sdcols) setdiff(names_x, c(.SDcols, bynames)) else .SDcols
@@ -1044,7 +1044,7 @@ replace_dot_alias = function(e) {
         # added 'mget' - fix for #994
         if (any(c("get", "mget") %chin% av)){
           if (verbose)
-            cat(gettextf("'(m)get' found in j. ansvars being set to all columns. Use .SDcols or a single j=eval(macro) instead. Both will detect the columns used which is important for efficiency.\nOld ansvars: %s \n", brackify(ansvars)))
+            catf("'(m)get' found in j. ansvars being set to all columns. Use .SDcols or a single j=eval(macro) instead. Both will detect the columns used which is important for efficiency.\nOld ansvars: %s \n", brackify(ansvars))
             # get('varname') is too difficult to detect which columns are used in general
             # eval(macro) column names are detected via the  if jsub[[1]]==eval switch earlier above.
 
@@ -1073,7 +1073,7 @@ replace_dot_alias = function(e) {
         }
         # .SDcols might include grouping columns if users wants that, but normally we expect user not to include them in .SDcols
       } else {
-        if (!missing(.SDcols)) warning("This j doesn't use .SD but .SDcols has been supplied. Ignoring .SDcols. See ?data.table.")
+        if (!missing(.SDcols)) warningf("This j doesn't use .SD but .SDcols has been supplied. Ignoring .SDcols. See ?data.table.")
         allcols = c(names_x, xdotprefix, names_i, idotprefix)
         ansvars = sdvars = setdiff(intersect(av, allcols), bynames)
         if (verbose) catf("Detected that j uses these columns: %s\n",if (!length(ansvars)) "<none>" else brackify(ansvars))
@@ -1089,7 +1089,7 @@ replace_dot_alias = function(e) {
       newnames = NULL
       suppPrint = identity
       if (length(av) && av[1L] == ":=") {
-        if (.Call(C_islocked, x)) stop(".SD is locked. Using := in .SD's j is reserved for possible future use; a tortuously flexible way to modify by group. Use := in j directly to modify by group by reference.")
+        if (.Call(C_islocked, x)) stopf(".SD is locked. Using := in .SD's j is reserved for possible future use; a tortuously flexible way to modify by group. Use := in j directly to modify by group by reference.")
         suppPrint = function(x) { .global$print=address(x); x }
         # Suppress print when returns ok not on error, bug #2376. Thanks to: http://stackoverflow.com/a/13606880/403310
         # All appropriate returns following this point are wrapped; i.e. return(suppPrint(x)).
@@ -1097,7 +1097,7 @@ replace_dot_alias = function(e) {
         if (is.null(names(jsub))) {
           # regular LHS:=RHS usage, or `:=`(...) with no named arguments (an error)
           # `:=`(LHS,RHS) is valid though, but more because can't see how to detect that, than desire
-          if (length(jsub)!=3L) stop("In `:=`(col1=val1, col2=val2, ...) form, all arguments must be named.")
+          if (length(jsub)!=3L) stopf("In `:=`(col1=val1, col2=val2, ...) form, all arguments must be named.")
           lhs = jsub[[2L]]
           jsub = jsub[[3L]]
           if (is.name(lhs)) {
@@ -1109,20 +1109,20 @@ replace_dot_alias = function(e) {
         } else {
           # `:=`(c2=1L,c3=2L,...)
           lhs = names(jsub)[-1L]
-          if (any(lhs=="")) stop("In `:=`(col1=val1, col2=val2, ...) form, all arguments must be named.")
+          if (any(lhs=="")) stopf("In `:=`(col1=val1, col2=val2, ...) form, all arguments must be named.")
           names(jsub)=""
           jsub[[1L]]=as.name("list")
         }
         av = all.vars(jsub,TRUE)
-        if (!is.atomic(lhs)) stop("LHS of := must be a symbol, or an atomic vector (column names or positions).")
+        if (!is.atomic(lhs)) stopf("LHS of := must be a symbol, or an atomic vector (column names or positions).")
         if (is.character(lhs)) {
           m = chmatch(lhs, names_x)
         } else if (is.numeric(lhs)) {
           m = as.integer(lhs)
-          if (any(m<1L | ncol(x)<m)) stop("LHS of := appears to be column positions but are outside [1,ncol] range. New columns can only be added by name.")
+          if (any(m<1L | ncol(x)<m)) stopf("LHS of := appears to be column positions but are outside [1,ncol] range. New columns can only be added by name.")
           lhs = names_x[m]
         } else
-          stop("LHS of := isn't column names ('character') or positions ('integer' or 'numeric')")
+          stopf("LHS of := isn't column names ('character') or positions ('integer' or 'numeric')")
         if (!anyNA(m)) {
           # updates by reference to existing columns
           cols = as.integer(m)
@@ -1153,7 +1153,7 @@ replace_dot_alias = function(e) {
           #   ok=-1 which will trigger setalloccol with verbose in the next
           #   branch, which again calls _selfrefok and returns the message then
           if ((ok<-selfrefok(x, verbose=FALSE))==0L)   # ok==0 so no warning when loaded from disk (-1) [-1 considered TRUE by R]
-            warning("Invalid .internal.selfref detected and fixed by taking a (shallow) copy of the data.table so that := can add this new column by reference. At an earlier point, this data.table has been copied by R (or was created manually using structure() or similar). Avoid names<- and attr<- which in R currently (and oddly) may copy the whole data.table. Use set* syntax instead to avoid copying: ?set, ?setnames and ?setattr. If this message doesn't help, please report your use case to the data.table issue tracker so the root cause can be fixed or this message improved.")
+            warningf("Invalid .internal.selfref detected and fixed by taking a (shallow) copy of the data.table so that := can add this new column by reference. At an earlier point, this data.table has been copied by R (or was created manually using structure() or similar). Avoid names<- and attr<- which in R currently (and oddly) may copy the whole data.table. Use set* syntax instead to avoid copying: ?set, ?setnames and ?setattr. If this message doesn't help, please report your use case to the data.table issue tracker so the root cause can be fixed or this message improved.")
           if ((ok<1L) || (truelength(x) < ncol(x)+length(newnames))) {
             DT = x  # in case getOption contains "ncol(DT)" as it used to.  TODO: warn and then remove
             n = length(newnames) + eval(getOption("datatable.alloccol"))  # TODO: warn about expressions and then drop the eval()
@@ -1239,7 +1239,7 @@ replace_dot_alias = function(e) {
   SDenv = new.env(parent=parent.frame())
   # taking care of warnings for posixlt type, #646
   SDenv$strptime = function(x, ...) {
-    warning("strptime() usage detected and wrapped with as.POSIXct(). This is to minimize the chance of assigning POSIXlt columns, which use 40+ bytes to store one date (versus 8 for POSIXct). Use as.POSIXct() (which will call strptime() as needed internally) to avoid this warning.")
+    warningf("strptime() usage detected and wrapped with as.POSIXct(). This is to minimize the chance of assigning POSIXlt columns, which use 40+ bytes to store one date (versus 8 for POSIXct). Use as.POSIXct() (which will call strptime() as needed internally) to avoid this warning.")
     as.POSIXct(base::strptime(x, ...))
   }
 
@@ -1251,7 +1251,7 @@ replace_dot_alias = function(e) {
       # if "..x" exists as column name, use column, for backwards compatibility; e.g. package socialmixr in rev dep checks #2779
       next
       # TODO in future, as warned in NEWS item for v1.11.0 :
-      # warning(sym," in j is looking for ",getName," in calling scope, but a column '", sym, "' exists. Column names should not start with ..")
+      # warningf(sym," in j is looking for ",getName," in calling scope, but a column '", sym, "' exists. Column names should not start with ..")
     }
     getName = substr(sym, 3L, nchar(sym))
     if (!exists(getName, parent.frame())) {
@@ -1278,7 +1278,7 @@ replace_dot_alias = function(e) {
       } else {
         # length(i) && length(icols)
         if (is.null(irows)) {
-          stop("Internal error: irows is NULL when making join result at R level. Should no longer happen now we use CsubsetDT earlier.")  # nocov
+          stopf("Internal error: irows is NULL when making join result at R level. Should no longer happen now we use CsubsetDT earlier.")  # nocov
           # TODO: Make subsetDT do a shallow copy when irows is NULL (it currently copies). Then copy only when user uses := or set* on the result
           # by using NAMED/REFCNT on columns, with warning if they copy. Since then, even foo = DT$b would cause the next set or := to copy that
           # column (so the warning is needed). To tackle that, we could have our own DT.NAMED attribute, perhaps.
@@ -1408,7 +1408,7 @@ replace_dot_alias = function(e) {
         setattr(jval, 'class', class(x)) # fix for #64
       if (haskey(x) && all(key(x) %chin% names(jval)) && is.sorted(jval, by=key(x)))
         setattr(jval, 'sorted', key(x))
-      if (any(vapply_1b(jval, is.null))) stop("Internal error: j has created a data.table result containing a NULL column") # nocov
+      if (any(vapply_1b(jval, is.null))) stopf("Internal error: j has created a data.table result containing a NULL column") # nocov
     }
     return(jval)
   }
@@ -1418,8 +1418,8 @@ replace_dot_alias = function(e) {
   ###########################################################################
 
   o__ = integer()
-  if (".N" %chin% ansvars) stop("The column '.N' can't be grouped because it conflicts with the special .N variable. Try setnames(DT,'.N','N') first.")
-  if (".I" %chin% ansvars) stop("The column '.I' can't be grouped because it conflicts with the special .I variable. Try setnames(DT,'.I','I') first.")
+  if (".N" %chin% ansvars) stopf("The column '.N' can't be grouped because it conflicts with the special .N variable. Try setnames(DT,'.N','N') first.")
+  if (".I" %chin% ansvars) stopf("The column '.I' can't be grouped because it conflicts with the special .I variable. Try setnames(DT,'.I','I') first.")
   SDenv$.iSD = NULL  # null.data.table()
   SDenv$.xSD = NULL  # null.data.table() - introducing for FR #2693 and Gabor's post on fixing for FAQ 2.8
 
@@ -1446,7 +1446,7 @@ replace_dot_alias = function(e) {
   if (byjoin) {
     # The groupings come instead from each row of the i data.table.
     # Much faster for a few known groups vs a 'by' for all followed by a subset
-    if (!is.data.table(i)) stop("logical error. i is not data.table, but mult='all' and 'by'=.EACHI")
+    if (!is.data.table(i)) stopf("logical error. i is not data.table, but mult='all' and 'by'=.EACHI")
     byval = i
     bynames = if (missing(on)) head(key(x),length(leftcols)) else names(on)
     allbyvars = NULL
@@ -1469,7 +1469,7 @@ replace_dot_alias = function(e) {
 
   } else {
     # Find the groups, using 'byval' ...
-    if (missingby) stop("Internal error: by= is missing")   # nocov
+    if (missingby) stopf("Internal error: by= is missing")   # nocov
 
     if (length(byval) && length(byval[[1L]])) {
       if (!bysameorder && isFALSE(byindex)) {
@@ -1510,10 +1510,10 @@ replace_dot_alias = function(e) {
           if (verbose) {catf("Finding groups using uniqlist on key ... ");flush.console()}
           f__ = uniqlist(byval)
         } else {
-          if (!is.character(byindex) || length(byindex)!=1L) stop("Internal error: byindex not the index name")  # nocov
+          if (!is.character(byindex) || length(byindex)!=1L) stopf("Internal error: byindex not the index name")  # nocov
           if (verbose) {catf("Finding groups using uniqlist on index '%s' ... ", byindex);flush.console()}
           o__ = getindex(x, byindex)
-          if (is.null(o__)) stop("Internal error: byindex not found")  # nocov
+          if (is.null(o__)) stopf("Internal error: byindex not found")  # nocov
           f__ = uniqlist(byval, order=o__)
         }
         if (verbose) {
@@ -1534,7 +1534,7 @@ replace_dot_alias = function(e) {
     # TO DO: allow secondary keys to be stored, then we see if our by matches one, if so use it, and no need to sort again. TO DO: document multiple keys.
   }
   if (length(xcols)) {
-    #  TODO add: if (max(len__)==nrow) stop("There is no need to deep copy x in this case")
+    #  TODO add: if (max(len__)==nrow) stopf("There is no need to deep copy x in this case")
     #  TODO move down to dogroup.c, too.
     SDenv$.SDall = .Call(CsubsetDT, x, if (length(len__)) seq_len(max(len__)) else 0L, xcols)  # must be deep copy when largest group is a subset
     if (xdotcols) setattr(SDenv$.SDall, 'names', ansvars[xcolsAns]) # now that we allow 'x.' prefix in 'j', #2313 bug fix - [xcolsAns]
@@ -1778,7 +1778,7 @@ replace_dot_alias = function(e) {
         jsub = .optmean(jsub)
       }
       if (nomeanopt) {
-        warning("Unable to optimize call to mean() and could be very slow. You must name 'na.rm' like that otherwise if you do mean(x,TRUE) the TRUE is taken to mean 'trim' which is the 2nd argument of mean. 'trim' is not yet optimized.",immediate.=TRUE)
+        warningf("Unable to optimize call to mean() and could be very slow. You must name 'na.rm' like that otherwise if you do mean(x,TRUE) the TRUE is taken to mean 'trim' which is the 2nd argument of mean. 'trim' is not yet optimized.", immediate.=TRUE)
       }
       if (verbose) {
         if (!identical(oldjsub, jsub))
@@ -1815,7 +1815,7 @@ replace_dot_alias = function(e) {
   # for #971, added !GForce. if (GForce) we do it much more (memory) efficiently than subset of order vector below.
   if (length(irows) && !isTRUE(irows) && !GForce) {
     # any zeros in irows were removed by convertNegAndZeroIdx earlier above; no need to check for zeros again. Test 1058-1061 check case #2758.
-    if (length(o__) && length(irows)!=length(o__)) stop("Internal error: length(irows)!=length(o__)") # nocov
+    if (length(o__) && length(irows)!=length(o__)) stopf("Internal error: length(irows)!=length(o__)") # nocov
     o__ = if (length(o__)) irows[o__]  # better do this once up front (even though another alloc) than deep repeated branch in dogroups.c
           else irows
   } # else grporder is left bound to same o__ memory (no cost of copy)
@@ -1874,7 +1874,7 @@ replace_dot_alias = function(e) {
         setkeyv(x,cnames)  # TO DO: setkey before grouping to get memcpy benefit.
         if (verbose) {cat(timetaken(last.started.at),"\n"); flush.console()}
       }
-      else warning("The setkey() normally performed by keyby= has been skipped (as if by= was used) because := is being used together with keyby= but the keyby= contains some expressions. To avoid this warning, use by= instead, or provide existing column names to keyby=.\n")
+      else warningf("The setkey() normally performed by keyby= has been skipped (as if by= was used) because := is being used together with keyby= but the keyby= contains some expressions. To avoid this warning, use by= instead, or provide existing column names to keyby=.\n")
     }
     return(suppPrint(x))
   }
@@ -1932,7 +1932,7 @@ replace_dot_alias = function(e) {
 
 #"[[<-.data.table" = function(x,i,j,value) {
 #    if (!cedta()) return(`[[<-.data.frame`(x,i,j,value))
-#    if (!missing(j)) stop("[[i,j]] assignment not available in data.table, put assignment(s) in [i,{...}] instead, more powerful")
+#    if (!missing(j)) stopf("[[i,j]] assignment not available in data.table, put assignment(s) in [i,{...}] instead, more powerful")
 #    cl = oldClass(x)  # [[<-.data.frame uses oldClass rather than class, don't know why but we'll follow suit
 #    class(x) = NULL
 #    x[[i]] = value
@@ -1943,16 +1943,16 @@ replace_dot_alias = function(e) {
 as.matrix.data.table = function(x, rownames=NULL, rownames.value=NULL, ...) {
   # rownames = the rownames column (most common usage)
   if (!is.null(rownames)) {
-    if (!is.null(rownames.value)) stop("rownames and rownames.value cannot both be used at the same time")
+    if (!is.null(rownames.value)) stopf("rownames and rownames.value cannot both be used at the same time")
     if (length(rownames)>1L) {
       # TODO in future as warned in NEWS for 1.11.6:
-      #   warning("length(rownames)>1 is deprecated. Please use rownames.value= instead")
+      #   warningf("length(rownames)>1 is deprecated. Please use rownames.value= instead")
       if (length(rownames)!=nrow(x))
         stopf("length(rownames)==%d but nrow(DT)==%d. The rownames argument specifies a single column name or number. Consider rownames.value= instead.", length(rownames), nrow(x))
       rownames.value = rownames
       rownames = NULL
     } else if (length(rownames)==0L) {
-      stop("length(rownames)==0 but should be a single column name or number, or NULL")
+      stopf("length(rownames)==0 but should be a single column name or number, or NULL")
     } else {
       if (isTRUE(rownames)) {
         if (length(key(x))>1L) {
@@ -2070,12 +2070,12 @@ tail.data.table = function(x, n=6L, ...) {
         else `[<-.data.frame`(x, i, j, value)
     return(setalloccol(x))    # over-allocate (again).   Avoid all this by using :=.
   }
-  # TO DO: warning("Please use DT[i,j:=value] syntax instead of DT[i,j]<-value, for efficiency. See ?':='")
+  # TO DO: warningf("Please use DT[i,j:=value] syntax instead of DT[i,j]<-value, for efficiency. See ?':='")
   if (!missing(i)) {
     isub=substitute(i)
     i = eval(.massagei(isub), x, parent.frame())
     if (is.matrix(i)) {
-      if (!missing(j)) stop("When i is a matrix in DT[i]<-value syntax, it doesn't make sense to provide j")
+      if (!missing(j)) stopf("When i is a matrix in DT[i]<-value syntax, it doesn't make sense to provide j")
       x = `[<-.data.frame`(x, i, value=value)
       return(setalloccol(x))
     }
@@ -2085,15 +2085,15 @@ tail.data.table = function(x, n=6L, ...) {
     # named 'value'".  So, users have to use := for that.
   } else i = NULL          # meaning (to C code) all rows, without allocating 1L:nrow(x) vector
   if (missing(j)) j=names(x)
-  if (!is.atomic(j)) stop("j must be an atomic vector, see ?is.atomic")
-  if (anyNA(j)) stop("NA in j")
+  if (!is.atomic(j)) stopf("j must be an atomic vector, see ?is.atomic")
+  if (anyNA(j)) stopf("NA in j")
   if (is.character(j)) {
     newnames = setdiff(j,names(x))
     cols = as.integer(chmatch(j, c(names(x),newnames)))
     # We can now mix existing columns and new columns
   } else {
-    if (!is.numeric(j)) stop("j must be vector of column name or positions")
-    if (any(j>ncol(x))) stop("Attempt to assign to column position greater than ncol(x). Create the column by name, instead. This logic intends to catch (most likely) user errors.")
+    if (!is.numeric(j)) stopf("j must be vector of column name or positions")
+    if (any(j>ncol(x))) stopf("Attempt to assign to column position greater than ncol(x). Create the column by name, instead. This logic intends to catch (most likely) user errors.")
     cols = as.integer(j)  # for convenience e.g. to convert 1 to 1L
     newnames = NULL
   }
@@ -2165,7 +2165,7 @@ as.list.data.table = function(x, ...) {
 dimnames.data.table = function(x) {
   if (!cedta()) {
     if (!inherits(x, "data.frame"))
-      stop("data.table inherits from data.frame (from v1.5), but this data.table does not. Has it been created manually (e.g. by using 'structure' rather than 'data.table') or saved to disk using a prior version of data.table?")
+      stopf("data.table inherits from data.frame (from v1.5), but this data.table does not. Has it been created manually (e.g. by using 'structure' rather than 'data.table') or saved to disk using a prior version of data.table?")
     return(`dimnames.data.frame`(x))
   }
   list(NULL, names(x))
@@ -2174,8 +2174,8 @@ dimnames.data.table = function(x) {
 "dimnames<-.data.table" = function (x, value)   # so that can do  colnames(dt)=<..>  as well as names(dt)=<..>
 {
   if (!cedta()) return(`dimnames<-.data.frame`(x,value))  # nocov ; will drop key but names<-.data.table (below) is more common usage and does retain the key
-  if (!is.list(value) || length(value) != 2L) stop("attempting to assign invalid object to dimnames of a data.table")
-  if (!is.null(value[[1L]])) stop("data.tables do not have rownames")
+  if (!is.list(value) || length(value) != 2L) stopf("attempting to assign invalid object to dimnames of a data.table")
+  if (!is.null(value[[1L]])) stopf("data.tables do not have rownames")
   if (ncol(x) != length(value[[2L]])) stopf("Can't assign %d names to a %d-column data.table", length(value[[2L]]), ncol(x))
   setnames(x,as.character(value[[2L]]))
   x  # this returned value is now shallow copied by R 3.1.0 via *tmp*. A very welcome change.
@@ -2253,7 +2253,7 @@ subset.data.table = function (x, subset, select, ...)
     e = substitute(subset)
     r = eval(e, x, parent.frame())
     if (!is.logical(r))
-      stop("'subset' must evaluate to logical")
+      stopf("'subset' must evaluate to logical")
     r = r & !is.na(r)
   }
 
@@ -2296,7 +2296,7 @@ na.omit.data.table = function (object, cols = seq_along(object), invert = FALSE,
   # compare to stats:::na.omit.data.frame
   if (!cedta()) return(NextMethod()) # nocov
   if ( !missing(invert) && is.na(as.logical(invert)) )
-    stop("Argument 'invert' must be logical TRUE/FALSE")
+    stopf("Argument 'invert' must be logical TRUE/FALSE")
   cols = colnamesInt(object, cols, check_dups=FALSE)
   ix = .Call(Cdt_na, object, cols)
   # forgot about invert with no NA case, #2660
@@ -2337,22 +2337,22 @@ Ops.data.table = function(e1, e2 = NULL)
 }
 
 split.data.table = function(x, f, drop = FALSE, by, sorted = FALSE, keep.by = TRUE, flatten = TRUE, ..., verbose = getOption("datatable.verbose")) {
-  if (!is.data.table(x)) stop("x argument must be a data.table")
+  if (!is.data.table(x)) stopf("x argument must be a data.table")
   stopifnot(is.logical(drop), is.logical(sorted), is.logical(keep.by),  is.logical(flatten))
   # split data.frame way, using `f` and not `by` argument
   if (!missing(f)) {
     if (!length(f) && nrow(x))
-      stop("group length is 0 but data nrow > 0")
+      stopf("group length is 0 but data nrow > 0")
     if (!missing(by))
-      stop("passing 'f' argument together with 'by' is not allowed, use 'by' when split by column in data.table and 'f' when split by external factor")
+      stopf("passing 'f' argument together with 'by' is not allowed, use 'by' when split by column in data.table and 'f' when split by external factor")
     # same as split.data.frame - handling all exceptions, factor orders etc, in a single stream of processing was a nightmare in factor and drop consistency
     return(lapply(split(x = seq_len(nrow(x)), f = f, drop = drop, ...), function(ind) x[ind]))
   }
-  if (missing(by)) stop("Either 'by' or 'f' argument must be supplied")
+  if (missing(by)) stopf("Either 'by' or 'f' argument must be supplied")
   # check reserved column names during processing
-  if (".ll.tech.split" %chin% names(x)) stop("Column '.ll.tech.split' is reserved for split.data.table processing")
-  if (".nm.tech.split" %chin% by) stop("Column '.nm.tech.split' is reserved for split.data.table processing")
-  if (!all(by %chin% names(x))) stop("Argument 'by' must refer to column names in x")
+  if (".ll.tech.split" %chin% names(x)) stopf("Column '.ll.tech.split' is reserved for split.data.table processing")
+  if (".nm.tech.split" %chin% by) stopf("Column '.nm.tech.split' is reserved for split.data.table processing")
+  if (!all(by %chin% names(x))) stopf("Argument 'by' must refer to column names in x")
   if (!all(by.atomic <- vapply_1b(by, function(.by) is.atomic(x[[.by]])))) stopf("Argument 'by' must refer only to atomic-type columns, but the following columns are non-atomic: %s", brackify(by[!by.atomic]))
   # list of data.tables (flatten) or list of lists of ... data.tables
   make.levels = function(x, cols, sorted) {
@@ -2482,7 +2482,7 @@ copy = function(x) {
 
 shallow = function(x, cols=NULL) {
   if (!is.data.table(x))
-    stop("x is not a data.table. Shallow copy is a copy of the vector of column pointers (only), so is only meaningful for data.table")
+    stopf("x is not a data.table. Shallow copy is a copy of the vector of column pointers (only), so is only meaningful for data.table")
   ans = .shallow(x, cols=cols, retain.key = TRUE)
   ans
 }
@@ -2490,7 +2490,7 @@ shallow = function(x, cols=NULL) {
 setalloccol = alloc.col = function(DT, n=getOption("datatable.alloccol"), verbose=getOption("datatable.verbose"))
 {
   name = substitute(DT)
-  if (identical(name, quote(`*tmp*`))) stop("setalloccol attempting to modify `*tmp*`")
+  if (identical(name, quote(`*tmp*`))) stopf("setalloccol attempting to modify `*tmp*`")
   ans = .Call(Calloccolwrapper, DT, eval(n), verbose)
   if (is.name(name)) {
     name = as.character(name)
@@ -2525,7 +2525,7 @@ setattr = function(x,name,value) {
     ans = .Call(Csetattrib, x, name, value)
     # If name=="names" and this is the first time names are assigned (e.g. in data.table()), this will be grown by setalloccol very shortly afterwards in the caller.
     if (!is.null(ans)) {
-      warning("Input is a length=1 logical that points to the same address as R's global value. Therefore the attribute has not been set by reference, rather on a copy. You will need to assign the result back to a variable. See issue #1281.")
+      warningf("Input is a length=1 logical that points to the same address as R's global value. Therefore the attribute has not been set by reference, rather on a copy. You will need to assign the result back to a variable. See issue #1281.")
       x = ans
     }
   }
@@ -2540,7 +2540,7 @@ setnames = function(x,old,new,skip_absent=FALSE) {
   # But also more convenient than names(DT)[i]="newname"  because we can also do setnames(DT,"oldname","newname")
   # without an onerous match() ourselves. old can be positions, too, but we encourage by name for robustness.
   # duplicates are permitted to be created without warning; e.g. in revdeps and for example, and setting spacer columns all with ""
-  if (!is.data.frame(x)) stop("x is not a data.table or data.frame")
+  if (!is.data.frame(x)) stopf("x is not a data.table or data.frame")
   ncol = length(x)
   if (length(names(x)) != ncol) stopf("x has %d columns but its names are length %d", ncol, length(names(x)))
   stopifnot(isTRUEorFALSE(skip_absent))
@@ -2562,8 +2562,8 @@ setnames = function(x,old,new,skip_absent=FALSE) {
     i = w
   } else {
     if (is.function(new)) new = if (is.numeric(old)) new(names(x)[old]) else new(old)
-    if (!is.character(new)) stop("'new' is not a character vector or a function")
-    #  if (anyDuplicated(new)) warning("Some duplicates exist in 'new': ", brackify(new[duplicated(new)]))  # dups allowed without warning; warn if and when the dup causes an ambiguity
+    if (!is.character(new)) stopf("'new' is not a character vector or a function")
+    #  if (anyDuplicated(new)) warningf("Some duplicates exist in 'new': ", brackify(new[duplicated(new)]))  # dups allowed without warning; warn if and when the dup causes an ambiguity
     if (anyNA(new)) stopf("NA in 'new' at positions %s", brackify(which(is.na(new))))
     if (anyDuplicated(old)) stopf("Some duplicates exist in 'old': %s", brackify(old[duplicated(old)]))
     if (is.numeric(old)) i = old = seq_along(x)[old]  # leave it to standard R to manipulate bounds and negative numbers
@@ -2590,7 +2590,7 @@ setnames = function(x,old,new,skip_absent=FALSE) {
       i = i[w]
     }
     if (!length(new)) return(invisible(x)) # no changes
-    if (length(i) != length(new)) stop("Internal error: length(i)!=length(new)") # nocov
+    if (length(i) != length(new)) stopf("Internal error: length(i)!=length(new)") # nocov
   }
   # update the key if the column name being change is in the key
   m = chmatch(names(x)[i], key(x))
@@ -2620,7 +2620,7 @@ setcolorder = function(x, neworder=key(x))
 {
   if (is.character(neworder) && anyDuplicated(names(x)))
     stopf("x has some duplicated column name(s): %s. Please remove or rename the duplicate(s) and try again.", brackify(unique(names(x)[duplicated(names(x))])))
-  # if (!is.data.table(x)) stop("x is not a data.table")
+  # if (!is.data.table(x)) stopf("x is not a data.table")
   neworder = colnamesInt(x, neworder, check_dups=FALSE)  # dups are now checked inside Csetcolorder below
   if (length(neworder) != length(x)) {
     #if shorter than length(x), pad by the missing
@@ -2676,14 +2676,14 @@ rbindlist = function(l, use.names="check", fill=FALSE, idcol=NULL) {
   if (isFALSE(idcol)) { idcol = NULL }
   else if (!is.null(idcol)) {
     if (isTRUE(idcol)) idcol = ".id"
-    if (!is.character(idcol)) stop("idcol must be a logical or character vector of length 1. If logical TRUE the id column will named '.id'.")
+    if (!is.character(idcol)) stopf("idcol must be a logical or character vector of length 1. If logical TRUE the id column will named '.id'.")
     idcol = idcol[1L]
   }
   miss = missing(use.names)
   # more checking of use.names happens at C level; this is just minimal to massage 'check' to NA
-  if (identical(use.names, NA)) stop("use.names=NA invalid")  # otherwise use.names=NA could creep in an usage equivalent to use.names='check'
+  if (identical(use.names, NA)) stopf("use.names=NA invalid")  # otherwise use.names=NA could creep in an usage equivalent to use.names='check'
   if (identical(use.names,"check")) {
-    if (!miss) stop("use.names='check' cannot be used explicitly because the value 'check' is new in v1.12.2 and subject to change. It is just meant to convey default behavior. See ?rbindlist.")
+    if (!miss) stopf("use.names='check' cannot be used explicitly because the value 'check' is new in v1.12.2 and subject to change. It is just meant to convey default behavior. See ?rbindlist.")
     use.names = NA
   }
   ans = .Call(Crbindlist, l, use.names, fill, idcol)
@@ -2698,12 +2698,12 @@ address = function(x) .Call(Caddress, eval(substitute(x), parent.frame()))
 
 ":=" = function(...) {
   # this error is detected when eval'ing isub and replaced with a more helpful one when using := in i due to forgetting a comma, #4227
-  stop('Check that is.data.table(DT) == TRUE. Otherwise, := and `:=`(...) are defined for use in j, once only and in particular ways. See help(":=").')
+  stopf('Check that is.data.table(DT) == TRUE. Otherwise, := and `:=`(...) are defined for use in j, once only and in particular ways. See help(":=").')
 }
 
 setDF = function(x, rownames=NULL) {
-  if (!is.list(x)) stop("setDF only accepts data.table, data.frame or list of equal length as input")
-  if (anyDuplicated(rownames)) stop("rownames contains duplicates")
+  if (!is.list(x)) stopf("setDF only accepts data.table, data.frame or list of equal length as input")
+  if (anyDuplicated(rownames)) stopf("rownames contains duplicates")
   if (is.data.table(x)) {
     # copied from as.data.frame.data.table
     if (is.null(rownames)) {
@@ -2728,7 +2728,7 @@ setDF = function(x, rownames=NULL) {
     n = vapply_1i(x, length)
     mn = max(n)
     if (any(n<mn))
-      stop("All elements in argument 'x' to 'setDF' must be of same length")
+      stopf("All elements in argument 'x' to 'setDF' must be of same length")
     xn = names(x)
     if (is.null(xn)) {
       setattr(x, "names", paste0("V",seq_len(length(x))))
@@ -2826,7 +2826,7 @@ setDT = function(x, keep.rownames=FALSE, key=NULL, check.names=FALSE) {
     setattr(x,"class",c("data.table","data.frame"))
     setalloccol(x)
   } else {
-    stop("Argument 'x' to 'setDT' should be a 'list', 'data.frame' or 'data.table'")
+    stopf("Argument 'x' to 'setDT' should be a 'list', 'data.frame' or 'data.table'")
   }
   if (!is.null(key)) setkeyv(x, key)
   if (is.name(name)) {
@@ -2866,14 +2866,14 @@ rowid = function(..., prefix=NULL) {
 
 rowidv = function(x, cols=seq_along(x), prefix=NULL) {
   if (!is.null(prefix) && (!is.character(prefix) || length(prefix) != 1L))
-    stop("'prefix' must be NULL or a character vector of length 1.")
+    stopf("'prefix' must be NULL or a character vector of length 1.")
   if (is.atomic(x)) {
     if (!missing(cols) && !is.null(cols))
-      stop("x is a single vector, non-NULL 'cols' doesn't make sense.")
+      stopf("x is a single vector, non-NULL 'cols' doesn't make sense.")
     cols = 1L
     x = as_list(x)
   } else if (!length(cols)) {
-    stop("x is a list, 'cols' cannot be 0-length.")
+    stopf("x is a list, 'cols' cannot be 0-length.")
   }
   xorder = forderv(x, by=cols, sort=FALSE, retGrp=TRUE) # speedup on char with sort=FALSE
   xstart = attr(xorder, 'starts', exact=TRUE)
@@ -2891,14 +2891,14 @@ rleid = function(..., prefix=NULL) {
 
 rleidv = function(x, cols=seq_along(x), prefix=NULL) {
   if (!is.null(prefix) && (!is.character(prefix) || length(prefix) != 1L))
-    stop("'prefix' must be NULL or a character vector of length 1.")
+    stopf("'prefix' must be NULL or a character vector of length 1.")
   if (is.atomic(x)) {
     if (!missing(cols) && !is.null(cols))
-      stop("x is a single vector, non-NULL 'cols' doesn't make sense.")
+      stopf("x is a single vector, non-NULL 'cols' doesn't make sense.")
     cols = 1L
     x = as_list(x)
   } else if (!length(cols)) {
-    stop("x is a list, 'cols' cannot be 0-length.")
+    stopf("x is a list, 'cols' cannot be 0-length.")
   }
   cols = colnamesInt(x, cols, check_dups=FALSE)
   ids = .Call(Crleid, x, cols)
@@ -3023,7 +3023,7 @@ isReallyReal = function(x) {
     on = c(on, setNames(paste0(col, validOps$on[validOps$op == operator], col), col))
     ## loop continues with remainingIsub
   }
-  if (length(i) == 0L) stop("Internal error in .isFastSubsettable. Please report to data.table developers") # nocov
+  if (length(i) == 0L) stopf("Internal error in .isFastSubsettable. Please report to data.table developers") # nocov
   ## convert i to data.table with all combinations in rows.
   if(length(i) > 1L && prod(vapply_1i(i, length)) > 1e4){
     ## CJ would result in more than 1e4 rows. This would be inefficient, especially memory-wise #2635
@@ -3110,7 +3110,7 @@ isReallyReal = function(x) {
   }
   on = eval(onsub, parent.frame(2L), parent.frame(2L))
   if (length(on) == 0L || !is.character(on))
-    stop("'on' argument should be a named atomic vector of column names indicating which columns in 'i' should be joined with which columns in 'x'.")
+    stopf("'on' argument should be a named atomic vector of column names indicating which columns in 'i' should be joined with which columns in 'x'.")
   ## extract the operators and potential variable names from 'on'.
   ## split at backticks to take care about variable names like `col1<=`.
   pieces = strsplit(on, "(?=[`])", perl = TRUE)

--- a/R/duplicated.R
+++ b/R/duplicated.R
@@ -4,7 +4,7 @@ duplicated.data.table = function(x, incomparables=FALSE, fromLast=FALSE, by=seq_
     .NotYetUsed("incomparables != FALSE")
   }
   if (nrow(x) == 0L || ncol(x) == 0L) return(logical(0L)) # fix for bug #28
-  if (is.na(fromLast) || !is.logical(fromLast)) stop("'fromLast' must be TRUE or FALSE")
+  if (is.na(fromLast) || !is.logical(fromLast)) stopf("'fromLast' must be TRUE or FALSE")
   if (!length(by)) by = NULL  #4594
   query = .duplicated.helper(x, by)
 
@@ -99,7 +99,7 @@ anyDuplicated.data.table = function(x, incomparables=FALSE, fromLast=FALSE, by=s
 uniqueN = function(x, by = if (is.list(x)) seq_along(x) else NULL, na.rm=FALSE) { # na.rm, #1455
   if (is.null(x)) return(0L)
   if (!is.atomic(x) && !is.data.frame(x))
-    stop("x must be an atomic vector or data.frames/data.tables")
+    stopf("x must be an atomic vector or data.frames/data.tables")
   if (is.atomic(x)) {
     if (is.logical(x)) return(.Call(CuniqueNlogical, x, na.rm=na.rm))
     x = as_list(x)

--- a/R/fcast.R
+++ b/R/fcast.R
@@ -28,12 +28,12 @@ dcast <- function(
 check_formula = function(formula, varnames, valnames) {
   if (is.character(formula)) formula = as.formula(formula)
   if (!inherits(formula, "formula") || length(formula) != 3L)
-    stop("Invalid formula. Cast formula should be of the form LHS ~ RHS, for e.g., a + b ~ c.")  # nocov; couldn't find a way to construct a test formula with length!=3L
+    stopf("Invalid formula. Cast formula should be of the form LHS ~ RHS, for e.g., a + b ~ c.")  # nocov; couldn't find a way to construct a test formula with length!=3L
   vars = all.vars(formula)
   vars = vars[!vars %chin% c(".", "...")]
   allvars = c(vars, valnames)
   if (any(allvars %chin% varnames[duplicated(varnames)]))
-    stop('data.table to cast must have unique column names')
+    stopf('data.table to cast must have unique column names')
   deparse_formula(as.list(formula)[-1L], varnames, allvars)
 }
 
@@ -73,7 +73,7 @@ aggregate_funs = function(funs, vals, sep="_", ...) {
   if (length(funs) != length(vals)) {
     if (length(vals) == 1L)
       vals = replicate(length(funs), vals)
-    else stop("When 'fun.aggregate' and 'value.var' are both lists, 'value.var' must be either of length =1 or =length(fun.aggregate).")
+    else stopf("When 'fun.aggregate' and 'value.var' are both lists, 'value.var' must be either of length =1 or =length(fun.aggregate).")
   }
   only_one_fun = length(unlist(funs)) == 1L
   dots = list(...)
@@ -106,9 +106,9 @@ aggregate_funs = function(funs, vals, sep="_", ...) {
 }
 
 dcast.data.table = function(data, formula, fun.aggregate = NULL, sep = "_", ..., margins = NULL, subset = NULL, fill = NULL, drop = TRUE, value.var = guess(data), verbose = getOption("datatable.verbose")) {
-  if (!is.data.table(data)) stop("'data' must be a data.table.")
+  if (!is.data.table(data)) stopf("'data' must be a data.table.")
   drop = as.logical(rep(drop, length.out=2L))
-  if (anyNA(drop)) stop("'drop' must be logical TRUE/FALSE")
+  if (anyNA(drop)) stopf("'drop' must be logical TRUE/FALSE")
   # #2980 if explicitly providing fun.aggregate=length but not a value.var,
   #   just use the last column (as guess(data) would do) because length will be
   #   the same on all columns
@@ -140,7 +140,7 @@ dcast.data.table = function(data, formula, fun.aggregate = NULL, sep = "_", ...,
   rhsnames = tail(varnames, -length(lvars$lhs))
   setattr(dat, 'names', c(varnames, valnames))
   if (any(vapply_1b(dat[varnames], is.list))) {
-    stop("Columns specified in formula can not be of type list")
+    stopf("Columns specified in formula can not be of type list")
   }
   setDT(dat)
 
@@ -151,13 +151,13 @@ dcast.data.table = function(data, formula, fun.aggregate = NULL, sep = "_", ...,
     idx = which(eval(subset, data, parent.frame())) # any advantage thro' secondary keys?
     dat = .Call(CsubsetDT, dat, idx, seq_along(dat))
   }
-  if (!nrow(dat) || !ncol(dat)) stop("Can not cast an empty data.table")
+  if (!nrow(dat) || !ncol(dat)) stopf("Can not cast an empty data.table")
   fun.call = m[["fun.aggregate"]]
   fill.default = NULL
   if (is.null(fun.call)) {
     oo = forderv(dat, by=varnames, retGrp=TRUE)
     if (attr(oo, 'maxgrpn', exact=TRUE) > 1L) {
-      message("Aggregate function missing, defaulting to 'length'")
+      messagef("Aggregate function missing, defaulting to 'length'")
       fun.call = quote(length)
     }
   }
@@ -166,8 +166,8 @@ dcast.data.table = function(data, formula, fun.aggregate = NULL, sep = "_", ...,
     errmsg = "Aggregating function(s) should take vector inputs and return a single value (length=1). However, function(s) returns length!=1. This value will have to be used to fill any missing combinations, and therefore must be length=1. Either override by setting the 'fill' argument explicitly or modify your function to handle this case appropriately."
     if (is.null(fill)) {
       fill.default = suppressWarnings(dat[0L][, eval(fun.call)])
-      # tryCatch(fill.default <- dat[0L][, eval(fun.call)], error = function(x) stop(errmsg, call.=FALSE))
-      if (nrow(fill.default) != 1L) stop(errmsg, call.=FALSE)
+      # tryCatch(fill.default <- dat[0L][, eval(fun.call)], error = function(x) stopf(errmsg, call.=FALSE))
+      if (nrow(fill.default) != 1L) stopf(errmsg, call.=FALSE)
     }
     dat = dat[, eval(fun.call), by=c(varnames)]
   }
@@ -220,6 +220,6 @@ dcast.data.table = function(data, formula, fun.aggregate = NULL, sep = "_", ...,
       # removed 'setcolorder()' here, #1153
     setattr(ans, 'names', c(lhsnames, allcols))
     setDT(ans); setattr(ans, 'sorted', lhsnames)
-  } else stop("Internal error -- empty rhsnames in dcast; please report") # nocov
+  } else stopf("Internal error -- empty rhsnames in dcast; please report") # nocov
   return (ans)
 }

--- a/R/fcast.R
+++ b/R/fcast.R
@@ -163,11 +163,11 @@ dcast.data.table = function(data, formula, fun.aggregate = NULL, sep = "_", ...,
   }
   if (!is.null(fun.call)) {
     fun.call = aggregate_funs(fun.call, lvals, sep, ...)
-    errmsg = "Aggregating function(s) should take vector inputs and return a single value (length=1). However, function(s) returns length!=1. This value will have to be used to fill any missing combinations, and therefore must be length=1. Either override by setting the 'fill' argument explicitly or modify your function to handle this case appropriately."
+    errmsg = gettext("Aggregating function(s) should take vector inputs and return a single value (length=1). However, function(s) returns length!=1. This value will have to be used to fill any missing combinations, and therefore must be length=1. Either override by setting the 'fill' argument explicitly or modify your function to handle this case appropriately.")
     if (is.null(fill)) {
       fill.default = suppressWarnings(dat[0L][, eval(fun.call)])
-      # tryCatch(fill.default <- dat[0L][, eval(fun.call)], error = function(x) stopf(errmsg, call.=FALSE))
-      if (nrow(fill.default) != 1L) stopf(errmsg, call.=FALSE)
+      # tryCatch(fill.default <- dat[0L][, eval(fun.call)], error = function(x) stopf(errmsg))
+      if (nrow(fill.default) != 1L) stopf(errmsg)
     }
     dat = dat[, eval(fun.call), by=c(varnames)]
   }

--- a/R/fmelt.R
+++ b/R/fmelt.R
@@ -25,11 +25,11 @@ patterns = function(..., cols=character(0L)) {
   L = list(...)
   p = unlist(L, use.names = any(nzchar(names(L))))
   if (!is.character(p))
-    stop("Input patterns must be of type character.")
+    stopf("Input patterns must be of type character.")
   matched = lapply(p, grep, cols)
   # replace with lengths when R 3.2.0 dependency arrives
   if (length(idx <- which(sapply(matched, length) == 0L)))
-    stop(domain = NA, sprintf(ngettext(length(idx), 'Pattern not found: [%s]', 'Patterns not found: [%s]'), brackify(p[idx])))
+    stopf('Pattern(s) not found: [%s]', brackify(p[idx]))
   matched
 }
 
@@ -71,13 +71,13 @@ measure = function(..., sep="_", pattern, cols, multiple.keyword="value.name") {
 measurev = function(fun.list, sep="_", pattern, cols, multiple.keyword="value.name", group.desc="elements of fun.list"){
   # 1. basic error checking.
   if (!missing(sep) && !missing(pattern)) {
-    stop("both sep and pattern arguments used; must use either sep or pattern (not both)")
+    stopf("both sep and pattern arguments used; must use either sep or pattern (not both)")
   }
   if (!(is.character(multiple.keyword) && length(multiple.keyword)==1 && !is.na(multiple.keyword) && nchar(multiple.keyword)>0)) {
-    stop("multiple.keyword must be a character string with nchar>0")
+    stopf("multiple.keyword must be a character string with nchar>0")
   }
   if (!is.character(cols)) {
-    stop("cols must be a character vector of column names")
+    stopf("cols must be a character vector of column names")
   }
   prob.i <- if (is.null(names(fun.list))) {
     seq_along(fun.list)
@@ -103,16 +103,16 @@ measurev = function(fun.list, sep="_", pattern, cols, multiple.keyword="value.na
   # 2. compute initial group data table, used as variable_table attribute.
   group.mat = if (!missing(pattern)) {
     if (!is.character(pattern)) {
-      stop("pattern must be character string")
+      stopf("pattern must be character string")
     }
     match.vec = regexpr(pattern, cols, perl=TRUE)
     measure.vec = which(0 < match.vec)
     if (length(measure.vec) == 0L) {
-      stop("pattern did not match any cols, so nothing would be melted; fix by changing pattern")
+      stopf("pattern did not match any cols, so nothing would be melted; fix by changing pattern")
     }
     start = attr(match.vec, "capture.start")[measure.vec, , drop=FALSE]
     if (is.null(start)) {
-      stop("pattern must contain at least one capture group (parenthesized sub-pattern)")
+      stopf("pattern must contain at least one capture group (parenthesized sub-pattern)")
     }
     err.args.groups("number of capture groups in pattern", ncol(start))
     end = attr(match.vec, "capture.length")[measure.vec,]+start-1L
@@ -120,13 +120,13 @@ measurev = function(fun.list, sep="_", pattern, cols, multiple.keyword="value.na
     substr(names.mat, start, end)
   } else { #pattern not specified, so split using sep.
     if (!is.character(sep)) {
-      stop("sep must be character string")
+      stopf("sep must be character string")
     }
     list.of.vectors = strsplit(cols, sep, fixed=TRUE)
     vector.lengths = sapply(list.of.vectors, length)
     n.groups = max(vector.lengths)
     if (n.groups == 1) {
-      stop("each column name results in only one item after splitting using sep, which means that all columns would be melted; to fix please either specify melt on all columns directly without using measure, or use a different sep/pattern specification")
+      stopf("each column name results in only one item after splitting using sep, which means that all columns would be melted; to fix please either specify melt on all columns directly without using measure, or use a different sep/pattern specification")
     }
     err.args.groups("max number of items after splitting column names", n.groups)
     measure.vec = which(vector.lengths==n.groups)
@@ -158,7 +158,7 @@ measurev = function(fun.list, sep="_", pattern, cols, multiple.keyword="value.na
   }
   group.uniq = unique(group.dt)
   if (nrow(group.uniq) < nrow(group.dt)) {
-    stop("number of unique groups after applying type conversion functions less than number of groups, change type conversion")
+    stopf("number of unique groups after applying type conversion functions less than number of groups, change type conversion")
   }
   # 4. compute measure.vars list or vector.
   if (multiple.keyword %in% names(fun.list)) {# multiple output columns.
@@ -190,7 +190,7 @@ measurev = function(fun.list, sep="_", pattern, cols, multiple.keyword="value.na
 melt.data.table = function(data, id.vars, measure.vars, variable.name = "variable",
        value.name = "value", ..., na.rm = FALSE, variable.factor = TRUE, value.factor = FALSE,
        verbose = getOption("datatable.verbose")) {
-  if (!is.data.table(data)) stop("'data' must be a data.table")
+  if (!is.data.table(data)) stopf("'data' must be a data.table")
   if (missing(id.vars)) id.vars=NULL
   if (missing(measure.vars)) measure.vars = NULL
   measure.sub = substitute(measure.vars)
@@ -209,10 +209,10 @@ melt.data.table = function(data, id.vars, measure.vars, variable.name = "variabl
       }
     } else {
       if (length(value.name) > 1L) {
-        warning("'value.name' provided in both 'measure.vars' and 'value.name argument'; value provided in 'measure.vars' is given precedence.")
+        warningf("'value.name' provided in both 'measure.vars' and 'value.name argument'; value provided in 'measure.vars' is given precedence.")
       }
       if (anyNA(meas.nm) || !all(nzchar(meas.nm))) {
-        stop("Please provide a name to each element of 'measure.vars'.")
+        stopf("Please provide a name to each element of 'measure.vars'.")
       }
       value.name = meas.nm
     }

--- a/R/foverlaps.R
+++ b/R/foverlaps.R
@@ -1,49 +1,49 @@
 foverlaps = function(x, y, by.x=if (!is.null(key(x))) key(x) else key(y), by.y=key(y), maxgap=0L, minoverlap=1L, type=c("any", "within", "start", "end", "equal"), mult=c("all", "first", "last"), nomatch=getOption("datatable.nomatch", NA), which=FALSE, verbose=getOption("datatable.verbose")) {
 
-  if (!is.data.table(y) || !is.data.table(x)) stop("y and x must both be data.tables. Use `setDT()` to convert list/data.frames to data.tables by reference or as.data.table() to convert to data.tables by copying.")
+  if (!is.data.table(y) || !is.data.table(x)) stopf("y and x must both be data.tables. Use `setDT()` to convert list/data.frames to data.tables by reference or as.data.table() to convert to data.tables by copying.")
   maxgap = as.integer(maxgap); minoverlap = as.integer(minoverlap)
   which = as.logical(which)
   .unsafe.opt() #3585
   nomatch = if (is.null(nomatch)) 0L else as.integer(nomatch)
   if (!length(maxgap) || length(maxgap) != 1L || is.na(maxgap) || maxgap < 0L)
-    stop("maxgap must be a non-negative integer value of length 1")
+    stopf("maxgap must be a non-negative integer value of length 1")
   if (!length(minoverlap) || length(minoverlap) != 1L || is.na(minoverlap) || minoverlap < 1L)
-    stop("minoverlap must be a positive integer value of length 1")
+    stopf("minoverlap must be a positive integer value of length 1")
   if (!length(which) || length(which) != 1L || is.na(which))
-    stop("which must be a logical vector of length 1. Either TRUE/FALSE")
+    stopf("which must be a logical vector of length 1. Either TRUE/FALSE")
   if (!length(nomatch) || length(nomatch) != 1L || (!is.na(nomatch) && nomatch!=0L))
-    stop("nomatch must either be NA or NULL")
+    stopf("nomatch must either be NA or NULL")
   type = match.arg(type)
   mult = match.arg(mult)
   # if (maxgap > 0L || minoverlap > 1L) # for future implementation
   if (maxgap != 0L || minoverlap != 1L)
-    stop("maxgap and minoverlap arguments are not yet implemented.")
+    stopf("maxgap and minoverlap arguments are not yet implemented.")
   if (is.null(by.y))
-    stop("y must be keyed (i.e., sorted, and, marked as sorted). Call setkey(y, ...) first, see ?setkey. Also check the examples in ?foverlaps.")
+    stopf("y must be keyed (i.e., sorted, and, marked as sorted). Call setkey(y, ...) first, see ?setkey. Also check the examples in ?foverlaps.")
   if (length(by.x) < 2L || length(by.y) < 2L)
-    stop("'by.x' and 'by.y' should contain at least two column names (or numbers) each - corresponding to 'start' and 'end' points of intervals. Please see ?foverlaps and examples for more info.")
+    stopf("'by.x' and 'by.y' should contain at least two column names (or numbers) each - corresponding to 'start' and 'end' points of intervals. Please see ?foverlaps and examples for more info.")
   if (is.numeric(by.x)) {
     if (any(by.x < 0L) || any(by.x > length(x)))
-      stop("Invalid numeric value for 'by.x'; it should be a vector with values 1 <= by.x <= length(x)")
+      stopf("Invalid numeric value for 'by.x'; it should be a vector with values 1 <= by.x <= length(x)")
     by.x = names(x)[by.x]
   }
   if (is.numeric(by.y)) {
     if (any(by.y < 0L) || any(by.y > length(y)))
-      stop("Invalid numeric value for 'by.y'; it should be a vector with values 1 <= by.y <= length(y)")
+      stopf("Invalid numeric value for 'by.y'; it should be a vector with values 1 <= by.y <= length(y)")
     by.y = names(y)[by.y]
   }
   if (!is.character(by.x))
-    stop("A non-empty vector of column names or numbers is required for by.x")
+    stopf("A non-empty vector of column names or numbers is required for by.x")
   if (!is.character(by.y))
-    stop("A non-empty vector of column names or numbers is required for by.y")
+    stopf("A non-empty vector of column names or numbers is required for by.y")
   if (!identical(by.y, key(y)[seq_along(by.y)]))
     stopf("The first %d columns of y's key must be identical to the columns specified in by.y.", length(by.y))
   if (anyNA(chmatch(by.x, names(x))))
-    stop("Elements listed in 'by.x' must be valid names in data.table x")
+    stopf("Elements listed in 'by.x' must be valid names in data.table x")
   if (anyDuplicated(by.x) || anyDuplicated(by.y))
-    stop("Duplicate columns are not allowed in overlap joins. This may change in the future.")
+    stopf("Duplicate columns are not allowed in overlap joins. This may change in the future.")
   if (length(by.x) != length(by.y))
-    stop("length(by.x) != length(by.y). Columns specified in by.x should correspond to columns specified in by.y and should be of same lengths.")
+    stopf("length(by.x) != length(by.y). Columns specified in by.x should correspond to columns specified in by.y and should be of same lengths.")
   if (any(dup.x<-duplicated(names(x)))) #1730 - handling join possible but would require workarounds on setcolorder further, it is really better just to rename dup column
     stopf("%s has some duplicated column name(s): %s. Please remove or rename the duplicate(s) and try again.", "x", brackify(unique(names(x)[dup.x])))
   if (any(dup.y<-duplicated(names(y))))
@@ -53,7 +53,7 @@ foverlaps = function(x, y, by.x=if (!is.null(key(x))) key(x) else key(y), by.y=k
   xval1 = x[[xintervals[1L]]]; xval2 = x[[xintervals[2L]]]
   yval1 = y[[yintervals[1L]]]; yval2 = y[[yintervals[2L]]]
   if (!storage.mode(xval1) %chin% c("double", "integer") || !storage.mode(xval2) %chin% c("double", "integer") || is.factor(xval1) || is.factor(xval2)) # adding factors to the bunch, #2645
-    stop("The last two columns in by.x should correspond to the 'start' and 'end' intervals in data.table x and must be integer/numeric type.")
+    stopf("The last two columns in by.x should correspond to the 'start' and 'end' intervals in data.table x and must be integer/numeric type.")
   if ( isTRUEorNA(any(xval2 - xval1 < 0L)) ) {
     # better error messages as suggested by @msummersgill in #3007. Thanks for the code too. Placing this inside so that it only runs if the general condition is satisfied. Should error anyway here.. So doesn't matter even if runs all if-statements; takes about 0.2s for anyNA check on 200 million elements .. acceptable speed for stoppage, I think, at least for now.
     if ( anyNA(xval1) ) {
@@ -63,7 +63,7 @@ foverlaps = function(x, y, by.x=if (!is.null(key(x))) key(x) else key(y), by.y=k
     } else stopf("All entries in column '%s' should be <= corresponding entries in column '%s' in data.table x.", xintervals[1L], xintervals[2L])
   }
   if (!storage.mode(yval1) %chin% c("double", "integer") || !storage.mode(yval2) %chin% c("double", "integer") || is.factor(yval1) || is.factor(yval2)) # adding factors to the bunch, #2645
-    stop("The last two columns in by.y should correspond to the 'start' and 'end' intervals in data.table y and must be integer/numeric type.")
+    stopf("The last two columns in by.y should correspond to the 'start' and 'end' intervals in data.table y and must be integer/numeric type.")
   if ( isTRUEorNA(any(yval2 - yval1 < 0L) )) {
     if ( anyNA(yval1) ) {
       stopf("NA values in data.table %s '%s' column: '%s'. All rows with NA values in the range columns must be removed for foverlaps() to work.", "y", "start", yintervals[1L])
@@ -74,13 +74,13 @@ foverlaps = function(x, y, by.x=if (!is.null(key(x))) key(x) else key(y), by.y=k
   # POSIXct interval cols error check
   posx_chk = sapply(list(xval1, xval2, yval1, yval2), inherits, 'POSIXct')
   if (any(posx_chk) && !all(posx_chk)) {
-    stop("Some interval cols are of type POSIXct while others are not. Please ensure all interval cols are (or are not) of POSIXct type")
+    stopf("Some interval cols are of type POSIXct while others are not. Please ensure all interval cols are (or are not) of POSIXct type")
   }
   # #1143, mismatched timezone
   getTZ = function(x) if (is.null(tz <- attr(x, "tzone", exact=TRUE))) "" else tz # "" == NULL AFAICT
   tzone_chk = c(getTZ(xval1), getTZ(xval2), getTZ(yval1), getTZ(yval2))
   if (length(unique(tzone_chk)) > 1L) {
-    warning("POSIXct interval cols have mixed timezones. Overlaps are performed on the internal numerical representation of POSIXct objects (always in UTC epoch time), therefore printed values may give the impression that values don't overlap but their internal representations do Please ensure that POSIXct type interval cols have identical 'tzone' attributes to avoid confusion.")
+    warningf("POSIXct interval cols have mixed timezones. Overlaps are performed on the internal numerical representation of POSIXct objects (always in UTC epoch time), therefore printed values may give the impression that values don't overlap but their internal representations do Please ensure that POSIXct type interval cols have identical 'tzone' attributes to avoid confusion.")
   }
   ## see NOTES below:
   yclass = c(class(yval1), class(yval2))
@@ -161,13 +161,13 @@ foverlaps = function(x, y, by.x=if (!is.null(key(x))) key(x) else key(y), by.y=k
   }
   # nocov start
   else if (maxgap == 0L && minoverlap > 1L) {
-    stop("Not yet implemented")
+    stopf("Not yet implemented")
   } else if (maxgap > 0L && minoverlap == 1L) {
-    stop("Not yet implemented")
+    stopf("Not yet implemented")
   } else if (maxgap > 0L && minoverlap > 1L) {
     if (maxgap > minoverlap)
-      warning("maxgap > minoverlap. maxgap will have no effect here.")
-    stop("Not yet implemented")
+      warningf("maxgap > minoverlap. maxgap will have no effect here.")
+    stopf("Not yet implemented")
   }
   # nocov end
 

--- a/R/frank.R
+++ b/R/frank.R
@@ -1,8 +1,8 @@
 frankv = function(x, cols=seq_along(x), order=1L, na.last=TRUE, ties.method=c("average", "first", "last", "random", "max", "min", "dense")) {
   ties.method = match.arg(ties.method)
-  if (!length(na.last)) stop('length(na.last) = 0')
+  if (!length(na.last)) stopf('length(na.last) = 0')
   if (length(na.last) != 1L) {
-    warning("length(na.last) > 1, only the first element will be used")
+    warningf("length(na.last) > 1, only the first element will be used")
     na.last = na.last[1L]
   }
   keep = (na.last == "keep")
@@ -14,13 +14,13 @@ frankv = function(x, cols=seq_along(x), order=1L, na.last=TRUE, ties.method=c("a
   }
   if (is.atomic(x)) {
     if (!missing(cols) && !is.null(cols))
-      stop("x is a single vector, non-NULL 'cols' doesn't make sense")
+      stopf("x is a single vector, non-NULL 'cols' doesn't make sense")
     cols = 1L
     x = as_list(x)
   } else {
     cols = colnamesInt(x, cols, check_dups=TRUE)
     if (!length(cols))
-      stop("x is a list, 'cols' can not be 0-length")
+      stopf("x is a list, 'cols' can not be 0-length")
   }
   # need to unlock for #4429
   x = .shallow(x, cols, unlock = TRUE) # shallow copy even if list..
@@ -28,7 +28,7 @@ frankv = function(x, cols=seq_along(x), order=1L, na.last=TRUE, ties.method=c("a
   cols = seq_along(cols)
   if (is.na(na.last)) {
     if ("..na_prefix.." %chin% names(x))
-      stop("Input column '..na_prefix..' conflicts with data.table internal usage; please rename")
+      stopf("Input column '..na_prefix..' conflicts with data.table internal usage; please rename")
     set(x, j = "..na_prefix..", value = is_na(x, cols))
     order = if (length(order) == 1L) c(1L, rep(order, length(cols))) else c(1L, order)
     cols = c(ncol(x), cols)
@@ -43,7 +43,7 @@ frankv = function(x, cols=seq_along(x), order=1L, na.last=TRUE, ties.method=c("a
       n = nrow(x)
     }
     if ('..stats_runif..' %chin% names(x))
-      stop("Input column '..stats_runif..' conflicts with data.table internal usage; please rename")
+      stopf("Input column '..stats_runif..' conflicts with data.table internal usage; please rename")
     set(x, idx, '..stats_runif..', stats::runif(n))
     order = if (length(order) == 1L) c(rep(order, length(cols)), 1L) else c(order, 1L)
     cols = c(cols, ncol(x))

--- a/R/fread.R
+++ b/R/fread.R
@@ -7,7 +7,7 @@ showProgress=getOption("datatable.showProgress",interactive()), data.table=getOp
 nThread=getDTthreads(verbose), logical01=getOption("datatable.logical01",FALSE), keepLeadingZeros=getOption("datatable.keepLeadingZeros",FALSE),
 yaml=FALSE, autostart=NA, tmpdir=tempdir(), tz="UTC")
 {
-  if (missing(input)+is.null(file)+is.null(text)+is.null(cmd) < 3L) stop("Used more than one of the arguments input=, file=, text= and cmd=.")
+  if (missing(input)+is.null(file)+is.null(text)+is.null(cmd) < 3L) stopf("Used more than one of the arguments input=, file=, text= and cmd=.")
   input_has_vars = length(all.vars(substitute(input)))>0L  # see news for v1.11.6
   if (is.null(sep)) sep="\n"         # C level knows that \n means \r\n on Windows, for example
   else {
@@ -19,7 +19,7 @@ yaml=FALSE, autostart=NA, tmpdir=tempdir(), tz="UTC")
   stopifnot( is.character(dec), length(dec)==1L, nchar(dec)==1L )
   # handle encoding, #563
   if (length(encoding) != 1L || !encoding %chin% c("unknown", "UTF-8", "Latin-1")) {
-    stop("Argument 'encoding' must be 'unknown', 'UTF-8' or 'Latin-1'.")
+    stopf("Argument 'encoding' must be 'unknown', 'UTF-8' or 'Latin-1'.")
   }
   stopifnot(
     isTRUEorFALSE(strip.white), isTRUEorFALSE(blank.lines.skip), isTRUEorFALSE(fill), isTRUEorFALSE(showProgress),
@@ -50,19 +50,19 @@ yaml=FALSE, autostart=NA, tmpdir=tempdir(), tz="UTC")
   }
   else if (is.null(cmd)) {
     if (!is.character(input) || length(input)!=1L) {
-      stop("input= must be a single character string containing a file name, a system command containing at least one space, a URL starting 'http[s]://', 'ftp[s]://' or 'file://', or, the input data itself containing at least one \\n or \\r")
+      stopf("input= must be a single character string containing a file name, a system command containing at least one space, a URL starting 'http[s]://', 'ftp[s]://' or 'file://', or, the input data itself containing at least one \\n or \\r")
     }
     if (input=="" || length(grep('\\n|\\r', input))) {
       # input is data itself containing at least one \n or \r
     } else {
       if (startsWith(input, " ")) {
-        stop("input= contains no \\n or \\r, but starts with a space. Please remove the leading space, or use text=, file= or cmd=")
+        stopf("input= contains no \\n or \\r, but starts with a space. Please remove the leading space, or use text=, file= or cmd=")
       }
       str7 = substr(input, 1L, 7L) # avoid grepl() for #2531
       if (str7=="ftps://" || startsWith(input, "https://")) {
         # nocov start
         if (!requireNamespace("curl", quietly = TRUE))
-          stop("Input URL requires https:// connection for which fread() requires 'curl' package which cannot be found. Please install 'curl' using 'install.packages('curl')'.") # nocov
+          stopf("Input URL requires https:// connection for which fread() requires 'curl' package which cannot be found. Please install 'curl' using 'install.packages('curl')'.") # nocov
         tmpFile = tempfile(fileext = paste0(".",tools::file_ext(input)), tmpdir=tmpdir)  # retain .gz extension in temp filename so it knows to be decompressed further below
         curl::curl_download(input, tmpFile, mode="wb", quiet = !showProgress)
         file = tmpFile
@@ -106,7 +106,7 @@ yaml=FALSE, autostart=NA, tmpdir=tempdir(), tz="UTC")
     }
     if ((is_gz <- endsWith(file, ".gz")) || endsWith(file, ".bz2")) {
       if (!requireNamespace("R.utils", quietly = TRUE))
-        stop("To read gz and bz2 files directly, fread() requires 'R.utils' package which cannot be found. Please install 'R.utils' using 'install.packages('R.utils')'.") # nocov
+        stopf("To read gz and bz2 files directly, fread() requires 'R.utils' package which cannot be found. Please install 'R.utils' using 'install.packages('R.utils')'.") # nocov
       FUN = if (is_gz) gzfile else bzfile
       R.utils::decompressFile(file, decompFile<-tempfile(tmpdir=tmpdir), ext=NULL, FUN=FUN, remove=FALSE)   # ext is not used by decompressFile when destname is supplied, but isn't optional
       file = decompFile   # don't use 'tmpFile' symbol again, as tmpFile might be the http://domain.org/file.csv.gz download
@@ -116,18 +116,18 @@ yaml=FALSE, autostart=NA, tmpdir=tempdir(), tz="UTC")
 
     input = file
   }
-  if (!missing(autostart)) warning("'autostart' is now deprecated and ignored. Consider skip='string' or skip=n");
+  if (!missing(autostart)) warningf("'autostart' is now deprecated and ignored. Consider skip='string' or skip=n");
   if (is.logical(colClasses)) {
-    if (!allNA(colClasses)) stop("colClasses is type 'logical' which is ok if all NA but it has some TRUE or FALSE values in it which is not allowed. Please consider the drop= or select= argument instead. See ?fread.")
+    if (!allNA(colClasses)) stopf("colClasses is type 'logical' which is ok if all NA but it has some TRUE or FALSE values in it which is not allowed. Please consider the drop= or select= argument instead. See ?fread.")
     colClasses = NULL
   }
   if (!is.null(colClasses) && is.atomic(colClasses)) {
-    if (!is.character(colClasses)) stop("colClasses is not type list or character vector")
+    if (!is.character(colClasses)) stopf("colClasses is not type list or character vector")
     if (!length(colClasses)) {
       colClasses=NULL;
     } else if (identical(colClasses, "NULL")) {
       colClasses = NULL
-      warning('colClasses="NULL" (quoted) is interpreted as colClasses=NULL (the default) as opposed to dropping every column.')
+      warningf('colClasses="NULL" (quoted) is interpreted as colClasses=NULL (the default) as opposed to dropping every column.')
     } else if (!is.null(names(colClasses))) {   # names are column names; convert to list approach
       colClasses = tapply(names(colClasses), colClasses, c, simplify=FALSE)
     }
@@ -154,11 +154,11 @@ yaml=FALSE, autostart=NA, tmpdir=tempdir(), tz="UTC")
   }
   if (yaml) {
     if (!requireNamespace('yaml', quietly = TRUE))
-      stop("'data.table' relies on the package 'yaml' to parse the file header; please add this to your library with install.packages('yaml') and try again.") # nocov
+      stopf("'data.table' relies on the package 'yaml' to parse the file header; please add this to your library with install.packages('yaml') and try again.") # nocov
     # for tracking which YAML elements may be overridden by being declared explicitly
     call_args = names(match.call())
     if (is.character(skip))
-      warning("Combining a search string as 'skip' and reading a YAML header may not work as expected -- currently, reading will proceed to search for 'skip' from the beginning of the file, NOT from the end of the metadata; please file an issue on GitHub if you'd like to see more intuitive behavior supported.")
+      warningf("Combining a search string as 'skip' and reading a YAML header may not work as expected -- currently, reading will proceed to search for 'skip' from the beginning of the file, NOT from the end of the metadata; please file an issue on GitHub if you'd like to see more intuitive behavior supported.")
     # create connection to stream header lines from file:
     #   https://stackoverflow.com/questions/9871307
     f = base::file(input, 'r')
@@ -194,7 +194,7 @@ yaml=FALSE, autostart=NA, tmpdir=tempdir(), tz="UTC")
     if (verbose) catf('Processed %d lines of YAML metadata with the following top-level fields: %s\n', n_read, brackify(yaml_names))
     # process header first since it impacts how to handle colClasses
     if ('header' %chin% yaml_names) {
-      if ('header' %chin% call_args) message("User-supplied 'header' will override that found in metadata.")
+      if ('header' %chin% call_args) messagef("User-supplied 'header' will override that found in metadata.")
       else header = as.logical(yaml_header$header)
     }
     if ('schema' %chin% yaml_names) {
@@ -212,7 +212,7 @@ yaml=FALSE, autostart=NA, tmpdir=tempdir(), tz="UTC")
       new_types = synonms[list(new_types)]$r_type
       new_names = sapply(yaml_header$schema$fields[!null_idx], `[[`, 'name')
 
-      if ('col.names' %chin% call_args) message("User-supplied column names in 'col.names' will override those found in YAML metadata.")
+      if ('col.names' %chin% call_args) messagef("User-supplied column names in 'col.names' will override those found in YAML metadata.")
       # resolve any conflicts with colClasses, if supplied;
       #   colClasses (if present) is already in list form by now
       if ('colClasses' %chin% call_args) {
@@ -242,21 +242,21 @@ yaml=FALSE, autostart=NA, tmpdir=tempdir(), tz="UTC")
     }
     sep_syn = c('sep', 'delimiter')
     if (any(sep_idx <- sep_syn %chin% yaml_names)) {
-      if ('sep' %chin% call_args) message("User-supplied 'sep' will override that found in metadata.")
+      if ('sep' %chin% call_args) messagef("User-supplied 'sep' will override that found in metadata.")
       else sep = yaml_header[[ sep_syn[sep_idx][1L] ]]
     }
     quote_syn = c('quote', 'quoteChar', 'quote_char')
     if (any(quote_idx <- quote_syn %chin% yaml_names)) {
-      if ('quote' %chin% call_args) message("User-supplied 'quote' will override that found in metadata.")
+      if ('quote' %chin% call_args) messagef("User-supplied 'quote' will override that found in metadata.")
       else quote = yaml_header[[ quote_syn[quote_idx][1L] ]]
     }
     dec_syn = c('dec', 'decimal')
     if (any(dec_idx <- dec_syn %chin% yaml_names)) {
-      if ('dec' %chin% call_args) message("User-supplied 'dec' will override that found in metadata.")
+      if ('dec' %chin% call_args) messagef("User-supplied 'dec' will override that found in metadata.")
       else dec = yaml_header[[ dec_syn[dec_idx][1L] ]]
     }
     if ('na.strings' %chin% yaml_names) {
-      if ('na.strings' %chin% call_args) message("User-supplied 'na.strings' will override that found in metadata.")
+      if ('na.strings' %chin% call_args) messagef("User-supplied 'na.strings' will override that found in metadata.")
       else na.strings = yaml_header$na.strings
     }
     if (is.integer(skip)) skip = skip + n_read
@@ -327,7 +327,7 @@ yaml=FALSE, autostart=NA, tmpdir=tempdir(), tz="UTC")
     setnames(ans, col.names) # setnames checks and errors automatically
   if (!is.null(key) && data.table) {
     if (!is.character(key))
-      stop("key argument of data.table() must be a character vector naming columns (NB: col.names are applied before this)")
+      stopf("key argument of data.table() must be a character vector naming columns (NB: col.names are applied before this)")
     if (length(key) == 1L) {
       key = strsplit(key, split = ",", fixed = TRUE)[[1L]]
     }
@@ -336,7 +336,7 @@ yaml=FALSE, autostart=NA, tmpdir=tempdir(), tz="UTC")
   if (yaml) setattr(ans, 'yaml_metadata', yaml_header)
   if (!is.null(index) && data.table) {
     if (!all(vapply_1b(index, is.character)))
-      stop("index argument of data.table() must be a character vector naming columns (NB: col.names are applied before this)")
+      stopf("index argument of data.table() must be a character vector naming columns (NB: col.names are applied before this)")
     if (is.list(index)) {
       to_split = vapply_1i(index, length) == 1L
       if (any(to_split))

--- a/R/fwrite.R
+++ b/R/fwrite.R
@@ -16,18 +16,18 @@ fwrite = function(x, file="", append=FALSE, quote="auto",
            encoding = "") {
   na = as.character(na[1L]) # fix for #1725
   if (length(encoding) != 1L || !encoding %chin% c("", "UTF-8", "native")) {
-    stop("Argument 'encoding' must be '', 'UTF-8' or 'native'.")
+    stopf("Argument 'encoding' must be '', 'UTF-8' or 'native'.")
   }
   if (missing(qmethod)) qmethod = qmethod[1L]
   if (missing(compress)) compress = compress[1L]
   if (missing(dateTimeAs)) { dateTimeAs = dateTimeAs[1L] }
-  else if (length(dateTimeAs)>1L) stop("dateTimeAs must be a single string")
+  else if (length(dateTimeAs)>1L) stopf("dateTimeAs must be a single string")
   dateTimeAs = chmatch(dateTimeAs, c("ISO","squash","epoch","write.csv"))-1L
-  if (is.na(dateTimeAs)) stop("dateTimeAs must be 'ISO','squash','epoch' or 'write.csv'")
+  if (is.na(dateTimeAs)) stopf("dateTimeAs must be 'ISO','squash','epoch' or 'write.csv'")
   if (!missing(logical01) && !missing(logicalAsInt))
-    stop("logicalAsInt has been renamed logical01. Use logical01 only, not both.")
+    stopf("logicalAsInt has been renamed logical01. Use logical01 only, not both.")
   if (!missing(logicalAsInt)) {
-    # TODO: warning("logicalAsInt has been renamed logical01 for consistency with fread. It will work fine but please change to logical01 at your convenience so we can remove logicalAsInt in future.")
+    # TODO: warningf("logicalAsInt has been renamed logical01 for consistency with fread. It will work fine but please change to logical01 at your convenience so we can remove logicalAsInt in future.")
     logical01 = logicalAsInt
     logicalAsInt=NULL
   }
@@ -37,7 +37,7 @@ fwrite = function(x, file="", append=FALSE, quote="auto",
   # write.csv default is 'double' so fwrite follows suit. write.table's default is 'escape'
   # validate arguments
   if (is.matrix(x)) { # coerce to data.table if input object is matrix
-    message("x being coerced from class: matrix to data.table")
+    messagef("x being coerced from class: matrix to data.table")
     x = as.data.table(x)
   }
   stopifnot(is.list(x),
@@ -87,7 +87,7 @@ fwrite = function(x, file="", append=FALSE, quote="auto",
   }
   yaml = if (!yaml) "" else {
     if (!requireNamespace('yaml', quietly=TRUE))
-      stop("'data.table' relies on the package 'yaml' to write the file header; please add this to your library with install.packages('yaml') and try again.") # nocov
+      stopf("'data.table' relies on the package 'yaml' to write the file header; please add this to your library with install.packages('yaml') and try again.") # nocov
     schema_vec = sapply(x, class)
     # multi-class objects reduced to first class
     if (is.list(schema_vec)) schema_vec = sapply(schema_vec, `[`, 1L)

--- a/R/groupingsets.R
+++ b/R/groupingsets.R
@@ -4,11 +4,11 @@ rollup = function(x, ...) {
 rollup.data.table = function(x, j, by, .SDcols, id = FALSE, ...) {
   # input data type basic validation
   if (!is.data.table(x))
-    stop("Argument 'x' must be a data.table object")
+    stopf("Argument 'x' must be a data.table object")
   if (!is.character(by))
-    stop("Argument 'by' must be a character vector of column names used in grouping.")
+    stopf("Argument 'by' must be a character vector of column names used in grouping.")
   if (!is.logical(id))
-    stop("Argument 'id' must be a logical scalar.")
+    stopf("Argument 'id' must be a logical scalar.")
   # generate grouping sets for rollup
   sets = lapply(length(by):0L, function(i) by[0L:i])
   # redirect to workhorse function
@@ -22,13 +22,13 @@ cube = function(x, ...) {
 cube.data.table = function(x, j, by, .SDcols, id = FALSE, ...) {
   # input data type basic validation
   if (!is.data.table(x))
-    stop("Argument 'x' must be a data.table object")
+    stopf("Argument 'x' must be a data.table object")
   if (!is.character(by))
-    stop("Argument 'by' must be a character vector of column names used in grouping.")
+    stopf("Argument 'by' must be a character vector of column names used in grouping.")
   if (!is.logical(id))
-    stop("Argument 'id' must be a logical scalar.")
+    stopf("Argument 'id' must be a logical scalar.")
   if (missing(j))
-    stop("Argument 'j' is required")
+    stopf("Argument 'j' is required")
   # generate grouping sets for cube - power set: http://stackoverflow.com/a/32187892/2490497
   n = length(by)
   keepBool = sapply(2L^(seq_len(n)-1L), function(k) rep(c(FALSE, TRUE), times=k, each=((2L^n)/(2L*k))))
@@ -44,41 +44,41 @@ groupingsets = function(x, ...) {
 groupingsets.data.table = function(x, j, by, sets, .SDcols, id = FALSE, jj, ...) {
   # input data type basic validation
   if (!is.data.table(x))
-    stop("Argument 'x' must be a data.table object")
+    stopf("Argument 'x' must be a data.table object")
   if (ncol(x) < 1L)
-    stop("Argument 'x' is a 0-column data.table; no measure to apply grouping over.")
+    stopf("Argument 'x' is a 0-column data.table; no measure to apply grouping over.")
   if (anyDuplicated(names(x)) > 0L)
-    stop("Input data.table must not contain duplicate column names.")
+    stopf("Input data.table must not contain duplicate column names.")
   if (!is.character(by))
-    stop("Argument 'by' must be a character vector of column names used in grouping.")
+    stopf("Argument 'by' must be a character vector of column names used in grouping.")
   if (anyDuplicated(by) > 0L)
-    stop("Argument 'by' must have unique column names for grouping.")
+    stopf("Argument 'by' must have unique column names for grouping.")
   if (!is.list(sets) || !all(vapply_1b(sets, is.character)))
-    stop("Argument 'sets' must be a list of character vectors.")
+    stopf("Argument 'sets' must be a list of character vectors.")
   if (!is.logical(id))
-    stop("Argument 'id' must be a logical scalar.")
+    stopf("Argument 'id' must be a logical scalar.")
   # logic constraints validation
   if (!all((sets.all.by <- unique(unlist(sets))) %chin% by))
     stopf("All columns used in 'sets' argument must be in 'by' too. Columns used in 'sets' but not present in 'by': %s", brackify(setdiff(sets.all.by, by)))
   if (id && "grouping" %chin% names(x))
-    stop("When using `id=TRUE` the 'x' data.table must not have a column named 'grouping'.")
+    stopf("When using `id=TRUE` the 'x' data.table must not have a column named 'grouping'.")
   if (any(vapply_1i(sets, anyDuplicated)))  # anyDuplicated returns index of first duplicate, otherwise 0L
-    stop("Character vectors in 'sets' list must not have duplicated column names within a single grouping set.")
+    stopf("Character vectors in 'sets' list must not have duplicated column names within a single grouping set.")
   if (length(sets) > 1L && (idx<-anyDuplicated(lapply(sets, sort))))
     warningf("'sets' contains a duplicate (i.e., equivalent up to sorting) element at index %d; as such, there will be duplicate rows in the output -- note that grouping by A,B and B,A will produce the same aggregations. Use `sets=unique(lapply(sets, sort))` to eliminate duplicates.", idx)
   # input arguments handling
   jj = if (!missing(jj)) jj else substitute(j)
   av = all.vars(jj, TRUE)
   if (":=" %chin% av)
-    stop("Expression passed to grouping sets function must not update by reference. Use ':=' on results of your grouping function.")
+    stopf("Expression passed to grouping sets function must not update by reference. Use ':=' on results of your grouping function.")
   if (missing(.SDcols))
     .SDcols = if (".SD" %chin% av) setdiff(names(x), by) else NULL
   # 0 rows template data.table to keep colorder and type
   empty = if (length(.SDcols)) x[0L, eval(jj), by, .SDcols=.SDcols] else x[0L, eval(jj), by]
   if (id && "grouping" %chin% names(empty)) # `j` could have been evaluated to `grouping` field
-    stop("When using `id=TRUE` the 'j' expression must not evaluate to a column named 'grouping'.")
+    stopf("When using `id=TRUE` the 'j' expression must not evaluate to a column named 'grouping'.")
   if (anyDuplicated(names(empty)) > 0L)
-    stop("There exists duplicated column names in the results, ensure the column passed/evaluated in `j` and those in `by` are not overlapping.")
+    stopf("There exists duplicated column names in the results, ensure the column passed/evaluated in `j` and those in `by` are not overlapping.")
   # adding grouping column to template - aggregation level identifier
   if (id) {
     set(empty, j = "grouping", value = integer())
@@ -88,7 +88,7 @@ groupingsets.data.table = function(x, j, by, sets, .SDcols, id = FALSE, jj, ...)
   int64.cols = vapply_1b(empty, inherits, "integer64")
   int64.cols = names(int64.cols)[int64.cols]
   if (length(int64.cols) && !requireNamespace("bit64", quietly=TRUE))
-    stop("Using integer64 class columns require to have 'bit64' package installed.") # nocov
+    stopf("Using integer64 class columns require to have 'bit64' package installed.") # nocov
   int64.by.cols = intersect(int64.cols, by)
   # aggregate function called for each grouping set
   aggregate.set = function(by.set) {

--- a/R/merge.R
+++ b/R/merge.R
@@ -1,9 +1,9 @@
 merge.data.table = function(x, y, by = NULL, by.x = NULL, by.y = NULL, all = FALSE, all.x = all,
                all.y = all, sort = TRUE, suffixes = c(".x", ".y"), no.dups = TRUE, allow.cartesian=getOption("datatable.allow.cartesian"), ...) {
   if (!sort %in% c(TRUE, FALSE))
-    stop("Argument 'sort' should be logical TRUE/FALSE")
+    stopf("Argument 'sort' should be logical TRUE/FALSE")
   if (!no.dups %in% c(TRUE, FALSE))
-    stop("Argument 'no.dups' should be logical TRUE/FALSE")
+    stopf("Argument 'no.dups' should be logical TRUE/FALSE")
   class_x = class(x)
   if (!is.data.table(y)) {
     y = as.data.table(y)
@@ -13,31 +13,31 @@ merge.data.table = function(x, y, by = NULL, by.x = NULL, by.y = NULL, all = FAL
   }
   x0 = length(x)==0L
   y0 = length(y)==0L
-  if (x0 || y0) warning(domain=NA, sprintf(
-    ngettext(
-      x0+y0,
-      "You are trying to join data.tables where %s has 0 columns.",
-      "You are trying to join data.tables where %s have 0 columns."
-    ),
-    if (x0 && y0) "'x' and 'y'" else if (x0) "'x'" else "'y'"
-  ))
+  if (x0 || y0) {
+    if (x0 && y0) 
+      warningf("Neither of the input data.tables to join have columns.")
+    else if (x0)
+      warningf("Input data.table '%s' has no columns.", "x")
+    else
+      warningf("Input data.table '%s' has no columns.", "y")
+  }
   nm_x = names(x)
   nm_y = names(y)
-  if (anyDuplicated(nm_x)) stop(gettextf("%s has some duplicated column name(s): %s. Please remove or rename the duplicate(s) and try again.", "x", brackify(nm_x[duplicated(nm_x)])))
-  if (anyDuplicated(nm_y)) stop(gettextf("%s has some duplicated column name(s): %s. Please remove or rename the duplicate(s) and try again.", "y", brackify(nm_y[duplicated(nm_y)])))
+  if (anyDuplicated(nm_x)) stopf("%s has some duplicated column name(s): %s. Please remove or rename the duplicate(s) and try again.", "x", brackify(nm_x[duplicated(nm_x)]))
+  if (anyDuplicated(nm_y)) stopf("%s has some duplicated column name(s): %s. Please remove or rename the duplicate(s) and try again.", "y", brackify(nm_y[duplicated(nm_y)]))
 
   ## set up 'by'/'by.x'/'by.y'
   if ( (!is.null(by.x) || !is.null(by.y)) && length(by.x)!=length(by.y) )
-    stop("`by.x` and `by.y` must be of same length.")
+    stopf("`by.x` and `by.y` must be of same length.")
   if (!missing(by) && !missing(by.x))
-    warning("Supplied both `by` and `by.x/by.y`. `by` argument will be ignored.")
+    warningf("Supplied both `by` and `by.x/by.y`. `by` argument will be ignored.")
   if (!is.null(by.x)) {
     if (length(by.x)==0L || !is.character(by.x) || !is.character(by.y))
-      stop("A non-empty vector of column names is required for `by.x` and `by.y`.")
+      stopf("A non-empty vector of column names is required for `by.x` and `by.y`.")
     if (!all(by.x %chin% nm_x))
-      stop("Elements listed in `by.x` must be valid column names in x.")
+      stopf("Elements listed in `by.x` must be valid column names in x.")
     if (!all(by.y %chin% nm_y))
-      stop("Elements listed in `by.y` must be valid column names in y.")
+      stopf("Elements listed in `by.y` must be valid column names in y.")
     by = by.x
     names(by) = by.y
   } else {
@@ -48,9 +48,9 @@ merge.data.table = function(x, y, by = NULL, by.x = NULL, by.y = NULL, all = FAL
     if (is.null(by))
       by = intersect(nm_x, nm_y)
     if (length(by) == 0L || !is.character(by))
-      stop("A non-empty vector of column names for `by` is required.")
+      stopf("A non-empty vector of column names for `by` is required.")
     if (!all(by %chin% intersect(nm_x, nm_y)))
-      stop("Elements listed in `by` must be valid column names in x and y")
+      stopf("Elements listed in `by` must be valid column names in x and y")
     by = unname(by)
     by.x = by.y = by
   }

--- a/R/onAttach.R
+++ b/R/onAttach.R
@@ -24,16 +24,16 @@
       packageStartupMessagef(domain="R-data.table", "data.table %s IN DEVELOPMENT built %s%s using %d threads (see ?getDTthreads).  ", v, d, g, nth, appendLF=FALSE)
     else 
       packageStartupMessagef(domain="R-data.table", "data.table %s using %d threads (see ?getDTthreads).  ", v, nth, appendLF=FALSE)
-    packageStartupMessage(domain="R-data.table", "Latest news: r-datatable.com")
+    packageStartupMessagef(domain="R-data.table", "Latest news: r-datatable.com")
     # NB: domain= is necessary in .onAttach and .onLoad, see ?gettext and https://bugs.r-project.org/bugzilla/show_bug.cgi?id=18092.
     if (gettext(domain="R-data.table", "TRANSLATION CHECK") != "TRANSLATION CHECK")
-      packageStartupMessage(domain="R-data.table", "**********\nRunning data.table in English; package support is available in English only. When searching for online help, be sure to also check for the English error message. This can be obtained by looking at the po/R-<locale>.po and po/<locale>.po files in the package source, where the native language and English error messages can be found side-by-side\n**********")
+      packageStartupMessagef(domain="R-data.table", "**********\nRunning data.table in English; package support is available in English only. When searching for online help, be sure to also check for the English error message. This can be obtained by looking at the po/R-<locale>.po and po/<locale>.po files in the package source, where the native language and English error messages can be found side-by-side\n**********")
     if (dev && (Sys.Date() - as.Date(d))>28L)
-      packageStartupMessage(domain="R-data.table", "**********\nThis development version of data.table was built more than 4 weeks ago. Please update: data.table::update.dev.pkg()\n**********")
+      packageStartupMessagef(domain="R-data.table", "**********\nThis development version of data.table was built more than 4 weeks ago. Please update: data.table::update.dev.pkg()\n**********")
     if (!.Call(ChasOpenMP)) {
-      packageStartupMessage(domain="R-data.table", "**********\nThis installation of data.table has not detected OpenMP support. It should still work but in single-threaded mode.\n", appendLF=FALSE)
+      packageStartupMessagef(domain="R-data.table", "**********\nThis installation of data.table has not detected OpenMP support. It should still work but in single-threaded mode.\n", appendLF=FALSE)
       if (Sys.info()["sysname"] == "Darwin")
-        packageStartupMessage(domain="R-data.table", "This is a Mac. Please read https://mac.r-project.org/openmp/. Please engage with Apple and ask them for support. Check r-datatable.com for updates, and our Mac instructions here: https://github.com/Rdatatable/data.table/wiki/Installation. After several years of many reports of installation problems on Mac, it's time to gingerly point out that there have been no similar problems on Windows or Linux.\n**********")
+        packageStartupMessagef(domain="R-data.table", "This is a Mac. Please read https://mac.r-project.org/openmp/. Please engage with Apple and ask them for support. Check r-datatable.com for updates, and our Mac instructions here: https://github.com/Rdatatable/data.table/wiki/Installation. After several years of many reports of installation problems on Mac, it's time to gingerly point out that there have been no similar problems on Windows or Linux.\n**********")
       else
         packageStartupMessagef(domain="R-data.table", "This is %s. This warning should not normally occur on Windows or Linux where OpenMP is turned on by data.table's configure script by passing -fopenmp to the compiler. If you see this warning on Windows or Linux, please file a GitHub issue.\n**********", Sys.info()["sysname"])
     }

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -9,7 +9,7 @@
   val = getOption("datatable.nomatch")
   if (is.null(val)) return(invisible())  # not set is ideal (it's no longer set in .onLoad)
   if (identical(val, NA) || identical(val, NA_integer_)) return(invisible())  # set to default NA is ok for now; in future possible message/warning asking to remove
-  message("The option 'datatable.nomatch' is being used and is not set to the default NA. This option is still honored for now but will be deprecated in future. Please see NEWS for 1.12.4 for detailed information and motivation. To specify inner join, please specify `nomatch=NULL` explicitly in your calls rather than changing the default using this option.")
+  messagef("The option 'datatable.nomatch' is being used and is not set to the default NA. This option is still honored for now but will be deprecated in future. Please see NEWS for 1.12.4 for detailed information and motivation. To specify inner join, please specify `nomatch=NULL` explicitly in your calls rather than changing the default using this option.")
   .pkg.store$.unsafe.done = TRUE
 }
 
@@ -94,14 +94,14 @@
   }
 
   if (!is.null(getOption("datatable.old.bywithoutby")))
-    warning(domain="R-data.table", "Option 'datatable.old.bywithoutby' has been removed as warned for 2 years. It is now ignored. Please use by=.EACHI instead and stop using this option.")
+    warningf(domain="R-data.table", "Option 'datatable.old.bywithoutby' has been removed as warned for 2 years. It is now ignored. Please use by=.EACHI instead and stop using this option.")
   if (!is.null(getOption("datatable.old.unique.by.key")))
-    warning(domain="R-data.table", "Option 'datatable.old.unique.by.key' has been removed as warned for 4 years. It is now ignored. Please use by=key(DT) instead and stop using this option.")
+    warningf(domain="R-data.table", "Option 'datatable.old.unique.by.key' has been removed as warned for 4 years. It is now ignored. Please use by=key(DT) instead and stop using this option.")
 
   # Test R behaviour that changed in v3.1 and is now depended on
   x = 1L:3L
   y = list(x)
-  if (address(x) != address(y[[1L]])) stop(domain="R-data.table", "Unexpected base R behaviour: list(x) has copied x")
+  if (address(x) != address(y[[1L]])) stopf(domain="R-data.table", "Unexpected base R behaviour: list(x) has copied x")
 
   DF = data.frame(a=1:3, b=4:6)
   add1 = address(DF$a)
@@ -109,7 +109,7 @@
   names(DF) = c("A","B")
   add3 = address(DF$A)
   add4 = address(DF$B)
-  if (add1!=add3 || add2!=add4) stop(domain="R-data.table", "Unexpected base R behaviour: names<- has copied column contents")
+  if (add1!=add3 || add2!=add4) stopf(domain="R-data.table", "Unexpected base R behaviour: names<- has copied column contents")
 
   DF = data.frame(a=1:3, b=4:6)
   add1 = address(DF$a)
@@ -119,10 +119,10 @@
   add4 = address(DF$a)
   add5 = address(DF$b)
   add6 = address(DF)
-  if (add2==add5) stop(domain="R-data.table", "Unexpected base R behaviour: DF[2,2]<- did not copy column 2 which was assigned to")
-  if (add1!=add4) stop(domain="R-data.table", "Unexpected base R behaviour: DF[2,2]<- copied the first column which was not assigned to, too")
+  if (add2==add5) stopf(domain="R-data.table", "Unexpected base R behaviour: DF[2,2]<- did not copy column 2 which was assigned to")
+  if (add1!=add4) stopf(domain="R-data.table", "Unexpected base R behaviour: DF[2,2]<- copied the first column which was not assigned to, too")
 
-  if (add3==add6) warning(domain="R-data.table", "Unexpected base R behaviour: DF[2,2]<- has not copied address(DF)")
+  if (add3==add6) warningf(domain="R-data.table", "Unexpected base R behaviour: DF[2,2]<- has not copied address(DF)")
   # R could feasibly in future not copy DF's vecsxp in this case. If that changes in R, we'd like to know via the warning
   # because tests will likely break too. The warning will quickly tell R-core and us why, so we can then update.
 
@@ -131,11 +131,11 @@
   invisible()
 }
 
-getRversion = function(...) stop("Reminder to data.table developers: don't use getRversion() internally. Add a behaviour test to .onLoad instead.")
+getRversion = function(...) stopf("Reminder to data.table developers: don't use getRversion() internally. Add a behaviour test to .onLoad instead.") # notranslate
 # 1) using getRversion() wasted time when R3.0.3beta was released without the changes we expected in getRversion()>"3.0.2".
 # 2) R-devel and ourselves may wish to tinker with R-devel, turning on and off features in the same version number. So it's better if data.table doesn't hard code expectations into the version number.
 # 3) The discipline of adding a feature test here helps fully understand the change.
-# 4) Defining getRversion with a stop() here helps prevent new switches on getRversion() being added in future. Easily circumvented but the point is to issue the message above.
+# 4) Defining getRversion with a stopf() here helps prevent new switches on getRversion() being added in future. Easily circumvented but the point is to issue the message above.
 
 .onUnload = function(libpath) {
   # fix for #474. the shared object name is different from package name

--- a/R/openmp-utils.R
+++ b/R/openmp-utils.R
@@ -1,6 +1,6 @@
 setDTthreads = function(threads=NULL, restore_after_fork=NULL, percent=NULL, throttle=NULL) {
   if (!missing(percent)) {
-    if (!missing(threads)) stop("Provide either threads= or percent= but not both")
+    if (!missing(threads)) stopf("Provide either threads= or percent= but not both")
     if (length(percent)!=1) stopf("percent= is provided but is length %d", length(percent))
     percent=as.integer(percent)
     if (is.na(percent) || percent<2L || percent>100L) stopf("percent==%d but should be a number between 2 and 100", percent)

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -14,11 +14,11 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
   # class - should column class be printed underneath column name? (FALSE)
   # trunc.cols - should only the columns be printed that can fit in the console? (FALSE)
   if (!col.names %chin% c("auto", "top", "none"))
-    stop("Valid options for col.names are 'auto', 'top', and 'none'")
+    stopf("Valid options for col.names are 'auto', 'top', and 'none'")
   if (length(trunc.cols) != 1L || !is.logical(trunc.cols) || is.na(trunc.cols))
-    stop("Valid options for trunc.cols are TRUE and FALSE")
+    stopf("Valid options for trunc.cols are TRUE and FALSE")
   if (col.names == "none" && class)
-    warning("Column classes will be suppressed when col.names is 'none'")
+    warningf("Column classes will be suppressed when col.names is 'none'")
   if (!shouldPrint(x)) {
     #  := in [.data.table sets .global$print=address(x) to suppress the next print i.e., like <- does. See FAQ 2.22 and README item in v1.9.5
     # The issue is distinguishing "> DT" (after a previous := in a function) from "> DT[,foo:=1]". To print.data.table(), there
@@ -142,7 +142,7 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
 
 format.data.table = function (x, ..., justify="none", timezone = FALSE) {
   if (is.atomic(x) && !is.null(x)) {
-    stop("Internal structure doesn't seem to be a list. Possibly corrupt data.table.")
+    stopf("Internal structure doesn't seem to be a list. Possibly corrupt data.table.")
   }
   format.item = function(x) {
     if (is.null(x))  # NULL item in a list column
@@ -234,9 +234,9 @@ toprint_subset = function(x, cols_to_print) {
 trunc_cols_message = function(not_printed, abbs, class, col.names){
   n = length(not_printed)
   if (class && col.names != "none") classes = paste0(" ", tail(abbs, n)) else classes = ""
-  cat(sprintf(
-    ngettext(n, "%d variable not shown: %s\n", "%d variables not shown: %s\n"),
+  catf(
+    "%d variable(s) not shown: %s\n",
     n, brackify(paste0(not_printed, classes))
-  ))
+  )
 }
 

--- a/R/programming.R
+++ b/R/programming.R
@@ -8,7 +8,7 @@ rm.AsIs = function(x) {
 }
 list2lang = function(x) {
   if (!is.list(x))
-    stop("'x' must be a list")
+    stopf("'x' must be a list")
   if (is.AsIs(x))
     return(rm.AsIs(x))
   asis = vapply(x, is.AsIs, FALSE)
@@ -34,7 +34,7 @@ list2lang = function(x) {
 }
 enlist = function(x) {
   if (!is.list(x))
-    stop("'x' must be a list")
+    stopf("'x' must be a list")
   if (is.AsIs(x))
     return(rm.AsIs(x))
   as.call(c(quote(list), list2lang(x)))
@@ -44,26 +44,26 @@ substitute2 = function(expr, env) {
   if (missing(expr))
     return(substitute())
   if (missing(env)) {
-    stop("'env' must not be missing")
+    stopf("'env' must not be missing")
   } else if (is.null(env)) {
     # null is fine, will be escaped few lines below
   } else if (is.environment(env)) {
     env = as.list(env, all.names=TRUE, sorted=TRUE)
   } else if (!is.list(env)) {
-    stop("'env' must be a list or an environment")
+    stopf("'env' must be a list or an environment")
   }
   if (!length(env)) {
     return(substitute(expr))
   }
   env.names = names(env)
   if (is.null(env.names)) {
-    stop("'env' argument does not have names")
+    stopf("'env' argument does not have names")
   } else if (!all(nzchar(env.names))) {
-    stop("'env' argument has zero char names")
+    stopf("'env' argument has zero char names")
   } else if (anyNA(env.names)) {
-    stop("'env' argument has NA names")
+    stopf("'env' argument has NA names")
   } else if (anyDuplicated(env.names)) {
-    stop("'env' argument has duplicated names")
+    stopf("'env' argument has duplicated names")
   }
   # character to name/symbol, and list to list call
   env = list2lang(env)

--- a/R/setkey.R
+++ b/R/setkey.R
@@ -1,6 +1,6 @@
 setkey = function(x, ..., verbose=getOption("datatable.verbose"), physical=TRUE)
 {
-  if (is.character(x)) stop("x may no longer be the character name of the data.table. The possibility was undocumented and has been removed.")
+  if (is.character(x)) stopf("x may no longer be the character name of the data.table. The possibility was undocumented and has been removed.")
   cols = as.character(substitute(list(...))[-1L])
   if (!length(cols)) { cols=colnames(x) }
   else if (identical(cols,"NULL")) cols=NULL
@@ -20,7 +20,7 @@ setindexv = function(x, cols, verbose=getOption("datatable.verbose")) {
 
 # upgrade to error after Mar 2020. Has already been warning since 2012, and stronger warning in Mar 2019 (note in news for 1.12.2); #3399
 "key<-" = function(x,value) {
-  warning("key(x)<-value is deprecated and not supported. Please change to use setkey() with perhaps copy(). Has been warning since 2012 and will be an error in future.")
+  warningf("key(x)<-value is deprecated and not supported. Please change to use setkey() with perhaps copy(). Has been warning since 2012 and will be an error in future.")
   setkeyv(x,value)
   # The returned value here from key<- is then copied by R before assigning to x, it seems. That's
   # why we can't do anything about it without a change in R itself. If we return NULL (or invisible()) from this key<-
@@ -42,16 +42,16 @@ setkeyv = function(x, cols, verbose=getOption("datatable.verbose"), physical=TRU
     oldverbose = options(datatable.verbose=verbose)
     on.exit(options(oldverbose))
   }
-  if (!is.data.table(x)) stop("x is not a data.table")
-  if (!is.character(cols)) stop("cols is not a character vector. Please see further information in ?setkey.")
-  if (physical && .Call(C_islocked, x)) stop("Setting a physical key on .SD is reserved for possible future use; to modify the original data's order by group. Try setindex() instead. Or, set*(copy(.SD)) as a (slow) last resort.")
+  if (!is.data.table(x)) stopf("x is not a data.table")
+  if (!is.character(cols)) stopf("cols is not a character vector. Please see further information in ?setkey.")
+  if (physical && .Call(C_islocked, x)) stopf("Setting a physical key on .SD is reserved for possible future use; to modify the original data's order by group. Try setindex() instead. Or, set*(copy(.SD)) as a (slow) last resort.")
   if (!length(cols)) {
-    warning("cols is a character vector of zero length. Removed the key, but use NULL instead, or wrap with suppressWarnings() to avoid this warning.")
+    warningf("cols is a character vector of zero length. Removed the key, but use NULL instead, or wrap with suppressWarnings() to avoid this warning.")
     setattr(x,"sorted",NULL)
     return(invisible(x))
   }
-  if (identical(cols,"")) stop("cols is the empty string. Use NULL to remove the key.")
-  if (!all(nzchar(cols))) stop("cols contains some blanks.")
+  if (identical(cols,"")) stopf("cols is the empty string. Use NULL to remove the key.")
+  if (!all(nzchar(cols))) stopf("cols contains some blanks.")
   cols = gsub("`", "", cols, fixed = TRUE)
   miss = !(cols %chin% colnames(x))
   if (any(miss)) stopf("some columns are not in the data.table: %s", brackify(cols[miss]))
@@ -76,12 +76,12 @@ setkeyv = function(x, cols, verbose=getOption("datatable.verbose"), physical=TRU
     return(invisible(x))
   }
 
-  if (".xi" %chin% names(x)) stop("x contains a column called '.xi'. Conflicts with internal use by data.table.")
+  if (".xi" %chin% names(x)) stopf("x contains a column called '.xi'. Conflicts with internal use by data.table.")
   for (i in cols) {
     .xi = x[[i]]  # [[ is copy on write, otherwise checking type would be copying each column
     if (!typeof(.xi) %chin% ORDERING_TYPES) stopf("Column '%s' is type '%s' which is not supported as a key column type, currently.", i, typeof(.xi))
   }
-  if (!is.character(cols) || length(cols)<1L) stop("Internal error. 'cols' should be character at this point in setkey; please report.") # nocov
+  if (!is.character(cols) || length(cols)<1L) stopf("Internal error. 'cols' should be character at this point in setkey; please report.") # nocov
 
   newkey = paste0(cols, collapse="__")
   if (!any(indices(x) == newkey)) {
@@ -142,7 +142,7 @@ haskey = function(x) !is.null(key(x))
 setreordervec = function(x, order) .Call(Creorder, x, order)
 
 # sort = sort.int = sort.list = order = is.unsorted = function(...)
-#    stop("Should never be called by data.table internals. Use is.sorted() on vectors, or forder() for lists and vectors.")
+#    stopf("Should never be called by data.table internals. Use is.sorted() on vectors, or forder() for lists and vectors.")
 # Nice idea, but users might use these in i or j e.g. blocking order caused tests 304 to fail.
 # Maybe just a grep through *.R for use of these function internally would be better (TO DO).
 
@@ -160,7 +160,7 @@ is.sorted = function(x, by=NULL) {
     if (missing(by)) by = seq_along(x)   # wouldn't make sense when x is a vector; hence by=seq_along(x) is not the argument default
     if (is.character(by)) by = chmatch(by, names(x))
   } else {
-    if (!missing(by)) stop("x is vector but 'by' is supplied")
+    if (!missing(by)) stopf("x is vector but 'by' is supplied")
   }
   .Call(Cissorted, x, as.integer(by))
   # Return value of TRUE/FALSE is relied on in [.data.table quite a bit on vectors. Simple. Stick with that (rather than -1/0/+1)
@@ -170,7 +170,7 @@ ORDERING_TYPES = c('logical', 'integer', 'double', 'complex', 'character')
 forderv = function(x, by=seq_along(x), retGrp=FALSE, sort=TRUE, order=1L, na.last=FALSE)
 {
   if (is.atomic(x)) {  # including forderv(NULL) which returns error consistent with base::order(NULL),
-    if (!missing(by) && !is.null(by)) stop("x is a single vector, non-NULL 'by' doesn't make sense")
+    if (!missing(by) && !is.null(by)) stopf("x is a single vector, non-NULL 'by' doesn't make sense")
     by = NULL
   } else {
     if (!length(x)) return(integer(0L)) # e.g. forderv(data.table(NULL)) and forderv(list()) return integer(0L))
@@ -202,12 +202,12 @@ forder = function(..., na.last=TRUE, decreasing=FALSE)
   }
   x = eval(sub[[2L]], parent.frame(), parent.frame())
   if (is.list(x)) {
-    if (length(x)==0L && is.data.frame(x)) stop("Attempting to order a 0-column data.table or data.frame.")
+    if (length(x)==0L && is.data.frame(x)) stopf("Attempting to order a 0-column data.table or data.frame.")
     sub[2L] = NULL  # change list(DT, ...) to list(...)
     if (length(sub)==1L) {
       data = x
     } else {
-      if (!is.data.frame(x)) stop("The first item passed to [f]order is a plain list but there are more items. It should be a data.table or data.frame.")
+      if (!is.data.frame(x)) stopf("The first item passed to [f]order is a plain list but there are more items. It should be a data.table or data.frame.")
       asc = asc[-1L]
       data = eval(sub, x, parent.frame())
     }
@@ -224,7 +224,7 @@ fsort = function(x, decreasing=FALSE, na.last=FALSE, internal=FALSE, verbose=FAL
 {
   containsNAs = FALSE
   if (typeof(x)=="double" && !decreasing && !(containsNAs <- anyNA(x))) {
-      if (internal) stop("Internal code should not be being called on type double")
+      if (internal) stopf("Internal code should not be being called on type double")
       return(.Call(Cfsort, x, verbose))
   }
   else {
@@ -232,9 +232,9 @@ fsort = function(x, decreasing=FALSE, na.last=FALSE, internal=FALSE, verbose=FAL
     # The only places internally we use fsort internally (3 calls, all on integer) have had internal=TRUE added for now.
     # TODO: implement integer and character in Cfsort and remove this branch and warning
     if (!internal){
-      if (typeof(x)!="double") warning("Input is not a vector of type double. New parallel sort has only been done for double vectors so far. Using one thread.")
-      if (decreasing)  warning("New parallel sort has not been implemented for decreasing=TRUE so far. Using one thread.")
-      if (containsNAs) warning("New parallel sort has not been implemented for vectors containing NA values so far. Using one thread.")
+      if (typeof(x)!="double") warningf("Input is not a vector of type double. New parallel sort has only been done for double vectors so far. Using one thread.")
+      if (decreasing)  warningf("New parallel sort has not been implemented for decreasing=TRUE so far. Using one thread.")
+      if (containsNAs) warningf("New parallel sort has not been implemented for vectors containing NA values so far. Using one thread.")
     }
     orderArg = if (decreasing) -1 else 1
     o = forderv(x, order=orderArg, na.last=na.last)
@@ -246,7 +246,7 @@ setorder = function(x, ..., na.last=FALSE)
 # na.last=FALSE here, to be consistent with data.table's default
 # as opposed to DT[order(.)] where na.last=TRUE, to be consistent with base
 {
-  if (!is.data.frame(x)) stop("x must be a data.frame or data.table")
+  if (!is.data.frame(x)) stopf("x must be a data.frame or data.table")
   cols = substitute(list(...))[-1L]
   if (identical(as.character(cols),"NULL")) return(x)
   if (length(cols)) {
@@ -272,25 +272,25 @@ setorder = function(x, ..., na.last=FALSE)
 setorderv = function(x, cols = colnames(x), order=1L, na.last=FALSE)
 {
   if (is.null(cols)) return(x)
-  if (!is.data.frame(x)) stop("x must be a data.frame or data.table")
+  if (!is.data.frame(x)) stopf("x must be a data.frame or data.table")
   na.last = as.logical(na.last)
-  if (is.na(na.last) || !length(na.last)) stop('na.last must be logical TRUE/FALSE')
-  if (!is.character(cols)) stop("cols is not a character vector. Please see further information in ?setorder.")
+  if (is.na(na.last) || !length(na.last)) stopf('na.last must be logical TRUE/FALSE')
+  if (!is.character(cols)) stopf("cols is not a character vector. Please see further information in ?setorder.")
   if (!length(cols)) {
-    warning("cols is a character vector of zero length. Use NULL instead, or wrap with suppressWarnings() to avoid this warning.")
+    warningf("cols is a character vector of zero length. Use NULL instead, or wrap with suppressWarnings() to avoid this warning.")
     return(x)
   }
-  if (!all(nzchar(cols))) stop("cols contains some blanks.")     # TODO: probably I'm checking more than necessary here.. there are checks in 'forderv' as well
+  if (!all(nzchar(cols))) stopf("cols contains some blanks.")     # TODO: probably I'm checking more than necessary here.. there are checks in 'forderv' as well
   # remove backticks from cols
   cols = gsub("`", "", cols, fixed = TRUE)
   miss = !(cols %chin% colnames(x))
   if (any(miss)) stopf("some columns are not in the data.table: %s", brackify(cols[miss]))
-  if (".xi" %chin% colnames(x)) stop("x contains a column called '.xi'. Conflicts with internal use by data.table.")
+  if (".xi" %chin% colnames(x)) stopf("x contains a column called '.xi'. Conflicts with internal use by data.table.")
   for (i in cols) {
     .xi = x[[i]]  # [[ is copy on write, otherwise checking type would be copying each column
     if (!typeof(.xi) %chin% ORDERING_TYPES) stopf("Column '%s' is type '%s' which is not supported for ordering currently.", i, typeof(.xi))
   }
-  if (!is.character(cols) || length(cols)<1L) stop("Internal error. 'cols' should be character at this point in setkey; please report.") # nocov
+  if (!is.character(cols) || length(cols)<1L) stopf("Internal error. 'cols' should be character at this point in setkey; please report.") # nocov
 
   o = forderv(x, cols, sort=TRUE, retGrp=FALSE, order=order, na.last=na.last)
   if (length(o)) {

--- a/R/setops.R
+++ b/R/setops.R
@@ -1,12 +1,12 @@
 # setdiff for data.tables, internal at the moment #547, used in not-join
 setdiff_ = function(x, y, by.x=seq_along(x), by.y=seq_along(y), use.names=FALSE) {
-  if (!is.data.table(x) || !is.data.table(y)) stop("x and y must both be data.tables")
+  if (!is.data.table(x) || !is.data.table(y)) stopf("x and y must both be data.tables")
   # !ncol redundant since all 0-column data.tables have 0 rows
   if (!nrow(x)) return(x)
   by.x = colnamesInt(x, by.x, check_dups=TRUE)
   if (!nrow(y)) return(unique(x, by=by.x))
   by.y = colnamesInt(y, by.y, check_dups=TRUE)
-  if (length(by.x) != length(by.y)) stop("length(by.x) != length(by.y)")
+  if (length(by.x) != length(by.y)) stopf("length(by.x) != length(by.y)")
   # factor in x should've factor/character in y, and viceversa
   for (a in seq_along(by.x)) {
     lc = by.y[a]
@@ -36,13 +36,13 @@ funique = function(x) {
 }
 
 .set_ops_arg_check = function(x, y, all, .seqn = FALSE, block_list = TRUE) {
-  if (!is.logical(all) || length(all) != 1L) stop("argument 'all' should be logical of length one")
-  if (!is.data.table(x) || !is.data.table(y)) stop("x and y must both be data.tables")
-  if (!identical(sort(names(x)), sort(names(y)))) stop("x and y must have the same column names")
-  if (!identical(names(x), names(y))) stop("x and y must have the same column order")
+  if (!is.logical(all) || length(all) != 1L) stopf("argument 'all' should be logical of length one")
+  if (!is.data.table(x) || !is.data.table(y)) stopf("x and y must both be data.tables")
+  if (!identical(sort(names(x)), sort(names(y)))) stopf("x and y must have the same column names")
+  if (!identical(names(x), names(y))) stopf("x and y must have the same column order")
   bad_types = c("raw", "complex", if (block_list) "list")
   found = bad_types %chin% c(vapply_1c(x, typeof), vapply_1c(y, typeof))
-  if (any(found)) stop(domain=NA, sprintf(ngettext(sum(found), "unsupported column type found in x or y: %s", "unsupported column types found in x or y: %s"), brackify(bad_types[found])))
+  if (any(found)) stopf("unsupported column type(s) found in x or y: %s", brackify(bad_types[found]))
   super = function(x) {
     # allow character->factor and integer->numeric because from v1.12.4 i's type is retained by joins, #3820
     ans = class(x)[1L]
@@ -52,7 +52,7 @@ funique = function(x) {
     w = which.first(sx!=sy)
     stopf("Item %d of x is '%s' but the corresponding item of y is '%s'.", w, class(x[[w]])[1L], class(y[[w]])[1L])
   }
-  if (.seqn && ".seqn" %chin% names(x)) stop("None of the datasets should contain a column named '.seqn'")
+  if (.seqn && ".seqn" %chin% names(x)) stopf("None of the datasets should contain a column named '.seqn'")
 }
 
 fintersect = function(x, y, all=FALSE) {
@@ -141,7 +141,7 @@ all.equal.data.table = function(target, current, trim.levels=TRUE, check.attribu
     targetTypes = vapply_1c(target, squashClass)
     currentTypes = vapply_1c(current, squashClass)
     if (length(targetTypes) != length(currentTypes))
-      stop("Internal error: ncol(current)==ncol(target) was checked above") # nocov
+      stopf("Internal error: ncol(current)==ncol(target) was checked above") # nocov
     if (any( d<-(targetTypes != currentTypes))) {
       w = head(which(d),3L)
       return(paste0("Datasets have different column classes. First 3: ",paste(
@@ -185,7 +185,7 @@ all.equal.data.table = function(target, current, trim.levels=TRUE, check.attribu
 
   if (ignore.row.order) {
     if (".seqn" %chin% names(target))
-      stop("None of the datasets to compare should contain a column named '.seqn'")
+      stopf("None of the datasets to compare should contain a column named '.seqn'")
     bad.type = setNames(c("raw","complex","list") %chin% c(vapply_1c(current, typeof), vapply_1c(target, typeof)), c("raw","complex","list"))
     if (any(bad.type))
       stopf("Datasets to compare with 'ignore.row.order' must not have unsupported column types: %s", brackify(names(bad.type)[bad.type]))
@@ -203,7 +203,7 @@ all.equal.data.table = function(target, current, trim.levels=TRUE, check.attribu
         else if (!target_dup && current_dup) msg = c(msg, "Dataset 'current' has duplicate rows while 'target' doesn't")
         else { # both
           if (!identical(tolerance, sqrt(.Machine$double.eps))) # non-default will raise error
-            stop("Duplicate rows in datasets, numeric columns and ignore.row.order cannot be used with non 0 tolerance argument")
+            stopf("Duplicate rows in datasets, numeric columns and ignore.row.order cannot be used with non 0 tolerance argument")
           msg = c(msg, "Both datasets have duplicate rows, they also have numeric columns, together with ignore.row.order this force 'tolerance' argument to 0")
           tolerance = 0
         }
@@ -217,7 +217,7 @@ all.equal.data.table = function(target, current, trim.levels=TRUE, check.attribu
     # handling 'tolerance' for factor cols - those `msg` will be returned only when equality with tolerance will fail
     if (any(vapply_1b(target,is.factor)) && !identical(tolerance, 0)) {
       if (!identical(tolerance, sqrt(.Machine$double.eps))) # non-default will raise error
-        stop("Factor columns and ignore.row.order cannot be used with non 0 tolerance argument")
+        stopf("Factor columns and ignore.row.order cannot be used with non 0 tolerance argument")
       msg = c(msg, "Using factor columns together together with ignore.row.order, this force 'tolerance' argument to 0")
       tolerance = 0
     }
@@ -261,7 +261,7 @@ all.equal.data.table = function(target, current, trim.levels=TRUE, check.attribu
       x = target[[i]]
       y = current[[i]]
       if (xor(is.factor(x),is.factor(y)))
-        stop("Internal error: factor type mismatch should have been caught earlier") # nocov
+        stopf("Internal error: factor type mismatch should have been caught earlier") # nocov
       cols.r = TRUE
       if (is.factor(x)) {
         if (!identical(levels(x),levels(y))) {

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -3,7 +3,7 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
   if (exists("test.data.table", .GlobalEnv,inherits=FALSE)) {
     # package developer
     # nocov start
-    if ("package:data.table" %chin% search()) stop("data.table package is loaded. Unload or start a fresh R session.")
+    if ("package:data.table" %chin% search()) stopf("data.table package is loaded. Unload or start a fresh R session.")
     rootdir = if (pkg!="." && pkg %chin% dir()) file.path(getwd(), pkg) else Sys.getenv("PROJ_PATH")
     subdir = file.path("inst","tests")
     # nocov end
@@ -16,7 +16,7 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
 
   stopifnot(is.character(script), length(script)==1L, !is.na(script), nzchar(script))
   if (!grepl(".Rraw$", script))
-    stop("script must end with '.Rraw'. If a file ending '.Rraw.bz2' exists, that will be found and used.") # nocov
+    stopf("script must end with '.Rraw'. If a file ending '.Rraw.bz2' exists, that will be found and used.") # nocov
 
   if (identical(script,"*.Rraw")) {
     # nocov start
@@ -160,16 +160,11 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
   ntest = env$ntest
   if (nfail > 0L) {
     # nocov start
-    # domain=NA since it's already translated by then
-    stop(domain = NA, sprintf(
-      ngettext(
-        nfail,
-        "%d error out of %d. Search %s for test number %s",
-        "%d errors out of %d. Search %s for test numbers %s"
-      ),
+    stopf(
+      "%d error(s) out of %d. Search %s for test number(s) %s",
       nfail, ntest, names(fn), toString(env$whichfail)
-    ))
-    # important to stop() here, so that 'R CMD check' fails
+    )
+    # important to stopf() here, so that 'R CMD check' fails
     # nocov end
   }
 
@@ -204,7 +199,7 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
   #    graphics::par(p)
   #    grDevices::dev.off()
   #  } else {
-  #    warning("test.data.table runs with memory testing but did not collect any memory statistics.")
+  #    warningf("test.data.table runs with memory testing but did not collect any memory statistics.")
   #  }
   #}
   #if (memtest<-get("memtest", envir=env)) memtest.plot(get("inittime", envir=env))

--- a/R/timetaken.R
+++ b/R/timetaken.R
@@ -1,6 +1,6 @@
 timetaken = function(started.at)
 {
-  if (!inherits(started.at,"proc_time")) stop("Use started.at=proc.time() not Sys.time() (POSIXt and slow)")  # nocov
+  if (!inherits(started.at,"proc_time")) stopf("Use started.at=proc.time() not Sys.time() (POSIXt and slow)")  # nocov
   format = function(secs) {
     if (secs > 60.0) {
       secs = as.integer(secs)

--- a/R/transpose.R
+++ b/R/transpose.R
@@ -25,7 +25,7 @@ transpose = function(l, fill=NA, ignore.empty=FALSE, keep.names=NULL, make.names
 
 tstrsplit = function(x, ..., fill=NA, type.convert=FALSE, keep, names=FALSE) {
   if (!isTRUEorFALSE(names) && !is.character(names))
-    stop("'names' must be TRUE/FALSE or a character vector.")
+    stopf("'names' must be TRUE/FALSE or a character vector.")
   ans = transpose(strsplit(as.character(x), ...), fill=fill, ignore.empty=FALSE)
   if (!missing(keep)) {
     keep = suppressWarnings(as.integer(keep))

--- a/R/uniqlist.R
+++ b/R/uniqlist.R
@@ -9,7 +9,7 @@ uniqlist = function (l, order = -1L)
   #    TRUE has the last in a sequence of dups FALSE (so you can keep the last if that's required)
   # l = list(...)
   if (!is.list(l))
-    stop("l not type list")
+    stopf("l not type list")
   if (!length(l))  return(list(0L))
   ans = .Call(Cuniqlist, l, as.integer(order))
   ans

--- a/R/utils.R
+++ b/R/utils.R
@@ -15,10 +15,10 @@ isTRUEorFALSE = function(x) is.logical(x) && length(x)==1L && !is.na(x)
 allNA = function(x) .Call(C_allNAR, x)
 # helper for nan argument (e.g. nafill): TRUE -> treat NaN as NA
 nan_is_na = function(x) {
-  if (length(x) != 1L) stop("Argument 'nan' must be length 1")
+  if (length(x) != 1L) stopf("Argument 'nan' must be length 1")
   if (identical(x, NA) || identical(x, NA_real_)) return(TRUE)
   if (identical(x, NaN)) return(FALSE)
-  stop("Argument 'nan' must be NA or NaN")
+  stopf("Argument 'nan' must be NA or NaN")
 }
 
 if (base::getRversion() < "3.2.0") {  # Apr 2015
@@ -36,7 +36,7 @@ if (!exists('endsWith', 'package:base', inherits=FALSE)) {
 which.first = function(x)
 {
   if (!is.logical(x)) {
-    stop("x not boolean")
+    stopf("x not boolean")
   }
   match(TRUE, x)
 }
@@ -45,7 +45,7 @@ which.first = function(x)
 which.last = function(x)
 {
   if (!is.logical(x)) {
-    stop("x not boolean")
+    stopf("x not boolean")
   }
   length(x) - match(TRUE, rev(x)) + 1L
 }
@@ -56,7 +56,7 @@ require_bit64_if_needed = function(DT) {
     # nocov start
     # a test was attempted to cover the requireNamespace() by using unloadNamespace() first, but that fails when nanotime is loaded because nanotime also uses bit64
     if (!requireNamespace("bit64",quietly=TRUE)) {
-      warning("Some columns are type 'integer64' but package bit64 is not installed. Those columns will print as strange looking floating point data. There is no need to reload the data. Simply install.packages('bit64') to obtain the integer64 print method and print the data again.")
+      warningf("Some columns are type 'integer64' but package bit64 is not installed. Those columns will print as strange looking floating point data. There is no need to reload the data. Simply install.packages('bit64') to obtain the integer64 print method and print the data again.")
     }
     # nocov end
   }

--- a/R/xts.R
+++ b/R/xts.R
@@ -1,7 +1,7 @@
 as.data.table.xts = function(x, keep.rownames = TRUE, key=NULL, ...) {
   stopifnot(requireNamespace("xts"), !missing(x), xts::is.xts(x))
-  if (length(keep.rownames) != 1L) stop("keep.rownames must be length 1")
-  if (is.na(keep.rownames)) stop("keep.rownames must not be NA")
+  if (length(keep.rownames) != 1L) stopf("keep.rownames must be length 1")
+  if (is.na(keep.rownames)) stopf("keep.rownames must not be NA")
   # as.data.frame.xts will handle copying, and
   #   the error check above ensures as.data.frame.xts is applied
   r = setDT(as.data.frame(x, row.names=NULL))
@@ -17,7 +17,7 @@ as.data.table.xts = function(x, keep.rownames = TRUE, key=NULL, ...) {
 
 as.xts.data.table = function(x, ...) {
   stopifnot(requireNamespace("xts"), !missing(x), is.data.table(x))
-  if (!xts::is.timeBased(x[[1L]])) stop("data.table must have a time based column in first position, use `setcolorder` function to change the order, or see ?timeBased for supported types")
+  if (!xts::is.timeBased(x[[1L]])) stopf("data.table must have a time based column in first position, use `setcolorder` function to change the order, or see ?timeBased for supported types")
   colsNumeric = vapply_1b(x, is.numeric)[-1L] # exclude first col, xts index
   if (!all(colsNumeric)) warningf("Following columns are not numeric and will be omitted: %s", brackify(names(colsNumeric)[!colsNumeric]))
   r = setDF(x[, .SD, .SDcols = names(colsNumeric)[colsNumeric]])

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -8395,13 +8395,13 @@ DT0 = data.table(NULL)
 DT1 = data.table(a=1)
 test(1601.1, merge(DT1, DT1, by="a"), data.table(a=1, key="a"))
 test(1601.2, merge(DT1, DT0, by="a"),
-     warning="You are trying to join data.tables where 'y' has 0 columns.",
+     warning="Input data.table 'y' has no columns.",
      error="Elements listed in `by`")
 test(1601.3, merge(DT0, DT1, by="a"),
-     warning="You are trying to join data.tables where 'x' has 0 columns.",
+     warning="Input data.table 'x' has no columns.",
      error="Elements listed in `by`")
 test(1601.4, merge(DT0, DT0, by="a"),
-     warning="You are trying to join data.tables where 'x' and 'y' have 0 columns.",
+     warning="Neither of the input data.tables to join have columns.",
      error="Elements listed in `by`")
 
 # fix for #1549
@@ -8845,26 +8845,26 @@ test(1626.45, nrow(fsetdiff(dt[rep(1L,4)], dt[rep(1L,5)], all=TRUE)), 0L)
 dt = data.table(V1 = 1:4, V2 = letters[1:4], V3 = lapply(1:4, function(x) new.env()))
 x = dt[c(2:4,2L,2L)]
 y = dt[c(1:3,2L)]
-test(1626.46, fintersect(x, y), error = "unsupported column type found in x or y: [list]")
-test(1626.47, fintersect(x, y, all=TRUE), error = "unsupported column type found in x or y: [list]")
-test(1626.48, fsetdiff(x, y), error = "unsupported column type found in x or y: [list]")
-test(1626.49, fsetdiff(x, y, all=TRUE), error = "unsupported column type found in x or y: [list]")
-test(1626.50, funion(x, y), error = "unsupported column type found in x or y: [list]")
+test(1626.46, fintersect(x, y), error = "unsupported column type(s) found in x or y: [list]")
+test(1626.47, fintersect(x, y, all=TRUE), error = "unsupported column type(s) found in x or y: [list]")
+test(1626.48, fsetdiff(x, y), error = "unsupported column type(s) found in x or y: [list]")
+test(1626.49, fsetdiff(x, y, all=TRUE), error = "unsupported column type(s) found in x or y: [list]")
+test(1626.50, funion(x, y), error = "unsupported column type(s) found in x or y: [list]")
 test(1626.51, funion(x, y, all=TRUE), dt[c(2:4,2L,2L,1:3,2L)])
-test(1626.52, fsetequal(x, y), error = "unsupported column type found in x or y: [list]")
-test(1626.53, fsetequal(dt[c(1:2,2L)], dt[c(1:2,2L)]), error = "unsupported column type found in x or y: [list]")
+test(1626.52, fsetequal(x, y), error = "unsupported column type(s) found in x or y: [list]")
+test(1626.53, fsetequal(dt[c(1:2,2L)], dt[c(1:2,2L)]), error = "unsupported column type(s) found in x or y: [list]")
 # unsupported type in set-ops: complex, raw
 dt = data.table(V1 = 1:4, V2 = letters[1:4], V3 = as.complex(1:4), V4 = as.raw(1:4), V5 = lapply(1:4, function(x) NULL))
 x = dt[c(2:4,2L,2L)]
 y = dt[c(1:3,2L)]
-test(1626.54, fintersect(x, y), error = "unsupported column types found in x or y: [raw, complex, list]")
-test(1626.55, fintersect(x, y, all=TRUE), error = "unsupported column types found in x or y: [raw, complex, list]")
-test(1626.56, fsetdiff(x, y), error = "unsupported column types found in x or y: [raw, complex, list]")
-test(1626.57, fsetdiff(x, y, all=TRUE), error = "unsupported column types found in x or y: [raw, complex, list]")
-test(1626.58, funion(x, y), error = "unsupported column types found in x or y: [raw, complex, list]")
-test(1626.59, funion(x, y, all=TRUE), error = "unsupported column types found in x or y: [raw, complex]") # no 'list' here which is supported for `all=TRUE`
-test(1626.60, fsetequal(x, y), error = "unsupported column types found in x or y: [raw, complex, list]")
-test(1626.61, fsetequal(dt[c(1:2,2L)], dt[c(1:2,2L)]), error = "unsupported column types found in x or y: [raw, complex, list]")
+test(1626.54, fintersect(x, y), error = "unsupported column type(s) found in x or y: [raw, complex, list]")
+test(1626.55, fintersect(x, y, all=TRUE), error = "unsupported column type(s) found in x or y: [raw, complex, list]")
+test(1626.56, fsetdiff(x, y), error = "unsupported column type(s) found in x or y: [raw, complex, list]")
+test(1626.57, fsetdiff(x, y, all=TRUE), error = "unsupported column type(s) found in x or y: [raw, complex, list]")
+test(1626.58, funion(x, y), error = "unsupported column type(s) found in x or y: [raw, complex, list]")
+test(1626.59, funion(x, y, all=TRUE), error = "unsupported column type(s) found in x or y: [raw, complex]") # no 'list' here which is supported for `all=TRUE`
+test(1626.60, fsetequal(x, y), error = "unsupported column type(s) found in x or y: [raw, complex, list]")
+test(1626.61, fsetequal(dt[c(1:2,2L)], dt[c(1:2,2L)]), error = "unsupported column type(s) found in x or y: [raw, complex, list]")
 # supported types multi column test
 dt = data.table(
   V1 = 1:4,
@@ -13310,9 +13310,9 @@ test(1952.2, d1[a==2, 2, which=TRUE], error="which==TRUE.*but j is also supplied
 # 3106 -- melt patterns don't match any columns (and more coverage tests)
 DT = data.table(id = 1:3, a1 = rnorm(3), a2 = rnorm(3))
 test(1953.1, melt(DT, id.vars = 'id', measure.vars = patterns(a = 'a', b = 'b')),
-             error = 'Pattern not found')
+             error = 'Pattern(s) not found')
 test(1953.2, melt(DT, id.vars = 'id', measure.vars = patterns(a = 'a', b = 'b', c = 'c')),
-             error = 'Patterns not found')
+             error = 'Pattern(s) not found')
 test(1953.3, melt(DT, id.vars = 'id', measure.vars = patterns(1L)),
              error = 'Input patterns must be of type character')
 setDF(DT)
@@ -16785,7 +16785,7 @@ DT = data.table(a = "aaaaaaaaaaaaa",
                 d = "ddddddddddddd")
 test(2125.01,
      capture.output(print(DT, trunc.cols=TRUE))[3L],
-     "2 variables not shown: [c, d]")
+     "2 variable(s) not shown: [c, d]")
 # Printing with dots
 DT = data.table(a = vector("integer", 102L),
                 b = "bbbbbbbbbbbbb",
@@ -16804,7 +16804,7 @@ test(2125.02, capture.output(print(DT, trunc.cols=TRUE)),
        "100: 0 bbbbbbbbbbbbb ccccccccccccc",
        "101: 0 bbbbbbbbbbbbb ccccccccccccc",
        "102: 0 bbbbbbbbbbbbb ccccccccccccc",
-       "1 variable not shown: [d]"))
+       "1 variable(s) not shown: [d]"))
 test(2125.03, capture.output(print(DT, trunc.cols=TRUE, row.names=FALSE)),
      c("    a             b             c",
        "    0 bbbbbbbbbbbbb ccccccccccccc",
@@ -16818,22 +16818,22 @@ test(2125.03, capture.output(print(DT, trunc.cols=TRUE, row.names=FALSE)),
        "    0 bbbbbbbbbbbbb ccccccccccccc",
        "    0 bbbbbbbbbbbbb ccccccccccccc",
        "    0 bbbbbbbbbbbbb ccccccccccccc",
-       "1 variable not shown: [d]" ))
+       "1 variable(s) not shown: [d]" ))
 # also testing #4266 -- getting width of row #s register right
 #   TODO: understand why 2 variables truncated here. a,b,c combined have width
 #     _exactly_ 40, but still wraps. If we set options(width=41) it won't truncate.
 #     seems to be an issue with print.default.
 test(2125.04, capture.output(print(DT, trunc.cols=TRUE, class=TRUE))[14L],
-     "2 variables not shown: [c <char>, d <char>]")
+     "2 variable(s) not shown: [c <char>, d <char>]")
 test(2125.05, capture.output(print(DT, trunc.cols=TRUE, class=TRUE, row.names=FALSE))[c(1,14)],
      c("        a             b             c",
-       "1 variable not shown: [d <char>]" ))
+       "1 variable(s) not shown: [d <char>]" ))
 test(2125.06, capture.output(print(DT, trunc.cols=TRUE, col.names="none"))[c(1,12)],
      c("  1: 0 bbbbbbbbbbbbb ccccccccccccc",
-       "1 variable not shown: [d]" ))
+       "1 variable(s) not shown: [d]" ))
 test(2125.07, capture.output(print(DT, trunc.cols=TRUE, class=TRUE, col.names="none"))[c(1,13)],
      c("  1: 0 bbbbbbbbbbbbb",
-       "2 variables not shown: [c, d]" ),
+       "2 variable(s) not shown: [c, d]" ),
      warning = "Column classes will be suppressed when col.names is 'none'")
 options("width" = 20)
 DT = data.table(a = vector("integer", 2),
@@ -16844,16 +16844,16 @@ test(2125.08, capture.output(print(DT, trunc.cols=TRUE)),
      c("   a             b",
        "1: 0 bbbbbbbbbbbbb",
        "2: 0 bbbbbbbbbbbbb",
-       "2 variables not shown: [c, d]"))
+       "2 variable(s) not shown: [c, d]"))
 options("width" = 10)
 DT = data.table(a = "aaaaaaaaaaaaa",
                 b = "bbbbbbbbbbbbb",
                 c = "ccccccccccccc",
                 d = "ddddddddddddd")
 test(2125.09, capture.output(print(DT, trunc.cols=TRUE)),
-     "4 variables not shown: [a, b, c, d]")
+     "4 variable(s) not shown: [a, b, c, d]")
 test(2125.10, capture.output(print(DT, trunc.cols=TRUE, class=TRUE)),
-     "4 variables not shown: [a <char>, b <char>, c <char>, d <char>]")
+     "4 variable(s) not shown: [a <char>, b <char>, c <char>, d <char>]")
 options(old_width)
 
 # segfault when i is NULL or zero-column, #4060


### PR DESCRIPTION
Follow-up to #5056

There is one more `ngettext()` usage left:

https://github.com/Rdatatable/data.table/blob/1759f3c750e90c2313fbec065b96231a17e68e8c/R/print.data.table.R#L51

I think `Index(ices)` or whatever the workaround would be is too awkward in this case.

One concern with moving to this style is that, because things will be sent to `gettextf()` (which wraps `sprintf(gettext())`), all strings will be `sprintf()`-interpreted, meaning `%` in error messages needs extra care. I just checked the existing message base & seems we're safe from that concern, so it would have to be something that creeps in later, which seems less likely.

I also left a lot of `cat()` usages not converted to `catf()`.

Actually almost all of them look like:

```
R/data.table.R:532:          if (verbose) {cat(timetaken(last.started.at),"\n"); flush.console()}
```

I am thinking it would be prudent to wrap this whole operation in its own helper. Leaving that for a different PR.

PS I considered adding a line in onLoad.R similar to this:

https://github.com/Rdatatable/data.table/blob/1759f3c750e90c2313fbec065b96231a17e68e8c/R/onLoad.R#L134

To turn help steer internal usage towards `stopf()/warningf()/messagef()` while we all get used to it, and to steer less frequent/new contributors. But that would mean we need to qualify `base::stop()`/base::warning()/`base::messagef()` in translations.R. Figured it's not worth it; added a TODO in #4278 to tackle it that way instead.