### PR TITLE
Set default domain="R-data.table" explicitly for translation functions

### DIFF
--- a/R/onAttach.R
+++ b/R/onAttach.R
@@ -18,24 +18,22 @@
   }
   dev = as.integer(v[1L, 3L]) %% 2L == 1L  # version number odd => dev
   if (!isTRUE(getOption("datatable.quiet"))) {   # new option in v1.12.4, #3489
-    # NB: we need to supply domain= for translation below since the below is technically not run in the data.table namespace
     nth = getDTthreads(verbose=FALSE)
     if (dev)
-      packageStartupMessagef(domain="R-data.table", "data.table %s IN DEVELOPMENT built %s%s using %d threads (see ?getDTthreads).  ", v, d, g, nth, appendLF=FALSE)
+      packageStartupMessagef("data.table %s IN DEVELOPMENT built %s%s using %d threads (see ?getDTthreads).  ", v, d, g, nth, appendLF=FALSE)
     else 
-      packageStartupMessagef(domain="R-data.table", "data.table %s using %d threads (see ?getDTthreads).  ", v, nth, appendLF=FALSE)
-    packageStartupMessagef(domain="R-data.table", "Latest news: r-datatable.com")
-    # NB: domain= is necessary in .onAttach and .onLoad, see ?gettext and https://bugs.r-project.org/bugzilla/show_bug.cgi?id=18092.
-    if (gettext(domain="R-data.table", "TRANSLATION CHECK") != "TRANSLATION CHECK")
-      packageStartupMessagef(domain="R-data.table", "**********\nRunning data.table in English; package support is available in English only. When searching for online help, be sure to also check for the English error message. This can be obtained by looking at the po/R-<locale>.po and po/<locale>.po files in the package source, where the native language and English error messages can be found side-by-side\n**********")
+      packageStartupMessagef("data.table %s using %d threads (see ?getDTthreads).  ", v, nth, appendLF=FALSE)
+    packageStartupMessagef("Latest news: r-datatable.com")
+    if (gettext("TRANSLATION CHECK") != "TRANSLATION CHECK")
+      packageStartupMessagef("**********\nRunning data.table in English; package support is available in English only. When searching for online help, be sure to also check for the English error message. This can be obtained by looking at the po/R-<locale>.po and po/<locale>.po files in the package source, where the native language and English error messages can be found side-by-side\n**********")
     if (dev && (Sys.Date() - as.Date(d))>28L)
-      packageStartupMessagef(domain="R-data.table", "**********\nThis development version of data.table was built more than 4 weeks ago. Please update: data.table::update.dev.pkg()\n**********")
+      packageStartupMessagef("**********\nThis development version of data.table was built more than 4 weeks ago. Please update: data.table::update.dev.pkg()\n**********")
     if (!.Call(ChasOpenMP)) {
-      packageStartupMessagef(domain="R-data.table", "**********\nThis installation of data.table has not detected OpenMP support. It should still work but in single-threaded mode.\n", appendLF=FALSE)
+      packageStartupMessagef("**********\nThis installation of data.table has not detected OpenMP support. It should still work but in single-threaded mode.\n", appendLF=FALSE)
       if (Sys.info()["sysname"] == "Darwin")
-        packageStartupMessagef(domain="R-data.table", "This is a Mac. Please read https://mac.r-project.org/openmp/. Please engage with Apple and ask them for support. Check r-datatable.com for updates, and our Mac instructions here: https://github.com/Rdatatable/data.table/wiki/Installation. After several years of many reports of installation problems on Mac, it's time to gingerly point out that there have been no similar problems on Windows or Linux.\n**********")
+        packageStartupMessagef("This is a Mac. Please read https://mac.r-project.org/openmp/. Please engage with Apple and ask them for support. Check r-datatable.com for updates, and our Mac instructions here: https://github.com/Rdatatable/data.table/wiki/Installation. After several years of many reports of installation problems on Mac, it's time to gingerly point out that there have been no similar problems on Windows or Linux.\n**********")
       else
-        packageStartupMessagef(domain="R-data.table", "This is %s. This warning should not normally occur on Windows or Linux where OpenMP is turned on by data.table's configure script by passing -fopenmp to the compiler. If you see this warning on Windows or Linux, please file a GitHub issue.\n**********", Sys.info()["sysname"])
+        packageStartupMessagef("This is %s. This warning should not normally occur on Windows or Linux where OpenMP is turned on by data.table's configure script by passing -fopenmp to the compiler. If you see this warning on Windows or Linux, please file a GitHub issue.\n**********", Sys.info()["sysname"])
     }
   }
 }

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -25,12 +25,11 @@
     if (dllV != RV) {
       dll = if (.Platform$OS.type=="windows") "dll" else "so"
       # https://bugs.r-project.org/bugzilla/show_bug.cgi?id=17478
-      # NB: domain= is necessary in .onAttach and .onLoad, see ?gettext and https://bugs.r-project.org/bugzilla/show_bug.cgi?id=18092.
-      stopf(domain="R-data.table", "The datatable.%s version (%s) does not match the package (%s). Please close all R sessions to release the old %s and reinstall data.table in a fresh R session. The root cause is that R's package installer can in some unconfirmed circumstances leave a package in a state that is apparently functional but where new R code is calling old C code silently: https://bugs.r-project.org/bugzilla/show_bug.cgi?id=17478. Once a package is in this mismatch state it may produce wrong results silently until you next upgrade the package. Please help by adding precise circumstances to 17478 to move the status to confirmed. This mismatch between R and C code can happen with any package not just data.table. It is just that data.table has added this check.", dll, dllV, RV, toupper(dll))
+      stopf("The datatable.%s version (%s) does not match the package (%s). Please close all R sessions to release the old %s and reinstall data.table in a fresh R session. The root cause is that R's package installer can in some unconfirmed circumstances leave a package in a state that is apparently functional but where new R code is calling old C code silently: https://bugs.r-project.org/bugzilla/show_bug.cgi?id=17478. Once a package is in this mismatch state it may produce wrong results silently until you next upgrade the package. Please help by adding precise circumstances to 17478 to move the status to confirmed. This mismatch between R and C code can happen with any package not just data.table. It is just that data.table has added this check.", dll, dllV, RV, toupper(dll))
     }
     builtUsing = readRDS(system.file("Meta/package.rds",package="data.table"))$Built$R
     if (!identical(base::getRversion()>="4.0.0", builtUsing>="4.0.0")) {
-      stopf(domain="R-data.table", "This is R %s but data.table has been installed using R %s. The major version must match. Please reinstall data.table.", base::getRversion(), builtUsing)
+      stopf("This is R %s but data.table has been installed using R %s. The major version must match. Please reinstall data.table.", base::getRversion(), builtUsing)
       # the if(R>=4.0.0) in NAMESPACE when registering S3 methods rbind.data.table and cbind.data.table happens on install; #3968
     }
   }
