### PR TITLE
Fwrite rounding

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -451,7 +451,7 @@
     
 47. `tables()` failed with `argument "..." is missing` when called from within a function taking `...`; e.g. `function(...) { tables() }`, [#5197](https://github.com/Rdatatable/data.table/issues/5197). Thanks @greg-minshall for the report and @michaelchirico for the fix.
 
-48. When writing `POSIXct` objects, `fread()` did not correctly handle the case when microseconds were rounded up to a whole second, producing incorrect output that was also not ISO compliant [#5238](https://github.com/Rdatatable/data.table/issues/5238). Thanks to @avraam-inside for the report and Václav Tlapák for the fix.
+48. When writing `POSIXct` objects, `fwrite()` did not correctly handle the case when microseconds were rounded up to a whole second, producing incorrect output that was also not ISO compliant [#5238](https://github.com/Rdatatable/data.table/issues/5238). Thanks to @avraam-inside for the report and Václav Tlapák for the fix.
 
 ## NOTES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -451,6 +451,8 @@
     
 47. `tables()` failed with `argument "..." is missing` when called from within a function taking `...`; e.g. `function(...) { tables() }`, [#5197](https://github.com/Rdatatable/data.table/issues/5197). Thanks @greg-minshall for the report and @michaelchirico for the fix.
 
+48. When writing `POSIXct` objects, `fread()` did not correctly handle the case when microseconds were rounded up to a whole second, producing incorrect output that was also not ISO compliant [#5238](https://github.com/Rdatatable/data.table/issues/5238). Thanks to @avraam-inside for the report and Václav Tlapák for the fix.
+
 ## NOTES
 
 1. New feature 29 in v1.12.4 (Oct 2019) introduced zero-copy coercion. Our thinking is that requiring you to get the type right in the case of `0` (type double) vs `0L` (type integer) is too inconvenient for you the user. So such coercions happen in `data.table` automatically without warning. Thanks to zero-copy coercion there is no speed penalty, even when calling `set()` many times in a loop, so there's no speed penalty to warn you about either. However, we believe that assigning a character value such as `"2"` into an integer column is more likely to be a user mistake that you would like to be warned about. The type difference (character vs integer) may be the only clue that you have selected the wrong column, or typed the wrong variable to be assigned to that column. For this reason we view character to numeric-like coercion differently and will warn about it. If it is correct, then the warning is intended to nudge you to wrap the RHS with `as.<type>()` so that it is clear to readers of your code that a coercion from character to that type is intended. For example :

--- a/NEWS.md
+++ b/NEWS.md
@@ -500,7 +500,7 @@
 
 49. `fintersect(..., all=TRUE)` and `fsetdiff(..., all=TRUE)` could return incorrect results when the inputs had columns named `x` and `y`, [#5255](https://github.com/Rdatatable/data.table/issues/5255). Thanks @Fpadt for the report, and @ben-schwen for the fix.
 
-50. When writing `POSIXct` objects, `fwrite()` did not correctly handle the case when microseconds were rounded up to a whole second, producing incorrect output that was also not ISO compliant [#5238](https://github.com/Rdatatable/data.table/issues/5238). Thanks to @avraam-inside for the report and Václav Tlapák for the fix.
+50. `fwrite()` could produce not-ISO-compliant timestamps such as `2023-03-08T17:22:32.:00Z` when under a whole second by less than numerical tolerance of one microsecond, [#5238](https://github.com/Rdatatable/data.table/issues/5238). Thanks to @avraam-inside for the report and Václav Tlapák for the fix.
 
 ## NOTES
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18417,5 +18417,5 @@ test(2227.2, fsetdiff(DT, DT, all=TRUE), DT[0])
 
 # fwrite POSIXct rounding, #5238
 DT = data.table(as.POSIXct(c(1678296152.99999952316284179688, -118944658.0000004, -.00000004), origin='1970-01-01 00:00:00'))
-test(2228, capture.output(fwrite(DT))[-1], c('2023-03-08T17:22:33Z', '1966-03-26T07:49:02Z', '1970-01-01T00:00:00Z'))
+test(2228, fwrite(DT), output="2023-03-08T17:22:33Z.*1966-03-26T07:49:02Z.*1970-01-01T00:00:00Z")
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -10969,7 +10969,7 @@ setattr(DT[[4]], "tzone", NULL)
 setattr(DT[[5]], "tzone", NULL)
 
 # format() now supports digits = 0, to display nsmall decimal places.
-options(digits.secs=0)
+old=options(digits.secs=0)
 test(1741.3, x1<-capture.output(fwrite(DT,dateTimeAs="write.csv")),
              capture.output(write.csv(DT,row.names=FALSE,quote=FALSE)))
 options(digits.secs=3)
@@ -10980,6 +10980,7 @@ test(1741.5, x3<-capture.output(fwrite(DT,dateTimeAs="write.csv")),
              capture.output(write.csv(DT,row.names=FALSE,quote=FALSE)))
 # check that extra digits made it into output
 test(1741.6, sum(nchar(x1)) < sum(nchar(x2)) && sum(nchar(x2)) < sum(nchar(x3)))
+options(old)
 
 # fread should properly handle NA in colClasses argument #1910
 test(1743.01, sapply(fread("a,b\n3,a", colClasses=c(NA, "factor")), class), c(a="integer", b="factor"))

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18348,3 +18348,6 @@ test(2225.1, groupingsets(data.table(iris), j=sum(Sepal.Length), by=c('Sp'='Spec
 test(2225.2, groupingsets(data.table(iris), j=mean(Sepal.Length), by=c('Sp'='Species'), sets=list('Species')),
              groupingsets(data.table(iris), j=mean(Sepal.Length), by=c('Species'), sets=list('Species')))
 
+# fwrite POSIXct rounding
+DT = data.table(as.POSIXct(c(1678296152.99999952316284179688, -118944658.0000004, -.00000004), origin = '1970-01-01 00:00:00'))
+test(2226, capture.output(fwrite(DT))[-1], c('2023-03-08T17:22:33Z', '1966-03-26T07:49:02Z', '1970-01-01T00:00:00Z'))

--- a/src/fwrite.c
+++ b/src/fwrite.c
@@ -424,7 +424,7 @@ void writePOSIXct(double *col, int64_t row, char **pch)
     int carry = m / 1000000; // Need to know if we rounded up to a whole second
     m -= carry * 1000000;
     xi += carry;
-    if (x>=0) {
+    if (xi>=0) {
       d = xi / 86400;
       t = xi % 86400;
     } else {

--- a/src/fwrite.c
+++ b/src/fwrite.c
@@ -417,19 +417,21 @@ void writePOSIXct(double *col, int64_t row, char **pch)
     write_chars(na, &ch);
   } else {
     int64_t xi, d, t;
+    xi = floor(x);
+    int m = ((x-xi)*10000000); // 7th digit used to round up if 9
+    m += (m%10);  // 9 is numerical accuracy, 8 or less then we truncate to last microsecond
+    m /= 10;
+    int carry = m / 1000000; // Need to know if we rounded up to a whole second
+    m -= carry * 1000000;
+    xi += carry;
     if (x>=0) {
-      xi = floor(x);
       d = xi / 86400;
       t = xi % 86400;
     } else {
       // before 1970-01-01T00:00:00Z
-      xi = floor(x);
       d = (xi+1)/86400 - 1;
       t = xi - d*86400;  // xi and d are both negative here; t becomes the positive number of seconds into the day
     }
-    int m = ((x-xi)*10000000); // 7th digit used to round up if 9
-    m += (m%10);  // 9 is numerical accuracy, 8 or less then we truncate to last microsecond
-    m /= 10;
     write_date(d, &ch);
     *ch++ = 'T';
     ch -= squashDateTime;


### PR DESCRIPTION
Closes  #5238

I have also cleaned up the `digits.secs` option that was set in earlier fwrite tests.

Note that base R does not correctly handle printing of fractional seconds for negative timestamps (on Windows at least). (The issue is somewhere in as.POSIXlt.POSIXct)