### PR TITLE
Tidy other.Rraw CI

### DIFF
--- a/.ci/README.md
+++ b/.ci/README.md
@@ -7,7 +7,7 @@ On each Pull Request opened in GitHub we run Travis CI and Appveyor to provide p
 ### [GitLab CI](./../.gitlab-ci.yml)
 
 Test jobs:
-- `test-rel-lin` - `r-release` on Linux, most comprehensive test environment, `-O3 -flto -fno-common -Wunused-result`, extra check for no compilation warnings, includes testing [_with other packages_](./../inst/tests/other.Rraw) ([extended suggests](./../inst/tests/tests-DESCRIPTION))
+- `test-rel-lin` - `r-release` on Linux, most comprehensive test environment, `-O3 -flto -fno-common -Wunused-result`, extra check for no compilation warnings, includes testing [_with other packages_](./../inst/tests/other.Rraw)
 - `test-rel-cran-lin` - `--as-cran` on Linux, `-g0`, extra check for final status of `R CMD check` where we allow one NOTE (_size of tarball_).
 - `test-dev-cran-lin` - `r-devel` and `--as-cran` on Linux, `--with-recommended-packages --enable-strict-barrier --disable-long-double`, tests for compilation warnings in pkg install and new NOTEs/Warnings in pkg check, and because it is R-devel it is marked as allow_failure
 - `test-rel-vanilla-lin` - `r-release` on Linux, no suggested deps, no OpenMP, `-O0`, tracks memory usage during tests

--- a/.dev/.bash_aliases
+++ b/.dev/.bash_aliases
@@ -31,3 +31,6 @@ export R_PROFILE_USER='~/.Rprofile'
 export R_DEFAULT_INTERNET_TIMEOUT=3600
 # increase from R's default 60, always not just in revdep testing, to help --as-cran
 
+export TEST_DATA_TABLE_WITH_OTHER_PACKAGES=true
+# R CMD check in dev should always run other.Rraw
+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -153,7 +153,7 @@ test-rel-lin: ## most comprehensive tests, force all suggests, also integration 
     OPENBLAS_MAIN_FREE: "1"
     TEST_DATA_TABLE_WITH_OTHER_PACKAGES: "TRUE"
   before_script:
-    - Rscript -e 'source(".ci/ci.R"); install.packages(dcf.dependencies(c("DESCRIPTION","inst/tests/tests-DESCRIPTION"), which="all"), quiet=TRUE, repos=c(getOption("repos"), file.path("file:", normalizePath("bus/mirror-other-packages/cran", mustWork=FALSE))))'
+    - Rscript -e 'source(".ci/ci.R"); eval(parse("inst/tests/other.Rraw", n=1L)); install.packages(c(dcf.dependencies("DESCRIPTION", which="all"), pkgs), quiet=TRUE, repos=c(getOption("repos"), file.path("file:", normalizePath("bus/mirror-other-packages/cran", mustWork=FALSE))))'
     - *cp-src
     - rm -r bus
     - mkdir -p ~/.R

