### PR TITLE
Strengthen CRAN_Release.cmd to find UBSAN errors in data.table.Rcheck

### DIFF
--- a/.dev/CRAN_Release.cmd
+++ b/.dev/CRAN_Release.cmd
@@ -289,11 +289,11 @@ cd ~/build
 wget -N https://stat.ethz.ch/R/daily/R-devel.tar.gz
 rm -rf R-devel
 rm -rf R-devel-strict-*
-tar xvf R-devel.tar.gz
+tar xf R-devel.tar.gz
 mv R-devel R-devel-strict-gcc
-tar xvf R-devel.tar.gz
+tar xf R-devel.tar.gz
 mv R-devel R-devel-strict-clang
-tar xvf R-devel.tar.gz
+tar xf R-devel.tar.gz
 
 sudo apt-get -y build-dep r-base
 cd R-devel  # may be used for revdep testing: .dev/revdep.R.
@@ -302,8 +302,13 @@ cd R-devel  # may be used for revdep testing: .dev/revdep.R.
 make
 
 # use latest available `apt-cache search gcc-` or `clang-`
+
+# wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+# sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main'
+# sudo apt-get install clang-15
+
 cd ~/build/R-devel-strict-clang
-./configure --without-recommended-packages --disable-byte-compiled-packages --enable-strict-barrier --disable-long-double CC="clang-11 -fsanitize=undefined,address -fno-sanitize=float-divide-by-zero -fno-omit-frame-pointer"
+./configure --without-recommended-packages --disable-byte-compiled-packages --enable-strict-barrier --disable-long-double CC="clang-15 -fsanitize=undefined,address -fno-sanitize=float-divide-by-zero -fno-sanitize=alignment -fno-omit-frame-pointer" CFLAGS="-g -O3 -Wall -pedantic"
 make
 
 cd ~/build/R-devel-strict-gcc
@@ -329,15 +334,22 @@ alias Rdevel-strict-gcc='~/build/R-devel-strict-gcc/bin/R --vanilla'
 alias Rdevel-strict-clang='~/build/R-devel-strict-clang/bin/R --vanilla'
 
 cd ~/GitHub/data.table
-Rdevel-strict-gcc CMD INSTALL data.table_1.14.1.tar.gz
-Rdevel-strict-clang CMD INSTALL data.table_1.14.1.tar.gz
-# Check UBSAN and ASAN flags appear in compiler output above. Rdevel was compiled with them so should be passed through to here
-Rdevel-strict-gcc
-Rdevel-strict-clang  # repeat below with clang and gcc
+Rdevel-strict-[gcc|clang] CMD INSTALL data.table_1.14.5.tar.gz
+# Check UBSAN and ASAN flags appear in compiler output above. Rdevel was compiled with them so they should be
+# passed through to here. However, our configure script seems to get in the way and get them from {R_HOME}/bin/R
+# so I needed to edit my ~/.R/Makevars to get CFLAGS the way I needed.
+Rdevel-strict-[gcc|clang] CMD check data.table_1.14.5.tar.gz
+# use the (failed) output to get the list of currently needed packages :
+Rdevel-strict-[gcc|clang]
 isTRUE(.Machine$sizeof.longdouble==0)  # check noLD is being tested
 options(repos = "http://cloud.r-project.org")
-install.packages(c("bit64","xts","nanotime","R.utils","yaml")) # minimum packages needed to not skip any tests in test.data.table()
-# install.packages(c("curl","knitr"))                          # for `R CMD check` when not strict. Too slow to install when strict
+install.packages(c("bit64", "bit", "curl", "R.utils", "xts","nanotime", "zoo", "yaml", "knitr", "rmarkdown"))
+# R CMD check doesn't allow any tests to be skipped by test.data.table due to missing packages
+# Issue #5491 showed that CRAN is running UBSAN on .Rd examples too which found an error so we now run full R CMD check here
+q("no")
+Rdevel-strict-[gcc|clang] CMD check data.table_1.14.5.tar.gz
+
+
 require(data.table)
 test.data.table(script="*.Rraw") # 7 mins (vs 1min normally) under UBSAN, ASAN and --strict-barrier
                                  # without the fix in PR#3515, the --disable-long-double lumped into this build does now work and correctly reproduces the noLD problem

--- a/.dev/CRAN_Release.cmd
+++ b/.dev/CRAN_Release.cmd
@@ -302,7 +302,6 @@ cd R-devel  # may be used for revdep testing: .dev/revdep.R.
 make
 
 # use latest available `apt-cache search gcc-` or `clang-`
-
 # wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
 # sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main'
 # sudo apt-get install clang-15

--- a/.dev/CRAN_Release.cmd
+++ b/.dev/CRAN_Release.cmd
@@ -335,19 +335,19 @@ alias Rdevel-strict-clang='~/build/R-devel-strict-clang/bin/R --vanilla'
 cd ~/GitHub/data.table
 Rdevel-strict-[gcc|clang] CMD INSTALL data.table_1.14.5.tar.gz
 # Check UBSAN and ASAN flags appear in compiler output above. Rdevel was compiled with them so they should be
