### PR TITLE
run correctly even when is.atomic(NULL) becomes FALSE

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -882,7 +882,7 @@ replace_dot_alias = function(e) {
           bynames = allbyvars = NULL
           # the rest now fall through
         } else bynames = names(byval)
-        if (is.atomic(byval)) {
+        if (is.atomic(byval) || is.null(byval)) {
           if (is.character(byval) && length(byval)<=ncol(x) && !(is.name(bysub) && bysub %chin% names_x) ) {
             stopf("'by' appears to evaluate to column names but isn't c() or key(). Use by=list(...) if you can. Otherwise, by=eval%s should work. This is for efficiency so data.table can detect which columns are needed.", deparse(bysub))
           } else {

--- a/R/frank.R
+++ b/R/frank.R
@@ -12,7 +12,7 @@ frankv = function(x, cols=seq_along(x), order=1L, na.last=TRUE, ties.method=c("a
     .Call(Csetlistelt, xx, 1L, x)
     xx
   }
-  if (is.atomic(x)) {
+  if (is.atomic(x) || is.null(x)) {
     if (!missing(cols) && !is.null(cols))
       stopf("x is a single vector, non-NULL 'cols' doesn't make sense")
     cols = 1L

--- a/R/fread.R
+++ b/R/fread.R
@@ -135,7 +135,7 @@ yaml=FALSE, autostart=NA, tmpdir=tempdir(), tz="UTC")
     if (!allNA(colClasses)) stopf("colClasses is type 'logical' which is ok if all NA but it has some TRUE or FALSE values in it which is not allowed. Please consider the drop= or select= argument instead. See ?fread.")
     colClasses = NULL
   }
-  if (!is.null(colClasses) && is.atomic(colClasses)) {
+  if (!is.null(colClasses) && is.atomic(colClasses)) { ## future R can use  if (is.atomic(.))
     if (!is.character(colClasses)) stopf("colClasses is not type list or character vector")
     if (!length(colClasses)) {
       colClasses=NULL;

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -141,7 +141,8 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
 }
 
 format.data.table = function (x, ..., justify="none") {
-  if (is.atomic(x) && !is.null(x)) {
+  if (is.atomic(x) && !is.null(x)) { ## future R can use  if (is.atomic(x))
+
     stopf("Internal structure doesn't seem to be a list. Possibly corrupt data.table.")
   }
   do.call("cbind", lapply(x, format_col, ..., justify=justify))

--- a/R/setkey.R
+++ b/R/setkey.R
@@ -169,7 +169,7 @@ is.sorted = function(x, by=NULL) {
 ORDERING_TYPES = c('logical', 'integer', 'double', 'complex', 'character')
 forderv = function(x, by=seq_along(x), retGrp=FALSE, sort=TRUE, order=1L, na.last=FALSE)
 {
-  if (is.atomic(x)) {  # including forderv(NULL) which returns error consistent with base::order(NULL),
+  if (is.atomic(x) || is.null(x)) {  # including forderv(NULL) which returns error consistent with base::order(NULL),
     if (!missing(by) && !is.null(by)) stopf("x is a single vector, non-NULL 'by' doesn't make sense")
     by = NULL
   } else {


### PR DESCRIPTION
We (R-core) plan for  `is.atomic(NULL)`  to become false {such that `is.atomic(.)` finally does what it promises}.
This is currently visible in our _R-is_ development branch of the the R sources, mirrored on github at
   https://github.com/wch/r-source/tree/R-is

This may become part of the official pre-release "R-devel" within less than a month.

When running  `R-devel-is CMD check --as-cran  data.table`   (`R-devel-is` being built from the above `R-is` sources of R),
about 4 out of ~10'000 tests failed (in ...`tests/main.R`).
I've fixed the corresponding R code in a way that continues to work correctly with current R,  basically by replacing three times   `is.atomic(x)`  by   `is.atomic(x) || is.null(x)`  (and remarking to places where you can *drop* an `is.null(.)` check in the future)  with this pull request.