### PR TITLE
restore supporting data.table not inheriting from data.frame

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2527,8 +2527,10 @@ copy = function(x) {
 }
 
 shallow = function(x, cols=NULL) {
-  if (!is.data.frame(x))
+  if (!is.data.frame(x) && !is.data.table(x)) {
+    #                      ^^ some revdeps do class(x)="data.table" without inheriting from data.frame, PR#XXXX
     stopf("x is not a data.table|frame. Shallow copy is a copy of the vector of column pointers (only), so is only meaningful for data.table|frame")
+  }
   ans = .shallow(x, cols=cols, retain.key=selfrefok(x))  # selfrefok for #5042
   ans
 }

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2528,7 +2528,7 @@ copy = function(x) {
 
 shallow = function(x, cols=NULL) {
   if (!is.data.frame(x) && !is.data.table(x)) {
-    #                      ^^ some revdeps do class(x)="data.table" without inheriting from data.frame, PR#XXXX
+    #                      ^^ some revdeps do class(x)="data.table" without inheriting from data.frame, PR#5210
     stopf("x is not a data.table|frame. Shallow copy is a copy of the vector of column pointers (only), so is only meaningful for data.table|frame")
   }
   ans = .shallow(x, cols=cols, retain.key=selfrefok(x))  # selfrefok for #5042

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18266,7 +18266,7 @@ test(testnum+0.01, DT[, prod(l), g], error="GForce prod can only be applied to c
 # tables() error when called from inside a function(...), #5197
 test(2221, (function(...) tables())(), output = "No objects of class data.table exist")
 
-# some revdeps do class(x)="data.table" without inheriting from data.frame, PR#XXXX
+# some revdeps do class(x)="data.table" without inheriting from data.frame, PR#5210
 DT = data.table(A=1:3)
 class(DT) = "data.table"
 test(2222, print(DT), output="A.*3")

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -640,7 +640,7 @@ test(211, ncol(TESTDT), 2L)
 DT = data.table(a=1:6,key="a")
 test(212, DT[J(3)]$a, 3L) # correct class c("data.table","data.frame")
 class(DT) = "data.table"  # incorrect class, but as from 1.8.1 it works. By accident when moving from colnames() to names(), it was dimnames() doing the check, but rather than add a check that identical(class(DT),c("data.frame","data.table")) at the top of [.data.table, we'll leave it flexible to user (user might not want to inherit from data.frame for some reason).
-test(213, DT[J(3)]$a, error="x is not a data.table|frame")  # from v1.14.2, data.table must inherit from data.frame (internals are too hard to reason if a data.table may not be data.frame too)
+test(213, DT[J(3)]$a, 3L)
 
 # setkey now auto coerces double and character for convenience, and
 # to solve bug #953
@@ -18265,4 +18265,9 @@ test(testnum+0.01, DT[, prod(l), g], error="GForce prod can only be applied to c
 
 # tables() error when called from inside a function(...), #5197
 test(2221, (function(...) tables())(), output = "No objects of class data.table exist")
+
+# some revdeps do class(x)="data.table" without inheriting from data.frame, PR#XXXX
+DT = data.table(A=1:3)
+class(DT) = "data.table"
+test(2222, print(DT), output="A.*3")
 


### PR DESCRIPTION
#5113 broke 4 revdeps doremi, dvmisc, EIX and iemisc which create a `data.table` that doesn't inherit from `data.frame`, e.g. doremi does `class(x)="data.table"` in its `print` method. I didn't debug the other 3 but the revdep log (in #5201) showed the same error from `shallow()`.
Test 213 restored to how it was before. Its comment `user might not want to inherit from data.frame for some reason` suggests it was intentional to support `class(x)="data.table"`, and since the fix is easy here, seems right to do.
At least, w.r.t. shallow. Almost surely `|> DT()` doesn't support `data.table` which do not inherit from `data.frame`, because `is.data.frame()` is used in many places to be true for data.table or data.frame. Maybe a new function `is.data.table.or.frame()` would be the way to go, and use that everywhere, and have a check in CRAN_Release.cmd that we don't use is.data.frame(), or mask and turn off is.data.frame(), or detect and error when objects are data.table without inheriting from data.frame.  But for now, that's for another day. 