### PR TITLE
print.class and print.keys now TRUE by default

### DIFF
--- a/.dev/cc.R
+++ b/.dev/cc.R
@@ -22,8 +22,6 @@
 # c
 # test and step between R and C
 
-options(datatable.print.class = TRUE)
-
 sourceDir = function(path=getwd(), trace = TRUE, ...) {
   # copied verbatim from example(source) in base R
   for (nm in list.files(path, pattern = "\\.[RrSsQq]$")) {

--- a/NEWS.md
+++ b/NEWS.md
@@ -551,6 +551,8 @@
 
 15. Many thanks to Kurt Hornik for investigating potential impact of a possible future change to `base::intersect()` on empty input, providing a patch so that `data.table` won't break if the change is made to R, and giving us plenty of notice, [#5183](https://github.com/Rdatatable/data.table/pull/5183).
 
+16. The options `datatable.print.class` and `datatable.print.keys` are now `TRUE` by default. They have been available since v1.9.8 (Nov 2016) and v1.11.0 (May 2018) respectively.
+
 
 # data.table [v1.14.2](https://github.com/Rdatatable/data.table/milestone/24?closed=1)  (27 Sep 2021)
 

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -73,10 +73,10 @@
        "datatable.optimize"="Inf",             # datatable.<argument name>
        "datatable.print.nrows"="100L",         # datatable.<argument name>
        "datatable.print.topn"="5L",            # datatable.<argument name>
-       "datatable.print.class"="FALSE",        # for print.data.table
+       "datatable.print.class"="TRUE",         # for print.data.table
        "datatable.print.rownames"="TRUE",      # for print.data.table
        "datatable.print.colnames"="'auto'",    # for print.data.table
-       "datatable.print.keys"="FALSE",         # for print.data.table
+       "datatable.print.keys"="TRUE",          # for print.data.table
        "datatable.print.trunc.cols"="FALSE",   # for print.data.table
        "datatable.allow.cartesian"="FALSE",    # datatable.<argument name>
        "datatable.dfdispatchwarn"="TRUE",                   # not a function argument

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -81,7 +81,8 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
     scipen = 0L,  # fwrite now respects scipen
     datatable.optimize = Inf,
     datatable.alloccol = 1024L,
-    datatable.print.class = FALSE,  # this is TRUE in cc.R and we like TRUE. But output= tests need to be updated (they assume FALSE currently)
+    datatable.print.class = FALSE,  # output= tests were written when default was FALSE
+    datatable.print.keys = FALSE,   # output= tests were written when default was FALSE
     datatable.print.trunc.cols = FALSE, #4552
     datatable.rbindlist.check = NULL,
     datatable.integer64 = "integer64",

--- a/man/print.data.table.Rd
+++ b/man/print.data.table.Rd
@@ -18,10 +18,10 @@
   \method{print}{data.table}(x,
     topn=getOption("datatable.print.topn"),             # default: 5
     nrows=getOption("datatable.print.nrows"),           # default: 100
-    class=getOption("datatable.print.class"),           # default: FALSE
+    class=getOption("datatable.print.class"),           # default: TRUE
     row.names=getOption("datatable.print.rownames"),    # default: TRUE
     col.names=getOption("datatable.print.colnames"),    # default: "auto"
-    print.keys=getOption("datatable.print.keys"),       # default: FALSE
+    print.keys=getOption("datatable.print.keys"),       # default: TRUE
     trunc.cols=getOption("datatable.print.trunc.cols"), # default: FALSE
     quote=FALSE,
     timezone=FALSE, \dots)

--- a/tests/autoprint.Rout.save
+++ b/tests/autoprint.Rout.save
@@ -1,6 +1,6 @@
 
-R version 3.1.1 (2014-07-10) -- "Sock it to Me"
-Copyright (C) 2014 The R Foundation for Statistical Computing
+R version 4.1.1 (2021-08-10) -- "Kick Things"
+Copyright (C) 2021 The R Foundation for Statistical Computing
 Platform: x86_64-pc-linux-gnu (64-bit)
 
 R is free software and comes with ABSOLUTELY NO WARRANTY.
@@ -21,104 +21,122 @@ Loading required package: data.table
 > # Since this tests autoprinting at the console, it needs to use the .Rout.save mechanism in R CMD check
 > DT = data.table(a=1:2)                # Should print at console?
 > DT                                    # yes
-   a
-1: 1
-2: 2
+       a
+   <int>
+1:     1
+2:     2
 > DT[1]                                 # yes
-   a
-1: 1
+       a
+   <int>
+1:     1
 > DT[2,a:=3L]                           # no
 > DT                                    # yes
-   a
-1: 1
-2: 3
+       a
+   <int>
+1:     1
+2:     3
 > DT[FALSE,a:=3L]                       # no
 > DT[a==4L,a:=5L]                       # no
 > DT[a %in% 4:8, a:=5L]                 # no
 > DT                                    # yes
-   a
-1: 1
-2: 3
+Index: <a>
+       a
+   <int>
+1:     1
+2:     3
 > print(DT[2,a:=4L])                    # no
 > print(DT)                             # yes
-   a
-1: 1
-2: 4
+       a
+   <int>
+1:     1
+2:     4
 > if (TRUE) DT[2,a:=5L]                 # no. used to print before v1.9.5
 > if (TRUE) if (TRUE) DT[2,a:=6L]       # no. used to print before v1.9.5
 > (function(){DT[2,a:=5L];NULL})()      # print NULL
 NULL
 > DT                                    # no (from v1.9.5+). := suppresses next auto print (can't distinguish just "DT" symbol alone at the prompt)
 > DT                                    # yes. 2nd time needed, or solutions below
-   a
-1: 1
-2: 5
+       a
+   <int>
+1:     1
+2:     5
 > (function(){DT[2,a:=5L];NULL})()      # print NULL
 NULL
 > DT[]                                  # yes. guaranteed print
-   a
-1: 1
-2: 5
+       a
+   <int>
+1:     1
+2:     5
 > (function(){DT[2,a:=5L];NULL})()      # print NULL
 NULL
 > print(DT)                             # no. only DT[] is guaranteed print from v1.9.6 and R 3.2.0
 > (function(){DT[2,a:=5L][];NULL})()    # print NULL
 NULL
 > DT                                    # yes. i) function needs to add [] after last one, so that "DT" alone is guaranteed anyway
-   a
-1: 1
-2: 5
+       a
+   <int>
+1:     1
+2:     5
 > (function(){DT[2,a:=5L];DT[];NULL})() # print NULL
 NULL
 > DT                                    # yes. ii) or as a separate DT[] after the last := inside the function
-   a
-1: 1
-2: 5
+       a
+   <int>
+1:     1
+2:     5
 > DT2 = data.table(b=3:4)               # no
 > (function(){DT[2,a:=6L];DT2[1,b:=7L];NULL})()
 NULL
 > DT                                    # yes. last := was on DT2 not DT
-   a
-1: 1
-2: 6
+       a
+   <int>
+1:     1
+2:     6
 > {DT[2,a:=6L];invisible()}             # no
 > print(DT)                             # no
 > (function(){print(DT[2,a:=7L]);print(DT);invisible()})()    # yes*2
-   a
-1: 1
-2: 7
-   a
-1: 1
-2: 7
+       a
+   <int>
+1:     1
+2:     7
+       a
+   <int>
+1:     1
+2:     7
 > {print(DT[2,a:=8L]);print(DT);invisible()}                  # yes*1  Not within function so as at prompt
-   a
-1: 1
-2: 8
+       a
+   <int>
+1:     1
+2:     8
 > DT[1][,a:=9L]      # no (was too tricky to detect that DT[1] is a new object). Simple rule is that := always doesn't print
 > DT[2,a:=10L][1]                       # yes
-   a
-1: 1
+       a
+   <int>
+1:     1
 > DT[1,a:=10L][1,a:=10L]                # no
 > DT[,a:=as.integer(a)]                 # no
 > DT[1,a:=as.integer(a)]                # no
 > DT[1,a:=10L][]                        # yes. ...[] == oops, forgot print(...)
-    a
-1: 10
-2: 10
+       a
+   <int>
+1:    10
+2:    10
 > 
 > # Test that error in := doesn't suppress next valid print, bug #2376
 > tryCatch(DT[,foo:=ColumnNameTypo], error=function(e) e$message)         # error: not found.
 [1] "object 'ColumnNameTypo' not found"
 > DT                                    # yes
-    a
-1: 10
-2: 10
+       a
+   <int>
+1:    10
+2:    10
 > DT                                    # yes
-    a
-1: 10
-2: 10
+       a
+   <int>
+1:    10
+2:    10
 > 
 > 
 > proc.time()
    user  system elapsed 
-   3.14    0.10    3.22 
+  0.723   0.637   0.217 

--- a/tests/knitr.Rout.save
+++ b/tests/knitr.Rout.save
@@ -1,6 +1,6 @@
 
-R version 3.1.1 (2014-07-10) -- "Sock it to Me"
-Copyright (C) 2014 The R Foundation for Statistical Computing
+R version 4.1.1 (2021-08-10) -- "Kick Things"
+Copyright (C) 2021 The R Foundation for Statistical Computing
 Platform: x86_64-pc-linux-gnu (64-bit)
 
 R is free software and comes with ABSOLUTELY NO WARRANTY.
@@ -33,10 +33,11 @@ DT                               # yes
 ```
 
 ```
-##    x y
-## 1: 1 4
-## 2: 2 5
-## 3: 3 6
+##        x     y
+##    <int> <int>
+## 1:     1     4
+## 2:     2     5
+## 3:     3     6
 ```
 
 ```r
@@ -45,10 +46,11 @@ print(DT[, z := 10:12])          # yes
 ```
 
 ```
-##    x y  z
-## 1: 1 4 10
-## 2: 2 5 11
-## 3: 3 6 12
+##        x     y     z
+##    <int> <int> <int>
+## 1:     1     4    10
+## 2:     2     5    11
+## 3:     3     6    12
 ```
 
 ```r
@@ -57,10 +59,11 @@ DT                               # yes
 ```
 
 ```
-##    x y  z a
-## 1: 1 4 10 1
-## 2: 2 5 11 1
-## 3: 3 6 12 1
+##        x     y     z     a
+##    <int> <int> <int> <int>
+## 1:     1     4    10     1
+## 2:     2     5    11     1
+## 3:     3     6    12     1
 ```
 Some text.
 
@@ -68,4 +71,4 @@ Some text.
 > 
 > proc.time()
    user  system elapsed 
-  3.116   0.128   3.257 
+  0.742   0.666   0.261 


### PR DESCRIPTION
Thanks to a suggestion by @grantmcdermott in https://github.com/Rdatatable/data.table/pull/5224#issuecomment-981117084.