### PR TITLE
Point to updated DuckDB benchmarks

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -52,7 +52,7 @@ navbar:
       href: news/index.html
     benchmarks:
       text: Benchmarks
-      href: https://h2oai.github.io/db-benchmark
+      href: https://duckdblabs.github.io/db-benchmark
     presentations:
       text: Presentations
       href: https://github.com/Rdatatable/data.table/wiki/Presentations


### PR DESCRIPTION
The minor PR swaps the old H2O.ai db-obs link with the resuscitated DuckDBLabs equivalent.

Background: https://duckdb.org/2023/04/14/h2oai.html