### PR TITLE
add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+#https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+* @mattdowle
+/R/fmelt.R @tdhock
+/src/fmelt.c @tdhock
+/man/melt.data.table.Rd @tdhock


### PR DESCRIPTION
The CODEOWNERS file is documented here, https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
Basically, github uses this file to automatically notify people for code review, when a (non-draft) PR is opened.
Creating this explicit mapping from files to reviewers would be essential to enable a more de-centralized code review process (less work for @mattdowle).
In this first draft of CODEOWNERS, I have volunteered to be reviewer for files related to melt.
@MichaelChirico @jangorecki @ben-schwen would you please (1) add lines to CODEOWNERS to indicate files that you would like to review, and (2) @tag-other-people who you think may be interested to volunteer as reviewers?