### PR TITLE
try setting NOT_CRAN=true during revdeps to activate more tests

### DIFF
--- a/.dev/revdep.R
+++ b/.dev/revdep.R
@@ -331,7 +331,7 @@ run = function(pkgs=NULL, R_CHECK_FORCE_SUGGESTS=TRUE, choose=NULL) {
   }
   if (!identical(pkgs,"_ALL_")) for (i in pkgs) system(paste0("rm -rf ./",i,".Rcheck"))
   SUGG = paste0("_R_CHECK_FORCE_SUGGESTS_=",tolower(R_CHECK_FORCE_SUGGESTS))
-  cmd = paste0("ls -1 *.tar.gz ", filter, "| TZ='UTC' OMP_THREAD_LIMIT=2 ",SUGG," parallel --max-procs 50% --timeout 1200 ",R," CMD check")
+  cmd = paste0("ls -1 *.tar.gz ", filter, "| NOT_CRAN=true TZ='UTC' OMP_THREAD_LIMIT=2 ",SUGG," parallel --max-procs 50% --timeout 1200 ",R," CMD check")
   # TZ='UTC' because some packages have failed locally for me but not on CRAN or for their maintainer, due to sensitivity of tests to timezone
   if (as.integer(system("ps -e | grep perfbar | wc -l", intern=TRUE)) < 1) system("perfbar",wait=FALSE)
   system("touch /tmp/started.flag ; rm -f /tmp/finished.flag")


### PR DESCRIPTION
This will activate tests using `testthat::skip_on_cran()`. Inspired by finding this:

https://github.com/kaufman-lab/intervalaverage/blob/c672cc4dafff051f50eded8c558a7e9bcea1a08b/tests/testthat/test-performance.R#L1-L10

This setting _may_ cause more headaches than it's worth as it will turn on a bunch of tests that aren't necessarily regularly passing already. But maybe worth giving it a try on next release.