### PR TITLE
update_dev_pkg uses GH for R repo (in master branch as well)

### DIFF
--- a/R/devel.R
+++ b/R/devel.R
@@ -17,7 +17,7 @@ dcf.repo = function(pkg, repo, field, type) {
   dcf[dcf[,"Package"]==pkg, field][[1L]]
 }
 
-update_dev_pkg = function(object="data.table", repo="https://Rdatatable.gitlab.io/data.table", field="Revision", type=getOption("pkgType"), lib=NULL, ...) {
+update_dev_pkg = function(object="data.table", repo="https://Rdatatable.github.io/data.table", field="Revision", type=getOption("pkgType"), lib=NULL, ...) {
   # this works for any package, not just data.table
   pkg = object
   # perform package upgrade when new Revision present

--- a/man/update_dev_pkg.Rd
+++ b/man/update_dev_pkg.Rd
@@ -5,7 +5,7 @@
   Downloads and installs latest development version only when a new commit is available which has also passed all tests. Defaults are set to update \code{data.table}, other packages can be used as well. Their repository has to include git commit information in PACKAGES file.
 }
 \usage{update_dev_pkg(object="data.table",
-       repo="https://Rdatatable.gitlab.io/data.table",
+       repo="https://Rdatatable.github.io/data.table",
        field="Revision", type=getOption("pkgType"), lib=NULL, \dots)
 }
 \arguments{


### PR DESCRIPTION
It is the same what https://github.com/Rdatatable/data.table/pull/5719 but this one merges to master