### PR TITLE
CI reporting improvements

### DIFF
--- a/.ci/publish.R
+++ b/.ci/publish.R
@@ -3,16 +3,20 @@ format.deps <- function(file, which) {
   if (all(is.na(deps.raw))) return(character())
   deps.raw = gsub("\n", " ", deps.raw, fixed=TRUE)
   deps.full = trimws(strsplit(deps.raw, ", ", fixed=TRUE)[[1L]])
-  deps = trimws(sapply(strsplit(deps.full, "(", fixed=TRUE), `[[`, 1L))
-  deps.full = gsub(">=", "&ge;", deps.full, fixed=TRUE)
-  deps.full = gsub("<=", "&le;", deps.full, fixed=TRUE)
-  if (any(grepl(">", deps.full, fixed=TRUE), grepl("<", deps.full, fixed=TRUE), grepl("=", deps.full, fixed=TRUE)))
+  deps.full.split = strsplit(deps.full, "(", fixed=TRUE)
+  deps = trimws(sapply(deps.full.split, `[[`, 1L))
+  vers = trimws(sapply(deps.full.split, function(x) if (length(x)>1L) paste0("(",x[[2L]]) else ""))
+  vers = gsub(">=", "&ge;", vers, fixed=TRUE)
+  vers = gsub("<=", "&le;", vers, fixed=TRUE)
+  if (any(grepl(">", vers, fixed=TRUE), grepl("<", vers, fixed=TRUE), grepl("=", vers, fixed=TRUE)))
     stop("formatting dependencies version for CRAN-line package website failed because some dependencies have version defined using operators other than >= and <=")
-  names(deps.full) <- deps
+  names(vers) <- deps
   base.deps = c("R", unlist(tools:::.get_standard_package_names(), use.names = FALSE))
   ans = sapply(deps, function(x) {
-    if (x %in% base.deps) deps.full[[x]] ## base R packages are not linked
-    else sprintf("<a href=\"../%s/index.html\">%s</a>", x, deps.full[[x]])
+    if (x %in% base.deps) {
+      if (nchar(vers[[x]])) paste(x, vers[[x]]) else x ## base R packages are not linked
+    }
+    else sprintf("<a href=\"https://cloud.r-project.org/package=%s\">%s</a>%s", x, x, if (nchar(vers[[x]])) paste0(" ",vers[[x]]) else "")
   })
   sprintf("<tr><td>%s:</td><td>%s</td></tr>", which, paste(ans, collapse=", "))
 }
