### PR TITLE
cast pointers to standard type for printf

### DIFF
--- a/src/assign.c
+++ b/src/assign.c
@@ -1140,7 +1140,7 @@ static R_len_t *savedtl=NULL, nalloc=0, nsaved=0;
 
 void savetl_init(void) {
   if (nsaved || nalloc || saveds || savedtl) {
-    error(_("Internal error: savetl_init checks failed (%d %d %p %p). please report to data.table issue tracker."), nsaved, nalloc, saveds, savedtl); // # nocov
+    error(_("Internal error: savetl_init checks failed (%d %d %p %p). please report to data.table issue tracker."), nsaved, nalloc, (void *)saveds, (void *)savedtl); // # nocov
   }
   nsaved = 0;
   nalloc = 100;


### PR DESCRIPTION
As noted https://github.com/Rdatatable/data.table/issues/5778#issuecomment-1837499818 (this time targeting `hotfix` branch)