### PR TITLE
use seq(), not seq.Date() in tests

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -9956,7 +9956,7 @@ test(1658.34, fwrite(data.table(id=c("A","B","C"), v=c(1.1,0.0,9.9))), output="i
 test(1658.35, fwrite(data.table(id=1:3,bool=c(TRUE,NA,FALSE)),na="NA",logical01=TRUE), output="\"id\",\"bool\"\n1,1\n2,NA\n3,0")
 
 # POSIXct
-test(1658.36, fwrite(data.table(D = as.POSIXct(seq.Date(as.Date("2038-01-19"), as.Date("2038-01-20"), by = "day")))),
+test(1658.36, fwrite(data.table(D = as.POSIXct(seq(as.Date("2038-01-19"), as.Date("2038-01-20"), by = "day")))),
     output="D\n2038-01-19T00:00:00Z\n2038-01-20T00:00:00Z")
 
 # input is of class matrix
@@ -10883,13 +10883,13 @@ test(1738.5, as.integer(as.Date(c("0000-03-01","9999-12-31"))), c(-719468L,29328
 
 if (FALSE) {
   # Full range takes too long for CRAN.
-  dts = seq.Date(as.Date("0000-03-01"),as.Date("9999-12-31"),by="day")
+  dts = seq(as.Date("0000-03-01"), as.Date("9999-12-31"), by="day")
   dtsCh = as.character(dts)   # 36s
   dtsCh = gsub(" ","0",sprintf("%10s",dtsCh))  # R does not 0 pad years < 1000
   test(1739.1, length(dtsCh)==3652365 && identical(dtsCh[c(1,3652365)],c("0000-03-01","9999-12-31")))
 } else {
   # test on CRAN a reduced but important range
-  dts = seq.Date(as.Date("1899-12-31"),as.Date("2100-01-01"),by="day")
+  dts = seq(as.Date("1899-12-31"), as.Date("2100-01-01"), by="day")
   dtsCh = as.character(dts)
   test(1739.2, length(dtsCh)==73051 && identical(dtsCh[c(1,73051)],c("1899-12-31","2100-01-01")))
 }


### PR DESCRIPTION
Minor point, but `seq.Date()` is probably not supposed to be called directly -- IINM it's only exported because the `base` namespace is "special" (`?asNamespace`) and all its functions are exported. For example, `?seq.Date` uses the S3 method style in the usage section, and only `seq()` is called in its examples.