@@ -94,14 +93,14 @@
   }
 
   if (!is.null(getOption("datatable.old.bywithoutby")))
-    warningf(domain="R-data.table", "Option 'datatable.old.bywithoutby' has been removed as warned for 2 years. It is now ignored. Please use by=.EACHI instead and stop using this option.")
+    warningf("Option 'datatable.old.bywithoutby' has been removed as warned for 2 years. It is now ignored. Please use by=.EACHI instead and stop using this option.")
   if (!is.null(getOption("datatable.old.unique.by.key")))
-    warningf(domain="R-data.table", "Option 'datatable.old.unique.by.key' has been removed as warned for 4 years. It is now ignored. Please use by=key(DT) instead and stop using this option.")
+    warningf("Option 'datatable.old.unique.by.key' has been removed as warned for 4 years. It is now ignored. Please use by=key(DT) instead and stop using this option.")
 
   # Test R behaviour that changed in v3.1 and is now depended on
   x = 1L:3L
   y = list(x)
-  if (address(x) != address(y[[1L]])) stopf(domain="R-data.table", "Unexpected base R behaviour: list(x) has copied x")
+  if (address(x) != address(y[[1L]])) stopf("Unexpected base R behaviour: list(x) has copied x")
 
   DF = data.frame(a=1:3, b=4:6)
   add1 = address(DF$a)
@@ -109,7 +108,7 @@
   names(DF) = c("A","B")
   add3 = address(DF$A)
   add4 = address(DF$B)
-  if (add1!=add3 || add2!=add4) stopf(domain="R-data.table", "Unexpected base R behaviour: names<- has copied column contents")
+  if (add1!=add3 || add2!=add4) stopf("Unexpected base R behaviour: names<- has copied column contents")
 
   DF = data.frame(a=1:3, b=4:6)
   add1 = address(DF$a)
@@ -119,10 +118,10 @@
   add4 = address(DF$a)
   add5 = address(DF$b)
   add6 = address(DF)
