### PR TITLE
rework gminmax

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -5178,8 +5178,8 @@ test(1313.04, DT[, max(y, na.rm=TRUE), by=x], DT[, base::max(y, na.rm=TRUE), by=
 DT[x==6, y := INT(NA)]
 test(1313.05, DT[, min(y), by=x], DT[, base::min(y), by=x])
 test(1313.06, DT[, max(y), by=x], DT[, base::max(y), by=x])
-test(1313.07, DT[, min(y, na.rm=TRUE), by=x], data.table(x=1:6, V1=c(-1,4,4,4,-2147483647,Inf)), warning="No non-missing")
-test(1313.08, DT[, max(y, na.rm=TRUE), by=x], data.table(x=1:6, V1=c(4,10,10,10,-2147483647,-Inf)), warning="No non-missing")
+test(1313.07, DT[, min(y, na.rm=TRUE), by=x], data.table(x=1:6, V1=INT(-1,4,4,4,-2147483647,NA)))
+test(1313.08, DT[, max(y, na.rm=TRUE), by=x], data.table(x=1:6, V1=INT(4,10,10,10,-2147483647,NA)))
 
 # for numeric
 DT <- data.table(x=rep(1:6, each=3), y=c(4,-1,0, NA,4,10, 4,NA,10, 4,10,NA, -Inf, NA, NA, Inf, NA, NA))
@@ -5191,8 +5191,8 @@ test(1313.12, DT[, max(y, na.rm=TRUE), by=x], DT[, base::max(y, na.rm=TRUE), by=
 DT[x==6, y := NA_real_]
 test(1313.13, DT[, min(y), by=x], DT[, base::min(y), by=x])
 test(1313.14, DT[, max(y), by=x], DT[, base::max(y), by=x])
-test(1313.15, DT[, min(y, na.rm=TRUE), by=x], data.table(x=1:6, V1=c(-1,4,4,4,-Inf,Inf)), warning="No non-missing")
-test(1313.16, DT[, max(y, na.rm=TRUE), by=x], data.table(x=1:6, V1=c(4,10,10,10,-Inf,-Inf)), warning="No non-missing")
+test(1313.15, DT[, min(y, na.rm=TRUE), by=x], data.table(x=1:6, V1=c(-1,4,4,4,-Inf,NA)))
+test(1313.16, DT[, max(y, na.rm=TRUE), by=x], data.table(x=1:6, V1=c(4,10,10,10,-Inf,NA)))
 
 # for date (attribute check.. especially after issues/689 !!!)
 DT <- data.table(x = rep(letters[1:2], each=5), y = as.POSIXct('2010-01-01', tz="UTC") + seq(0, 86400*9, 86400))
@@ -5215,8 +5215,8 @@ test(1313.26, DT[, max(y, na.rm=TRUE), by=x], DT[, base::max(y, na.rm=TRUE), by=
 DT[x==6, y := NA_character_]
 test(1313.27, DT[, min(y), by=x], DT[, base::min(y), by=x])
 test(1313.28, DT[, max(y), by=x], DT[, base::max(y), by=x])
-test(1313.29, DT[, min(y, na.rm=TRUE), by=x], data.table(x=1:7, V1=c("a","a","c","","a",NA,"")), warning="No non-missing")
-test(1313.30, DT[, max(y, na.rm=TRUE), by=x], data.table(x=1:7, V1=c("b","a","c","a","c",NA,"c")), warning="No non-missing")
+test(1313.29, DT[, min(y, na.rm=TRUE), by=x], data.table(x=1:7, V1=c("a","a","c","","a",NA,"")))
+test(1313.30, DT[, max(y, na.rm=TRUE), by=x], data.table(x=1:7, V1=c("b","a","c","a","c",NA,"c")))
 
 # bug 700 - bmerge, roll=TRUE and nomatch=0L when i's key group occurs more than once
 dt1 <- data.table(structure(list(x = c(7L, 33L), y = structure(c(15912, 15912), class = "Date"), z = c(626550.35284, 7766.385)), .Names =
@@ -8220,18 +8220,23 @@ test(1581.19, DT, DT0[ , var := c('A', 'A', 'B')])
 # handle NULL value correctly #1429
 test(1582, uniqueN(NULL), 0L)
 
-# bug fix #1461
-dt = data.table(x=c(1,1,1,2,2,2,3,3,3,4,4,4,5), y=c(NaN,1,2, 2,NaN,1, NA,NaN,2, NaN,NA,NaN, NaN))
-# make sure gforce is on
-options(datatable.optimize=Inf)
-ans1 = suppressWarnings(dt[, base::min(y, na.rm=TRUE), by=x])
-ans2 = suppressWarnings(dt[, base::max(y, na.rm=TRUE), by=x])
-test(1583.1, dt[, min(y, na.rm=TRUE), by=x], ans1, warning="No non-missing values found")
-test(1583.2, dt[, max(y, na.rm=TRUE), by=x], ans2, warning="No non-missing values found")
-ans3 = suppressWarnings(dt[, base::min(y), by=x])
-ans4 = suppressWarnings(dt[, base::max(y), by=x])
-test(1583.3, dt[, min(y), by=x], ans3)
-test(1583.4, dt[, max(y), by=x], ans4)
+# bug fix #1461 related to NaN not being recognized due to ISNA vs ISNAN at C level
+# verbatim test from the original report:
+options(datatable.optimize=Inf)   # ensure gforce is on
+DT = data.table(
+     C1 = c(rep("A", 4), rep("B",4), rep("C", 4)),
+     C2 = c(rep("a", 3), rep("b",3), rep("c",3), rep("d",3)),
+     Val = c(1:5, NaN, NaN, 8,9,10,NaN,12))
+test(1583.1, DT[, .(agg = min(Val, na.rm=TRUE)), by=c('C1', 'C2')],
+             data.table(C1=c("A","A","B","B","C","C"),
+                        C2=c("a","b","b","c","c","d"),
+                        agg=c(1,4,5,8,9,10)))
+# extra test with a size-1 group containing one NaN too
+DT = data.table(x=INT(1,1,1,2,2,2,3,3,3,4,4,4,5), y=c(NaN,1,2, 2,NaN,1, NA,NaN,2, NaN,NA,NaN, NaN))
+test(1583.2, DT[, min(y, na.rm=TRUE), by=x], data.table(x=1:5, V1=c(1,1,2,NA,NA)))
+test(1583.3, DT[, max(y, na.rm=TRUE), by=x], data.table(x=1:5, V1=c(2,2,2,NA,NA)))
+test(1583.4, DT[, min(y), by=x], data.table(x=1:5, V1=c(NaN,NaN,NA,NaN,NaN)))
+test(1583.5, DT[, max(y), by=x], data.table(x=1:5, V1=c(NaN,NaN,NA,NaN,NaN)))
 
 # Fixed a minor bug in fread when blank.lines.skip=TRUE
 f1 <- function(x, f=TRUE, b=FALSE) fread(x, fill=f, blank.lines.skip=b, data.table=FALSE, logical01=FALSE)
@@ -14700,8 +14705,8 @@ if (test_bit64) {
   test(2019, DT[2:6, sum(v), id], data.table(id=1:2, V1=bit64::as.integer64(c(5L,15L)))) # gather, case of int64 and irows
 }
 DT = data.table(id = c(1L,1L,2L), v = as.raw(0:2))
-test(2020.01, DT[, min(v), by=id], error="'raw' not supported by GForce min")
-test(2020.02, DT[, max(v), by=id], error="'raw' not supported by GForce max")
+test(2020.01, DT[, min(v), by=id], error="'raw' not supported by GForce min/max")
+test(2020.02, DT[, max(v), by=id], error="'raw' not supported by GForce min/max")
 test(2020.03, DT[, median(v), by=id], error="'raw' not supported by GForce median")
 test(2020.04, DT[, head(v, 1), by=id], error="'raw' not supported by GForce head")
 test(2020.05, DT[, tail(v, 1), by=id], error="'raw' not supported by GForce tail")
@@ -15820,8 +15825,8 @@ test(2065.7, DT[1L, z_sum := 1i][1L, z_sum], 1i)
 
 # GForce for complex columns, part of #3690
 DT = data.table(id=c(1L,1L,2L), v=c(1i, 2i, 3i))
-test(2066.01, DT[, min(v), by=id], error="'complex' has no well-defined min")
-test(2066.02, DT[, max(v), by=id], error="'complex' has no well-defined max")
+test(2066.01, DT[, min(v), by=id], error="'complex' has no well-defined min/max")
+test(2066.02, DT[, max(v), by=id], error="'complex' has no well-defined min/max")
 test(2066.03, DT[, head(v, 1), by=id], data.table(id=1:2, V1=c(1, 3)*1i))
 test(2066.04, DT[, tail(v, 1), by=id], data.table(id=1:2, V1=(2:3)*1i))
 test(2066.05, DT[, v[2], by=id], data.table(id = 1:2, V1=c(2i, NA)))


### PR DESCRIPTION
- [x] folds `gmax` into `gmin` becoming `gminmax` to avoid the duplicated logic so that future maintenance can be in one place
- [x] reviewed the logic and changed it slightly; e.g. with default `na.rm=FALSE`, once an `NA` has occurred in a group, there is no need to fetch the value of the remaining values in that group
- [x] moved R API outside loops
- [x] removed the warnings (closes #4999) and it's now type consistent. I don't know why we ever thought it was a good idea to return `Inf`, it was just to be consistent with base
- [x] news item with detailed example

There is some overlap with @MichaelChirico's #4445 here which fixes `integer64` support in `gmin`/`gmax`. I'll merge that next which should be easier as it's now in one `gminmax`.

Merging so the NEWS item is published in dev and folk can test dev. Everything in dev is still open for discussion and reconsideration before release.