### PR TITLE
tidy plyr::arrange (not dplyr) comments and test

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -150,7 +150,7 @@ replace_dot_alias = function(e) {
         else if (missing(drop)) `[.data.frame`(x,i,j)
         else `[.data.frame`(x,i,j,drop)
     # added is.data.table(ans) check to fix bug #81
-    if (!missing(i) && is.data.table(ans)) setkey(ans, NULL)  # See test 304
+    if (!missing(i) && is.data.table(ans)) setkey(ans, NULL)  # drops index too; tested by plyr::arrange test in other.Rraw
     return(ans)
   }
   if (!missing(verbose)) {

--- a/inst/tests/other.Rraw
+++ b/inst/tests/other.Rraw
@@ -1,11 +1,8 @@
-
-# Usage: require(data.table); test.data.table(with.other.packages=TRUE)
-
-if (exists("test.data.table",.GlobalEnv,inherits=FALSE)) {
-  warning("This is dev where with.other.packages should not be run. Instead, use a fresh R session with data.table installed. ",
-          "Not doing so in dev can be the cause of both false errors and false passes.")
+if (exists("test.data.table",.GlobalEnv,inherits=FALSE) ||
+    !"package:data.table" %in% search()) {
+  stop("Usage: R CMD INSTALL; require(data.table); test.data.table('other.Rraw')")
+  # running other.Raw in dev mode (i.e. when data.table is not installed) is not intended to work
 }
-if (!"package:data.table" %in% search()) stop("data.table should be already attached. Usage: require(data.table); test.data.table(with.other.packages=TRUE)")
 
 test = data.table:::test
 INT = data.table:::INT
@@ -57,9 +54,10 @@ if (loaded[["ggplot2"]]) {
 }
 
 if (loaded[["plyr"]]) {
-  # Test key is dropped when non-dt-aware packages (here, plyr) reorders rows of data.table.
+  # Test key and indices are dropped when non-dt-aware packages (here, plyr) reorders rows of data.table.
   DT = data.table(a=1:10,b=1:2,key="a")
-  test(2, arrange(DT,b), data.table(a=INT(1,3,5,7,9,2,4,6,8,10),b=INT(1,1,1,1,1,2,2,2,2,2), key=NULL))
+  setindex(DT, b)
+  test(2, arrange(DT,b), data.table(a=INT(1,3,5,7,9,2,4,6,8,10),b=INT(1,1,1,1,1,2,2,2,2,2)))
 }
 
 if (FALSE) {  # loaded[["reshape"]]
@@ -75,7 +73,7 @@ if (FALSE) {  # loaded[["reshape"]]
 if (loaded[["caret"]]) {
   # Fix for #476
   # caret seems heavy (plyr, reshape2 and withr). win-builder halts at this point consistently, but we pass on Travis and locally.
-  # So I put the win-builder fail down to resource issues and moved this test into test.data.table(with.other.packages=TRUE).
+  # So I put the win-builder fail down to resource issues and moved this test into test.data.table("other.Rraw").
   DT = data.table(x = rnorm(10), y = rnorm(10))
   cv.ctrl = trainControl(method = 'repeatedcv', number = 5, repeats = 1)
   fit = train(y ~ x, data = DT, 'lm', trControl = cv.ctrl)
@@ -93,8 +91,8 @@ if (loaded[["xts"]]) {
   test(5, last(x,10), x[91:100,])
   # The important thing this tests is that data.table's last() dispatches to xts's method when data.table is loaded above xts.
   # But this might not be the case, depending on whether xts was already loaded before loading data.table.
-  # So to make this test relevant, in a fresh R session type: "require(xts);require(data.table);test.data.table(with.other.packages=TRUE)"
-  #                                              rather than: "require(data.table);require(xts);test.data.table(with.other.packages=TRUE)"
+  # So to make this test relevant, in a fresh R session type: "require(xts);require(data.table);test.data.table('other.Rraw')"
+  #                                              rather than: "require(data.table);require(xts);test.data.table('other.Rraw')"
   # Which was the main thrust of bug#2312 fixed in v1.8.3
 }
 
@@ -186,6 +184,6 @@ if (loaded[["parallel"]]) {
 }
 
 # example(":=", local=TRUE) triggered cedta==FALSE and then error, #2972
-test(14.1, {example(':=', package='data.table', local=TRUE); TRUE})
-test(14.2, {example('CJ', package='data.table', local=TRUE); TRUE})
+test(14.1, {example(':=', package='data.table', local=TRUE, echo=FALSE); TRUE})
+test(14.2, {example('CJ', package='data.table', local=TRUE, echo=FALSE); TRUE})
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -958,7 +958,7 @@ test(302, DT, data.table(a=c(1L,2L,2L,3L),b=c(4L,42L,6L,7L),key="a"))
 DT[J(2),b:=84L]
 test(303, DT, data.table(a=c(1L,2L,2L,3L),b=c(4L,84L,84L,7L),key="a"))
 
-# Test 304 was testing compatibility with package:plyr. Moved to the ggplot2 block above to be moved to a separate test package.
+# Test 304 was testing compatibility with package:plyr. #2671 moved it to other.Rraw.
 
 # Test that changing colnames keep key in sync.
 # TO DO: will have to do this for secondary keys, too, when implemented.


### PR DESCRIPTION
* Just a tidy for the `plyr::arrange` test following comments in #5042. Unlike `dplyr::arrange`, `plyr::arrange` does go through `[` method dispatch via its `df[ord, , drop = FALSE]`
* Adds checking dropped index to the `plyr::arrange` test which was already correct. That test serves as a proxy for other similar usage by non-data.table-aware packages.
* Test 304 was not moved 'above' but to other.Rraw in #2671
* A few internal references to `test.data.table(with.other.package=)` which is `test.data.table('other.Rraw')` now
* Clearer simpler Usage: error to prevent running other.Rraw in dev mode

Does not address #5042 at all.