### PR TITLE
Test 1613.605 relaxed to pass different all.equal output in R-devel

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -617,6 +617,8 @@
 
 ## NOTES
 
+1. Test 1613.605 now passes changes to `as.data.frame()` in R-devel, [#5597](https://github.com/Rdatatable/data.table/pull/5597). Thanks to Avraham Adler for reporting.
+
 
 # data.table [v1.14.6](https://github.com/Rdatatable/data.table/milestone/27?closed=1)  (16 Nov 2022)
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -8687,7 +8687,7 @@ test(1613.601, all.equal(data.table(a=1), data.frame(a=1)), "target is data.tabl
 test(1613.602, all.equal(data.table(a=1), data.frame(a=1), check.attributes = FALSE))
 test(1613.603, all.equal(data.table(a=1), list(a=1), check.attributes = FALSE))
 test(1613.604, all.equal(data.table(a=1), 1, check.attributes = FALSE))
-test(1613.605, all.equal(data.table(a=1), try(stop('this wont work'), silent = TRUE), check.attributes = FALSE), "target is data.table but current is not and failed to be coerced to it")
+test(1613.605, !isTRUE(all.equal(data.table(a=1), try(stop('this wont work'), silent = TRUE), check.attributes = FALSE)))
 L1 = list(a = data.table(1), b = setattr("foo1613", "tbl", data.table(1)))
 L2 = list(a = 1, b = setattr("foo1613", "tbl", 1))
 test(1613.606, all(grepl("target is data.table, current is numeric", all.equal(L1, L2))))


### PR DESCRIPTION
Closes #5579
The root of it is this difference in R-devel.
```R
# R 4.2.2
> as.data.frame(try(stop(), silent=TRUE))
Error in as.data.frame.default(try(stop(), silent=TRUE)) : 
  cannot coerce class ‘"try-error"’ to a data.frame

# R-devel r83848
> as.data.frame(try(stop(), silent=TRUE))
                                         x
1 Error in try(stop(), silent=TRUE) : \n
> 
```

Likely related to these news items from R-devel news :

> as.data.frame()'s default method now also works fine with atomic objects inheriting from classes such as "roman", "octmode" and "hexmode", such fulfilling the wish of [PR#18421](https://bugs.r-project.org/show_bug.cgi?id=18421), by Benjamin Feakins.

> The as.data.frame.vector() utility now errors for wrong-length row.names. It warned for almost six years, with “Will be an error!”.

> Calling as.data.frame.<class>() directly (for 12 atomic classes) is going to be formally deprecated, currently activated by setting the environment variable _R_CHECK_AS_DATA_FRAME_EXPLICIT_METHOD_ to non-empty, which also happens in R CMD check --as-cran.

The test was testing that `all.equal()` doesn't pass, which it still does just with a different difference. 