### PR TITLE
Use 'duration', not repetitive 'elapsed'

### DIFF
--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -175,7 +175,7 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
   if (nfail > 0L) {
     # nocov start
     stopf(
-      "%d error(s) out of %d. Search %s for test number(s) %s. Elapsed time: %s.",
+      "%d error(s) out of %d. Search %s for test number(s) %s. Duration: %s.",
       nfail, ntest, names(fn), toString(env$whichfail), timetaken(env$started.at)
     )
     # important to stopf() here, so that 'R CMD check' fails


### PR DESCRIPTION
Follow-up to #5519, I forgot `timetaken()` itself produces a string like `%s elapsed (%s cpu)`, so the output would look like `Elapsed time: %s elapsed (%s cpu)`, pretty redundant.