### PR TITLE
shift fix type coercion for integer64

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -378,7 +378,7 @@
 
 45. `shift(xInt64, fill=0)` and `shift(xInt64, fill=as.integer64(0))` (but not `shift(xInt64, fill=0L)`) would error with `INTEGER() can only be applied to a 'integer', not a 'double'` where `xInt64` conveys `bit64::integer64`, `0` is type `double` and `0L` is type integer, [#4865](https://github.com/Rdatatable/data.table/issues/4865). Thanks to @peterlittlejohn for reporting and Benjamin Schwendinger for the PR.
 
-46. `DT[i, strCol:=classVal]` did not coerce using the `as.character` method for the class resulting in either an unexpected string value or an error like `To assign integer64 to a target of type character, please use as.character() for clarity`. Discovered during work on the previous issue, [#5189](https://github.com/Rdatatable/data.table/pull/5189).
+46. `DT[i, strCol:=classVal]` did not coerce using the `as.character` method for the class, resulting in either an unexpected string value or an error such as `To assign integer64 to a target of type character, please use as.character() for clarity`. Discovered during work on the previous issue, [#5189](https://github.com/Rdatatable/data.table/pull/5189).
 
     ```R
     DT

--- a/NEWS.md
+++ b/NEWS.md
@@ -376,7 +376,7 @@
 
 44. In v1.13.2 a version of an old bug was reintroduced where during a grouping operation list columns could retain a pointer to the last group. This affected only attributes of list elements and only if those were updated during the grouping operation, [#4963](https://github.com/Rdatatable/data.table/issues/4963). Thanks to @fujiaxiang for reporting and @avimallu and Václav Tlapák for investigating and the PR.
 
-45. `shift(xInt64, fill=0)` would error with `INTEGER() can only be applied to a 'integer', not a 'double'` where `xInt64` conveys `bit64::integer64` and `0` is type `double` in R, [#4865](https://github.com/Rdatatable/data.table/issues/4865). Thanks to @peterlittlejohn for reporting and Benjamin Schwendinger for the PR.
+45. `shift(xInt64, fill=0)` and `shift(xInt64, fill=as.integer64(0))` (but not `shift(xInt64, fill=0L)`) would error with `INTEGER() can only be applied to a 'integer', not a 'double'` where `xInt64` conveys `bit64::integer64`, `0` is type `double` and `0L` is type integer, [#4865](https://github.com/Rdatatable/data.table/issues/4865). Thanks to @peterlittlejohn for reporting and Benjamin Schwendinger for the PR.
 
 ## NOTES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -376,7 +376,7 @@
 
 44. In v1.13.2 a version of an old bug was reintroduced where during a grouping operation list columns could retain a pointer to the last group. This affected only attributes of list elements and only if those were updated during the grouping operation, [#4963](https://github.com/Rdatatable/data.table/issues/4963). Thanks to @fujiaxiang for reporting and @avimallu and Václav Tlapák for investigating and the PR.
 
-45. `shift(x, fill)` could error if `x` had type `bit64::integer64` and a `fill` argument of type different than `integer32` was also provided, [#4865](https://github.com/Rdatatable/data.table/issues/4865). Thanks to @peterlittlejohn for reporting and Benjamin Schwendinger for the PR.
+45. `shift(x, fill)` could error if `x` had type `bit64::integer64` and a `fill` argument of different type than `integer32` was also provided, [#4865](https://github.com/Rdatatable/data.table/issues/4865). Thanks to @peterlittlejohn for reporting and Benjamin Schwendinger for the PR.
 
 ## NOTES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -378,6 +378,25 @@
 
 45. `shift(xInt64, fill=0)` and `shift(xInt64, fill=as.integer64(0))` (but not `shift(xInt64, fill=0L)`) would error with `INTEGER() can only be applied to a 'integer', not a 'double'` where `xInt64` conveys `bit64::integer64`, `0` is type `double` and `0L` is type integer, [#4865](https://github.com/Rdatatable/data.table/issues/4865). Thanks to @peterlittlejohn for reporting and Benjamin Schwendinger for the PR.
 
+46. `DT[i, strCol:=classVal]` did not coerce using the `as.character` method for the class resulting in either an unexpected string value or an error like `To assign integer64 to a target of type character, please use as.character() for clarity`. Discovered during work on the previous issue, [#5189](https://github.com/Rdatatable/data.table/pull/5189).
+
+    ```R
+    DT
+    #         A
+    #    <char>
+    # 1:      a
+    # 2:      b
+    # 3:      c
+    DT[2, A:=as.IDate("2021-02-03")]
+    DT[3, A:=bit64::as.integer64("4611686018427387906")]
+    DT
+    #                      A
+    #                 <char>
+    # 1:                   a
+    # 2:          2021-02-03  # was 18661
+    # 3: 4611686018427387906  # was error 'please use as.character'
+    ```
+
 ## NOTES
 
 1. New feature 29 in v1.12.4 (Oct 2019) introduced zero-copy coercion. Our thinking is that requiring you to get the type right in the case of `0` (type double) vs `0L` (type integer) is too inconvenient for you the user. So such coercions happen in `data.table` automatically without warning. Thanks to zero-copy coercion there is no speed penalty, even when calling `set()` many times in a loop, so there's no speed penalty to warn you about either. However, we believe that assigning a character value such as `"2"` into an integer column is more likely to be a user mistake that you would like to be warned about. The type difference (character vs integer) may be the only clue that you have selected the wrong column, or typed the wrong variable to be assigned to that column. For this reason we view character to numeric-like coercion differently and will warn about it. If it is correct, then the warning is intended to nudge you to wrap the RHS with `as.<type>()` so that it is clear to readers of your code that a coercion from character to that type is intended. For example :

--- a/NEWS.md
+++ b/NEWS.md
@@ -376,7 +376,7 @@
 
 44. In v1.13.2 a version of an old bug was reintroduced where during a grouping operation list columns could retain a pointer to the last group. This affected only attributes of list elements and only if those were updated during the grouping operation, [#4963](https://github.com/Rdatatable/data.table/issues/4963). Thanks to @fujiaxiang for reporting and @avimallu and Václav Tlapák for investigating and the PR.
 
-45. `shift(x, fill)` could error if `x` had type `bit64::integer64` and a `fill` argument of different type than `integer32` was also provided, [#4865](https://github.com/Rdatatable/data.table/issues/4865). Thanks to @peterlittlejohn for reporting and Benjamin Schwendinger for the PR.
+45. `shift(xInt64, fill=0)` would error with `INTEGER() can only be applied to a 'integer', not a 'double'` where `xInt64` conveys `bit64::integer64` and `0` is type `double` in R, [#4865](https://github.com/Rdatatable/data.table/issues/4865). Thanks to @peterlittlejohn for reporting and Benjamin Schwendinger for the PR.
 
 ## NOTES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -376,6 +376,8 @@
 
 44. In v1.13.2 a version of an old bug was reintroduced where during a grouping operation list columns could retain a pointer to the last group. This affected only attributes of list elements and only if those were updated during the grouping operation, [#4963](https://github.com/Rdatatable/data.table/issues/4963). Thanks to @fujiaxiang for reporting and @avimallu and Václav Tlapák for investigating and the PR.
 
+45. `shift(x, fill)` could error if `x` had type `bit64::integer64` and a `fill` argument was also provided, [#4865](https://github.com/Rdatatable/data.table/issues/4865). Thanks to @peterlittlejohn for reporting and Benjamin Schwendinger for the PR.
+
 ## NOTES
 
 1. New feature 29 in v1.12.4 (Oct 2019) introduced zero-copy coercion. Our thinking is that requiring you to get the type right in the case of `0` (type double) vs `0L` (type integer) is too inconvenient for you the user. So such coercions happen in `data.table` automatically without warning. Thanks to zero-copy coercion there is no speed penalty, even when calling `set()` many times in a loop, so there's no speed penalty to warn you about either. However, we believe that assigning a character value such as `"2"` into an integer column is more likely to be a user mistake that you would like to be warned about. The type difference (character vs integer) may be the only clue that you have selected the wrong column, or typed the wrong variable to be assigned to that column. For this reason we view character to numeric-like coercion differently and will warn about it. If it is correct, then the warning is intended to nudge you to wrap the RHS with `as.<type>()` so that it is clear to readers of your code that a coercion from character to that type is intended. For example :

--- a/NEWS.md
+++ b/NEWS.md
@@ -376,7 +376,7 @@
 
 44. In v1.13.2 a version of an old bug was reintroduced where during a grouping operation list columns could retain a pointer to the last group. This affected only attributes of list elements and only if those were updated during the grouping operation, [#4963](https://github.com/Rdatatable/data.table/issues/4963). Thanks to @fujiaxiang for reporting and @avimallu and Václav Tlapák for investigating and the PR.
 
-45. `shift(x, fill)` could error if `x` had type `bit64::integer64` and a `fill` argument was also provided, [#4865](https://github.com/Rdatatable/data.table/issues/4865). Thanks to @peterlittlejohn for reporting and Benjamin Schwendinger for the PR.
+45. `shift(x, fill)` could error if `x` had type `bit64::integer64` and a `fill` argument of type different than `integer32` was also provided, [#4865](https://github.com/Rdatatable/data.table/issues/4865). Thanks to @peterlittlejohn for reporting and Benjamin Schwendinger for the PR.
 
 ## NOTES
 

--- a/inst/tests/nafill.Rraw
+++ b/inst/tests/nafill.Rraw
@@ -294,7 +294,7 @@ if (test_nanotime) {
   x = nanotime(1L)
   test(10.91, coerceAs(x, 1), 1, output="double[nanotime] into double[numeric]")
   test(10.92, coerceAs(x, 1L), 1L, output="double[nanotime] into integer[integer]")
-  test(10.93, coerceAs(x, "1"), error="please use as.character", output="double[nanotime] into character[character]") # not yet implemented
+  test(10.93, coerceAs(x, "1"), "1", output="double[nanotime] into character[character]") # nanotime needs an as.character method for "1" to be "1970-01-01T00:00:00.000000001+00:00"
   test(10.94, coerceAs(1, x), x, output="double[numeric] into double[nanotime]")
   test(10.95, coerceAs(1L, x), x, output="integer[integer] into double[nanotime]")
   test(10.96, coerceAs("1", x), x, output="character[character] into double[nanotime]", warning="Coercing.*character")

--- a/inst/tests/nafill.Rraw
+++ b/inst/tests/nafill.Rraw
@@ -294,7 +294,8 @@ if (test_nanotime) {
   x = nanotime(1L)
   test(10.91, coerceAs(x, 1), 1, output="double[nanotime] into double[numeric]")
   test(10.92, coerceAs(x, 1L), 1L, output="double[nanotime] into integer[integer]")
-  test(10.93, coerceAs(x, "1"), "1", output="double[nanotime] into character[character]") # nanotime needs an as.character method for "1" to be "1970-01-01T00:00:00.000000001+00:00"
+  test(10.93, substring(coerceAs(x, "1"),1,11) %in% c("1","1970-01-01T"), output="double[nanotime] into character[character]")
+                                                     # ^ https://github.com/eddelbuettel/nanotime/issues/92; %in% so as not to break if nanotime adds as.character method
   test(10.94, coerceAs(1, x), x, output="double[numeric] into double[nanotime]")
   test(10.95, coerceAs(1L, x), x, output="integer[integer] into double[nanotime]")
   test(10.96, coerceAs("1", x), x, output="character[character] into double[nanotime]", warning="Coercing.*character")

--- a/inst/tests/nafill.Rraw
+++ b/inst/tests/nafill.Rraw
@@ -281,7 +281,7 @@ if (test_bit64) {
   x = as.integer64(1L)
   test(10.81, coerceAs(x, 1), 1, output="double[integer64] into double[numeric]")
   test(10.82, coerceAs(x, 1L), 1L, output="double[integer64] into integer[integer]")
-  test(10.83, coerceAs(x, "1"), error="please use as.character", output="double[integer64] into character[character]") # not yet implemented
+  test(10.83, coerceAs(x, "1"), "1", output="double[integer64] into character[character]")
   test(10.84, coerceAs(1, x), x, output="double[numeric] into double[integer64]")
   test(10.85, coerceAs(1L, x), x, output="integer[integer] into double[integer64]")
   test(10.86, coerceAs("1", x), x, output="character[character] into double[integer64]", warning="Coercing.*character")
@@ -301,7 +301,7 @@ if (test_nanotime) {
 }
 options(datatable.verbose=FALSE)
 test(11.01, coerceAs(list(a=1), 1), error="is not atomic")
-test(11.02, coerceAs(1, list(a=1)), error="is not atomic")
+test(11.02, coerceAs(1, list(a=1)), list(1))
 test(11.03, coerceAs(sum, 1), error="is not atomic")
 test(11.04, coerceAs(quote(1+1), 1), error="is not atomic")
 test(11.05, coerceAs(as.name("x"), 1), error="is not atomic")

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18226,13 +18226,14 @@ for (f1 in funs) {
     testnum = testnum + 0.01
     test(testnum, DT[, shift(x)],               f1(c(NA, 1:3)))
     testnum = testnum + 0.01
-    test(testnum, DT[, shift(x, fill=f2(NA))],  f1(c(NA, 1:3)))
+    w = if (identical(f2,as.character) && (identical(f1,as.integer) || identical(f1,as.double))) "Coercing.*character.*to match the type of target vector"
+    test(testnum, DT[, shift(x, fill=f2(NA))],  f1(c(NA, 1:3)), warning=w)
     testnum = testnum + 0.01
     if (identical(f1,as.character) && identical(f2,as.complex))
       # one special case due to as.complex(0)=="0+0i"!="0"
       test(testnum, DT[, shift(x, fill="0")],   f1(0:3))
     else 
-      test(testnum, DT[, shift(x, fill=f2(0))], f1(0:3))
+      test(testnum, DT[, shift(x, fill=f2(0))], f1(0:3), warning=w)
   }
 }
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18244,3 +18244,8 @@ for (f1 in funs) {
   }
 }
 
+# subassign coerce a class to character, part of PR#5189
+DT = data.table(A=letters[1:3])
+test(2219.1, DT[2, A:=as.IDate("2021-02-03")],                              data.table(A=c("a","2021-02-03","c")))
+if (test_bit64) test(2219.2, DT[3, A:=as.integer64("4611686018427387906")], data.table(A=c("a","2021-02-03","4611686018427387906")))
+

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18218,8 +18218,7 @@ test(2217, DT1[, by = grp, .(agg = list(setNames(as.numeric(value), id)))], DT2)
 # shift integer64 when fill isn't integer32, #4865
 # when test_bit64==FALSE these all passed before
 testnum = 2218
-funs = list(as.integer, as.double, as.complex, as.character)
-if (test_bit64) funs = c(funs, as.integer64)
+funs = c(as.integer, as.double, as.complex, as.character, if (test_bit64) as.integer64)
 for (f1 in funs) {
   DT = data.table(x=f1(1:4))
   for (f2 in funs) {

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -14611,7 +14611,7 @@ if (test_bit64) {
                 warning="-1.*integer64.*position 1 taken as 0 when assigning.*raw.*column 3 named 'c'")
   test(2005.66, DT[2:3, f:=as.integer64(c(NA,"2147483648"))]$f, as.complex(c(-42,NA,2147483648)))
   DT[,h:=LETTERS[1:3]]
-  test(2005.67, DT[2:3, h:=as.integer64(1:2)]$h, c("A","1","2"))   # tests coerceI64toStr PR#5189
+  test(2005.67, DT[2:3, h:=as.integer64(1:2)]$h, c("A","1","2"))   # PR#5189
 }
 
 # rbindlist raw type, #2819
@@ -18223,9 +18223,9 @@ DT2 = data.table(grp = c('a', 'b'), agg = list(c('1' = 4, '2' = 5), c('3' = 6)))
 test(2217, DT1[, by = grp, .(agg = list(setNames(as.numeric(value), id)))], DT2)
 
 # shift integer64 when fill isn't integer32, #4865
-# when test_bit64==FALSE these all passed before
 testnum = 2218
 funs = c(as.integer, as.double, as.complex, as.character, if (test_bit64) as.integer64)
+# when test_bit64==FALSE these all passed before; now passes with test_bit64==TRUE too
 for (f1 in funs) {
   DT = data.table(x=f1(1:4))
   for (f2 in funs) {

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18215,25 +18215,24 @@ DT1 = data.table(id=1:3, grp=c('a', 'a', 'b'), value=4:6)
 DT2 = data.table(grp = c('a', 'b'), agg = list(c('1' = 4, '2' = 5), c('3' = 6)))
 test(2217, DT1[, by = grp, .(agg = list(setNames(as.numeric(value), id)))], DT2)
 
-# 4865 shift coerceAs with data
-funs = list(as.integer, as.double, as.complex, as.character)
+# shift integer64 when fill isn't integer32, #4865
+# when test_bit64==FALSE these all passed before
 testnum = 2218
-for (f in funs) {
-  testnum = testnum + 0.01
-  DT = data.table(x=f(1:4))
-  test(testnum, DT[, shift(x)], f(c(NA, 1:3)))
-  testnum = testnum + 0.01
-  test(testnum, DT[, shift(x, fill=f(0))], f(0:3))
-}
-
-funs = list(as.integer, as.double)
+funs = list(as.integer, as.double, as.complex, as.character)
 if (test_bit64) funs = c(funs, as.integer64)
 for (f1 in funs) {
   DT = data.table(x=f1(1:4))
   for (f2 in funs) {
     testnum = testnum + 0.01
-    test(testnum, DT[, shift(x, fill=f2(NA))], f1(c(NA, 1:3)))
+    test(testnum, DT[, shift(x)],               f1(c(NA, 1:3)))
     testnum = testnum + 0.01
-    test(testnum, DT[, shift(x, fill=f2(0))],  f1(0:3))
+    test(testnum, DT[, shift(x, fill=f2(NA))],  f1(c(NA, 1:3)))
+    testnum = testnum + 0.01
+    if (identical(f1,as.character) && identical(f2,as.complex))
+      # one special case due to as.complex(0)=="0+0i"!="0"
+      test(testnum, DT[, shift(x, fill="0")],   f1(0:3))
+    else 
+      test(testnum, DT[, shift(x, fill=f2(0))], f1(0:3))
   }
 }
+

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18215,3 +18215,25 @@ DT1 = data.table(id=1:3, grp=c('a', 'a', 'b'), value=4:6)
 DT2 = data.table(grp = c('a', 'b'), agg = list(c('1' = 4, '2' = 5), c('3' = 6)))
 test(2217, DT1[, by = grp, .(agg = list(setNames(as.numeric(value), id)))], DT2)
 
+# 4865 shift coerceAs with data
+funs = list(as.integer, as.double, as.complex, as.character)
+testnum = 2218
+for (f in funs) {
+  testnum = testnum + 0.01
+  DT = data.table(x=f(1:4))
+  test(testnum, DT[, shift(x)], f(c(NA, 1:3)))
+  testnum = testnum + 0.01
+  test(testnum, DT[, shift(x, fill=f(0))], f(0:3))
+}
+
+funs = list(as.integer, as.double)
+if (test_bit64) funs = c(funs, as.integer64)
+for (f1 in funs) {
+  DT = data.table(x=f1(1:4))
+  for (f2 in funs) {
+    testnum = testnum + 0.01
+    test(testnum, DT[, shift(x, fill=f2(NA))], f1(c(NA, 1:3)))
+    testnum = testnum + 0.01
+    test(testnum, DT[, shift(x, fill=f2(0))],  f1(0:3))
+  }
+}

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18226,14 +18226,15 @@ for (f1 in funs) {
     testnum = testnum + 0.01
     test(testnum, DT[, shift(x)],               f1(c(NA, 1:3)))
     testnum = testnum + 0.01
-    w = if (identical(f2,as.character) && (identical(f1,as.integer) || identical(f1,as.double))) "Coercing.*character.*to match the type of target vector"
+    w = if (identical(f2,as.character) && !identical(f1,as.character)) "Coercing.*character.*to match the type of target vector"
     test(testnum, DT[, shift(x, fill=f2(NA))],  f1(c(NA, 1:3)), warning=w)
     testnum = testnum + 0.01
-    if (identical(f1,as.character) && identical(f2,as.complex))
+    if (identical(f1,as.character) && identical(f2,as.complex)) {
       # one special case due to as.complex(0)=="0+0i"!="0"
       test(testnum, DT[, shift(x, fill="0")],   f1(0:3))
-    else 
+    } else { 
       test(testnum, DT[, shift(x, fill=f2(0))], f1(0:3), warning=w)
+    }
   }
 }
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -14611,7 +14611,7 @@ if (test_bit64) {
                 warning="-1.*integer64.*position 1 taken as 0 when assigning.*raw.*column 3 named 'c'")
   test(2005.66, DT[2:3, f:=as.integer64(c(NA,"2147483648"))]$f, as.complex(c(-42,NA,2147483648)))
   DT[,h:=LETTERS[1:3]]
-  test(2005.67, DT[2:3, h:=as.integer64(1:2)], error="To assign integer64 to.*type character, please use as.character.")
+  test(2005.67, DT[2:3, h:=as.integer64(1:2)]$h, c("A","1","2"))   # tests coerceI64toStr PR#5189
 }
 
 # rbindlist raw type, #2819

--- a/src/assign.c
+++ b/src/assign.c
@@ -1072,7 +1072,7 @@ const char *memrecycle(const SEXP target, const SEXP where, const int start, con
           break;
         }
         if (OBJECT(source) && getAttrib(source, R_ClassSymbol)!=R_NilValue) {
-          // otherwise coerceVector doesn't call the as.character method for Date, integer64, nanotime, etc; PR#5189
+          // otherwise coerceVector doesn't call the as.character method for Date, IDate, integer64, nanotime, etc; PR#5189
           // this if() is to save the overhead of the R call eval() when we know there can be no method
           source = PROTECT(eval(PROTECT(lang2(sym_as_character, source)), R_GlobalEnv)); protecti+=2;
         } else {

--- a/src/assign.c
+++ b/src/assign.c
@@ -830,7 +830,7 @@ const char *memrecycle(const SEXP target, const SEXP where, const int start, con
       }
     }
   } else if (isString(source) && !isString(target) && !isNewList(target)) {
-    warning(_("Coercing 'character' RHS to '%s' to match the type of %s."), type2char(TYPEOF(target)), targetDesc);
+    warning(_("Coercing 'character' RHS to '%s' to match the type of %s."), targetIsI64?"integer64":type2char(TYPEOF(target)), targetDesc);
     // this "Coercing ..." warning first to give context in case coerceVector warns 'NAs introduced by coercion'
     // and also because 'character' to integer/double coercion is often a user mistake (e.g. wrong target column, or wrong
     // variable on RHS) which they are more likely to appreciate than find inconvenient
@@ -900,6 +900,7 @@ const char *memrecycle(const SEXP target, const SEXP where, const int start, con
       switch (TYPEOF(source)) {
       case REALSXP: if (targetIsI64 && !sourceIsI64)
                     CHECK_RANGE(double, REAL,  !ISNAN(val) && (!R_FINITE(val) || (int)val!=val),        "f",     "truncated (precision lost)", val)
+                    break;
       case CPLXSXP: if (targetIsI64)
                     CHECK_RANGE(Rcomplex, COMPLEX, !((ISNAN(val.i) || (R_FINITE(val.i) && val.i==0.0)) &&
                                                      (ISNAN(val.r) || (R_FINITE(val.r) && (int64_t)val.r==val.r))), "f", "either imaginary part discarded or real part truncated (precision lost)", val.r)

--- a/src/assign.c
+++ b/src/assign.c
@@ -1071,9 +1071,9 @@ const char *memrecycle(const SEXP target, const SEXP where, const int start, con
           }
           break;
         }
-        if (sourceIsI64)
-          error(_("To assign integer64 to a target of type character, please use as.character() for clarity.")); // TODO: handle that here as well
-        source = PROTECT(coerceVector(source, STRSXP)); protecti++;
+        if (sourceIsI64 && INHERITS(source, char_nanotime))
+          error(_("To assign nanotime to a target of type character, please use as.character() for clarity.")); // TODO: eval as.character here, perhaps instead of coerceVector too 
+        source = PROTECT(sourceIsI64 ? coerceI64toStr(source) : coerceVector(source, STRSXP)); protecti++;
       }
       BODY(SEXP, STRING_PTR, SEXP, val,  SET_STRING_ELT(target, off+i, cval))
     }

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -243,6 +243,7 @@ SEXP islockedR(SEXP x);
 bool need2utf8(SEXP x);
 SEXP coerceUtf8IfNeeded(SEXP x);
 SEXP coerceAs(SEXP x, SEXP as, SEXP copyArg);
+SEXP coerceI64toStr(SEXP x);
 
 // types.c
 char *end(char *start);

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -103,6 +103,7 @@ extern SEXP sym_datatable_locked;
 extern SEXP sym_tzone;
 extern SEXP sym_old_fread_datetime_character;
 extern SEXP sym_variable_table;
+extern SEXP sym_as_character;
 extern double NA_INT64_D;
 extern long long NA_INT64_LL;
 extern Rcomplex NA_CPLX;  // initialized in init.c; see there for comments
@@ -243,7 +244,6 @@ SEXP islockedR(SEXP x);
 bool need2utf8(SEXP x);
 SEXP coerceUtf8IfNeeded(SEXP x);
 SEXP coerceAs(SEXP x, SEXP as, SEXP copyArg);
-SEXP coerceI64toStr(SEXP x);
 
 // types.c
 char *end(char *start);

--- a/src/init.c
+++ b/src/init.c
@@ -36,6 +36,7 @@ SEXP sym_datatable_locked;
 SEXP sym_tzone;
 SEXP sym_old_fread_datetime_character;
 SEXP sym_variable_table;
+SEXP sym_as_character;
 double NA_INT64_D;
 long long NA_INT64_LL;
 Rcomplex NA_CPLX;
@@ -366,6 +367,7 @@ void attribute_visible R_init_data_table(DllInfo *info)
   sym_tzone = install("tzone");
   sym_old_fread_datetime_character = install("datatable.old.fread.datetime.character");
   sym_variable_table = install("variable_table");
+  sym_as_character = install("as.character");
 
   initDTthreads();
   avoid_openmp_hang_within_fork();

--- a/src/shift.c
+++ b/src/shift.c
@@ -38,11 +38,10 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type)
     SEXP elem  = VECTOR_ELT(x, i);
     size_t size  = SIZEOF(elem);
     R_xlen_t xrows = xlength(elem);
+    SEXP thisfill = PROTECT(coerceAs(fill, elem, ScalarLogical(0))); nprotect++;  // #4865 use coerceAs for type coercion
     switch (TYPEOF(elem)) {
     case INTSXP : {
-      SEXP thisfill = PROTECT(coerceAs(fill, elem, ScalarLogical(0)));
       const int ifill = INTEGER(thisfill)[0];
-      UNPROTECT(1);
       for (int j=0; j<nk; j++) {
         SEXP tmp;
         SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(INTSXP, xrows) );
@@ -67,11 +66,8 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type)
         if (isFactor(elem)) setAttrib(tmp, R_LevelsSymbol, getAttrib(elem, R_LevelsSymbol));
       }
     } break;
-
     case REALSXP : {
-      SEXP thisfill = PROTECT(coerceAs(fill, elem, ScalarLogical(0))); // #4865 use coerceAs for (NA) type coercion
       const double dfill = REAL(thisfill)[0];
-      UNPROTECT(1); // thisfill
       for (int j=0; j<nk; j++) {
         SEXP tmp;
         SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(REALSXP, xrows) );
@@ -93,11 +89,8 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type)
         copyMostAttrib(elem, tmp);
       }
     } break;
-
     case CPLXSXP : {
-      SEXP thisfill = PROTECT(coerceAs(fill, elem, ScalarLogical(0)));  // #4865 use coerceAs too
       const Rcomplex cfill = COMPLEX(thisfill)[0];
-      UNPROTECT(1);
       for (int j=0; j<nk; j++) {
         SEXP tmp;
         SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(CPLXSXP, xrows) );
@@ -119,11 +112,8 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type)
         copyMostAttrib(elem, tmp);
       }
     } break;
-
     case LGLSXP : {
-      SEXP thisfill = PROTECT(coerceVector(fill, LGLSXP));
       const int lfill = LOGICAL(thisfill)[0];
-      UNPROTECT(1);
       for (int j=0; j<nk; j++) {
         SEXP tmp;
         SET_VECTOR_ELT(ans, i*nk+j, tmp=allocVector(LGLSXP, xrows) );
@@ -145,9 +135,7 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type)
         copyMostAttrib(elem, tmp);
       }
     } break;
-
     case STRSXP : {
-      SEXP thisfill = PROTECT(coerceAs(fill, elem, ScalarLogical(0)));
       const SEXP sfill = STRING_ELT(thisfill, 0);
       for (int j=0; j<nk; j++) {
         SEXP tmp;
@@ -161,11 +149,8 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type)
         }
         copyMostAttrib(elem, tmp);
       }
-      UNPROTECT(1);
     } break;
-
     case VECSXP : {
-      SEXP thisfill = PROTECT(coerceVector(fill, VECSXP));
       const SEXP vfill = VECTOR_ELT(thisfill, 0);
       for (int j=0; j<nk; j++) {
         SEXP tmp;
@@ -179,14 +164,11 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type)
         }
         copyMostAttrib(elem, tmp);
       }
-      UNPROTECT(1);
     } break;
-
     default :
       error(_("Type '%s' is not supported"), type2char(TYPEOF(elem)));
     }
   }
-
   UNPROTECT(nprotect);
   return isVectorAtomic(obj) && length(ans) == 1 ? VECTOR_ELT(ans, 0) : ans;
 }

--- a/src/shift.c
+++ b/src/shift.c
@@ -40,7 +40,7 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type)
     R_xlen_t xrows = xlength(elem);
     switch (TYPEOF(elem)) {
     case INTSXP : {
-      SEXP thisfill = PROTECT(coerceVector(fill, INTSXP));
+      SEXP thisfill = PROTECT(coerceAs(fill, elem, ScalarLogical(0)));
       const int ifill = INTEGER(thisfill)[0];
       UNPROTECT(1);
       for (int j=0; j<nk; j++) {
@@ -69,16 +69,7 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type)
     } break;
 
     case REALSXP : {
-      SEXP thisfill;
-      if (INHERITS(elem, char_integer64)) {
-        thisfill = PROTECT(allocVector(REALSXP, 1));
-        unsigned long long *dthisfill = (unsigned long long *)REAL(thisfill);
-        if (INTEGER(fill)[0] == NA_INTEGER)
-          dthisfill[0] = NA_INT64_LL;
-        else dthisfill[0] = (unsigned long long)INTEGER(fill)[0];
-      } else {
-        thisfill = PROTECT(coerceVector(fill, REALSXP));
-      }
+      SEXP thisfill = PROTECT(coerceAs(fill, elem, ScalarLogical(0))); // #4865 use coerceAs for (NA) type coercion
       const double dfill = REAL(thisfill)[0];
       UNPROTECT(1); // thisfill
       for (int j=0; j<nk; j++) {

--- a/src/shift.c
+++ b/src/shift.c
@@ -95,7 +95,7 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type)
     } break;
 
     case CPLXSXP : {
-      SEXP thisfill = PROTECT(coerceVector(fill, CPLXSXP));
+      SEXP thisfill = PROTECT(coerceAs(fill, elem, ScalarLogical(0)));  // #4865 use coerceAs too
       const Rcomplex cfill = COMPLEX(thisfill)[0];
       UNPROTECT(1);
       for (int j=0; j<nk; j++) {
@@ -147,7 +147,7 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type)
     } break;
 
     case STRSXP : {
-      SEXP thisfill = PROTECT(coerceVector(fill, STRSXP));
+      SEXP thisfill = PROTECT(coerceAs(fill, elem, ScalarLogical(0)));
       const SEXP sfill = STRING_ELT(thisfill, 0);
       for (int j=0; j<nk; j++) {
         SEXP tmp;

--- a/src/utils.c
+++ b/src/utils.c
@@ -345,8 +345,6 @@ SEXP coerceAs(SEXP x, SEXP as, SEXP copyArg) {
   // copyArg does not update in place, but only IF an object is of the same type-class as class to be coerced, it will return with no copy
   if (!isVectorAtomic(x))
     error(_("'x' is not atomic"));
-  if (!isVectorAtomic(as))
-    error(_("'as' is not atomic"));
   if (!isNull(getAttrib(x, R_DimSymbol)))
     error(_("'x' must not be matrix or array"));
   if (!isNull(getAttrib(as, R_DimSymbol)))

--- a/src/utils.c
+++ b/src/utils.c
@@ -406,3 +406,32 @@ SEXP startsWithAny(const SEXP x, const SEXP y, SEXP start) {
   return ScalarLogical(false);
 }
 
+SEXP coerceI64toStr(SEXP x) {
+  // similar to fwrite.c:writeInt64 but given the need to call mkChar we can avoid its reverse()
+  if (!isReal(x) || !INHERITS(x, char_integer64))
+    error(_("Internal error: coerceI64toStr not passed an integer64"));  // # nocov
+  static char s[21];  // longest int -(2^63) == -9223372036854775807\0
+  const int n = length(x);
+  const int64_t *xd = (const int64_t *)REAL(x);
+  SEXP ans = PROTECT(allocVector(STRSXP, n));
+  const SEXP *ansd = STRING_PTR(ans);
+  for (int i=0; i<n; ++i) {
+    int64_t v = xd[i];
+    if (v==NA_INTEGER64)
+      SET_STRING_ELT(ans, i, NA_STRING);
+    else if (i>0 && v==xd[i-1])
+      SET_STRING_ELT(ans, i, ansd[i-1]);
+    else {
+      bool neg=false;
+      if (v<0) { neg=true; v=-v; }
+      char *ch = s+20;
+      *ch-- = '\0';
+      do { *ch-- = '0'+v%10; v/=10; } while (v>0);
+      if (neg) *ch='-'; else ch++;
+      SET_STRING_ELT(ans, i, mkChar(ch));
+    }
+  }
+  UNPROTECT(1);
+  return ans;
+}
+


### PR DESCRIPTION
Closes #4865 

Also changes type coercion for the `integer` case to switch neatless between `integer`, `double` and `integer64`.