### PR TITLE
Limit deparse in name_dots to 1 line

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -550,6 +550,8 @@
 
 53. `as.data.frame(DT, row.names=)` no longer silently ignores `row.names`, [#5319](https://github.com/Rdatatable/data.table/issues/5319). Thanks to @dereckdemezquita for the fix and PR, and @ben-schwen for guidance.
 
+54. data.table construction uses `deparse` to try and automatically name un-named cols. The attempt is now limited to 1- line which gives substantial speedup in [some edge cases](https://github.com/Rdatatable/data.table/pull/5501). Thanks @OfekShilon for the report and fix, @michaelchirico for guidance.
+
 ## NOTES
 
 1. New feature 29 in v1.12.4 (Oct 2019) introduced zero-copy coercion. Our thinking is that requiring you to get the type right in the case of `0` (type double) vs `0L` (type integer) is too inconvenient for you the user. So such coercions happen in `data.table` automatically without warning. Thanks to zero-copy coercion there is no speed penalty, even when calling `set()` many times in a loop, so there's no speed penalty to warn you about either. However, we believe that assigning a character value such as `"2"` into an integer column is more likely to be a user mistake that you would like to be warned about. The type difference (character vs integer) may be the only clue that you have selected the wrong column, or typed the wrong variable to be assigned to that column. For this reason we view character to numeric-like coercion differently and will warn about it. If it is correct, then the warning is intended to nudge you to wrap the RHS with `as.<type>()` so that it is clear to readers of your code that a coercion from character to that type is intended. For example :

--- a/NEWS.md
+++ b/NEWS.md
@@ -550,8 +550,15 @@
 
 53. `as.data.frame(DT, row.names=)` no longer silently ignores `row.names`, [#5319](https://github.com/Rdatatable/data.table/issues/5319). Thanks to @dereckdemezquita for the fix and PR, and @ben-schwen for guidance.
 
-54. Certain flavours of data.table construction try to use `deparse` to automatically name un-named cols. The attempt is now limited to 1 line of the `deparse` input which gives substantial speedup in [some cases](https://github.com/Rdatatable/data.table/pull/5501). Thanks @OfekShilon for the report and fix, @michaelchirico for guidance.
+54. `data.table(...)` unnamed arguments are deparsed in an attempt to name the columns but when called from `do.call()`, the input data itself was deparsed taking a very long time, [#5501](https://github.com/Rdatatable/data.table/pull/5501). Many thanks to @OfekShilon for the report and fix, and @michaelchirico for guidance. Unnamed arguments to `data.table(...)` may now be faster in other cases not involving `do.call()` too; e.g. expressions spanning a lot of lines or other function call constructions that led to the data itself being deparsed.
 
+    ```R
+    DF = data.frame(a=runif(1e6), b=runif(1e6))
+    DT1 = data.table(DF)                 # 0.02s before and after
+    DT2 = do.call(data.table, list(DF))  # 3.07s before, 0.02s after
+    identical(DT1, DT2)                  # TRUE
+    ```
+    
 ## NOTES
 
 1. New feature 29 in v1.12.4 (Oct 2019) introduced zero-copy coercion. Our thinking is that requiring you to get the type right in the case of `0` (type double) vs `0L` (type integer) is too inconvenient for you the user. So such coercions happen in `data.table` automatically without warning. Thanks to zero-copy coercion there is no speed penalty, even when calling `set()` many times in a loop, so there's no speed penalty to warn you about either. However, we believe that assigning a character value such as `"2"` into an integer column is more likely to be a user mistake that you would like to be warned about. The type difference (character vs integer) may be the only clue that you have selected the wrong column, or typed the wrong variable to be assigned to that column. For this reason we view character to numeric-like coercion differently and will warn about it. If it is correct, then the warning is intended to nudge you to wrap the RHS with `as.<type>()` so that it is clear to readers of your code that a coercion from character to that type is intended. For example :

--- a/NEWS.md
+++ b/NEWS.md
@@ -550,7 +550,7 @@
 
 53. `as.data.frame(DT, row.names=)` no longer silently ignores `row.names`, [#5319](https://github.com/Rdatatable/data.table/issues/5319). Thanks to @dereckdemezquita for the fix and PR, and @ben-schwen for guidance.
 
-54. data.table construction uses `deparse` to try and automatically name un-named cols. The attempt is now limited to 1- line which gives substantial speedup in [some edge cases](https://github.com/Rdatatable/data.table/pull/5501). Thanks @OfekShilon for the report and fix, @michaelchirico for guidance.
+54. Certain flavours of data.table construction try to use `deparse` to automatically name un-named cols. The attempt is now limited to 1 line of the `deparse` input which gives substantial speedup in [some cases](https://github.com/Rdatatable/data.table/pull/5501). Thanks @OfekShilon for the report and fix, @michaelchirico for guidance.
 
 ## NOTES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -550,7 +550,7 @@
 
 53. `as.data.frame(DT, row.names=)` no longer silently ignores `row.names`, [#5319](https://github.com/Rdatatable/data.table/issues/5319). Thanks to @dereckdemezquita for the fix and PR, and @ben-schwen for guidance.
 
-54. `data.table(...)` unnamed arguments are deparsed in an attempt to name the columns but when called from `do.call()`, the input data itself was deparsed taking a very long time, [#5501](https://github.com/Rdatatable/data.table/pull/5501). Many thanks to @OfekShilon for the report and fix, and @michaelchirico for guidance. Unnamed arguments to `data.table(...)` may now be faster in other cases not involving `do.call()` too; e.g. expressions spanning a lot of lines or other function call constructions that led to the data itself being deparsed.
+54. `data.table(...)` unnamed arguments are deparsed in an attempt to name the columns but when called from `do.call()` the input data itself was deparsed taking a very long time, [#5501](https://github.com/Rdatatable/data.table/pull/5501). Many thanks to @OfekShilon for the report and fix, and @michaelchirico for guidance. Unnamed arguments to `data.table(...)` may now be faster in other cases not involving `do.call()` too; e.g. expressions spanning a lot of lines or other function call constructions that led to the data itself being deparsed.
 
     ```R
     DF = data.frame(a=runif(1e6), b=runif(1e6))

--- a/R/utils.R
+++ b/R/utils.R
@@ -97,7 +97,7 @@ name_dots = function(...) {
   if (any(notnamed)) {
     syms = vapply_1b(dot_sub, is.symbol)  # save the deparse() in most cases of plain symbol
     for (i in which(notnamed)) {
-      tmp = if (syms[i]) as.character(dot_sub[[i]]) else deparse(dot_sub[[i]])[1L]
+      tmp = if (syms[i]) as.character(dot_sub[[i]]) else deparse(dot_sub[[i]], nlines=1)[1L]
       if (tmp == make.names(tmp)) vnames[i]=tmp
     }
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -97,7 +97,7 @@ name_dots = function(...) {
   if (any(notnamed)) {
     syms = vapply_1b(dot_sub, is.symbol)  # save the deparse() in most cases of plain symbol
     for (i in which(notnamed)) {
-      tmp = if (syms[i]) as.character(dot_sub[[i]]) else deparse(dot_sub[[i]], nlines=1)[1L]
+      tmp = if (syms[i]) as.character(dot_sub[[i]]) else deparse(dot_sub[[i]], nlines=1L)[1L]
       if (tmp == make.names(tmp)) vnames[i]=tmp
     }
   }

--- a/inst/tests/benchmark.Rraw
+++ b/inst/tests/benchmark.Rraw
@@ -168,3 +168,12 @@ test(1742.5, substr(x, nchar(x)-10L, nchar(x)), c("50,28,95,76","62,87,23,40"))
 
 # Add scaled-up non-ASCII forder test 1896
 
+
+# Test performance of constructing one DT from another via do.call, #5492
+# Before the fix this went through a large `deparse` and dt2/dt1 was >30.
+# Currently it is typically ~0.15
+t1 <- system.time(dt1 <- data.table(a=runif(1e5), b=runif(1e5)))
+t2 <- system.time(dt2 <- do.call(data.table, list(dt1)))
+
+test(2239.1, all.equal(dt1,dt2), TRUE)
+test(2239.2, t2["elapsed"]/t1["elapsed"]<5, TRUE)

--- a/inst/tests/benchmark.Rraw
+++ b/inst/tests/benchmark.Rraw
@@ -168,7 +168,7 @@ test(1742.5, substr(x, nchar(x)-10L, nchar(x)), c("50,28,95,76","62,87,23,40"))
 
 # Add scaled-up non-ASCII forder test 1896
 
-# Before #5501 do.call(data.table,) went through a large `deparse` for unnamed args, #5492.
+# Before #5501 do.call(data.table,) fully deparsed large unnamed args, #5492.
 DF = data.frame(a=runif(1e6), b=runif(1e6))
 t1 = system.time(DT1 <- data.table(DF))                 # 0.02s before and after
 t2 = system.time(DT2 <- do.call(data.table, list(DF)))  # 3.07s before, 0.02s after

--- a/inst/tests/benchmark.Rraw
+++ b/inst/tests/benchmark.Rraw
@@ -170,7 +170,7 @@ test(1742.5, substr(x, nchar(x)-10L, nchar(x)), c("50,28,95,76","62,87,23,40"))
 
 
 # Test performance of constructing one DT from another via do.call, #5492
-# Before the fix this went through a large `deparse` and dt2/dt1 was >30.
+# Before the fix this went through a large `deparse` and t2/t1 was >30.
 # Currently it is typically ~0.15
 t1 <- system.time(dt1 <- data.table(a=runif(1e5), b=runif(1e5)))
 t2 <- system.time(dt2 <- do.call(data.table, list(dt1)))

--- a/inst/tests/benchmark.Rraw
+++ b/inst/tests/benchmark.Rraw
@@ -172,6 +172,6 @@ test(1742.5, substr(x, nchar(x)-10L, nchar(x)), c("50,28,95,76","62,87,23,40"))
 DF = data.frame(a=runif(1e6), b=runif(1e6))
 t1 = system.time(DT1 <- data.table(DF))                 # 0.02s before and after
 t2 = system.time(DT2 <- do.call(data.table, list(DF)))  # 3.07s before, 0.02s after
-test(2239.1, identical(DT1, DT2))
-test(2239.2, t2["elapsed"]/t1["elapsed"]<2)
+test(, identical(DT1, DT2))
+test(, t2["elapsed"]/t1["elapsed"]<2)
 

--- a/inst/tests/benchmark.Rraw
+++ b/inst/tests/benchmark.Rraw
@@ -168,12 +168,10 @@ test(1742.5, substr(x, nchar(x)-10L, nchar(x)), c("50,28,95,76","62,87,23,40"))
 
 # Add scaled-up non-ASCII forder test 1896
 
+# Before #5501 do.call(data.table,) went through a large `deparse` for unnamed args, #5492.
+DF = data.frame(a=runif(1e6), b=runif(1e6))
+t1 = system.time(DT1 <- data.table(DF))                 # 0.02s before and after
+t2 = system.time(DT2 <- do.call(data.table, list(DF)))  # 3.07s before, 0.02s after
+test(2239.1, identical(DT1, DT2))
+test(2239.2, t2["elapsed"]/t1["elapsed"]<2)
 
-# Test performance of constructing one DT from another via do.call, #5492
-# Before the fix this went through a large `deparse` and t2/t1 was >30.
-# Currently it is typically ~0.15
-t1 <- system.time(dt1 <- data.table(a=runif(1e5), b=runif(1e5)))
-t2 <- system.time(dt2 <- do.call(data.table, list(dt1)))
-
-test(2239.1, all.equal(dt1,dt2), TRUE)
-test(2239.2, t2["elapsed"]/t1["elapsed"]<5, TRUE)


### PR DESCRIPTION
Per @MichaelChirico 's [request](https://github.com/Rdatatable/data.table/pull/5493#pullrequestreview-1152996040), this improvement is separated to its own PR.