@@ -207,24 +211,11 @@ check.copy <- function(job, repodir="bus/integration/cran"){
   dir.create(job.checks<-file.path(repodir, "web", "checks", pkg<-"data.table", job), recursive=TRUE);
   os = plat(job)
   from = file.path("bus", sprintf("%s/%s.Rcheck", job, pkg))
-  current.rout = c("main.Rout","main.Rout.fail","knitr.Rout","knitr.Rout.fail","memtest.csv","memtest.png")
-  if (os=="Windows") {
-    dir.create(file.path(job.checks, "tests_i386"), showWarnings=FALSE)
-    dir.create(file.path(job.checks, "tests_x64"), showWarnings=FALSE)
-    rout32 = file.path("tests_i386", current.rout)
-    rout64 = file.path("tests_x64", current.rout)
-    file.copy(file.path(from, rout32)[file.exists(file.path(from, rout32))], file.path(job.checks, "tests_i386"))
-    file.copy(file.path(from, rout64)[file.exists(file.path(from, rout64))], file.path(job.checks, "tests_x64"))
-    routs = c(rout32, rout64)
-  } else if (os=="Mac OS X") {
-    dir.create(file.path(job.checks, "tests"), showWarnings=FALSE)
-    routs = file.path("tests", current.rout)
-    file.copy(file.path(from, routs)[file.exists(file.path(from, routs))], file.path(job.checks, "tests"))
-  } else {
-    dir.create(file.path(job.checks, "tests"), showWarnings=FALSE)
-    routs = file.path("tests", current.rout)
-    file.copy(file.path(from, routs)[file.exists(file.path(from, routs))], file.path(job.checks, "tests"))
-  }
+  tests = list.files("tests", pattern="\\.R$")
+  current.rout = c(paste0(tests, "out"), paste0(tests, "out.fail"))
+  dir.create(file.path(job.checks, "tests"), showWarnings=FALSE)
+  routs = file.path("tests", current.rout)
+  file.copy(file.path(from, routs)[file.exists(file.path(from, routs))], file.path(job.checks, "tests"))
   inst.check.files = file.path(from, inst.check<-c("00install.out","00check.log"))
   file.copy(inst.check.files[file.exists(inst.check.files)], job.checks)
   setNames(file.exists(file.path(job.checks, c(inst.check, routs))), c(inst.check, routs))
@@ -274,75 +265,46 @@ log.copy <- function(job, repodir="bus/integration/cran") {
   Sys.sleep(0.1) ## to not get ban from gitlab.com
   setNames(file.exists(to), "log")
 }
-
 ci.status <- function(job) {
   if (!file.exists(status_file <- file.path("bus", job, "status")))
     return(NA_character_)
   readLines(status_file, warn=FALSE)[1L]
 }
-
 ci.log <- function(jobs, repodir="bus/integration/cran") {
   pkg = "data.table"
   ans = vector("character", length(jobs))
   logs = sapply(jobs, log.copy, repodir=repodir)
   statuses = sapply(jobs, ci.status)
+  statuses[statuses=="success"] = paste0("<span class=\"check_ok\">",statuses[statuses=="success"],"</span>")
+  statuses[statuses=="failed"] = paste0("<span class=\"check_ko\">",statuses[statuses=="failed"],"</span>")
   ans[!logs] = statuses[!logs]
   ans[logs] = sprintf('<a href=\"%s/%s/log\">%s</a>', pkg[any(logs)], jobs[logs], statuses[logs])
   ans
 }
 
 check.index <- function(pkg, jobs, repodir="bus/integration/cran") {
-  status = function(x) if (grepl("^.*ERROR", x)) "ERROR" else if (grepl("^.*WARNING", x)) "WARNING" else if (grepl("^.*NOTE", x)) "NOTE" else if (grepl("^.*OK", x)) "OK" else NA_character_
-  test.files = function(job, files, trim.name=FALSE, trim.exts=0L, pkg="data.table") {
-    stopifnot(trim.name + as.logical(trim.exts) < 2L) # cannot use both
+  status = function(x) if (grepl("^.*ERROR", x)) "<span class=\"check_ko\">ERROR</span>" else if (grepl("^.*WARNING", x)) "<span class=\"check_ko\">WARNING</span>" else if (grepl("^.*NOTE", x)) "<span class=\"CRAN\">NOTE</span>" else if (grepl("^.*OK", x)) "<span class=\"check_ok\">OK</span>" else NA_character_
+  test.files = function(job, trim=TRUE, pkg="data.table") {
+    files = paste0("tests/", list.files("tests", pattern="\\.R$"), "out.fail")
     links = sapply(files, function(file) {
       if (!file.exists(file.path(repodir, "web/checks", pkg, job, file))) return(NA_character_)
       dir = if (!identical(d<-dirname(file), ".")) d
       sprintf("<a href=\"%s/%s/%s\">%s</a>", pkg, job, file,
-              if (trim.name) paste(c(dir, tools::file_ext(file)), collapse="/") else if (trim.exts) { for (i in 1:trim.exts) { file<-tools::file_path_sans_ext(file) }; file } else file)
+              if (trim) sub(".Rout.fail", "", basename(file), fixed=TRUE) else file)
     })
     paste(na.omit(links), collapse=", ")
   }
-  routs = lapply(jobs, function(job) {
-    current.rout = c("main.Rout.fail","knitr.Rout.fail")
-    os = plat(job)
-    if (os=="Windows") {
-      rout32 = file.path("tests_i386", current.rout)
-      rout64 = file.path("tests_x64", current.rout)
-      routs = c(rout32, rout64)
-    } else if (os=="Mac OS X") {
-      routs = file.path("tests", current.rout)
-    } else {
-      routs = file.path("tests", current.rout)
-    }
-    routs
-  })
-  memouts = lapply(jobs, function(job) {
-    current.memout = c("memtest.csv","memtest.png")
-    os = plat(job)
-    if (os=="Windows") {
-      mem32 = file.path("tests_i386", current.memout)
-      mem64 = file.path("tests_x64", current.memout)
-      memouts = c(mem32, mem64)
-    } else if (os=="Mac OS X") {
-      memouts = file.path("tests", current.memout)
-    } else {
-      memouts = file.path("tests", current.memout)
-    }
-    memouts
-  })
-  th = "<th>Flavor</th><th>Version</th><th>Revision</th><th>Install</th><th>Status</th><th>Flags</th><th>Rout.fail</th><th>Log</th><th>Memtest</th>"
+  th = "<th>Flavor</th><th>Version</th><th>Revision</th><th>Install</th><th>Check</th><th>Flags</th><th>Rout.fail</th><th>Log</th>"
   tbl = sprintf(
-    "<tr><td><a href=\"check_flavors.html\">%s</a></td><td>%s</td><td>%s</td><td><a href=\"%s/%s/00install.out\">out</a></td><td><a href=\"%s/%s/00check.log\">%s</a></td><td>%s</td><td>%s</td><td>%s</td><td>%s</td></tr>",
+    "<tr><td><a href=\"check_flavors.html\">%s</a></td><td>%s</td><td>%s</td><td><a href=\"%s/%s/00install.out\">out</a></td><td><a href=\"%s/%s/00check.log\">%s</a></td><td>%s</td><td>%s</td><td>%s</td></tr>",
     sub("test-", "", jobs, fixed=TRUE), ## Flavor
     sapply(jobs, pkg.version, pkg),     ## Version
     sapply(jobs, pkg.revision, pkg),    ## Revision
     pkg, jobs,                          ## Install
-    pkg, jobs, sapply(sapply(jobs, check.test, pkg="data.table"), status), ## Status
+    pkg, jobs, sapply(sapply(jobs, check.test, pkg="data.table"), status), ## Check
     sapply(jobs, pkg.flags, pkg),                                          ## Flags
-    mapply(test.files, jobs, routs, trim.exts=2L),                         ## Rout.fail: 1st fail, 2nd Rout, keep just: tests_x64/main
-    ci.log(jobs),                                                          ## CI job logs
-    mapply(test.files, jobs, memouts, trim.name=TRUE)                      ## Memtest // currently not used
+    sapply(jobs, test.files),                                              ## Rout.fail
+    ci.log(jobs)                                                           ## CI job logs
   )
   file = file.path(repodir, "web/checks", sprintf("check_results_%s.html", pkg))
   writeLines(c(
@@ -378,29 +340,3 @@ check.test <- function(job, pkg) {
   check[length(check)]
 }
 
-move.bin <- function(job, bin.version, os.type, file="DESCRIPTION", silent=TRUE) {
-  ## currently not used, if not used for macos in future then can be removed
-  if (os.type=="unix") {
-    stop("publish of linux binaries not supported")
-  } else if (os.type=="windows") {
-    plat.path = "windows"
-    extension = "zip"
-  } else if (os.type=="macosx") {
-    plat.path = "macosx/el-capitan"
-    extension = "tgz"
-  }
-  dcf = read.dcf(file)
-  pkg = dcf[,"Package"][[1L]]
-  version = dcf[,"Version"][[1L]]
-  src.path = file.path("bus",job,"cran/bin",plat.path,"contrib",bin.version)
-  if (!silent && !dir.exists(src.path)) stop(sprintf("expected directory does not exists %s", src.path))
-  bin.file = sprintf("%s_%s.%s", pkg, version, extension)
-  tgt.path = file.path("bus/integration/cran/bin",plat.path,"contrib",bin.version)
-  if (!file.exists(file.path(src.path, bin.file))) {
-    if (!silent) stop(sprintf("expected binaries does not exists %s", file.path(src.path, bin.file)))
-  } else {
-    if (!dir.exists(tgt.path)) dir.create(tgt.path, recursive=TRUE)
-    file.rename(file.path(src.path,bin.file), file.path(tgt.path,bin.file))
-  }
-  setNames(file.exists(file.path(tgt.path,bin.file)), file.path(tgt.path,bin.file))
-}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -351,7 +351,7 @@ integration:
     ## library html manual, vignettes
     - Rscript -e 'lib.copy(lib.from="/tmp/opencran/library")'
     ## web/checks/$pkg/$job 00install.out, 00check.log, *.Rout
-    - Rscript -e 'sapply(names(test.jobs), check.copy, simplify=TRUE)'
+    - Rscript -e 'sapply(names(test.jobs), check.copy)'
     ## web/packages/$pkg/$pkg.pdf
     - Rscript -e 'pdf.copy("data.table", "test-lin-rel")'
     ## web/checks/check_results_$pkg.html

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -332,20 +332,17 @@ integration:
     - Rscript -e 'tools::write_PACKAGES(contrib.url("bus/integration/cran", type="win.binary", ver=Sys.getenv("R_REL_VERSION")), type="win.binary", fields="Revision", addFiles=TRUE)'
     - Rscript -e 'tools::write_PACKAGES(contrib.url("bus/integration/cran", type="win.binary", ver=Sys.getenv("R_DEV_VERSION")), type="win.binary", fields="Revision", addFiles=TRUE)'
     - Rscript -e 'tools::write_PACKAGES(contrib.url("bus/integration/cran", type="win.binary", ver=Sys.getenv("R_OLD_VERSION")), type="win.binary", fields="Revision", addFiles=TRUE)'
-    #- Rscript -e 'move.bin("test-mac-rel", Sys.getenv("R_REL_VERSION"), os.type="macosx")'
-    #- Rscript -e 'move.bin("test-mac-dev", Sys.getenv("R_DEV_VERSION"), os.type="macosx")'
-    #- Rscript -e 'move.bin("test-mac-old", Sys.getenv("R_OLD_VERSION"), os.type="macosx")'
-    #- Rscript -e 'tools::write_PACKAGES(contrib.url("bus/integration/cran", type="mac.binary.el-capitan", ver=Sys.getenv("R_REL_VERSION")), type="mac.binary.el-capitan", fields="Revision", addFiles=TRUE)'
-    #- Rscript -e 'tools::write_PACKAGES(contrib.url("bus/integration/cran", type="mac.binary.el-capitan", ver=Sys.getenv("R_DEV_VERSION")), type="mac.binary.el-capitan", fields="Revision", addFiles=TRUE)'
-    #- Rscript -e 'tools::write_PACKAGES(contrib.url("bus/integration/cran", type="mac.binary.el-capitan", ver=Sys.getenv("R_OLD_VERSION")), type="mac.binary.el-capitan", fields="Revision", addFiles=TRUE)'
-    ## install all pkgs to render html and double check successful installation of all devel packages
-    - mkdir -p /tmp/opencran/library /tmp/opencran/doc/html ## reset R_LIBS_USER to re-install all with html because pkgdown image has pre installed curl knitr
-    - R_LIBS_USER="" Rscript -e 'install.packages("data.table", dependencies=TRUE, lib="/tmp/opencran/library", repos=file.path("file:",normalizePath("bus/integration/cran")), INSTALL_opts="--html", quiet=TRUE)'
+    #### macos mkdir cran/bin/.../contrib/...
+    #### macos move binaries
+    #### macos write_PACKAGES
+    ## install pkg to render html
+    - mkdir -p /tmp/opencran/library /tmp/opencran/doc/html
+    - Rscript -e 'install.packages("data.table", lib="/tmp/opencran/library", repos=file.path("file:",normalizePath("bus/integration/cran")), INSTALL_opts="--html", quiet=TRUE)'
     - Rscript -e 'packageVersion("data.table", lib.loc="/tmp/opencran/library")'
     ## CRAN style web/CRAN_web.css
     - wget -q -P bus/integration/cran/web https://cran.r-project.org/web/CRAN_web.css
     ## web/packages/$pkg/index.html
-    - Rscript -e 'sapply(rownames(installed.packages(lib.loc="/tmp/opencran/library", priority="NA")), package.index, lib.loc="/tmp/opencran/library")'
+    - Rscript -e 'sapply(setNames(nm=rownames(installed.packages(lib.loc="/tmp/opencran/library", priority="NA"))), package.index, lib.loc="/tmp/opencran/library")'
     ## R docs, html, css, icons
     - Rscript -e 'doc.copy(repodir="/tmp/opencran")'
     ## Update packages.html, fix paths
@@ -353,8 +350,8 @@ integration:
     - mv /tmp/opencran/doc bus/integration/cran/
     ## library html manual, vignettes
     - Rscript -e 'lib.copy(lib.from="/tmp/opencran/library")'
-    ## web/checks/$pkg/$job 00install.out, 00check.log, *.Rout, memtest.csv, memtest.png ## memtest not available for now #5764
-    - Rscript -e 'sapply(names(test.jobs), check.copy, simplify=FALSE)'
+    ## web/checks/$pkg/$job 00install.out, 00check.log, *.Rout
+    - Rscript -e 'sapply(names(test.jobs), check.copy, simplify=TRUE)'
     ## web/packages/$pkg/$pkg.pdf
     - Rscript -e 'pdf.copy("data.table", "test-lin-rel")'
     ## web/checks/check_results_$pkg.html

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -177,7 +177,7 @@ test-lin-dev-gcc-strict-cran:
         Rscript -e 'l=tail(readLines("data.table.Rcheck/00check.log"), 1L); notes<-"Status: 2 NOTEs"; if (!identical(l, notes)) stop("Last line of ", shQuote("00check.log"), " is not ", shQuote(notes), " (size of tarball, installed package size) but ", shQuote(l)) else q("no")'
 
 ## R-devel on Linux clang
-# R compiled with clang
+# R compiled with clang, flags removed: -flto=auto -fopenmp
 # tests for compilation warnings
 # tests for new notes
 test-lin-dev-clang-cran:
@@ -189,8 +189,8 @@ test-lin-dev-clang-cran:
     _R_S3_METHOD_LOOKUP_BASEENV_AFTER_GLOBALENV_: "FALSE"
     _R_S3_METHOD_LOOKUP_REPORT_SEARCH_PATH_USES_: "TRUE"
   script:
-    - echo 'CFLAGS=-g -O2 -flto=auto -fno-common -fopenmp -Wall -pedantic -fstack-protector-strong -D_FORTIFY_SOURCE=2' > ~/.R/Makevars
-    - echo 'CXXFLAGS=-g -O2 -flto=auto -fno-common -fopenmp -Wall -pedantic -fstack-protector-strong -D_FORTIFY_SOURCE=2' >> ~/.R/Makevars
+    - echo 'CFLAGS=-g -O2 -fno-common -Wall -pedantic -fstack-protector-strong -D_FORTIFY_SOURCE=2' > ~/.R/Makevars
+    - echo 'CXXFLAGS=-g -O2 -fno-common -Wall -pedantic -fstack-protector-strong -D_FORTIFY_SOURCE=2' >> ~/.R/Makevars
     - *install-deps
     - R CMD check --as-cran $(ls -1t data.table_*.tar.gz | head -n 1)
     - (! grep "warning:" data.table.Rcheck/00install.out)


### PR DESCRIPTION
- removed code to provide memtest results in CI report table - closes #5764
- simplified code for windows 64bit only, 32bit is not supported anymore, therefore we don't need separate tests_x64 and tests_i386 directories anymore
- do not publish docs of dependencies (links now points to cloud.r-project.org CRAN descriptions)
- simplified logic in couple places
- checks status table now has nice colors
- amend clang flags