### PR TITLE
retain nomatch=FALSE for backwards compatibility

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -222,7 +222,7 @@ replace_dot_alias = function(e) {
   .unsafe.opt() #3585
   missingnomatch = missing(nomatch)
   nomatch0 = identical(nomatch,0) || identical(nomatch,0L) || identical(nomatch, FALSE)  # for warning with row-numbers in i; #4353
-  if (nomatch0) nomatch=NULL  # retain nomatch=0|FALSE backwards compatibility, #857 #XXXX
+  if (nomatch0) nomatch=NULL  # retain nomatch=0|FALSE backwards compatibility, #857 #5214
   if (!(is.null(nomatch) || (length(nomatch)==1L && is.na(nomatch)))) stopf("nomatch= must be either NA or NULL (or 0 for backwards compatibility which is the same as NULL but please use NULL)")
   if (!is.logical(which) || length(which)>1L) stopf("which= must be a logical vector length 1. Either FALSE, TRUE or NA.")
   if ((isTRUE(which)||is.na(which)) && !missing(j)) stopf("which==%s (meaning return row numbers) but j is also supplied. Either you need row numbers or the result of j, but only one type of result can be returned.", which)

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -221,8 +221,8 @@ replace_dot_alias = function(e) {
   # TO DO (document/faq/example). Removed for now ... if ((roll || rolltolast) && missing(mult)) mult="last" # for when there is exact match to mult. This does not control cases where the roll is mult, that is always the last one.
   .unsafe.opt() #3585
   missingnomatch = missing(nomatch)
-  nomatch0 = identical(nomatch,0) || identical(nomatch,0L)  # for warning with row-numbers in i; #4353
-  if (nomatch0) nomatch=NULL  # retain nomatch=0 backwards compatibility; #857
+  nomatch0 = identical(nomatch,0) || identical(nomatch,0L) || identical(nomatch, FALSE)  # for warning with row-numbers in i; #4353
+  if (nomatch0) nomatch=NULL  # retain nomatch=0|FALSE backwards compatibility, #857 #XXXX
   if (!(is.null(nomatch) || (length(nomatch)==1L && is.na(nomatch)))) stopf("nomatch= must be either NA or NULL (or 0 for backwards compatibility which is the same as NULL but please use NULL)")
   if (!is.logical(which) || length(which)>1L) stopf("which= must be a logical vector length 1. Either FALSE, TRUE or NA.")
   if ((isTRUE(which)||is.na(which)) && !missing(j)) stopf("which==%s (meaning return row numbers) but j is also supplied. Either you need row numbers or the result of j, but only one type of result can be returned.", which)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18271,7 +18271,7 @@ DT = data.table(A=1:3)
 class(DT) = "data.table"
 test(2222, print(DT), output="A.*3")
 
-# retain nomatch=FALSE backwards compatibility
+# retain nomatch=FALSE backwards compatibility, #5214
 DT = data.table(A=1:3, key="A")
 test(2223, DT[.(4), nomatch=FALSE], data.table(A=integer(), key="A"))
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18271,3 +18271,7 @@ DT = data.table(A=1:3)
 class(DT) = "data.table"
 test(2222, print(DT), output="A.*3")
 
+# retain nomatch=FALSE backwards compatibility
+DT = data.table(A=1:3, key="A")
+test(2223, DT[.(4), nomatch=FALSE], data.table(A=integer(), key="A"))
+


### PR DESCRIPTION
Resolves revdeps NADIA and VIM (highlighted in #5208) which use `nomatch=FALSE`. Were broken by #4353.
