### PR TITLE
set operations for DT containing x and y as column names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -448,8 +448,10 @@
     # 2:          2021-02-03  # was 18661
     # 3: 4611686018427387906  # was error 'please use as.character'
     ```
-    
+
 47. `tables()` failed with `argument "..." is missing` when called from within a function taking `...`; e.g. `function(...) { tables() }`, [#5197](https://github.com/Rdatatable/data.table/issues/5197). Thanks @greg-minshall for the report and @michaelchirico for the fix.
+
+48. `fintersect(DT, DT, all=TRUE)` and `fsetdiff(DT, DT, all=TRUE)` could return wrong results when `DT` had column names `x` and `y`, [#5255](https://github.com/Rdatatable/data.table/issues/5255). Thanks @Fpadt for the report, and @ben-schwen for the fix.
 
 ## NOTES
 

--- a/R/setops.R
+++ b/R/setops.R
@@ -59,8 +59,8 @@ fintersect = function(x, y, all=FALSE) {
   .set_ops_arg_check(x, y, all, .seqn = TRUE)
   if (!nrow(x) || !nrow(y)) return(x[0L])
   if (all) {
-    x = shallow(x)[, ".seqn" := rowidv(x)]
-    y = shallow(y)[, ".seqn" := rowidv(y)]
+    x = shallow(x)[, ".seqn" := rowidv(.seqn_id), env=list(.seqn_id=x)]
+    y = shallow(y)[, ".seqn" := rowidv(.seqn_id), env=list(.seqn_id=y)]
     jn.on = c(".seqn",setdiff(names(y),".seqn"))
     # fixes #4716 by preserving order of 1st (uses y[x] join) argument instead of 2nd (uses x[y] join)
     y[x, .SD, .SDcols=setdiff(names(y),".seqn"), nomatch=NULL, on=jn.on]
@@ -75,8 +75,8 @@ fsetdiff = function(x, y, all=FALSE) {
   if (!nrow(x)) return(x)
   if (!nrow(y)) return(if (!all) funique(x) else x)
   if (all) {
-    x = shallow(x)[, ".seqn" := rowidv(x)]
-    y = shallow(y)[, ".seqn" := rowidv(y)]
+    x = shallow(x)[, ".seqn" := rowidv(.seqn_id), env=list(.seqn_id=x)]
+    y = shallow(y)[, ".seqn" := rowidv(.seqn_id), env=list(.seqn_id=y)]
     jn.on = c(".seqn",setdiff(names(x),".seqn"))
     x[!y, .SD, .SDcols=setdiff(names(x),".seqn"), on=jn.on]
   } else {

--- a/R/setops.R
+++ b/R/setops.R
@@ -59,6 +59,7 @@ fintersect = function(x, y, all=FALSE) {
   .set_ops_arg_check(x, y, all, .seqn = TRUE)
   if (!nrow(x) || !nrow(y)) return(x[0L])
   if (all) {
+    .seqn_id = NULL  # to avoid 'no visible binding for global variable' note from R CMD check
     x = shallow(x)[, ".seqn" := rowidv(.seqn_id), env=list(.seqn_id=x)]
     y = shallow(y)[, ".seqn" := rowidv(.seqn_id), env=list(.seqn_id=y)]
     jn.on = c(".seqn",setdiff(names(y),".seqn"))
@@ -75,6 +76,7 @@ fsetdiff = function(x, y, all=FALSE) {
   if (!nrow(x)) return(x)
   if (!nrow(y)) return(if (!all) funique(x) else x)
   if (all) {
+    .seqn_id = NULL  # to avoid 'no visible binding for global variable' note from R CMD check
     x = shallow(x)[, ".seqn" := rowidv(.seqn_id), env=list(.seqn_id=x)]
     y = shallow(y)[, ".seqn" := rowidv(.seqn_id), env=list(.seqn_id=y)]
     jn.on = c(".seqn",setdiff(names(x),".seqn"))

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18348,3 +18348,7 @@ test(2225.1, groupingsets(data.table(iris), j=sum(Sepal.Length), by=c('Sp'='Spec
 test(2225.2, groupingsets(data.table(iris), j=mean(Sepal.Length), by=c('Sp'='Species'), sets=list('Species')),
              groupingsets(data.table(iris), j=mean(Sepal.Length), by=c('Species'), sets=list('Species')))
 
+# 5255 set operations for DT containing x and y as column names
+DT = data.table(x=c(1,2,2,2), y=LETTERS[c(1,2,2,3)])
+test(2226.1, fintersect(DT, DT, all=TRUE), DT)
+test(2226.2, fsetdiff(DT, DT, all=TRUE), DT[0])


### PR DESCRIPTION
Closes #5255

Problem is that `shallow(x)[, j]` gives precedence to columns names over object names and so `rowidv(x)` uses column and not the data.table `x`. Same argument holds for `y`.

https://github.com/Rdatatable/data.table/blob/e88826e94127991754a8821ac8149d15f1f9c3c2/R/setops.R#L58-L63

Fix avoids naming conflict by using the new programming environment. Could achieve the same by replacing `:=` with `set`, as below

```R
x = set(shallow(x), j=".seqn", value=rowidv(x))
y = set(shallow(y), j=".seqn", value=rowidv(y))
```