### PR TITLE
Stop exporting .rbind.data.table in R>=4.0.0

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -90,19 +90,18 @@ if (getRversion() >= "4.0.0") {
   # if we register these (new in v1.12.6) methods always though, the previous workaround no longer works in R<4.0.0. Hence only register in R>=4.0.0.
   S3method(cbind, data.table)
   S3method(rbind, data.table)
+} else {
+  # and if we export but don't register in R < 4.0.0 we get this note:
+  # > Found the following apparent S3 methods exported but not registered:
+  # > cbind.data.table rbind.data.table
+  # in addition to errors in tests 324, 326, 414.1, 414.2, 442, 445, 451
+  # export(cbind.data.table)
+  # export(rbind.data.table)
+  # A revdep using rbind.data.frame() directly before (which data.table changed in base) should change to rbind() generic and that should work
+  # in all combinations of R before/after 4.0.0 and data.table before/after 1.12.6, so long as data.table is installed using the same major
+  # version of R (and that is checked in .onLoad with error if not).
+  export(.rbind.data.table) # only export in R < 4.0.0 where it is still used because R-devel now detects it is missing manual entry
 }
-# else {
-#  # and if we export but don't register in R < 4.0.0 we get this note:
-#  # > Found the following apparent S3 methods exported but not registered:
-#  # > cbind.data.table rbind.data.table
-#  # in addition to errors in tests 324, 326, 414.1, 414.2, 442, 445, 451
-#  export(cbind.data.table)
-#  export(rbind.data.table)
-#  # A revdep using rbind.data.frame() directly before (which data.table changed in base) should change to rbind() generic and that should work
-#  # in all combinations of R before/after 4.0.0 and data.table before/after 1.12.6, so long as data.table is installed using the same major
-#  # version of R (and that is checked in .onLoad with error if not).
-# }
-export(.rbind.data.table) # continue to export for now because it has been exported in the past so it may be depended on
 S3method(dim, data.table)
 S3method(dimnames, data.table)
 S3method("dimnames<-", data.table)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -100,7 +100,7 @@ if (getRversion() >= "4.0.0") {
   # A revdep using rbind.data.frame() directly before (which data.table changed in base) should change to rbind() generic and that should work
   # in all combinations of R before/after 4.0.0 and data.table before/after 1.12.6, so long as data.table is installed using the same major
   # version of R (and that is checked in .onLoad with error if not).
-  export(.rbind.data.table) # only export in R < 4.0.0 where it is still used because R-devel now detects it is missing manual entry
+  export(.rbind.data.table) # only export in R<4.0.0 where it is still used; R-devel now detects it is missing doc, #5600
 }
 S3method(dim, data.table)
 S3method(dimnames, data.table)

--- a/NEWS.md
+++ b/NEWS.md
@@ -619,6 +619,8 @@
 
 2. An out of bounds read when combining non-equi join with `by=.EACHI` has been found and fixed thanks to clang ASAN, [#5598](https://github.com/Rdatatable/data.table/issues/5598). There was no bug or consequence because the read was followed (now preceded) by a bounds test.
 
+3. `.rbind.data.table` (note the leading `.`) is no longer exported when `data.table` is installed in R>=4.0.0 (Apr 2020). It was never documented which R-devel now detects and warns about. It is only needed by `data.table` internals to support R<4.0.0; see note 1 in v1.12.6 (Oct 2019) below in this file for more details.
+
 
 # data.table [v1.14.6](https://github.com/Rdatatable/data.table/milestone/27?closed=1)  (16 Nov 2022)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -619,7 +619,7 @@
 
 2. An out of bounds read when combining non-equi join with `by=.EACHI` has been found and fixed thanks to clang ASAN, [#5598](https://github.com/Rdatatable/data.table/issues/5598). There was no bug or consequence because the read was followed (now preceded) by a bounds test.
 
-3. `.rbind.data.table` (note the leading `.`) is no longer exported when `data.table` is installed in R>=4.0.0 (Apr 2020). It was never documented which R-devel now detects and warns about. It is only needed by `data.table` internals to support R<4.0.0; see note 1 in v1.12.6 (Oct 2019) below in this file for more details.
+3. `.rbind.data.table` (note the leading `.`) is no longer exported when `data.table` is installed in R>=4.0.0 (Apr 2020), [#5600](https://github.com/Rdatatable/data.table/pull/5600). It was never documented which R-devel now detects and warns about. It is only needed by `data.table` internals to support R<4.0.0; see note 1 in v1.12.6 (Oct 2019) below in this file for more details.
 
 
 # data.table [v1.14.6](https://github.com/Rdatatable/data.table/milestone/27?closed=1)  (16 Nov 2022)


### PR DESCRIPTION
```
Version: 1.14.6
Flags: --no-tests
Check: for missing documentation entries
Result: WARN
    Undocumented code objects:
     ‘.rbind.data.table’
    All user-level objects in a package should have documentation entries.
    See chapter ‘Writing R documentation files’ in the ‘Writing R
    Extensions’ manual.
Flavor: [r-devel-linux-x86_64-debian-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-gcc/data.table-00check.html)
```

News item explains.