### PR TITLE
set automatically allocates new column slots if needed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -453,6 +453,8 @@
 
 48. `DT[, prod(int64Col), by=grp]` produced wrong results for `bit64::integer64` due to incorrect optimization, [#5225](https://github.com/Rdatatable/data.table/issues/5225). Thanks to Benjamin Schwendinger for reporting and fixing.
 
+49. `set()` now automatically pre-allocates new column slots if needed, similarly as `:=` already does, [#496](https://github.com/Rdatatable/data.table/issues/496) [#4100](https://github.com/Rdatatable/data.table/issues/4100). Thanks to Huashan Chen and Benjamin Tyner for the report and Benjamin Schwendinger for the fix.
+
 ## NOTES
 
 1. New feature 29 in v1.12.4 (Oct 2019) introduced zero-copy coercion. Our thinking is that requiring you to get the type right in the case of `0` (type double) vs `0L` (type integer) is too inconvenient for you the user. So such coercions happen in `data.table` automatically without warning. Thanks to zero-copy coercion there is no speed penalty, even when calling `set()` many times in a loop, so there's no speed penalty to warn you about either. However, we believe that assigning a character value such as `"2"` into an integer column is more likely to be a user mistake that you would like to be warned about. The type difference (character vs integer) may be the only clue that you have selected the wrong column, or typed the wrong variable to be assigned to that column. For this reason we view character to numeric-like coercion differently and will warn about it. If it is correct, then the warning is intended to nudge you to wrap the RHS with `as.<type>()` so that it is clear to readers of your code that a coercion from character to that type is intended. For example :

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2707,7 +2707,7 @@ setcolorder = function(x, neworder=key(x), before=NULL, after=NULL)  # before/af
 
 set = function(x,i=NULL,j,value)  # low overhead, loopable
 {
-  if (is.character(j)) {
+  if (is.character(j) && truelength(x) < ncol(x)+length(j)) {
     newnames = NULL
     names_x = names(x)
     m = chmatch(j, names_x)

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2715,9 +2715,9 @@ set = function(x,i=NULL,j,value)  # low overhead, loopable
       newnames = j[is.na(m)]
     }
     if (truelength(x) < ncol(x)+length(newnames)) {
-      name = substitute(x)
       n = length(newnames) + eval(getOption("datatable.alloccol"))
-      setalloccol(x, n)
+      name = substitute(x)
+      x = .Call(Calloccolwrapper, x, eval(n), getOption("datatable.verbose"))
       if (is.name(name)) {
         assign(as.character(name),x,parent.frame(),inherits=TRUE)
       }

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2707,6 +2707,22 @@ setcolorder = function(x, neworder=key(x), before=NULL, after=NULL)  # before/af
 
 set = function(x,i=NULL,j,value)  # low overhead, loopable
 {
+  if (is.character(j)) {
+    newnames = NULL
+    names_x = names(x)
+    m = chmatch(j, names_x)
+    if (anyNA(m)) {
+      newnames = j[is.na(m)]
+    }
+    if (truelength(x) < ncol(x)+length(newnames)) {
+      name = substitute(x)
+      n = length(newnames) + eval(getOption("datatable.alloccol"))
+      setalloccol(x, n)
+      if (is.name(name)) {
+        assign(as.character(name),x,parent.frame(),inherits=TRUE)
+      }
+    }
+  }
   .Call(Cassign,x,i,j,NULL,value)
   invisible(x)
 }

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -14784,7 +14784,7 @@ test(2016.1, name, "DT")
 test(2016.2, DT, data.table(a=1:3))
 test(2016.3, DT[2,a:=4L], data.table(a=INT(1,4,3)))        # no error for := when existing column
 test(2016.4, set(DT,3L,1L,5L), data.table(a=INT(1,4,5)))   # no error for set() when existing column
-test(2016.5, set(DT,2L,"newCol",5L), error="either been loaded from disk.*or constructed manually.*Please run setDT.*setalloccol.*on it first")   # just set()
+test(2016.5, set(DT,2L,"newCol",5L), data.table(a=INT(1,4,5), newCol=INT(NA,5L,NA)))   # works since set overallocates
 test(2016.6, DT[2,newCol:=6L], data.table(a=INT(1,4,5), newCol=INT(NA,6L,NA)))  # := ok (it changes DT in caller)
 unlink(tt)
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18378,7 +18378,9 @@ if (test_bit64) {
 }
 
 # re-overallocate in set if quota is reached #496 #4100
+opt = options(datatable.alloccol=1L)
 n = getOption("datatable.alloccol")
 DT = data.table()
 for (i in seq(2*n)) set(DT, j = paste0("V",i), value = i)
 test(2227.1, ncol(DT), 2L*n)
+options(opt)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18377,3 +18377,8 @@ if (test_bit64) {
   test(2226.3, DT[, prod(x,na.rm=TRUE), g], data.table(g=1:3, V1=as.integer64(c(NA,"9223372036854775807",-8L))))
 }
 
+# re-overallocate in set if quota is reached #496 #4100
+n = getOption("datatable.alloccol")
+DT = data.table()
+for (i in seq(2*n)) set(DT, j = paste0("V",i), value = i)
+test(2227.1, ncol(DT), 2L*n)


### PR DESCRIPTION
Closes #4100 (what's left is the duplicate of #496)
Towards #496 establishing consistent behavior between `set` and `:=`