### PR TITLE
test.data.table(memtest=TRUE)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -599,6 +599,8 @@
 
 15. Thanks to @ssh352, Václav Tlapák, Cole Miller, András Svraka and Toby Dylan Hocking for reporting and bisecting a significant performance regression in dev. This was fixed before release thanks to a PR by Jan Gorecki, [#5463](https://github.com/Rdatatable/data.table/pull/5463). 
 
+16. `test.data.table()` no longer creates `DT` in `.GlobalEnv` and gains `memtest=` for use on Linux to report which tests use the most memory.
+
 
 # data.table [v1.14.4](https://github.com/Rdatatable/data.table/milestone/26?closed=1)  (17 Oct 2022)
 

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -1,4 +1,5 @@
-test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=FALSE, showProgress=interactive()&&!silent) {
+test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=FALSE, showProgress=interactive()&&!silent,
+                           memtest=as.logical(Sys.getenv("TEST_DATA_TABLE_MEMTEST", "FALSE"))) {
   stopifnot(isTRUEorFALSE(verbose), isTRUEorFALSE(silent), isTRUEorFALSE(showProgress))
   if (exists("test.data.table", .GlobalEnv, inherits=FALSE)) {
     # package developer
@@ -112,10 +113,9 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
   assign("whichfail", NULL, envir=env)
   assign("started.at", proc.time(), envir=env)
   assign("lasttime", proc.time()[3L], envir=env)  # used by test() to attribute time inbetween tests to the next test
-  assign("timings", data.table( ID = seq_len(9999L), time=0.0, nTest=0L ), envir=env)   # test timings aggregated to integer id
-  assign("memtest", TRUE, envir=env)  # as.logical(Sys.getenv("TEST_DATA_TABLE_MEMTEST", "FALSE")), envir=env)
+  assign("timings", data.table( ID = seq_len(9999L), time=0.0, nTest=0L, RSS=0.0 ), envir=env)   # test timings aggregated to integer id
+  assign("memtest", memtest, envir=env)
   assign("filename", fn, envir=env)
-  assign("inittime", as.integer(Sys.time()), envir=env) # keep measures from various test.data.table runs
   assign("showProgress", showProgress, envir=env)
 
   owd = setwd(tempdir()) # ensure writeable directory; e.g. tests that plot may write .pdf here depending on device option and/or batch mode; #5190
@@ -175,19 +175,19 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
 
   # There aren't any errors, so we can use up 11 lines for the timings table
   timings = env$timings[nTest>0]
-  if (!env$memtest) {
-    ans = head(timings[-1L][order(-time)], 10L)   # exclude id 1 as in dev that includes JIT
+  if (!memtest) {
+    ans = head(timings[-1L][order(-time)], 10L)[,RSS:=NULL]   # exclude id 1 as in dev that includes JIT
     if ((x<-sum(timings[["nTest"]])) != ntest) {
       warningf("Timings count mismatch: %d vs %d", x, ntest)  # nocov
     }
-    catf("10 longest running tests took %ds (%d%% of %ds)\n", as.integer(tt<-DT[, sum(time)]), as.integer(100*tt/(ss<-timings[,sum(time)])), as.integer(ss))
+    catf("10 longest running tests took %ds (%d%% of %ds)\n", as.integer(tt<-ans[, sum(time)]), as.integer(100*tt/(ss<-timings[,sum(time)])), as.integer(ss))
     print(ans, class=FALSE)
   } else {
     y = head(order(-diff(timings$RSS)), 10L)
     ans = timings[, diff:=c(NA,round(diff(RSS),1))][y+1L][,time:=NULL]  # time is distracting and influenced by gc() calls; just focus on RAM usage here
-    catf("10 largest RAM increases (MB); see plot for cummulative effect (if any)\n")
+    catf("10 largest RAM increases (MB); see plot for cumulative effect (if any)\n")
     print(ans, class=FALSE)
-    plot(timings$RSS)
+    plot(timings$RSS, main=fn, ylab="RSS (MB)")
   }
 
   catf("All %d tests (last %.8g) in %s completed ok in %s\n", ntest, env$prevtest, names(fn), timetaken(env$started.at))
@@ -288,20 +288,18 @@ test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,no
     lasttime = get("lasttime", parent.frame())
     timings = get("timings", parent.frame())
     memtest = get("memtest", parent.frame())
-    # inittime = get("inittime", parent.frame())
     filename = get("filename", parent.frame())
     foreign = get("foreign", parent.frame())
     showProgress = get("showProgress", parent.frame())
     time = nTest = NULL  # to avoid 'no visible binding' note
     if (num>0) on.exit( {
        took = proc.time()[3L]-lasttime  # so that prep time between tests is attributed to the following test
-       # mem = as.list(c(inittime=inittime, filename=basename(filename), timestamp=timestamp, test=num, ps_mem(), gc_mem())) # nocov
        timings[as.integer(num), `:=`(time=time+took, nTest=nTest+1L), verbose=FALSE]
        if (memtest) {
-         gc() # force gc so we can find tests that use relatively larger amounts of RAM and don't rm() them
-         timings[as.integer(num), RSS:=max(ps_mem(),RSS,na.rm=TRUE), verbose=FALSE]
+         gc() # force gc so we can find tests that use relatively larger amounts of RAM
+         timings[as.integer(num), RSS:=max(ps_mem(),RSS), verbose=FALSE]
        }
-       assign("lasttime", proc.time()[3L], parent.frame(), inherits=TRUE)  # proc.time() after gc() to exclude gc() time when memtest
+       assign("lasttime", proc.time()[3L], parent.frame(), inherits=TRUE)  # after gc() to exclude gc() time from next test when memtest
     } )
     if (showProgress)
       # \r can't be in gettextf msg
@@ -344,9 +342,6 @@ test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,no
     actual$message <<- c(actual$message, conditionMessage(m))
     m
   }
-  if (memtest) {
-    timestamp = as.numeric(Sys.time())   # nocov
-  }
   if (is.null(output) && is.null(notOutput)) {
     x = suppressMessages(withCallingHandlers(tryCatch(x, error=eHandler), warning=wHandler, message=mHandler))
     # save the overhead of capture.output() since there are a lot of tests, often called in loops
@@ -354,11 +349,6 @@ test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,no
   } else {
     out = capture.output(print(x <- suppressMessages(withCallingHandlers(tryCatch(x, error=eHandler), warning=wHandler, message=mHandler))))
   }
-  #if (memtest) {
-  #  mem = as.list(c(inittime=inittime, filename=basename(filename), timestamp=timestamp, test=num, ps_mem(), gc_mem())) # nocov
-  #  
-  #  fwrite(mem, "memtest.csv", append=TRUE, verbose=FALSE)                                                                             # nocov
-  #}
   fail = FALSE
   if (.test.data.table && num>0) {
     if (num<prevtest+0.0000005) {

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -4,6 +4,7 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
   if (exists("test.data.table", .GlobalEnv, inherits=FALSE)) {
     # package developer
     # nocov start
+    dev = TRUE
     if ("package:data.table" %chin% search()) stopf("data.table package is loaded. Unload or start a fresh R session.")
     rootdir = if (pkg!="." && pkg %chin% dir()) file.path(getwd(), pkg) else Sys.getenv("PROJ_PATH")
     subdir = file.path("inst","tests")
@@ -11,6 +12,7 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
     # nocov end
   } else {
     # i) R CMD check and ii) user running test.data.table()
+    dev = FALSE
     rootdir = getNamespaceInfo("data.table","path")
     subdir = "tests"
     env = new.env(parent=parent.env(.GlobalEnv))  # when user runs test.data.table() we don't want their variables in .GlobalEnv affecting tests, #3705
@@ -182,7 +184,7 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
   nTest = RSS = NULL  # to avoid 'no visible binding' note
   timings = env$timings[nTest>0]
   if (!memtest) {
-    ans = head(timings[-1L][order(-time)], 10L)[,RSS:=NULL]   # exclude id 1 as in dev that includes JIT
+    ans = head(timings[if (dev) -1L else TRUE][order(-time)], 10L)[,RSS:=NULL]   # exclude id 1 in dev as that includes JIT
     if ((x<-sum(timings[["nTest"]])) != ntest) {
       warningf("Timings count mismatch: %d vs %d", x, ntest)  # nocov
     }

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -120,6 +120,8 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
 
   owd = setwd(tempdir()) # ensure writeable directory; e.g. tests that plot may write .pdf here depending on device option and/or batch mode; #5190
   on.exit(setwd(owd))
+  
+  if (memtest) catf("\n***\n*** memtest=TRUE. This should be the first task in a fresh R session for best results. Ctrl-C now if not.\n***\n\n")
 
   err = try(sys.source(fn, envir=env), silent=silent)
 

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -189,36 +189,10 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
     ans = timings[, diff:=c(NA,round(diff(RSS),1))][y+1L][,time:=NULL]  # time is distracting and influenced by gc() calls; just focus on RAM usage here
     catf("10 largest RAM increases (MB); see plot for cumulative effect (if any)\n")
     print(ans, class=FALSE)
-    plot(timings$RSS, main=fn, ylab="RSS (MB)")
+    plot(timings$RSS, main=basename(fn), ylab="RSS (MB)")
   }
 
   catf("All %d tests (last %.8g) in %s completed ok in %s\n", ntest, env$prevtest, names(fn), timetaken(env$started.at))
-
-  ## this chunk requires to include new suggested deps: graphics, grDevices
-  #memtest.plot = function(.inittime) {
-  #  if (!all(requireNamespace(c("graphics","grDevices"), quietly=TRUE))) return(invisible())
-  #  inittime=PS_rss=GC_used=GC_max_used=NULL
-  #  m = fread("memtest.csv")[inittime==.inittime]
-  #  if (nrow(m)) {
-  #    ps_na = allNA(m[["PS_rss"]]) # OS with no 'ps -o rss R' support
-  #    grDevices::png("memtest.png")
-  #    p = graphics::par(mfrow=c(if (ps_na) 2 else 3, 2))
-  #    if (!ps_na) {
-  #      m[, graphics::plot(test, PS_rss, pch=18, xlab="test num", ylab="mem MB", main="ps -o rss R")]
-  #      m[, graphics::plot(timestamp, PS_rss, type="l", xlab="timestamp", ylab="mem MB", main="ps -o rss R")]
-  #    }
-  #    m[, graphics::plot(test, GC_used, pch=18, xlab="test num", ylab="mem MB", main="gc used")]
-  #    m[, graphics::plot(timestamp, GC_used, type="l", xlab="timestamp", ylab="mem MB", main="gc used")]
-  #    m[, graphics::plot(test, GC_max_used, pch=18, xlab="test num", ylab="mem MB", main="gc max used")]
-  #    m[, graphics::plot(timestamp, GC_max_used, type="l", xlab="timestamp", ylab="mem MB", main="gc max used")]
-  #    graphics::par(p)
-  #    grDevices::dev.off()
-  #  } else {
-  #    warningf("test.data.table runs with memory testing but did not collect any memory statistics.")
-  #  }
-  #}
-  #if (memtest<-get("memtest", envir=env)) memtest.plot(get("inittime", envir=env))
-
   ans = nfail==0L
   attr(ans, "timings") = timings  # as attr to not upset callers who expect a TRUE/FALSE result
   invisible(ans)

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -179,6 +179,7 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
   }
 
   # There aren't any errors, so we can use up 11 lines for the timings table
+  nTest = RSS = NULL  # to avoid 'no visible binding' note
   timings = env$timings[nTest>0]
   if (!memtest) {
     ans = head(timings[-1L][order(-time)], 10L)[,RSS:=NULL]   # exclude id 1 as in dev that includes JIT
@@ -269,7 +270,7 @@ test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,no
     filename = get("filename", parent.frame())
     foreign = get("foreign", parent.frame())
     showProgress = get("showProgress", parent.frame())
-    time = nTest = NULL  # to avoid 'no visible binding' note
+    time = nTest = RSS = NULL  # to avoid 'no visible binding' note
     if (num>0) on.exit( {
        took = proc.time()[3L]-lasttime  # so that prep time between tests is attributed to the following test
        timings[as.integer(num), `:=`(time=time+took, nTest=nTest+1L), verbose=FALSE]

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -163,7 +163,8 @@ base_messages = list(
 ##########################
 
 test(1.1, tables(env=new.env()), null.data.table(), output = "No objects of class")
-test(1.2, tables(silent=TRUE), data.table(NAME="timings", NROW=9999L, NCOL=3L, MB=0, COLS=list(c("ID","time","nTest")), KEY=list(NULL)))
+test(1.2, tables(silent=TRUE)[,.(NAME,NROW,MB)], # memtest=TRUE adds some columns so exclude NCOL and COLS here
+          data.table(NAME="timings", NROW=9999L, MB=0))
 
 TESTDT = data.table(a=as.integer(c(1,3,4,4,4,4,7)), b=as.integer(c(5,5,6,6,9,9,2)), v=1:7)
 setkey(TESTDT,a,b)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -7,7 +7,6 @@ if (exists("test.data.table", .GlobalEnv, inherits=FALSE)) {
   }
   if ((tt<-compiler::enableJIT(-1))>0)
     cat("This is dev mode and JIT is enabled (level ", tt, ") so there will be a brief pause around the first test.\n", sep="")
-  DTfun = DT  # just in dev-mode, DT() gets overwritten in .GlobalEnv by DT objects here in tests.Rraw; we restore DT() in test 2212
 } else {
   require(data.table)
   # Make symbols to the installed version's ::: so that we can i) test internal-only not-exposed R functions
@@ -15326,10 +15325,10 @@ test(2035.3, fread('A,B\n"foo","ba"r"', quote=""), ans)
 # source() printing edge case; #2369
 setup = c('DT = data.table(a = 1)')
 writeLines(c(setup, 'DT[ , a := 1]'), tmp<-tempfile())
-test(2036.1, !any(grepl("1:     1", capture.output(source(tmp, echo = TRUE)), fixed = TRUE)))
+test(2036.1, !any(grepl("1:     1", capture.output(source(tmp, echo=TRUE, local=TRUE)), fixed=TRUE)))  # local= #5514
 ## test force-printing still works
 writeLines(c(setup, 'DT[ , a := 1][]'), tmp)
-test(2036.2, source(tmp, echo = TRUE), output = "1:\\s+1")
+test(2036.2, source(tmp, echo=TRUE, local=TRUE), output="1:\\s+1")
 
 # more helpful guidance when assigning before setDT() after readRDS(); #1729
 DT = data.table(a = 1:3)
@@ -18318,7 +18317,6 @@ for (col in c("a","b","c")) {
 # DT() functional form, #4872 #5106 #5107 #5129
 if (base::getRversion() >= "4.1.0") {
   # we have to EVAL "|>" here too otherwise this tests.Rraw file won't parse in R<4.1.0
-  if (exists("DTfun")) DT=DTfun  # just in dev-mode restore DT() in .GlobalEnv as DT object overwrote it in tests above
   droprn = function(df) { rownames(df)=NULL; df }  # TODO: could retain rownames where droprn is currently used below
   test(2212.011, EVAL("mtcars |> DT(mpg>20, .(mean_hp=round(mean(hp),2)), by=cyl)"),
                  data.frame(cyl=c(6,4), mean_hp=c(110.0, 82.64)))

--- a/man/test.data.table.Rd
+++ b/man/test.data.table.Rd
@@ -8,7 +8,7 @@
 test.data.table(script = "tests.Rraw", verbose = FALSE, pkg = ".",
                 silent = FALSE,
                 showProgress = interactive() && !silent,
-                memtest = as.logical(Sys.getenv("TEST_DATA_TABLE_MEMTEST", "FALSE")))
+                memtest = Sys.getenv("TEST_DATA_TABLE_MEMTEST", 0))
 }
 \arguments{
 \item{script}{ Run arbitrary R test script. }
@@ -16,7 +16,7 @@ test.data.table(script = "tests.Rraw", verbose = FALSE, pkg = ".",
 \item{pkg}{ Root directory name under which all package content (ex: DESCRIPTION, src/, R/, inst/ etc..) resides. Used only in \emph{dev-mode}. }
 \item{silent}{ Controls what happens if a test fails. Like \code{silent} in \code{\link{try}}, \code{TRUE} causes the error message to be suppressed and \code{FALSE} to be returned, otherwise the error is returned. }
 \item{showProgress}{ Output 'Running test <n> ...\\r' at the start of each test? }
-\item{memtest}{ Measure and report memory usage of tests rather than time taken. Intended for and tested on Linux. }
+\item{memtest}{ Measure and report memory usage of tests (1:gc before ps, 2:gc after ps) rather than time taken (0) by default. Intended for and tested on Linux. See PR #5515 for more details. }
 }
 \details{
   Runs a series of tests. These can be used to see features and examples of usage, too. Running test.data.table will tell you the full location of the test file(s) to open.

--- a/man/test.data.table.Rd
+++ b/man/test.data.table.Rd
@@ -7,7 +7,8 @@
 \usage{
 test.data.table(script = "tests.Rraw", verbose = FALSE, pkg = ".",
                 silent = FALSE,
-                showProgress = interactive() && !silent)
+                showProgress = interactive() && !silent,
+                memtest = as.logical(Sys.getenv("TEST_DATA_TABLE_MEMTEST", "FALSE")))
 }
 \arguments{
 \item{script}{ Run arbitrary R test script. }
@@ -15,6 +16,7 @@ test.data.table(script = "tests.Rraw", verbose = FALSE, pkg = ".",
 \item{pkg}{ Root directory name under which all package content (ex: DESCRIPTION, src/, R/, inst/ etc..) resides. Used only in \emph{dev-mode}. }
 \item{silent}{ Controls what happens if a test fails. Like \code{silent} in \code{\link{try}}, \code{TRUE} causes the error message to be suppressed and \code{FALSE} to be returned, otherwise the error is returned. }
 \item{showProgress}{ Output 'Running test <n> ...\\r' at the start of each test? }
+\item{memtest}{ Measure and report memory usage of tests rather than time taken. Intended for and tested on Linux. }
 }
 \details{
   Runs a series of tests. These can be used to see features and examples of usage, too. Running test.data.table will tell you the full location of the test file(s) to open.


### PR DESCRIPTION
* memtest now an argument rather than solely an env variable
* reports 10 largest RAM increases as text table analogous to the 10 longest tests by default
* adds RSS column to the timings table rather than memtest.csv file, and returns the timings
* no longer builds up multiple sets of timings from multiple runs, not needed
* ps_mem() was being called before gc_mem() which did the gc(); now calls gc() before ps_mem() as intended
* closes #5514 too although not related to memtest per se

Current output below. Shows steps up where we have relatively bigger test data sizes which could be reduced. The plot is just to show shape and extents; use the table to identify the tests. This growth to 280MB might be enough to tip the overloaded CRAN Windows server to decide to kill, #5507. If we can reduce that down to 170MB it might help avoid that tipping point and kill. I still think that the CRAN Windows server is severely overloaded due to the install time being 5 times longer (214s) than the non-Windows CRAN servers (42s). If we can reduce ram usage in tests, then we should, just to show willing if nothing else. In the absence of any reply from Uwe, this is the best I can guess and do. The FAIL is on CRAN Windows again now.

```
10 largest RAM increases (MB); see plot for cumulative effect (if any)
      ID nTest   RSS diff
 1:  637     3 211.7 33.1
 2:  819     1 218.9 20.6
 3: 1978     1 280.9 15.8
 4: 1151     2 237.6 15.7
 5: 1739     5 250.0 15.1
 6:  301     2 190.7 14.6
 7: 1158     1 220.2 12.6
 8:  167     3 177.5 11.6
 9: 1549     1 234.9  7.7
10: 1888     9 264.6  6.7
```

![image](https://user-images.githubusercontent.com/2779998/200454071-0c102d7b-0fcf-4cc5-99bf-b909b352e0fd.png)
