### PR TITLE
names<- retain key and option to turn new warning on

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -1514,11 +1514,11 @@ test(488, data.table(stats::reshape(DT, idvar="ID", timevar="TIME", direction="w
           data.table(ID=1:3,X.1=INT(1,4,7),Y.1=INT(10,13,16),X.2=INT(2,5,8),Y.2=INT(11,14,17),X.3=INT(3,6,9),Y.3=INT(12,15,18)))
 
 # Test warnings for names<- and colnames<-,  but only warnings when caller is data.table aware.
-DT = data.table(a=1:3,b=4:6)
+DT = data.table(a=1:3,b=4:6,key="a")
 test(489, names(DT)[1]<-"A", "A")  # needs R >= 3.1.0, which is stated dependency now
-test(490, names(DT), c("A","b"))
+test(490, DT, data.table(A=1:3, b=4:6, key="a"))  # key wasn't retained in dev after #5084
 test(491, colnames(DT)[2]<-"B", "B")
-test(492, names(DT), c("A","B"))
+test(492, DT, data.table(A=1:3, B=4:6, key="a"))
 
 # Check setnames out of bounds errors
 test(493, setnames(DT,"foo","bar"), error="not found.*foo")


### PR DESCRIPTION
The existing names<- test didn't check retaining key, fixed.