-# passed through to here. However, our configure script seems to get in the way and get them from {R_HOME}/bin/R
-# so I needed to edit my ~/.R/Makevars to get CFLAGS the way I needed.
+# passed through to here. However, our configure script seems to get in the way and gets them from {R_HOME}/bin/R
+# So I needed to edit my ~/.R/Makevars to get CFLAGS the way I needed.
 Rdevel-strict-[gcc|clang] CMD check data.table_1.14.5.tar.gz
-# use the (failed) output to get the list of currently needed packages :
+# Use the (failed) output to get the list of currently needed packages and install them
 Rdevel-strict-[gcc|clang]
 isTRUE(.Machine$sizeof.longdouble==0)  # check noLD is being tested
 options(repos = "http://cloud.r-project.org")
 install.packages(c("bit64", "bit", "curl", "R.utils", "xts","nanotime", "zoo", "yaml", "knitr", "rmarkdown"))
-# R CMD check doesn't allow any tests to be skipped by test.data.table due to missing packages
-# Issue #5491 showed that CRAN is running UBSAN on .Rd examples too which found an error so we now run full R CMD check here
+# Issue #5491 showed that CRAN is running UBSAN on .Rd examples which found an error so we now run full R CMD check
 q("no")
 Rdevel-strict-[gcc|clang] CMD check data.table_1.14.5.tar.gz
-
+# UBSAN errors occur on stderr and don't affect R CMD check result. Made many failed attempts to capture them. So grep for them. 
+find data.table.Rcheck -name "*.Rout" -exec grep -H "runtime error" {} \;
 
 require(data.table)
 test.data.table(script="*.Rraw") # 7 mins (vs 1min normally) under UBSAN, ASAN and --strict-barrier

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -117,18 +117,9 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
   assign("filename", fn, envir=env)
   assign("inittime", as.integer(Sys.time()), envir=env) # keep measures from various test.data.table runs
   assign("showProgress", showProgress, envir=env)
-  assign("stderr_sink", tempfile(), envir=env)
 
   owd = setwd(tempdir()) # ensure writeable directory; e.g. tests that plot may write .pdf here depending on device option and/or batch mode; #5190
   on.exit(setwd(owd))
-  
-  if (sink.number()>0L) {
-    catf("**** sink.number()>0 so not sinking stderr and test() will not error on UBSAN errors on stderr for example\n")
-  } else {
-    # capture stderr to detect UBSAN errors, errors, warning and R level messages are still 
-    sink(file(env$stderr_sink), type="message", split=TRUE)
-    on.exit({sink(NULL, type="message"); unlink(env$stderr_sink)})
-  }
 
   err = try(sys.source(fn, envir=env), silent=silent)
 
@@ -291,8 +282,6 @@ test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,no
     filename = get("filename", parent.frame())
     foreign = get("foreign", parent.frame())
     showProgress = get("showProgress", parent.frame())
-    stderr_sink = get("stderr_sink", parent_frame())
-    last_stderr = file.info(tmp)$mtime
     time = nTest = NULL  # to avoid 'no visible binding' note
     if (num>0) on.exit( {
        now = proc.time()[3L]
@@ -315,7 +304,6 @@ test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,no
     filename = NA_character_ # nocov
     foreign = FALSE          # nocov ; assumes users of 'cc(F); test(...)' has LANGUAGE=en
     showProgress = FALSE     # nocov
-    stderr_sink = NULL       # nocov
   }
   if (!missing(error) && !missing(y))
     stopf("Test %s is invalid: when error= is provided it does not make sense to pass y as well", numStr)  # nocov
@@ -365,10 +353,6 @@ test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,no
       # nocov end
     }
     assign("prevtest", num, parent.frame(), inherits=TRUE)
-  }
-  if (!fail && !is.null(stderr_sink) && !is.na(tt<-file.info(stderr_sink)$mtime) && (is.na(last_stderr) || tt>last_stderr)) {
-    catf("Test %s produced output on stderr\n", numStr)
-    fail = TRUE
   }
   if (!fail) for (type in c("warning","error","message")) {
     observed = actual[[type]]


### PR DESCRIPTION
Closes #5496

Made many attempts to capture UBSAN errors on stderr but nothing worked. sink()-ing type="message" does work but the UBSAN errors still appeared in the output rather than the sink'd file. Also tried a Linux only `stat /proc/self/fd/2` before and after the test to see if the timestamp of stderr had increased, with no luck. Setting ` UBSAN_OPTIONS=log_path=....` is possible but seems too UBSAN specific; I was hoping to capture anything on stderr to include ASAN too for example and any other tool that might arise in future.

So in the end, just strengthened CRAN_Release.cmd to do a full `R CMD check` under UBSAN/ASAN rather than just test.data.table(). So now .Rd examples and vignettes are covered too. And included a `grep` on data.table.Rcheck/*.Rout for the UBSAN errors. Can refine it in future.