### PR TITLE
Fix two "unusual" format warnings

### DIFF
--- a/src/assign.c
+++ b/src/assign.c
@@ -471,7 +471,7 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values)
       // strong error message for now.
     else if (TRUELENGTH(names) != oldtncol)
       // Use (long long) to cast R_xlen_t to a fixed type to robustly avoid -Wformat compiler warnings, see #5768, PRId64 didnt work
-      error(_("Internal error: selfrefnames is ok but tl names [%ld] != tl [%d]"), TRUELENGTH(names), oldtncol);  // # nocov
+      error(_("Internal error: selfrefnames is ok but tl names [%ld] != tl [%d]"), (long long)TRUELENGTH(names), oldtncol);  // # nocov
     SETLENGTH(dt, oldncol+LENGTH(newcolnames));
     SETLENGTH(names, oldncol+LENGTH(newcolnames));
     for (int i=0; i<LENGTH(newcolnames); ++i)

--- a/src/fread.c
+++ b/src/fread.c
@@ -146,7 +146,7 @@ bool freadCleanup(void)
     // may call freadCleanup(), thus resulting in an infinite loop.
     #ifdef WIN32
       if (!UnmapViewOfFile(mmp))
-        DTPRINT(_("System error %d unmapping view of file\n"), GetLastError());      // # nocov
+        DTPRINT(_("System error %lu unmapping view of file\n"), GetLastError());      // # nocov
     #else
       if (munmap(mmp, fileSize))
         DTPRINT(_("System errno %d unmapping file: %s\n"), errno, strerror(errno));  // # nocov


### PR DESCRIPTION
Part of #5790

I don't see clear answers about `DWORD` but it seems like `%ld` will work:

https://copyprogramming.com/howto/what-is-the-format-specifier-for-dword-c

For `TRUELENGTH()` we wrote the comment about casting to `long long` but there is no cast. So trying to actually do the cast.