### PR TITLE
Raw support setkey as column (not key)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -155,6 +155,8 @@
     # [1] 5 1 2 3 4
     ```
 
+28. `setkey` now supports type `raw` as value columns (not as key columns), [#5100](https://github.com/Rdatatable/data.table/issues/1444). Thanks Hugh Parsonage for requesting, and Benjamin Schwendinger for the PR.
+
 ## BUG FIXES
 
 1. `by=.EACHI` when `i` is keyed but `on=` different columns than `i`'s key could create an invalidly keyed result, [#4603](https://github.com/Rdatatable/data.table/issues/4603) [#4911](https://github.com/Rdatatable/data.table/issues/4911). Thanks to @myoung3 and @adamaltmejd for reporting, and @ColeMiller1 for the PR. An invalid key is where a `data.table` is marked as sorted by the key columns but the data is not sorted by those columns, leading to incorrect results from subsequent queries.

--- a/NEWS.md
+++ b/NEWS.md
@@ -155,7 +155,7 @@
     # [1] 5 1 2 3 4
     ```
 
-28. `setkey` now supports type `raw` as value columns (not as key columns), [#5100](https://github.com/Rdatatable/data.table/issues/1444). Thanks Hugh Parsonage for requesting, and Benjamin Schwendinger for the PR.
+28. `setkey` now supports type `raw` as value columns (not as key columns), [#5100](https://github.com/Rdatatable/data.table/issues/5100). Thanks Hugh Parsonage for requesting, and Benjamin Schwendinger for the PR.
 
 ## BUG FIXES
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -15941,11 +15941,17 @@ test(2067.8, shift(list(z, 1L:3L), n=-1, type = 'cyclic'), list(c(z[2:3], z[1]),
 DT = data.table(a = 2:1, z = complex(0, 0:1))
 test(2068.1, setkey(copy(DT), a), data.table(a=1:2, z=complex(0, 1:0), key='a'))
 test(2068.2, DT[ , abs(z), by=a], data.table(a=2:1, V1=c(0, 1)))
-# raw continues not to be supported
+# support for ordering tables with raw columns, #5100
 DT = data.table(ID=2:1, r=as.raw(0:1))
-test(2068.3, setkey(DT, ID), error="Item 2 of list is type 'raw'")
+test(2068.3, setkey(copy(DT), ID), data.table(ID=1:2, r=as.raw(1:0), key='ID'))
+DT = data.table(x=c(1, 2, 1), y=raw(3))
+test(2068.4, setkey(copy(DT), x), data.table(x=c(1,1,2), y=raw(3), key='x'))
+test(2068.5, DT[, y[.N], x], data.table(x=c(1,2), V1=raw(2)))
+# expression continue to be not supported
+DT = data.table(ID=2:1, r=expression(1, 2))
+test(2068.6, setkey(DT, ID), error="Item 2 of list is type 'expression'")
 # setreordervec triggers !isNewList branch for coverage
-test(2068.4, setreordervec(DT$r, order(DT$ID)), error="reorder accepts vectors but this non-VECSXP")
+test(2068.7, setreordervec(DT$r, order(DT$ID)), error="reorder accepts vectors but this non-VECSXP")
 
 # forderv (and downstream functions) handles complex vector input, part of #3690
 DT = data.table(

--- a/src/reorder.c
+++ b/src/reorder.c
@@ -13,7 +13,7 @@ SEXP reorder(SEXP x, SEXP order)
     ncol = length(x);
     for (int i=0; i<ncol; i++) {
       SEXP v = VECTOR_ELT(x,i);
-      if (SIZEOF(v)!=4 && SIZEOF(v)!=8 && SIZEOF(v)!=16)
+      if (SIZEOF(v)!=1 && SIZEOF(v)!=4 && SIZEOF(v)!=8 && SIZEOF(v)!=16)
         error(_("Item %d of list is type '%s' which isn't yet supported (SIZEOF=%d)"), i+1, type2char(TYPEOF(v)), SIZEOF(v));
       if (length(v)!=nrow)
         error(_("Column %d is length %d which differs from length of column 1 (%d). Invalid data.table."), i+1, length(v), nrow);
@@ -23,7 +23,7 @@ SEXP reorder(SEXP x, SEXP order)
     }
     copySharedColumns(x); // otherwise two columns which point to the same vector would be reordered and then re-reordered, issues linked in PR#3768
   } else {
-    if (SIZEOF(x)!=4 && SIZEOF(x)!=8 && SIZEOF(x)!=16)
+    if (SIZEOF(x)!=1 && SIZEOF(x)!=4 && SIZEOF(x)!=8 && SIZEOF(x)!=16)
       error(_("reorder accepts vectors but this non-VECSXP is type '%s' which isn't yet supported (SIZEOF=%d)"), type2char(TYPEOF(x)), SIZEOF(x));
     if (ALTREP(x)) error(_("Internal error in reorder.c: cannot reorder an ALTREP vector. Please see NEWS item 2 in v1.11.4 and report this as a bug.")); // # nocov
     maxSize = SIZEOF(x);
@@ -61,7 +61,14 @@ SEXP reorder(SEXP x, SEXP order)
   for (int i=0; i<ncol; ++i) {
     const SEXP v = isNewList(x) ? VECTOR_ELT(x,i) : x;
     const size_t size = SIZEOF(v);    // size_t, otherwise #61 (integer overflow in memcpy)
-    if (size==4) {
+    if (size==1) { // support raw as column #5100
+      const Rbyte *restrict vd = DATAPTR_RO(v);
+      Rbyte *restrict tmp = (Rbyte *)TMP;
+      #pragma omp parallel for num_threads(getDTthreads(end, true))
+      for (int i=start; i<=end; ++i) {
+        tmp[i-start] = vd[idx[i]-1];  // copies 1 bytes; e.g. RAW
+      }
+    } else if (size==4) {
       const int *restrict vd = DATAPTR_RO(v);
       int *restrict tmp = (int *)TMP;
       #pragma omp parallel for num_threads(getDTthreads(end, true))

--- a/src/reorder.c
+++ b/src/reorder.c
@@ -13,7 +13,7 @@ SEXP reorder(SEXP x, SEXP order)
     ncol = length(x);
     for (int i=0; i<ncol; i++) {
       SEXP v = VECTOR_ELT(x,i);
-      if (SIZEOF(v)!=1 && SIZEOF(v)!=4 && SIZEOF(v)!=8 && SIZEOF(v)!=16)
+      if (SIZEOF(v)!=4 && SIZEOF(v)!=8 && SIZEOF(v)!=16 && SIZEOF(v)!=1)
         error(_("Item %d of list is type '%s' which isn't yet supported (SIZEOF=%d)"), i+1, type2char(TYPEOF(v)), SIZEOF(v));
       if (length(v)!=nrow)
         error(_("Column %d is length %d which differs from length of column 1 (%d). Invalid data.table."), i+1, length(v), nrow);
@@ -23,7 +23,7 @@ SEXP reorder(SEXP x, SEXP order)
     }
     copySharedColumns(x); // otherwise two columns which point to the same vector would be reordered and then re-reordered, issues linked in PR#3768
   } else {
-    if (SIZEOF(x)!=1 && SIZEOF(x)!=4 && SIZEOF(x)!=8 && SIZEOF(x)!=16)
+    if (SIZEOF(x)!=4 && SIZEOF(x)!=8 && SIZEOF(x)!=16 && SIZEOF(x)!=1)
       error(_("reorder accepts vectors but this non-VECSXP is type '%s' which isn't yet supported (SIZEOF=%d)"), type2char(TYPEOF(x)), SIZEOF(x));
     if (ALTREP(x)) error(_("Internal error in reorder.c: cannot reorder an ALTREP vector. Please see NEWS item 2 in v1.11.4 and report this as a bug.")); // # nocov
     maxSize = SIZEOF(x);
@@ -61,14 +61,7 @@ SEXP reorder(SEXP x, SEXP order)
   for (int i=0; i<ncol; ++i) {
     const SEXP v = isNewList(x) ? VECTOR_ELT(x,i) : x;
     const size_t size = SIZEOF(v);    // size_t, otherwise #61 (integer overflow in memcpy)
-    if (size==1) { // support raw as column #5100
-      const Rbyte *restrict vd = DATAPTR_RO(v);
-      Rbyte *restrict tmp = (Rbyte *)TMP;
-      #pragma omp parallel for num_threads(getDTthreads(end, true))
-      for (int i=start; i<=end; ++i) {
-        tmp[i-start] = vd[idx[i]-1];  // copies 1 bytes; e.g. RAW
-      }
-    } else if (size==4) {
+    if (size==4) {
       const int *restrict vd = DATAPTR_RO(v);
       int *restrict tmp = (int *)TMP;
       #pragma omp parallel for num_threads(getDTthreads(end, true))
@@ -86,15 +79,21 @@ SEXP reorder(SEXP x, SEXP order)
       for (int i=start; i<=end; ++i) {
         tmp[i-start] = vd[idx[i]-1];  // copies 8 bytes; e.g. REALSXP and also SEXP pointers on 64bit (STRSXP and VECSXP)
       }
-    } else { // size 16; checked up front
+    } else if (size==16) {
       const Rcomplex *restrict vd = DATAPTR_RO(v);
       Rcomplex *restrict tmp = (Rcomplex *)TMP;
       #pragma omp parallel for num_threads(getDTthreads(end, true))
       for (int i=start; i<=end; ++i) {
         tmp[i-start] = vd[idx[i]-1];
       }
+    } else { // size 1; checked up front // support raw as column #5100
+      const Rbyte *restrict vd = DATAPTR_RO(v);
+      Rbyte *restrict tmp = (Rbyte *)TMP;
+      #pragma omp parallel for num_threads(getDTthreads(end, true))
+      for (int i=start; i<=end; ++i) {
+        tmp[i-start] = vd[idx[i]-1];  // copies 1 bytes; e.g. RAWSXP
+      }
     }
-
     // Unique and somber line. Not done lightly. Please read all comments in this file.
     memcpy(((char *)DATAPTR_RO(v)) + size*start, TMP, size*nmid);
     // The one and only place in data.table where we write behind the write-barrier. Fundamental to setkey and data.table.


### PR DESCRIPTION
Towards #5100.

While enabling the usage of `raw` in functions like `setkey` for columns seems a good idea, I don't see the potential/use case for fully support `raw` in every place of `data.table`. Not even `base` enables e.g. the use of `order` for `raw`. 

Maybe this changes when seeing more use cases of `raw`. The only one I'm currently aware of is its use for serializing/deserializing objects.