### PR TITLE
restore nomatch=NA_character_

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -223,7 +223,10 @@ replace_dot_alias = function(e) {
   missingnomatch = missing(nomatch)
   nomatch0 = identical(nomatch,0) || identical(nomatch,0L) || identical(nomatch, FALSE)  # for warning with row-numbers in i; #4353
   if (nomatch0) nomatch=NULL  # retain nomatch=0|FALSE backwards compatibility, #857 #5214
-  if (!(is.null(nomatch) || (length(nomatch)==1L && is.na(nomatch)))) stopf("nomatch= must be either NA or NULL (or 0 for backwards compatibility which is the same as NULL but please use NULL)")
+  if (!is.null(nomatch)) {
+    if (!(length(nomatch)==1L && is.na(nomatch))) stopf("nomatch= must be either NA or NULL (or 0 for backwards compatibility which is the same as NULL but please use NULL)")
+    nomatch=NA  # convert NA_character_ to NA_logical_, PR#XXXX
+  }
   if (!is.logical(which) || length(which)>1L) stopf("which= must be a logical vector length 1. Either FALSE, TRUE or NA.")
   if ((isTRUE(which)||is.na(which)) && !missing(j)) stopf("which==%s (meaning return row numbers) but j is also supplied. Either you need row numbers or the result of j, but only one type of result can be returned.", which)
   if (is.null(nomatch) && is.na(which)) stopf("which=NA with nomatch=0|NULL would always return an empty vector. Please change or remove either which or nomatch.")

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18271,7 +18271,8 @@ DT = data.table(A=1:3)
 class(DT) = "data.table"
 test(2222, print(DT), output="A.*3")
 
-# retain nomatch=FALSE backwards compatibility, #5214
+# retain nomatch=FALSE backwards compatibility #5214, and nomatch=NA_character_ PR#XXXX
 DT = data.table(A=1:3, key="A")
-test(2223, DT[.(4), nomatch=FALSE], data.table(A=integer(), key="A"))
+test(2223.1, DT[.(4), nomatch=FALSE], data.table(A=integer(), key="A"))
+test(2223.2, DT[.(4), nomatch=NA_character_], data.table(A=4L, key="A"))
 


### PR DESCRIPTION
Resolves revdep SpaDES.Core (highlighted in #5208) which uses `nomatch=NA_character_`. Similar to #5214, #4353 also broke it; there was an `as.integer(nomatch)` before.