### PR TITLE
lto warning fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -136,7 +136,6 @@ test-rel-lin:
   <<: *test-lin
   image: registry.gitlab.com/jangorecki/dockerfiles/r-data.table
   needs: ["mirror-packages","build"]
-  allow_failure: true ## temp workaround #5760
   variables:
     _R_CHECK_CRAN_INCOMING_: "FALSE"
     _R_CHECK_CRAN_INCOMING_REMOTE_: "FALSE"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -129,7 +129,7 @@ build:
 
 ## most comprehensive tests
 # force all suggests
-# flags: gcc -O3 -flto -fno-common -Wunused-result
+# flags: gcc -O3 -flto=auto -fno-common -Wunused-result
 # tests for compilation warnings
 # measure memory usage during tests
 test-rel-lin:
@@ -149,8 +149,8 @@ test-rel-lin:
     - *cp-src
     - rm -r bus
     - mkdir -p ~/.R
-    - echo 'CFLAGS=-g -O3 -flto -fno-common -Wunused-result -fopenmp -Wall -pedantic -fstack-protector-strong -D_FORTIFY_SOURCE=2' > ~/.R/Makevars
-    - echo 'CXXFLAGS=-g -O3 -flto -fno-common -Wunused-result -fopenmp -Wall -pedantic -fstack-protector-strong -D_FORTIFY_SOURCE=2' >> ~/.R/Makevars
+    - echo 'CFLAGS=-g -O3 -flto=auto -fno-common -Wunused-result -fopenmp -Wall -pedantic -fstack-protector-strong -D_FORTIFY_SOURCE=2' > ~/.R/Makevars
+    - echo 'CXXFLAGS=-g -O3 -flto=auto -fno-common -Wunused-result -fopenmp -Wall -pedantic -fstack-protector-strong -D_FORTIFY_SOURCE=2' >> ~/.R/Makevars
   script:
     - *mv-src
     - cd bus/$CI_JOB_NAME

--- a/src/chmatch.c
+++ b/src/chmatch.c
@@ -95,8 +95,8 @@ static SEXP chmatchMain(SEXP x, SEXP table, int nomatch, bool chin, bool chmatch
     // For example: A,B,C,B,D,E,A,A   =>   A(TL=1),B(2),C(3),D(4),E(5)   =>   dupMap    1  2  3  5  6 | 8  7  4
     //                                                                        dupLink   7  8          |    6     (blank=0)
     int *counts = (int *)calloc(nuniq, sizeof(int));
-    unsigned int mapsize = tablelen+nuniq; // lto compilation warning #5760
-    int *map =    (int *)calloc(mapsize, sizeof(int));  // +nuniq to store a 0 at the end of each group
+    unsigned int mapsize = tablelen+nuniq; // lto compilation warning #5760 // +nuniq to store a 0 at the end of each group
+    int *map =    (int *)calloc(mapsize, sizeof(int));
     if (!counts || !map) {
       // # nocov start
       for (int i=0; i<tablelen; i++) SET_TRUELENGTH(td[i], 0);

--- a/src/chmatch.c
+++ b/src/chmatch.c
@@ -95,7 +95,8 @@ static SEXP chmatchMain(SEXP x, SEXP table, int nomatch, bool chin, bool chmatch
     // For example: A,B,C,B,D,E,A,A   =>   A(TL=1),B(2),C(3),D(4),E(5)   =>   dupMap    1  2  3  5  6 | 8  7  4
     //                                                                        dupLink   7  8          |    6     (blank=0)
     int *counts = (int *)calloc(nuniq, sizeof(int));
-    int *map =    (int *)calloc(tablelen+nuniq, sizeof(int));  // +nuniq to store a 0 at the end of each group
+    int mapsize = tablelen+nuniq; // lto compilation warning #5760
+    int *map =    (int *)calloc(mapsize, sizeof(int));  // +nuniq to store a 0 at the end of each group
     if (!counts || !map) {
       // # nocov start
       for (int i=0; i<tablelen; i++) SET_TRUELENGTH(td[i], 0);

--- a/src/chmatch.c
+++ b/src/chmatch.c
@@ -95,7 +95,7 @@ static SEXP chmatchMain(SEXP x, SEXP table, int nomatch, bool chin, bool chmatch
     // For example: A,B,C,B,D,E,A,A   =>   A(TL=1),B(2),C(3),D(4),E(5)   =>   dupMap    1  2  3  5  6 | 8  7  4
     //                                                                        dupLink   7  8          |    6     (blank=0)
     int *counts = (int *)calloc(nuniq, sizeof(int));
-    int mapsize = tablelen+nuniq; // lto compilation warning #5760
+    unsigned int mapsize = tablelen+nuniq; // lto compilation warning #5760
     int *map =    (int *)calloc(mapsize, sizeof(int));  // +nuniq to store a 0 at the end of each group
     if (!counts || !map) {
       // # nocov start


### PR DESCRIPTION
Closes #5760

There are 2 warnings actually, chmatch resolved by unsigned int, another by -flto=auto


