### PR TITLE
fix bit64 coercion in memrecycle

### DIFF
--- a/inst/tests/nafill.Rraw
+++ b/inst/tests/nafill.Rraw
@@ -181,7 +181,7 @@ if (test_bit64) {
   test(6.44, identical(coerceFill(NaN), list(NA_integer_, NaN, as.integer64(NA))))
   test(6.45, identical(coerceFill(Inf), list(NA_integer_, Inf, as.integer64(NA))), warning=c("precision lost","precision lost"))
   test(6.46, identical(coerceFill(-Inf), list(NA_integer_, -Inf, as.integer64(NA))), warning=c("precision lost","precision lost"))
-  test(6.47, identical(coerceFill(-(2^62)), list(NA_integer_, -(2^62), as.integer64("-4611686018427387904"))), warning=c("precision lost"))
+  test(6.47, identical(coerceFill(-(2^62)), list(NA_integer_, -(2^62), as.integer64("-4611686018427387904"))), warning="precision lost")
   test(6.48, identical(coerceFill(-(2^64)), list(NA_integer_, -(2^64), as.integer64(NA))), warning=c("precision lost","precision lost"))
   test(6.49, identical(coerceFill(x<-as.integer64(-2147483647)), list(-2147483647L, -2147483647, x)))
   test(6.50, identical(coerceFill(x<-as.integer64(-2147483648)), list(NA_integer_, -2147483648, x)), warning="out-of-range")

--- a/inst/tests/nafill.Rraw
+++ b/inst/tests/nafill.Rraw
@@ -188,7 +188,7 @@ if (test_bit64) {
   test(6.51, identical(coerceFill(x<-as.integer64(-2147483649)), list(NA_integer_, -2147483649, x)), warning="out-of-range")
   test(6.52, identical(coerceFill(-2147483647), list(-2147483647L, -2147483647, as.integer64("-2147483647"))))
   test(6.53, identical(coerceFill(-2147483648), list(NA_integer_, -2147483648,  as.integer64("-2147483648"))))
-  test(6.54, identical(coerceFill(-2147483649), list(NA_integer_, -2147483649,  as.integer64("-2147483649"))), warning=c("precision lost"))
+  test(6.54, identical(coerceFill(-2147483649), list(NA_integer_, -2147483649,  as.integer64("-2147483649"))), warning="precision lost")
 }
 
 # nan argument to treat NaN as NA in nafill, #4020

--- a/inst/tests/nafill.Rraw
+++ b/inst/tests/nafill.Rraw
@@ -181,14 +181,14 @@ if (test_bit64) {
   test(6.44, identical(coerceFill(NaN), list(NA_integer_, NaN, as.integer64(NA))))
   test(6.45, identical(coerceFill(Inf), list(NA_integer_, Inf, as.integer64(NA))), warning=c("precision lost","precision lost"))
   test(6.46, identical(coerceFill(-Inf), list(NA_integer_, -Inf, as.integer64(NA))), warning=c("precision lost","precision lost"))
-  test(6.47, identical(coerceFill(-(2^62)), list(NA_integer_, -(2^62), as.integer64("-4611686018427387904"))), warning=c("precision lost","precision lost"))
+  test(6.47, identical(coerceFill(-(2^62)), list(NA_integer_, -(2^62), as.integer64("-4611686018427387904"))), warning=c("precision lost"))
   test(6.48, identical(coerceFill(-(2^64)), list(NA_integer_, -(2^64), as.integer64(NA))), warning=c("precision lost","precision lost"))
   test(6.49, identical(coerceFill(x<-as.integer64(-2147483647)), list(-2147483647L, -2147483647, x)))
   test(6.50, identical(coerceFill(x<-as.integer64(-2147483648)), list(NA_integer_, -2147483648, x)), warning="out-of-range")
   test(6.51, identical(coerceFill(x<-as.integer64(-2147483649)), list(NA_integer_, -2147483649, x)), warning="out-of-range")
   test(6.52, identical(coerceFill(-2147483647), list(-2147483647L, -2147483647, as.integer64("-2147483647"))))
   test(6.53, identical(coerceFill(-2147483648), list(NA_integer_, -2147483648,  as.integer64("-2147483648"))))
-  test(6.54, identical(coerceFill(-2147483649), list(NA_integer_, -2147483649,  as.integer64("-2147483649"))), warning=c("precision lost","precision lost"))
+  test(6.54, identical(coerceFill(-2147483649), list(NA_integer_, -2147483649,  as.integer64("-2147483649"))), warning=c("precision lost"))
 }
 
 # nan argument to treat NaN as NA in nafill, #4020
@@ -289,6 +289,10 @@ if (test_bit64) {
   test(10.87, coerceAs(x, 1L), 1L, output=c("double[integer64] into integer[integer]","Zero-copy coerce when assigning 'integer64' to 'integer'"))
   test(10.88, coerceAs(1L, x), x, output=c("integer[integer] into double[integer64]","Zero-copy coerce when assigning 'integer' to 'integer64'"))
   options(datatable.verbose=2L)
+  test(10.881, coerceAs(-2147483648, x), as.integer64(-2147483648), output="double[numeric] into double[integer64]")
+  test(10.882, coerceAs(-2147483649, x), as.integer64(-2147483649), output="double[numeric] into double[integer64]")
+  test(10.883, coerceAs(2147483648, x), as.integer64(2147483648), output="double[numeric] into double[integer64]")
+  test(10.884, coerceAs(2147483649, x), as.integer64(2147483649), output="double[numeric] into double[integer64]")
 }
 if (test_nanotime) {
   x = nanotime(1L)

--- a/inst/tests/nafill.Rraw
+++ b/inst/tests/nafill.Rraw
@@ -289,10 +289,7 @@ if (test_bit64) {
   test(10.87, coerceAs(x, 1L), 1L, output=c("double[integer64] into integer[integer]","Zero-copy coerce when assigning 'integer64' to 'integer'"))
   test(10.88, coerceAs(1L, x), x, output=c("integer[integer] into double[integer64]","Zero-copy coerce when assigning 'integer' to 'integer64'"))
   options(datatable.verbose=2L)
-  test(10.881, coerceAs(-2147483648, x), as.integer64(-2147483648), output="double[numeric] into double[integer64]")
-  test(10.882, coerceAs(-2147483649, x), as.integer64(-2147483649), output="double[numeric] into double[integer64]")
-  test(10.883, coerceAs(2147483648, x), as.integer64(2147483648), output="double[numeric] into double[integer64]")
-  test(10.884, coerceAs(2147483649, x), as.integer64(2147483649), output="double[numeric] into double[integer64]")
+  test(10.89, coerceAs(-2147483649, x), as.integer64(-2147483649), output="double[numeric] into double[integer64]")
 }
 if (test_nanotime) {
   x = nanotime(1L)

--- a/src/assign.c
+++ b/src/assign.c
@@ -904,7 +904,7 @@ const char *memrecycle(const SEXP target, const SEXP where, const int start, con
     case REALSXP:
       switch (TYPEOF(source)) {
       case REALSXP: if (targetIsI64 && !sourceIsI64)
-                    CHECK_RANGE(double, REAL,  !ISNAN(val) && (!R_FINITE(val) || (int)val!=val),        "f",     "truncated (precision lost)", val)
+                    CHECK_RANGE(double, REAL,  !ISNAN(val) && (!R_FINITE(val) || (int64_t)val!=val),        "f",     "truncated (precision lost)", val)
                     break;
       case CPLXSXP: if (targetIsI64)
                     CHECK_RANGE(Rcomplex, COMPLEX, !((ISNAN(val.i) || (R_FINITE(val.i) && val.i==0.0)) &&


### PR DESCRIPTION
Closes #5834
Follow up to #5189

Type coercion is from double[numeric] into double[integer64].
Previously we checked `int(val)!=val` for detecting truncation.
Since integer64 can handle much longer values the correct check is `(int64_t)val!=val`.

Alters two tests since no truncation/precision loss takes place.

@jangorecki does this need a NEWS item?