### PR TITLE
workaround pkgdown bug by copy rather link to avoid dead links

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -361,6 +361,10 @@ integration:
     - Rscript -e 'check.index("data.table", names(test.jobs))'
     ## web/checks/check_flavors.html
     - Rscript -e 'check.flavors(names(test.jobs))'
+    ## pkgdown vignettes workaround r-lib/pkgdown#2383
+    - mkdir -p pkgdown/articles
+    - cp bus/integration/cran/library/data.table/doc/*.html pkgdown/articles/.
+    - rm pkgdown/articles/index.html
     ## pkgdown merge
     - Rscript -e 'common_files<-function(path1, path2) intersect(list.files(path1, all.files=TRUE, no..=TRUE), list.files(path2, all.files=TRUE, no..=TRUE)); msg = if (length(f<-common_files("pkgdown","bus/integration/cran"))) paste(c("Following artifacts will be overwritten by pkgdown artifacts:", paste0("  ", f)), collapse="\n") else "No overlapping files from pkgdown artifacts"; message(msg); q("no")'
     - mv pkgdown/* bus/integration/cran/

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -20,30 +20,30 @@ navbar:
       href: index.html
     introduction:
       text: Introduction
-      href: library/data.table/doc/datatable-intro.html
+      href: articles/datatable-intro.html
     articles:
       text: Vignettes
       menu:
       - text: "Introduction to data.table"
-        href: library/data.table/doc/datatable-intro.html
+        href: articles/datatable-intro.html
       - text: "Reference semantics"
-        href: library/data.table/doc/datatable-reference-semantics.html
+        href: articles/datatable-reference-semantics.html
       - text: "Using .SD for Data Analysis"
-        href: library/data.table/doc/datatable-sd-usage.html
+        href: articles/datatable-sd-usage.html
       - text: "Keys and fast binary search based subset"
-        href: library/data.table/doc/datatable-keys-fast-subset.html
+        href: articles/datatable-keys-fast-subset.html
       - text: "Secondary indices and auto indexing"
-        href: library/data.table/doc/datatable-secondary-indices-and-auto-indexing.html
+        href: articles/datatable-secondary-indices-and-auto-indexing.html
       - text: "Efficient reshaping using data.table"
-        href: library/data.table/doc/datatable-reshape.html
+        href: articles/datatable-reshape.html
       - text: "Programming on data.table"
-        href: library/data.table/doc/datatable-programming.html
+        href: articles/datatable-programming.html
       - text: "Frequently asked questions"
-        href: library/data.table/doc/datatable-faq.html
+        href: articles/datatable-faq.html
       - text: "Importing data.table"
-        href: library/data.table/doc/datatable-importing.html
+        href: articles/datatable-importing.html
       - text: "Benchmarking data.table"
-        href: library/data.table/doc/datatable-benchmarking.html
+        href: articles/datatable-benchmarking.html
     news:
       text: News
       href: news/index.html


### PR DESCRIPTION
I observed people are hitting currently dead links from online resources.
Therefore better to copy vignettes to previous location rather than linking.
Workaround due to https://github.com/r-lib/pkgdown/issues/2383