--- a/inst/tests/other.Rraw
+++ b/inst/tests/other.Rraw
@@ -1,3 +1,9 @@
+pkgs = c("ggplot2", "hexbin", "plyr", "dplyr", "caret", "xts", "gdata", "zoo", "nlme", "bit64", "knitr", "parallel")
+# First expression of this file must be as above: .gitlab-ci.yml uses parse(,n=1L) to read one expression from this file and installs pkgs.
+# So that these dependencies of other.Rraw are maintained in a single place.
+# TEST_DATA_TABLE_WITH_OTHER_PACKAGES is off by default so this other.Rraw doesn't run on CRAN. It is run by GLCI, locally in dev, and by
+# users running test.data.table("other.Rraw").
+
 if (exists("test.data.table",.GlobalEnv,inherits=FALSE) ||
     !"package:data.table" %in% search()) {
   stop("Usage: R CMD INSTALL; require(data.table); test.data.table('other.Rraw')")
@@ -7,18 +13,16 @@ if (exists("test.data.table",.GlobalEnv,inherits=FALSE) ||
 test = data.table:::test
 INT = data.table:::INT
 
-pkgs = c("ggplot2", "hexbin", "plyr", "dplyr", "caret", "xts", "gdata", "zoo", "nlme", "bit64", "knitr", "parallel")
 if (any(duplicated(pkgs))) stop("Packages defined to be loaded for integration tests in 'inst/tests/other.Rraw' contains duplicates.")
 
-is.require = function(pkg) suppressWarnings(suppressMessages(isTRUE(require(pkg, character.only=TRUE, quietly=TRUE, warn.conflicts=FALSE))))
-loaded = sapply(pkgs, is.require)
-
-if (sum(!loaded)) {
-  if (as.logical(Sys.getenv("_R_CHECK_FORCE_SUGGESTS_", "TRUE"))) {
-    stop(sprintf("Package (extended) suggested but not available: %s\n\nThe (extended) suggested packages are required for a complete check of data.table integration tests.\nChecking can be attempted without them by setting the environment variable _R_CHECK_FORCE_SUGGESTS_ to a false value.\nList of extended suggested packages used for integration tests can be found in `system.file(file.path('tests','tests-DESCRIPTION'), package='data.table')`.", paste("'", names(loaded)[!loaded], "'", sep="", collapse=", ")))
-  } else {
-    invisible(sapply(names(loaded)[!loaded], function(s) cat("\n**** Other package",s,"is not installed. Tests using it will be skipped.\n")))
-  }
+f = function(pkg) suppressMessages(isTRUE(require(pkg, character.only=TRUE, quietly=TRUE, warn.conflicts=FALSE)))
+loaded = sapply(pkgs, f)
+if (any(!loaded)) {
+  stop("test.data.table('other.Rraw') is missing required package(s): ", paste(names(loaded)[!loaded], collapse=", "), ". If you can't install them and this is R CMD check, please set environment variable TEST_DATA_TABLE_WITH_OTHER_PACKAGES back to the default, false.")
+  # Would like to install them now for convenience but gitlab-ci.yml seems to install to bus/mirror-other-packages/cran.
+  # If that's a cache, that's nice, but we don't know at this point whether this script is being run by GLCI or by a user or in dev.
+  # We don't allow skipping (e.g. if _R_CHECK_FORCE_SUGGESTS_ is FALSE) to keep things simple and to keep things strict; i.e.
+  # if this script runs then we want to be sure it has fully passed.
 }
 
 cat("\n")

--- a/inst/tests/tests-DESCRIPTION
+++ b/inst/tests/tests-DESCRIPTION
@@ -1,7 +1,0 @@
-Package: test.data.table
-Version: 0.1
-Type: Backend
-Title: List of data.table dependencies used in integration tests
-Authors@R: c(person("data.table team", role = c("aut", "cre", "cph"), email="mattjdowle@gmail.com"))
-Description: Standalone R DESCRIPTION file which defines R dependencies for integration tests of data.table package. Integration tests are not part of main testing workflow. They are performed only when TEST_DATA_TABLE_WITH_OTHER_PACKAGES environment variable is set to true. This allows us to run those integration tests in our CI pipeline and not impose dependency chains on the user.
-Suggests: ggplot2 (>= 0.9.0), reshape, hexbin, fastmatch, nlme, gdata, caret, rmarkdown, parallel

--- a/tests/other.R
+++ b/tests/other.R
@@ -1,4 +1,17 @@
 require(data.table)
 # integration tests for packages excluded from Suggests in 1.10.5
 # for list of used packages see inst/tests/tests-DESCRIPTION
-if (as.logical(Sys.getenv("TEST_DATA_TABLE_WITH_OTHER_PACKAGES","FALSE"))) test.data.table(script="other.Rraw")
+if (as.logical(Sys.getenv("TEST_DATA_TABLE_WITH_OTHER_PACKAGES","FALSE"))) {
+
+  options(warn=1)
+  # test.data.table() turns on R's warnPartial* options and currently there
+  # are partial argument names used in base and other packages. Without the
+  # options(warn=1), other.Rout just contains "There were 16 warnings (use
+  # warnings() to see them)". However, a print(warnings()) after test.data.table()
+  # just results in NULL in other.Rout. Hence options(warn=1) because that
+  # worked to display the warnings, not because we want them displayed at the
+  # time per se.
+    
+  test.data.table(script="other.Rraw")
+}
+

--- a/tests/other.R
+++ b/tests/other.R
@@ -1,6 +1,4 @@
 require(data.table)
-# integration tests for packages excluded from Suggests in 1.10.5
-# for list of used packages see inst/tests/tests-DESCRIPTION
 if (as.logical(Sys.getenv("TEST_DATA_TABLE_WITH_OTHER_PACKAGES","FALSE"))) {
 
   options(warn=1)


### PR DESCRIPTION
* one place for `other.Rraw`'s package; the two places had gotten out of line
* `TEST_DATA_TABLE_WITH_OTHER_PACKAGES=true` is now in my `.bash_aliases` (which is here in GitHub) so that I always run `other.Rraw` when I run `R CMD check` locally.
* partial argument name warnings from base and other packages are now displayed in `other.Rout` rather than just 'there were 14 warnings'
* it's now all or nothing for `other.Rraw` (i.e. `_R_CHECK_FORCE_SUGGESTS_` now ignored) to prevent skipping some packages that `other.Rraw` tests just because they're not installed.
