### PR TITLE
Update repo link for lubridate

### DIFF
--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -315,8 +315,8 @@ clip_msec = function(secs, action) {
 #   Adapted from Hadley Wickham's routines cited below to ensure
 #   integer results.
 #     http://gist.github.com/10238
-#   See also Hadley's more advanced and complex lubridate package:
-#     http://github.com/hadley/lubridate
+#   See also Hadley et al's more advanced and complex lubridate package:
+#     https://github.com/tidyverse/lubridate
 #   lubridate routines do not return integer values.
 ###################################################################
 


### PR DESCRIPTION
Also qualify 'et al' since Hadley hasn't been the listed maintainer of the package since 2010:

https://github.com/tidyverse/lubridate/commit/0f5e7957a3dccbde8ef2981451fd31d148f925cf

"See also the Tidyverse team's more advanced..." may be most appropriate.