### PR TITLE
fix compile-time warning on windows rtools42

### DIFF
--- a/src/fread.c
+++ b/src/fread.c
@@ -1,3 +1,5 @@
+#include "fread.h"
+
 #if defined(CLOCK_REALTIME) && !defined(DISABLE_CLOCK_REALTIME)
 #define HAS_CLOCK_REALTIME
 #endif
@@ -24,7 +26,6 @@
   #include <math.h>      // ceil, sqrt, isfinite
 #endif
 #include <stdbool.h>
-#include "fread.h"
 #include "freadLookups.h"
 
 // Private globals to save passing all of them through to highly iterated field processors

--- a/src/fread.c
+++ b/src/fread.c
@@ -1,5 +1,5 @@
 #include "fread.h"
-
+// include fread.h should happen before include time.h to avoid compilation warning on windows about re-defining __USE_MINGW_ANSI_STDIO, PR#5395.
 #if defined(CLOCK_REALTIME) && !defined(DISABLE_CLOCK_REALTIME)
 #define HAS_CLOCK_REALTIME
 #endif


### PR DESCRIPTION
fixes #5374 

In fread.c near the top there is an `#include <time.h>` which eventually includes
`C:/rtools42/x86_64-w64-mingw32.static.posix/include/_mingw.h` which has `#define __USE_MINGW_ANSI_STDIO 0`

In fread.c after that there is `#include "fread.h"` which includes dt_stdio.h which has `#define __USE_MINGW_ANSI_STDIO 1`

That caused a compilation warning (not allowed to do another `#define` on something which has already been defined).

My suggested fix is in fread.c, to move the `#include "fread.h"` to the top, so it does `#define __USE_MINGW_ANSI_STDIO 1` first, and then afterwards there is no warning because I guess there is some logic in `C:/rtools42/x86_64-w64-mingw32.static.posix/include/_mingw.h` which says not to re-define if it already is defined.

I don't know the fread C code, so could somebody tell me if it is OK to have `#include "fread.h"` at the very top of fread.c?