-  if (add2==add5) stopf(domain="R-data.table", "Unexpected base R behaviour: DF[2,2]<- did not copy column 2 which was assigned to")
-  if (add1!=add4) stopf(domain="R-data.table", "Unexpected base R behaviour: DF[2,2]<- copied the first column which was not assigned to, too")
+  if (add2==add5) stopf("Unexpected base R behaviour: DF[2,2]<- did not copy column 2 which was assigned to")
+  if (add1!=add4) stopf("Unexpected base R behaviour: DF[2,2]<- copied the first column which was not assigned to, too")
 
-  if (add3==add6) warningf(domain="R-data.table", "Unexpected base R behaviour: DF[2,2]<- has not copied address(DF)")
+  if (add3==add6) warningf("Unexpected base R behaviour: DF[2,2]<- has not copied address(DF)")
   # R could feasibly in future not copy DF's vecsxp in this case. If that changes in R, we'd like to know via the warning
   # because tests will likely break too. The warning will quickly tell R-core and us why, so we can then update.
 

--- a/R/translation.R
+++ b/R/translation.R
@@ -1,21 +1,21 @@
 # templated warning/error functions to smooth translation & development
 
-catf = function(fmt, ..., sep=" ", domain=NULL) {
+catf = function(fmt, ..., sep=" ", domain="R-data.table") {
   cat(gettextf(fmt, ..., domain=domain), sep=sep)
 }
 
-stopf = function(fmt, ..., domain=NULL) {
+stopf = function(fmt, ..., domain="R-data.table") {
   stop(gettextf(fmt, ..., domain=domain), domain=NA, call. = FALSE)
 }
 
-warningf = function(fmt, ..., immediate.=FALSE, noBreaks.=FALSE, domain=NULL) {
+warningf = function(fmt, ..., immediate.=FALSE, noBreaks.=FALSE, domain="R-data.table") {
   warning(gettextf(fmt, ..., domain=domain), domain=NA, call.=FALSE, immediate.=immediate., noBreaks.=noBreaks.)
 }
 
-messagef = function(fmt, ..., appendLF=TRUE, domain=NULL) {
+messagef = function(fmt, ..., appendLF=TRUE, domain="R-data.table") {
   message(gettextf(fmt, ..., domain=domain), domain=NA, appendLF=appendLF)
 }
 
-packageStartupMessagef = function(fmt, ..., appendLF=TRUE, domain=NULL) {
+packageStartupMessagef = function(fmt, ..., appendLF=TRUE, domain="R-data.table") {
   packageStartupMessage(gettextf(fmt, ..., domain=domain), domain=NA, appendLF=appendLF)
 }


### PR DESCRIPTION
@eliocamp helped point out that messages within `print()` are not translated, apparently for similar reasons as why `onAttach()`/`onLoad()` aren't -- it seems because `print()` is a base method, it looks for messages in the base domain. That sounds weird to me, but it is what it is.

See this thread starting from Elio's post:

https://twitter.com/d_olivaw/status/1414673149875179523

And my subsequent post to r-devel pointing out the potential error:

https://stat.ethz.ch/pipermail/r-devel/2021-July/080913.html

Anyway, we can sidestep this by always supplying the `domain`. As a bonus, a quick benchmark shows it's about a 10x speedup to do so:

```
# on current master
microbenchmark::microbenchmark(times = 1e5, tryCatch(print(as.data.table(mtcars), col.names = 'ijiji'), error=identity))
# Unit: microseconds
#                                                                           expr
#  tryCatch(print(as.data.table(mtcars), col.names = "ijiji"), error = identity)
#      min       lq     mean   median      uq      max neval
#  155.327 164.9255 185.2734 169.9765 174.553 28580.92 1e+05
```

vs

```
# on this branch
microbenchmark::microbenchmark(times = 1e5, tryCatch(print(as.data.table(mtcars), col.names = 'ijiji'), error=identity))
# Unit: microseconds
#                                                                           expr
#  tryCatch(print(as.data.table(mtcars), col.names = "ijiji"), error = identity)
#     min     lq     mean median     uq      max neval
#  13.517 14.874 16.54797 15.306 15.895 3358.671 1e+05
```

PS we still have some `gettext()`/`gettextf()` calls (especially in setops.R) -- maybe we should write a quick `DTgettext` / `DTgettextf` wrapper for those to get default domains there too? The cost is yet another internal helper...