### PR TITLE
applied suggestion from Kurt Kornik

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -424,6 +424,8 @@
     ```
 
     The message is now upgraded to warning that the option is now ignored.
+    
+15. Thanks to Kurt Hornik for investigating potential impact of a possible future change to `base::intersect()` on empty input, pinpointing what we need to change, and giving us plenty of notice, [#XXXX]( ... ).
 
 
 # data.table [v1.14.2](https://github.com/Rdatatable/data.table/milestone/24?closed=1)

--- a/R/merge.R
+++ b/R/merge.R
@@ -43,9 +43,9 @@ merge.data.table = function(x, y, by = NULL, by.x = NULL, by.y = NULL, all = FAL
   } else {
     if (is.null(by))
       by = intersect(key(x), key(y))
-    if (is.null(by))
+    if (!length(by))   # was is.null() before PR#  changed to !length()
       by = key(x)
-    if (is.null(by))
+    if (!length(by))
       by = intersect(nm_x, nm_y)
     if (length(by) == 0L || !is.character(by))
       stopf("A non-empty vector of column names for `by` is required.")

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -13576,7 +13576,7 @@ test(1962.014, merge(DT1, DT2),
      data.table(a = integer(0), V = character(0)))
 setkey(DT1, a)
 test(1962.015, merge(DT1, DT2),
-     data.table(a = 2:3, V.x = c("a", "a"), V.y = c("b", "b"), key = 'a'))
+     ans<-data.table(a = 2:3, V.x = c("a", "a"), V.y = c("b", "b"), key = 'a'))
 test(1962.016, merge(DT1, DT2, by.x = 'a', by.y = c('a', 'V')),
      error = 'must be of same length')
 test(1962.017, merge(DT1, DT2, by = 'V', by.x = 'a', by.y = 'a'),
@@ -13586,8 +13586,8 @@ test(1962.018, merge(DT1, DT2, by.x = 'z', by.y = 'a'),
      error = 'Elements listed in `by.x`')
 test(1962.019, merge(DT1, DT2, by.x = 'a', by.y = 'z'),
      error = 'Elements listed in `by.y`')
-test(1962.020, merge(DT1, DT2, by = character(0L)),
-     error = 'non-empty vector of column names')
+test(1962.0201, merge(DT1, DT2, by=character(0L)), ans)  # was error before PR#
+test(1962.0202, merge(DT1, DT2, by=NULL),          ans)  # test explicit NULL too as missing() could be used inside merge()
 test(1962.021, merge(DT1, DT2, by = 'z'),
      error = 'must be valid column names in x and y')
 


### PR DESCRIPTION
Matt,

Recent r-devel improvements showed that in merge.data.table you relied
on

R> intersect("A", NULL)
NULL

which was more of an implementation "detail" than really intended, with
the old implementation also giving

R> intersect(NULL, "A")
character(0)

I have (for now) changed intersect() to consistently give NULL when one
of the operands is NULL, so merge.data.table works "as intended", but
perhaps you want to

        if (is.null(by))
            by = intersect(key(x), key(y))
        if (is.null(by))
            by = key(x)
        if (is.null(by))
            by = intersect(names(x), names(y))

to something like

        if (is.null(by))
            by = intersect(key(x), key(y))
        if (!length(by))
            by = key(x)
        if (!length(by))
            by = intersect(names(x), names(y))

to be on the safe side?

Best
-k