### PR TITLE
run plot() in tempdir()

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -510,10 +510,13 @@ test(165, subset(DT,a>2), DT[a>2])
 test(166, suppressWarnings(split(DT,DT$grp)[[2]]), DT[grp==2])
 
 # and that plotting works
+# ensure plots are writeable by switching to tempdir()
+owd <- setwd(tempdir())
 test(167.1, DT[,plot(b,f)], NULL)
 test(167.2, as.integer(DT[,hist(b)]$breaks), seq.int(10L,50L,by=5L)) # as.integer needed for R 3.1.0
 test(167.3, DT[,plot(b,f),by=.(grp)], data.table(grp=integer()))
 try(graphics.off(),silent=TRUE)
+setwd(owd)
 
 # IDateTime conversion methods that ggplot2 uses (it calls as.data.frame method)
 # Since %b is e.g. "nov." in LC_TIME=fr_FR.UTF-8 locale, we need to


### PR DESCRIPTION
Our tests run in an environment where the test executing directory is not writeable, so plain `plot()` fails when trying to create `Rplots.pdf` locally. Switching to `tempdir()` for the write solves this.