### PR TITLE
Update Mandarin translations

### DIFF
--- a/po/R-zh_CN.po
+++ b/po/R-zh_CN.po
@@ -1452,10 +1452,9 @@ msgid "x must be an atomic vector or data.frames/data.tables"
 msgstr "x 必须是原子向量或data.frame/data.table"
 
 #: fcast.R:7
-#, fuzzy, c-format
-#| msgid "' as value column. Use 'value.var' to override"
+#, c-format
 msgid "Using '%s' as value column. Use 'value.var' to override"
-msgstr "' 作为 value 列。可使用 'value.var' 修改"
+msgstr "用 '%s' 作为 value 列。可使用 'value.var' 修改"
 
 #: fcast.R:20 fmelt.R:16
 #, c-format
@@ -1521,10 +1520,9 @@ msgid "'drop' must be logical TRUE/FALSE"
 msgstr "'drop' 必须为逻辑 TRUE/FALSE"
 
 #: fcast.R:128
-#, fuzzy, c-format
-#| msgid "] not found or of unknown type."
+#, c-format
 msgid "Column [%s] not found or of unknown type."
-msgstr "] 无法找到或其类型未知。"
+msgstr "列 [%s]] 无法找到或其类型未知。"
 
 #: fcast.R:143
 #, c-format
@@ -1768,15 +1766,12 @@ msgid "maxgap and minoverlap arguments are not yet implemented."
 msgstr "maxgap 和 minoverlap 参数还未实现。"
 
 #: foverlaps.R:22
-#, fuzzy, c-format
-#| msgid ""
-#| "'y' must be keyed (i.e., sorted, and, marked as sorted). Call "
-#| "setkey(y, ...) first, see ?setkey. Also check the examples in ?foverlaps."
+#, c-format
 msgid ""
 "y must be keyed (i.e., sorted, and, marked as sorted). Call setkey(y, ...) "
 "first, see ?setkey. Also check the examples in ?foverlaps."
 msgstr ""
-"'y' 必须有键（key:已经排序并且标记为已排序）。请先用 setkey(y, ...) 设置主"
+"y 必须有键（key:已经排序并且标记为已排序）。请先用 setkey(y, ...) 设置主"
 "键，可以参考 ?setkey 以及 ?foverlaps 中提供的例子。"
 
 #: foverlaps.R:24
@@ -1824,10 +1819,9 @@ msgid ""
 msgstr "在'by.y'中，y键(key)的列必须与指定的列相同"
 
 #: foverlaps.R:42
-#, fuzzy, c-format
-#| msgid "Elements listed in 'by.x' must be valid names in data.table 'x'"
+#, c-format
 msgid "Elements listed in 'by.x' must be valid names in data.table x"
-msgstr "对于data.table中的'X'，'by.x'中的元素必须是有效名称"
+msgstr "'by.x'中的元素必须是有效名称对于data.table x"
 
 #: foverlaps.R:44
 #, c-format
@@ -1852,15 +1846,12 @@ msgid ""
 msgstr "请移除或者重命名重复项并重试"
 
 #: foverlaps.R:56
-#, fuzzy, c-format
-#| msgid ""
-#| "The last two columns in by.x should correspond to the 'start' and 'end' "
-#| "intervals in data.table 'x' and must be integer/numeric type."
+#, c-format
 msgid ""
 "The last two columns in by.x should correspond to the 'start' and 'end' "
 "intervals in data.table x and must be integer/numeric type."
 msgstr ""
-"'by.x'的最后两列应该与data.table 'x'中的'开始'与'结尾'的间隔对应且必须是整数/"
+"'by.x'的最后两列应该与data.table x中的'开始'与'结尾'的间隔对应且必须是整数/"
 "数字类型"
 
 #: foverlaps.R:60 foverlaps.R:62 foverlaps.R:69 foverlaps.R:71
@@ -1882,15 +1873,12 @@ msgid ""
 msgstr "应该<=列中相应的条目"
 
 #: foverlaps.R:66
-#, fuzzy, c-format
-#| msgid ""
-#| "The last two columns in by.y should correspond to the 'start' and 'end' "
-#| "intervals in data.table 'y' and must be integer/numeric type."
+#, c-format
 msgid ""
 "The last two columns in by.y should correspond to the 'start' and 'end' "
 "intervals in data.table y and must be integer/numeric type."
 msgstr ""
-"'by.y'的最后两列应该与data.table 'y'中的'开始'与'结尾'的间隔对应且必须是整数/"
+"'by.y'的最后两列应该与data.table y中的'开始'与'结尾'的间隔对应且必须是整数/"
 "数字类型"
 
 #: foverlaps.R:72
@@ -2051,22 +2039,19 @@ msgid ""
 msgstr ""
 
 #: fread.R:91
-#, fuzzy, c-format
-#| msgid "' does not exist or is non-readable. getwd()=='"
+#, c-format
 msgid "File '%s' does not exist or is non-readable. getwd()=='%s'"
-msgstr "' 不存在, 或不可读. getwd()=='"
+msgstr "文件 '%s' 不存在, 或不可读. getwd()=='%s'"
 
 #: fread.R:92
-#, fuzzy, c-format
-#| msgid "' is a directory. Not yet implemented."
+#, c-format
 msgid "File '%s' is a directory. Not yet implemented."
-msgstr "'是个目录。还没有编程实现。"
+msgstr "文件 '%s' 是个目录。还没有编程实现。"
 
 #: fread.R:94
-#, fuzzy, c-format
-#| msgid "' has size 0. Returning a NULL"
+#, c-format
 msgid "File '%s' has size 0. Returning a NULL %s."
-msgstr "' 的大小为0. 返回一个NULL"
+msgstr "文件 '%s' 的大小为0. 返回一个NULL %s."
 
 #: fread.R:107
 #, c-format
@@ -2121,39 +2106,30 @@ msgid "na.strings[%d]==\"%s\" consists only of whitespace, ignoring"
 msgstr ""
 
 #: fread.R:155
-#, fuzzy, c-format
-#| msgid ""
-#| "strip.white==TRUE (default) and \"\" is present in na.strings, so any "
-#| "number of spaces in string columns will already be read as <NA>."
+#, c-format
 msgid ""
 "%s. strip.white==TRUE (default) and \"\" is present in na.strings, so any "
 "number of spaces in string columns will already be read as <NA>."
 msgstr ""
-"na.strings 中包含 strip.white==TRUE (默认情况) 和 \"\", 因此(字符类型的)列中"
+"%s. na.strings 中包含 strip.white==TRUE (默认情况) 和 \"\", 因此(字符类型的)列中"
 "的空格会被当作 <NA>."
 
 #: fread.R:157
-#, fuzzy, c-format
-#| msgid ""
-#| "Since strip.white=TRUE (default), use na.strings=\"\" to specify that any "
-#| "number of spaces in a string column should be read as <NA>."
+#, c-format
 msgid ""
 "%s. Since strip.white=TRUE (default), use na.strings=\"\" to specify that "
 "any number of spaces in a string column should be read as <NA>."
 msgstr ""
-"因为 strip.white=TRUE (默认情况), 请使用 na.strings=\"\" 以使得(字符类型的)列"
+"%s. 因为 strip.white=TRUE (默认情况), 请使用 na.strings=\"\" 以使得(字符类型的)列"
 "中的空格会被当作 <NA>."
 
 #: fread.R:161
-#, fuzzy, c-format
-#| msgid ""
-#| "But strip.white=FALSE. Use strip.white=TRUE (default) together with na."
-#| "strings=\"\" to turn any number of spaces in string columns into <NA>"
+#, c-format
 msgid ""
 "%s. But strip.white=FALSE. Use strip.white=TRUE (default) together with na."
 "strings=\"\" to turn any number of spaces in string columns into <NA>"
 msgstr ""
-"但是 strip.white=FALSE. 请使用 strip.white=TRUE (默认情况), 同时na."
+"%s. 但是 strip.white=FALSE. 请使用 strip.white=TRUE (默认情况), 同时na."
 "strings=\"\", 以使得(字符类型的)列中的空格转成 <NA>."
 
 #: fread.R:167
@@ -2264,10 +2240,9 @@ msgstr ""
 "过）"
 
 #: fwrite.R:19
-#, fuzzy, c-format
-#| msgid "Argument 'encoding' must be 'unknown', 'UTF-8' or 'Latin-1'."
+#, c-format
 msgid "Argument 'encoding' must be '', 'UTF-8' or 'native'."
-msgstr "参数 'encoding' 必须为 'unknown', 'UTF-8' 或 'Latin-1'."
+msgstr "参数 'encoding' 必须为 '', 'unknown', 'UTF-8' 或 'native'."
 
 #: fwrite.R:24
 #, c-format
@@ -2307,10 +2282,9 @@ msgid ""
 msgstr "为空文件，请先使用 file.remove。"
 
 #: fwrite.R:80
-#, fuzzy, c-format
-#| msgid "Input has no columns; doing nothing."
+#, c-format
 msgid "Input has no columns; doing nothing.%s"
-msgstr "输入没有列，不执行任何操作。"
+msgstr "输入没有列，不执行任何操作。%s"
 
 #: fwrite.R:83
 #, fuzzy, c-format
@@ -2370,16 +2344,13 @@ msgid "Argument 'sets' must be a list of character vectors."
 msgstr "'sets' 参数必须是一个字符向量的列表。"
 
 #: groupingsets.R:62
-#, fuzzy, c-format
-#| msgid ""
-#| "All columns used in 'sets' argument must be in 'by' too. Columns used in "
-#| "'sets' but not present in 'by':"
+#, c-format
 msgid ""
 "All columns used in 'sets' argument must be in 'by' too. Columns used in "
 "'sets' but not present in 'by': %s"
 msgstr ""
 "在 'sets' 参数中应用的所有列也必须在 'by' 中。当前 'sets' 包含而 'by' 中不含"
-"的列有："
+"的列有：%s"
 
 #: groupingsets.R:64
 #, c-format
@@ -2514,10 +2485,9 @@ msgid "Passed %d unknown and unnamed arguments."
 msgstr ""
 
 #: merge.R:128
-#, fuzzy, c-format
-#| msgid "are duplicated in the result"
+#, c-format
 msgid "column names %s are duplicated in the result"
-msgstr "在结果中是重复的"
+msgstr "列名 %s 在结果中是重复的"
 
 #: onAttach.R:23
 #, c-format
@@ -2531,10 +2501,9 @@ msgid "data.table %s using %d threads (see ?getDTthreads)."
 msgstr ""
 
 #: onAttach.R:26
-#, fuzzy, c-format
-#| msgid "threads (see ?getDTthreads).  Latest news: r-datatable.com"
+#, c-format
 msgid "Latest news: r-datatable.com"
-msgstr "线程（请参阅?getDTthreads）。最新的消息：r-datatable.com"
+msgstr "最新的消息：r-datatable.com"
 
 #: onAttach.R:27
 msgid "TRANSLATION CHECK"
@@ -2570,25 +2539,17 @@ msgstr ""
 "**********"
 
 #: onAttach.R:32
-#, fuzzy, c-format
-#| msgid ""
-#| "This installation of data.table has not detected OpenMP support. It "
-#| "should still work but in single-threaded mode."
+#, c-format
 msgid ""
 "**********\n"
 "This installation of data.table has not detected OpenMP support. It should "
 "still work but in single-threaded mode."
-msgstr "data.table的安装未检测到OpenMP支持。在单线程模式下应该仍能运行"
+msgstr ""
+"**********\n"
+"data.table的安装未检测到OpenMP支持。在单线程模式下应该仍能运行"
 
 #: onAttach.R:34
-#, fuzzy, c-format
-#| msgid ""
-#| "This is a Mac. Please read https://mac.r-project.org/openmp/. Please "
-#| "engage with Apple and ask them for support. Check r-datatable.com for "
-#| "updates, and our Mac instructions here: https://github.com/Rdatatable/"
-#| "data.table/wiki/Installation. After several years of many reports of "
-#| "installation problems on Mac, it's time to gingerly point out that there "
-#| "have been no similar problems on Windows or Linux."
+#, c-format
 msgid ""
 "This is a Mac. Please read https://mac.r-project.org/openmp/. Please engage "
 "with Apple and ask them for support. Check r-datatable.com for updates, and "
@@ -2602,15 +2563,11 @@ msgstr ""
 "获取支持。查看 r-datatable.com 以获取更新，并参阅我们的 Mac 设备说明："
 "https://github.com/Rdatatable/data.table/wiki/Installation在 Mac 上出现相关安"
 "装问题的报告已数年之久，需要指出的是在 Windows 或 Linux 平台上一般不存在类似"
-"问题。"
+"问题。\n"
+"**********""
 
 #: onAttach.R:36
-#, fuzzy, c-format
-#| msgid ""
-#| ". This warning should not normally occur on Windows or Linux where OpenMP "
-#| "is turned on by data.table's configure script by passing -fopenmp to the "
-#| "compiler. If you see this warning on Windows or Linux, please file a "
-#| "GitHub issue."
+#, c-format
 msgid ""
 "This is %s. This warning should not normally occur on Windows or Linux where "
 "OpenMP is turned on by data.table's configure script by passing -fopenmp to "
@@ -2618,7 +2575,7 @@ msgid ""
 "GitHub issue.\n"
 "**********"
 msgstr ""
-"。此警告一般不应出现在 Windows 或 Linux 平台中，因为data.table 的 configure "
+"这是 %s。此警告一般不应出现在 Windows 或 Linux 平台中，因为data.table 的 configure "
 "脚本中已通过向编译器传递 -fopenmp 参数启用了 OpenMP。如果你在 Windows 或 "
 "Linux 平台中发现此警告，请在 GitHub 中提交 issue。"
 
@@ -2643,19 +2600,7 @@ msgid ""
 msgstr ""
 
 #: onLoad.R:26
-#, fuzzy, c-format
-#| msgid ""
-#| "The datatable.%s version (%s) does not match the package (%s). Please "
-#| "close all R sessions to release the old %s and reinstall data.table in a "
-#| "fresh R session. The root cause is that R's package installer can in some "
-#| "unconfirmed circumstances leave a package in a state that is apparently "
-#| "functional but where new R code is calling old C code silently: https://"
-#| "bugs.r-project.org/bugzilla/show_bug.cgi?id=17478. Once a package is in "
-#| "this mismatch state it may produce wrong results silently until you next "
-#| "upgrade the package. Please help by adding precise circumstances to 17478 "
-#| "to move the status to confirmed. This mismatch between R and C code can "
-#| "happen with any package not just data.table. It is just that data.table "
-#| "has added this check."
+#, c-format
 msgid ""
 "The data_table.%s version (%s) does not match the package (%s). Please close "
 "all R sessions to release the old %s and reinstall data.table in a fresh R "
@@ -2669,7 +2614,7 @@ msgid ""
 "any package not just data.table. It is just that data.table has added this "
 "check."
 msgstr ""
-"data.table.%s版本(%s)和包不匹配版本(%s)。请关闭所有R会话以释放旧%s并在全新的R"
+"data_table.%s版本(%s)和包不匹配版本(%s)。请关闭所有R会话以释放旧%s并在全新的R"
 "会话中重新安装data.table。根本原因是R包安装程序可能在某些未经确认的条件下将包"
 "置于显然可以正常工作的状态，但是新的R代码正在默默地调用旧的C代码：https://"
 "bugs.r-project.org/bugzilla/show_bug.cgi?id=17478。一旦安装包处于这不匹配的状"
@@ -2728,16 +2673,14 @@ msgid "Provide either threads= or percent= but not both"
 msgstr "提供threads=或percent=，但不能两者都提供"
 
 #: openmp-utils.R:4
-#, fuzzy, c-format
-#| msgid "percent= is provided but is length"
+#, c-format
 msgid "percent= is provided but is length %d"
-msgstr "提供了percent =，但为长度"
+msgstr "提供了percent=，但为长度 %d"
 
 #: openmp-utils.R:6
-#, fuzzy, c-format
-#| msgid "but should be a number between 2 and 100"
+#, c-format
 msgid "percent==%d but should be a number between 2 and 100"
-msgstr "但应为2到100之间的数字"
+msgstr "percent==%d 但应为2到100之间的数字"
 
 #: print.data.table.R:17
 #, c-format
@@ -2745,10 +2688,9 @@ msgid "Valid options for col.names are 'auto', 'top', and 'none'"
 msgstr "对col.names有效的参数为'auto', 'top', and 'none'"
 
 #: print.data.table.R:19
-#, fuzzy, c-format
-#| msgid "Valid options for col.names are 'auto', 'top', and 'none'"
+#, c-format
 msgid "Valid options for trunc.cols are TRUE and FALSE"
-msgstr "对col.names有效的参数为'auto', 'top', and 'none'"
+msgstr "对trunc.cols有效的参数为TRUE和FALSE"
 
 #: print.data.table.R:21
 #, c-format
@@ -2762,10 +2704,9 @@ msgid ""
 msgstr "内部类型可能不是一个列表，该操作可能会损坏data.table"
 
 #: programming.R:14 programming.R:40
-#, fuzzy, c-format
-#| msgid "'data' must be a data.table"
+#, c-format
 msgid "'x' must be a list"
-msgstr "'data' 必须是一个 data.table"
+msgstr "'x' 必须是一个 list"
 
 #: programming.R:22
 #, c-format
@@ -2785,10 +2726,9 @@ msgid "'env' must be a list or an environment"
 msgstr ""
 
 #: programming.R:63
-#, fuzzy, c-format
-#| msgid "data.tables do not have rownames"
+#, c-format
 msgid "'env' argument does not have names"
-msgstr "data.tables没有rownames"
+msgstr "参数 'env' 没有名"
 
 #: programming.R:65
 #, c-format
@@ -2796,16 +2736,14 @@ msgid "'env' argument has zero char names"
 msgstr ""
 
 #: programming.R:67
-#, fuzzy, c-format
-#| msgid "'x' argument is"
+#, c-format
 msgid "'env' argument has NA names"
-msgstr "参数'x'的值为"
+msgstr "参数 'env' 有 NA 的名`"
 
 #: programming.R:69
-#, fuzzy, c-format
-#| msgid "rownames contains duplicates"
+#, c-format
 msgid "'env' argument has duplicated names"
-msgstr "行名含有重复"
+msgstr "参数 'env' 的名含有重复"
 
 #: setkey.R:3
 #, c-format
@@ -2868,10 +2806,9 @@ msgid "cols contains some blanks."
 msgstr "列中包含空白"
 
 #: setkey.R:51 setkey.R:281
-#, fuzzy, c-format
-#| msgid "some columns are not in the data.table:"
+#, c-format
 msgid "some columns are not in the data.table: %s"
-msgstr "一些列不在data.table中"
+msgstr "一些列不在data.table中：%ｓ"
 
 #: setkey.R:73 setkey.R:282
 #, c-format
@@ -3054,10 +2991,9 @@ msgid "x and y must have the same column order"
 msgstr "x 和 y 的列顺序必须保持一致"
 
 #: setops.R:45
-#, fuzzy, c-format
-#| msgid "unsupported column type"
+#, c-format
 msgid "unsupported column type(s) found in x or y: %s"
-msgstr "不支持的列类型"
+msgstr "找到不支持的列类型在 x 或 y: %s"
 
 #: setops.R:53
 #, fuzzy, c-format
@@ -3096,26 +3032,20 @@ msgid "None of the datasets to compare should contain a column named '.seqn'"
 msgstr "所有参与比较的数据集都不应该包含名为 '.seqn' 的列"
 
 #: setops.R:193
-#, fuzzy, c-format
-#| msgid ""
-#| "Datasets to compare with 'ignore.row.order' must not have unsupported "
-#| "column types:"
+#, c-format
 msgid ""
 "Datasets to compare with 'ignore.row.order' must not have unsupported column "
 "types: %s"
-msgstr "与 'ignore.row.order' 进行比较的数据集，不能存在不支持的列类型："
+msgstr "与 'ignore.row.order' 进行比较的数据集，不能存在不支持的列类型：%s"
 
 #: setops.R:195
-#, fuzzy, c-format
-#| msgid ""
-#| "Argument 'tolerance' was forced to lowest accepted value `sqrt(."
-#| "Machine$double.eps)` from provided"
+#, c-format
 msgid ""
 "Argument 'tolerance' was forced to lowest accepted value `sqrt(."
 "Machine$double.eps)` from provided %s"
 msgstr ""
 "参数 'tolerance' 被强制设定为最低接受值 `sqrt(.Machine$double.eps)`，此值来自"
-"于："
+"于 %s"
 
 #: setops.R:208
 #, c-format
@@ -3147,10 +3077,9 @@ msgid "will be ignored since type='shift'."
 msgstr ""
 
 #: tables.R:46
-#, fuzzy, c-format
-#| msgid "' not a column name of info"
+#, c-format
 msgid "order.col='%s' not a column name of info"
-msgstr "' 并非info的一个列名"
+msgstr "order.col='%s' 并非info的一个列名"
 
 #: test.data.table.R:17
 #, c-format
@@ -3196,20 +3125,16 @@ msgid "%d error(s) out of %d. Search %s for test number(s) %s. Duration: %s."
 msgstr "%d错误总数为%d. %s中搜索测试编号%s"
 
 #: test.data.table.R:199
-#, fuzzy, c-format
-#| msgid "Timings count mismatch:"
+#, c-format
 msgid "Timings count mismatch: %d vs %d"
-msgstr "计时不一致:"
+msgstr "计时不一致: %d 对 %d"
 
 #: test.data.table.R:312
-#, fuzzy, c-format
-#| msgid ""
-#| "is invalid: when error= is provided it does not make sense to pass y as "
-#| "well"
+#, c-format
 msgid ""
 "Test %s is invalid: when error= is provided it does not make sense to pass y "
 "as well"
-msgstr "无效：当使用了error=，不应再输入y"
+msgstr "%s 无效：当使用了error=，不应再输入y"
 
 #: timetaken.R:3
 #, c-format
@@ -3217,16 +3142,14 @@ msgid "Use started.at=proc.time() not Sys.time() (POSIXt and slow)"
 msgstr "使用started.at=proc.time()而非Sys.time() (返回POSIXt类型，处理较慢)"
 
 #: transpose.R:7
-#, fuzzy, c-format
-#| msgid "' not found in names of input"
+#, c-format
 msgid "make.names='%s' not found in names of input"
-msgstr "'不存在于输入的名字里"
+msgstr "make.names='%s' 不存在于输入的名字里"
 
 #: transpose.R:12
-#, fuzzy, c-format
-#| msgid "is out of range [1,ncol="
+#, c-format
 msgid "make.names=%d is out of range [1,ncol=%d]"
-msgstr "不在以下区间[1,ncol="
+msgstr "make.names=%d 不在以下区间[1,ncol=%d]"
 
 #: transpose.R:28
 #, c-format
@@ -3234,10 +3157,9 @@ msgid "'names' must be TRUE/FALSE or a character vector."
 msgstr "'names'必须为TRUE/FALSE，或一个字符（character）向量。"
 
 #: transpose.R:34
-#, fuzzy, c-format
-#| msgid "'keep' should contain integer values between"
+#, c-format
 msgid "'keep' should contain integer values between %d and %d."
-msgstr "'keep'所含整数值应在区间"
+msgstr "'keep'所含整数值应在 %d 和 %d 间"
 
 #: transpose.R:51
 #, c-format
@@ -3288,10 +3210,9 @@ msgid ""
 msgstr ""
 
 #: transpose.R:88
-#, fuzzy, c-format
-#| msgid ") is not equal to length("
+#, c-format
 msgid "length(names) (= %d) is not equal to length(%s) (= %d)."
-msgstr ") 并不等于(="
+msgstr "length(names) (= %d) 并不等于 length(%s) (= %d)。"
 
 #: uniqlist.R:12
 #, c-format
@@ -3360,18 +3281,14 @@ msgstr ""
 "顺序，或者通过?timeBased来查看支持的类型"
 
 #: xts.R:24
-#, fuzzy, c-format
-#| msgid "Following columns are not numeric and will be omitted:"
+#, c-format
 msgid "Following columns are not numeric and will be omitted: %s"
-msgstr "以下的列并非数值类型，将被忽略："
+msgstr "以下的列并非数值类型，将被忽略：%s"
 
 #: print.data.table.R:51
-#, fuzzy
-#| msgid "Index: "
-#| msgid_plural "Indices: "
 msgid "Index: %s\n"
 msgid_plural "Indices: %s\n"
-msgstr[0] "索引(index): "
+msgstr[0] "索引(index): %s\n"
 
 #~ msgid "'nearest', and 'ceil'."
 #~ msgstr "'nearest'和'ceil'"

--- a/po/R-zh_CN.po
+++ b/po/R-zh_CN.po
@@ -184,7 +184,7 @@ msgstr "或许你想用的是 %s？"
 msgid ""
 "RHS has length() %d; expecting length 2. %sThe first element should be the "
 "lower bound(s); the second element should be the upper bound(s)."
-msgstr ""
+msgstr "<needs translation>"
 
 #: bmerge.R:48 bmerge.R:49
 #, c-format
@@ -265,7 +265,7 @@ msgstr "因为没有提供 j= ，所以忽略 by/keyby"
 #: data.table.R:180
 #, c-format
 msgid "When by and keyby are both provided, keyby must be TRUE or FALSE"
-msgstr ""
+msgstr "<needs translation>"
 
 #: data.table.R:192
 #, c-format
@@ -459,7 +459,7 @@ msgid ""
 "wish to select rows where that column contains TRUE, or perhaps that column "
 "contains row numbers of itself to select, try DT[(col)], DT[DT$col], or "
 "DT[col==TRUE} is particularly clear and is optimized"
-msgstr ""
+msgstr "<needs translation>"
 
 #: data.table.R:422
 #, c-format
@@ -527,7 +527,7 @@ msgstr "。期望布尔类型，整型或浮点型。"
 msgid ""
 "internal error: notjoin and which=NA (non-matches), huh? please provide "
 "reproducible example to issue tracker"
-msgstr ""
+msgstr "<needs translation>"
 
 #: data.table.R:623
 #, fuzzy, c-format
@@ -548,7 +548,7 @@ msgstr ""
 msgid ""
 "Please use nomatch=NULL instead of nomatch=0; see news item 5 in v1.12.0 "
 "(Jan 2019)"
-msgstr ""
+msgstr "<needs translation>"
 
 #: data.table.R:639
 #, c-format
@@ -607,7 +607,7 @@ msgstr "当 with=FALSE，参数 j 必须为布尔型/字符型/整型之一，�
 msgid ""
 "'by' contains .I but only the following are currently supported: by=.I, by=."
 "(.I), by=c(.I), by=list(.I)"
-msgstr ""
+msgstr "<needs translation>"
 
 #: data.table.R:795
 #, c-format
@@ -633,7 +633,7 @@ msgstr ""
 
 #: data.table.R:812
 msgid "At least one entry of by is empty"
-msgstr ""
+msgstr "<needs translation>"
 
 #: data.table.R:853
 #, c-format
@@ -670,7 +670,7 @@ msgid ""
 "https://github.com/Rdatatable/data.table/issues/1597. As a workaround, "
 "consider converting the column to a supported type, e.g. by=sapply(list_col, "
 "toString), whilst taking care to maintain distinctness in the process."
-msgstr ""
+msgstr "<needs translation>"
 
 #: data.table.R:906
 #, c-format
@@ -698,7 +698,7 @@ msgid ""
 "j may not evaluate to the same number of columns for each group; if you're "
 "sure this warning is in error, please put the branching logic outside of "
 "[ for efficiency"
-msgstr ""
+msgstr "<needs translation>"
 
 #: data.table.R:967
 #, c-format
@@ -709,7 +709,7 @@ msgid ""
 "controlled by a function argument), please (1) pull this branch out of the "
 "call; (2) explicitly provide missing defaults for each branch in all cases; "
 "or (3) use the same name for each branch and re-name it in a follow-up call."
-msgstr ""
+msgstr "<needs translation>"
 
 #: data.table.R:1030
 #, c-format
@@ -729,7 +729,7 @@ msgstr ".SDcols 的如下位置为缺失值：%s"
 #: data.table.R:1038
 #, c-format
 msgid ".SDcols is a logical vector length %d but there are %d columns"
-msgstr ""
+msgstr "<needs translation>"
 
 #: data.table.R:1044
 #, c-format
@@ -877,7 +877,7 @@ msgid ""
 "is not found. If you intended to select columns using a variable in calling "
 "scope, please try DT[, ..%1$s]. The .. prefix conveys one-level-up similar "
 "to a file system path."
-msgstr ""
+msgstr "<needs translation>"
 
 #: data.table.R:1419
 #, c-format
@@ -1005,7 +1005,7 @@ msgstr "length(rownames.value)==%d 但应该是 nrow(x)==%d"
 #, c-format
 msgid ""
 "Internal error: as.matrix.data.table length(X)==%d but a dimension is zero"
-msgstr ""
+msgstr "<needs translation>"
 
 #: data.table.R:2152
 #, c-format
@@ -1230,7 +1230,7 @@ msgstr "提供 before= 或 after= ，但两者不能同时存在"
 #: data.table.R:2699
 #, c-format
 msgid "before=/after= accept a single column name or number, not more than one"
-msgstr ""
+msgstr "<needs translation>"
 
 #: data.table.R:2754
 #, c-format
@@ -1464,7 +1464,7 @@ msgid ""
 "data.table, with setDT(%3$s) or as.data.table(%3$s). If you intend to use a "
 "method from reshape2, try installing that package first, but do note that "
 "reshape2 is superseded and is no longer actively developed."
-msgstr ""
+msgstr "<needs translation>"
 
 #: fcast.R:21
 #, fuzzy, c-format
@@ -1541,7 +1541,7 @@ msgid ""
 "be used to fill any missing combinations, and therefore must be length=1. "
 "Either override by setting the 'fill' argument explicitly or modify your "
 "function to handle this case appropriately."
-msgstr ""
+msgstr "<needs translation>"
 
 #: fcast.R:222
 #, c-format
@@ -1585,33 +1585,33 @@ msgstr "列不存在"
 msgid ""
 "each ... argument to measure must be either a symbol without argument name, "
 "or a function with argument name, problems: %s"
-msgstr ""
+msgstr "<needs translation>"
 
 #: fmelt.R:54
 #, c-format
 msgid ""
 "group names specified in ... conflict with measure argument names; please "
 "fix by changing group names: %s"
-msgstr ""
+msgstr "<needs translation>"
 
 #: fmelt.R:60
 #, c-format
 msgid ""
 "each ... argument to measure must be a function with at least one argument, "
 "problem: %s"
-msgstr ""
+msgstr "<needs translation>"
 
 #: fmelt.R:74
 #, c-format
 msgid ""
 "both sep and pattern arguments used; must use either sep or pattern (not "
 "both)"
-msgstr ""
+msgstr "<needs translation>"
 
 #: fmelt.R:77
 #, c-format
 msgid "multiple.keyword must be a character string with nchar>0"
-msgstr ""
+msgstr "<needs translation>"
 
 #: fmelt.R:80
 #, fuzzy, c-format
@@ -1623,17 +1623,17 @@ msgstr "'by' 参数必须是一个字符向量，向量的元素是列名，用�
 #: fmelt.R:88
 #, c-format
 msgid "in measurev, %s must be named, problems: %s"
-msgstr ""
+msgstr "<needs translation>"
 
 #: fmelt.R:94
 #, c-format
 msgid "%s should be uniquely named, problems: %s"
-msgstr ""
+msgstr "<needs translation>"
 
 #: fmelt.R:99
 #, c-format
 msgid "number of %s =%d must be same as %s =%d"
-msgstr ""
+msgstr "<needs translation>"
 
 #: fmelt.R:106
 #, fuzzy, c-format
@@ -1646,13 +1646,13 @@ msgstr "但必须是字符."
 msgid ""
 "pattern did not match any cols, so nothing would be melted; fix by changing "
 "pattern"
-msgstr ""
+msgstr "<needs translation>"
 
 #: fmelt.R:115
 #, c-format
 msgid ""
 "pattern must contain at least one capture group (parenthesized sub-pattern)"
-msgstr ""
+msgstr "<needs translation>"
 
 #: fmelt.R:123
 #, fuzzy, c-format
@@ -1667,51 +1667,51 @@ msgid ""
 "means that all columns would be melted; to fix please either specify melt on "
 "all columns directly without using measure, or use a different sep/pattern "
 "specification"
-msgstr ""
+msgstr "<needs translation>"
 
 #: fmelt.R:138
 #, c-format
 msgid ""
 "number of unique column IDs =%d is less than number of melted columns =%d; "
 "fix by changing pattern/sep"
-msgstr ""
+msgstr "<needs translation>"
 
 #: fmelt.R:148
 #, c-format
 msgid ""
 "in the measurev fun.list, each non-NULL element must be a function with at "
 "least one argument, problem: %s"
-msgstr ""
+msgstr "<needs translation>"
 
 #: fmelt.R:152
 #, c-format
 msgid ""
 "each conversion function must return an atomic vector with same length as "
 "its first argument, problem: %s"
-msgstr ""
+msgstr "<needs translation>"
 
 #: fmelt.R:155
 #, c-format
 msgid "%s conversion function returned vector of all NA"
-msgstr ""
+msgstr "<needs translation>"
 
 #: fmelt.R:161
 #, c-format
 msgid ""
 "number of unique groups after applying type conversion functions less than "
 "number of groups, change type conversion"
-msgstr ""
+msgstr "<needs translation>"
 
 #: fmelt.R:166
 #, c-format
 msgid ""
 "%s column class=%s after applying conversion function, but must be character"
-msgstr ""
+msgstr "<needs translation>"
 
 #: fmelt.R:170
 #, c-format
 msgid "%s is the only group; fix by creating at least one more group"
-msgstr ""
+msgstr "<needs translation>"
 
 #: fmelt.R:193
 #, c-format
@@ -1723,7 +1723,7 @@ msgstr "'data' 必须是一个 data.table"
 msgid ""
 "'value.name' provided in both 'measure.vars' and 'value.name argument'; "
 "value provided in 'measure.vars' is given precedence."
-msgstr ""
+msgstr "<needs translation>"
 
 #: fmelt.R:215
 #, c-format
@@ -1947,14 +1947,14 @@ msgstr "x是一个list, 'cols'不能为0长度"
 msgid ""
 "Input column '..na_prefix..' conflicts with data.table internal usage; "
 "please rename"
-msgstr ""
+msgstr "<needs translation>"
 
 #: frank.R:46
 #, c-format
 msgid ""
 "Input column '..stats_runif..' conflicts with data.table internal usage; "
 "please rename"
-msgstr ""
+msgstr "<needs translation>"
 
 #: fread.R:10
 #, c-format
@@ -2036,7 +2036,7 @@ msgstr ""
 msgid ""
 "URL requires download.file functionalities from R >=3.2.2. You can still "
 "manually download the file and fread the downloaded file."
-msgstr ""
+msgstr "<needs translation>"
 
 #: fread.R:91
 #, c-format
@@ -2057,7 +2057,7 @@ msgstr "文件 '%s' 的大小为0. 返回一个NULL %s."
 #, c-format
 msgid ""
 "Compressed files containing more than 1 file are currently not supported."
-msgstr ""
+msgstr "<needs translation>"
 
 #: fread.R:119
 #, c-format
@@ -2103,7 +2103,7 @@ msgstr ""
 #: fread.R:152
 #, c-format
 msgid "na.strings[%d]==\"%s\" consists only of whitespace, ignoring"
-msgstr ""
+msgstr "<needs translation>"
 
 #: fread.R:155
 #, c-format
@@ -2148,7 +2148,7 @@ msgid ""
 "as expected -- currently, reading will proceed to search for 'skip' from the "
 "beginning of the file, NOT from the end of the metadata; please file an "
 "issue on GitHub if you'd like to see more intuitive behavior supported."
-msgstr ""
+msgstr "<needs translation>"
 
 #: fread.R:181
 #, c-format
@@ -2156,7 +2156,7 @@ msgid ""
 "Encountered <%s%s> at the first unskipped line (%d), which does not "
 "constitute the start to a valid YAML header (expecting something matching "
 "regex \"%s\"); please check your input and try again."
-msgstr ""
+msgstr "<needs translation>"
 
 #: fread.R:193
 #, fuzzy, c-format
@@ -2191,7 +2191,7 @@ msgid ""
 "input was an intentional override and will ignore the type(s) implied by the "
 "YAML header; please exclude the column(s) from colClasses if this was "
 "unintentional."
-msgstr ""
+msgstr "<needs translation>"
 
 #: fread.R:255
 #, c-format
@@ -2220,7 +2220,7 @@ msgid ""
 "%s:\n"
 "\t%s\n"
 "so the column has been left as type '%s'"
-msgstr ""
+msgstr "<needs translation>"
 
 #: fread.R:340
 #, c-format
@@ -2266,7 +2266,7 @@ msgid ""
 "logicalAsInt has been renamed logical01 for consistency with fread. It works "
 "fine for now but please change to logical01 at your convenience so we can "
 "remove logicalAsInt in future."
-msgstr ""
+msgstr "<needs translation>"
 
 #: fwrite.R:40
 #, c-format
@@ -2320,7 +2320,7 @@ msgstr "'id' 参数必须是一个逻辑标量。"
 #: groupingsets.R:31
 #, c-format
 msgid "Argument 'j' is required"
-msgstr ""
+msgstr "<needs translation>"
 
 #: groupingsets.R:49
 #, c-format
@@ -2477,12 +2477,12 @@ msgstr "`by`中的列名必须是x和y的有效列"
 #: merge.R:61
 #, c-format
 msgid "Unknown argument '%s' has been passed."
-msgstr ""
+msgstr "<needs translation>"
 
 #: merge.R:64
 #, c-format
 msgid "Passed %d unknown and unnamed arguments."
-msgstr ""
+msgstr "<needs translation>"
 
 #: merge.R:128
 #, c-format
@@ -2493,12 +2493,12 @@ msgstr "列名 %s 在结果中是重复的"
 #, c-format
 msgid ""
 "data.table %s IN DEVELOPMENT built %s%s using %d threads (see ?getDTthreads)."
-msgstr ""
+msgstr "<needs translation>"
 
 #: onAttach.R:25
 #, c-format
 msgid "data.table %s using %d threads (see ?getDTthreads)."
-msgstr ""
+msgstr "<needs translation>"
 
 #: onAttach.R:26
 #, c-format
@@ -2590,14 +2590,14 @@ msgid ""
 "table's dependency from 8 year old R 3.1.0 (Apr 2014) to 5 year old R 3.4.0 "
 "(Apr 2017).\n"
 "**********"
-msgstr ""
+msgstr "<needs translation>"
 
 #: onLoad.R:9
 #, c-format
 msgid ""
 "Option 'datatable.nomatch' is defined but is now ignored. Please see note 11 "
 "in v1.12.4 NEWS (Oct 2019), and note 14 in v1.14.2."
-msgstr ""
+msgstr "<needs translation>"
 
 #: onLoad.R:26
 #, c-format
@@ -2636,7 +2636,7 @@ msgid ""
 "Option 'datatable.CJ.names' no longer has any effect, as promised for 4 "
 "years. It is now ignored. Manually name `...` entries as needed if you still "
 "prefer the old behavior."
-msgstr ""
+msgstr "<needs translation>"
 
 #: onLoad.R:100
 #, c-format
@@ -2713,17 +2713,17 @@ msgstr "'x' 必须是一个 list"
 msgid ""
 "Character objects provided in the input are not scalar objects, if you need "
 "them as character vector rather than a name, then wrap each into 'I' call: %s"
-msgstr ""
+msgstr "<needs translation>"
 
 #: programming.R:50
 #, c-format
 msgid "'env' must not be missing"
-msgstr ""
+msgstr "<needs translation>"
 
 #: programming.R:56
 #, c-format
 msgid "'env' must be a list or an environment"
-msgstr ""
+msgstr "<needs translation>"
 
 #: programming.R:63
 #, c-format
@@ -2733,7 +2733,7 @@ msgstr "参数 'env' 没有名"
 #: programming.R:65
 #, c-format
 msgid "'env' argument has zero char names"
-msgstr ""
+msgstr "<needs translation>"
 
 #: programming.R:67
 #, c-format
@@ -3014,17 +3014,17 @@ msgstr "内部错误：ncol(current)==ncol(target) 之前已经检查"
 #: setops.R:159 setops.R:170
 #, c-format
 msgid "Datasets have different %s. 'target': %s. 'current': %s."
-msgstr ""
+msgstr "<needs translation>"
 
 #: setops.R:161 setops.R:162
 #, c-format
 msgid "has no key"
-msgstr ""
+msgstr "<needs translation>"
 
 #: setops.R:172 setops.R:173
 #, c-format
 msgid "has no index"
-msgstr ""
+msgstr "<needs translation>"
 
 #: setops.R:190
 #, c-format
@@ -3070,11 +3070,11 @@ msgstr "内部错误：此时不匹配的因子类型应已被发现"
 
 #: shift.R:3
 msgid "Provided argument fill="
-msgstr ""
+msgstr "<needs translation>"
 
 #: shift.R:3
 msgid "will be ignored since type='shift'."
-msgstr ""
+msgstr "<needs translation>"
 
 #: tables.R:46
 #, c-format
@@ -3102,14 +3102,14 @@ msgstr "%3$s 中 %1$s 也 %2$s 不存在"
 
 #: test.data.table.R:114
 msgid "object '%s' not found"
-msgstr ""
+msgstr "<needs translation>"
 
 #: test.data.table.R:138
 #, c-format
 msgid ""
 "memtest intended for Linux. Step through data.table:::rss() to see what went "
 "wrong."
-msgstr ""
+msgstr "<needs translation>"
 
 #: test.data.table.R:176
 #, fuzzy, c-format
@@ -3164,7 +3164,7 @@ msgstr "'keep'所含整数值应在 %d 和 %d 间"
 #: transpose.R:51
 #, c-format
 msgid "The argument 'type.convert' does not support empty list."
-msgstr ""
+msgstr "<needs translation>"
 
 #: transpose.R:57
 #, c-format
@@ -3174,7 +3174,7 @@ msgid ""
 "element is not allowed unless all elements are functions with length equal "
 "to %d (the length of the transpose list or 'keep' argument if it is "
 "specified)."
-msgstr ""
+msgstr "<needs translation>"
 
 #: transpose.R:66
 #, c-format
@@ -3182,7 +3182,7 @@ msgid ""
 "When the argument 'type.convert' contains transpose list indices, it should "
 "be a named list of non-missing integer values (with no duplicate) except the "
 "last element that should be unnamed if it is a function."
-msgstr ""
+msgstr "<needs translation>"
 
 #: transpose.R:68
 #, c-format
@@ -3191,7 +3191,7 @@ msgid ""
 "should be integer values contained in the argument 'keep' (if it is "
 "specified) or be between %d and %d (if it is not). But '%s' is/are not "
 "contained in '%s'."
-msgstr ""
+msgstr "<needs translation>"
 
 #: transpose.R:74
 #, c-format
@@ -3199,7 +3199,7 @@ msgid ""
 "In the argument 'type.convert', '%s' was ignored because all elements in the "
 "transpose list or elements corrisponding to indices specified in the 'keep' "
 "argument have already been converted."
-msgstr ""
+msgstr "<needs translation>"
 
 #: transpose.R:83
 #, c-format
@@ -3207,7 +3207,7 @@ msgid ""
 "The argument 'type.convert' should be TRUE/FALSE, a function, a list of "
 "functions, or a named list of pairs 'fun=indices' with optionally one "
 "unnamed element (a function) but an object of type '%s' was provided."
-msgstr ""
+msgstr "<needs translation>"
 
 #: transpose.R:88
 #, c-format
@@ -3231,7 +3231,7 @@ msgstr "参数 'nan' 必须为 NA 或 NaN"
 
 #: utils.R:32
 msgid "Internal error: use endsWithAny instead of base::endsWith"
-msgstr ""
+msgstr "<needs translation>"
 
 #: utils.R:43 utils.R:52
 #, c-format

--- a/po/R-zh_CN.po
+++ b/po/R-zh_CN.po
@@ -3291,310 +3291,310 @@ msgid_plural "Indices: %s\n"
 msgstr[0] "索引(index): %s\n"
 
 #~ msgid "'nearest', and 'ceil'."
-#~ msgstr "'nearest'和'ceil'"
+#~ msgstr "<possible fragment for fuzzy translation>'nearest'和'ceil'"
 
 #~ msgid "Item"
-#~ msgstr "条目"
+#~ msgstr "<possible fragment for fuzzy translation>条目"
 
 #~ msgid "has"
-#~ msgstr "具有"
+#~ msgstr "<possible fragment for fuzzy translation>具有"
 
 #~ msgid "rows but longest item has"
-#~ msgstr "行，但最长条目有"
+#~ msgstr "<possible fragment for fuzzy translation>行，但最长条目有"
 
 #~ msgid "; recycled with remainder."
-#~ msgstr "用余数循环填充"
+#~ msgstr "<possible fragment for fuzzy translation>用余数循环填充"
 
 #~ msgid "; filled with NA"
-#~ msgstr "用NA填充"
+#~ msgstr "<possible fragment for fuzzy translation>用NA填充"
 
 #~ msgid ""
 #~ "'between' function the 'x' argument is a POSIX class while 'upper' was "
 #~ "not, coercion to POSIX failed with:"
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "'between' 中的 'x' 参数为 POSIX 类，而 'upper' 并不是，将 'upper' 自动转换"
 #~ "成 POSIX 失败："
 
 #~ msgid ". Please align their time zones."
-#~ msgstr "。请确保二者的时区一致。"
+#~ msgstr "<possible fragment for fuzzy translation>。请确保二者的时区一致。"
 
 #~ msgid ". The UTC times will be compared."
-#~ msgstr "。将采用 UTC 时间进行比较。"
+#~ msgstr "<possible fragment for fuzzy translation>。将采用 UTC 时间进行比较。"
 
 #~ msgid ""
 #~ "optimised between not available for this data type, fallback to slow R "
 #~ "routine"
-#~ msgstr "对这种数据类型的优化尚未实现，使用备用较慢的R方法。"
+#~ msgstr "<possible fragment for fuzzy translation>对这种数据类型的优化尚未实现，使用备用较慢的R方法。"
 
 #~ msgid "RHS has length()"
-#~ msgstr "右手侧（RHS）的长度为"
+#~ msgstr "<possible fragment for fuzzy translation>右手侧（RHS）的长度为"
 
 #~ msgid "; expecting length 2."
-#~ msgstr "；其长度应为 2。"
+#~ msgstr "<possible fragment for fuzzy translation>；其长度应为 2。"
 
 #~ msgid "c"
-#~ msgstr "c"
+#~ msgstr "<possible fragment for fuzzy translation>c"
 
 #~ msgid "The first element should be the lower bound(s);"
-#~ msgstr "第一个元素应为下界；"
+#~ msgstr "<possible fragment for fuzzy translation>第一个元素应为下界；"
 
 #~ msgid "the second element should be the upper bound(s)."
-#~ msgstr "第二个元素应为上界。"
+#~ msgstr "<possible fragment for fuzzy translation>第二个元素应为上界。"
 
 #~ msgid "forderv(query) took ..."
-#~ msgstr "forderv(query) 用了 ..."
+#~ msgstr "<possible fragment for fuzzy translation>forderv(query) 用了 ..."
 
 #~ msgid "Generating final logical vector ..."
-#~ msgstr "产生最后的逻辑向量 ..."
+#~ msgstr "<possible fragment for fuzzy translation>产生最后的逻辑向量 ..."
 
 #~ msgid "done in"
-#~ msgstr "用了"
+#~ msgstr "<possible fragment for fuzzy translation>用了"
 
 #~ msgid "Matching %s factor levels to %s factor levels."
-#~ msgstr "匹配 %s 的因子水平和 %s 的因子水平。"
+#~ msgstr "<possible fragment for fuzzy translation>匹配 %s 的因子水平和 %s 的因子水平。"
 
 #~ msgid "Coercing factor column %s to type character to match type of %s."
-#~ msgstr "将因子类型列 %s 强制转换成字符来匹配目 %s。"
+#~ msgstr "<possible fragment for fuzzy translation>将因子类型列 %s 强制转换成字符来匹配目 %s。"
 
 #~ msgid "Matching character column %s to factor levels in %s."
-#~ msgstr "匹配字符类型列 %s 和 %s 的因子水平。"
+#~ msgstr "<possible fragment for fuzzy translation>匹配字符类型列 %s 和 %s 的因子水平。"
 
 #~ msgid "%s has same type (%s) as %s. No coercion needed."
-#~ msgstr "%1$s 与 %3$s 为相同类型 (%2$s)。不需要强制转换。"
+#~ msgstr "<possible fragment for fuzzy translation>%1$s 与 %3$s 为相同类型 (%2$s)。不需要强制转换。"
 
 #~ msgid "Coercing all-NA %s (%s) to type %s to match type of %s."
-#~ msgstr "强制转换 all-NA %s (%s) 为 %s 类型用来匹配 %s 类型。"
+#~ msgstr "<possible fragment for fuzzy translation>强制转换 all-NA %s (%s) 为 %s 类型用来匹配 %s 类型。"
 
 #~ msgid "Coercing %s column %s%s to type integer64 to match type of %s."
-#~ msgstr "强制转换 %s 个列 %s%s 为整数64类型用来匹配 %s 类型。"
+#~ msgstr "<possible fragment for fuzzy translation>强制转换 %s 个列 %s%s 为整数64类型用来匹配 %s 类型。"
 
 #~ msgid ""
 #~ "Coercing double column %s (which contains no fractions) to type integer "
 #~ "to match type of %s"
-#~ msgstr "强制转换双精度列 %s (不含有分数) 为整数用来匹配 %s 类型"
+#~ msgstr "<possible fragment for fuzzy translation>强制转换双精度列 %s (不含有分数) 为整数用来匹配 %s 类型"
 
 #~ msgid ""
 #~ "Coercing integer column %s to type double to match type of %s which "
 #~ "contains fractions."
-#~ msgstr "强制转换整数列 %s 为双精度用来匹配含有分数的 %s 类型。"
+#~ msgstr "<possible fragment for fuzzy translation>强制转换整数列 %s 为双精度用来匹配含有分数的 %s 类型。"
 
 #~ msgid ""
 #~ "Coercing integer column %s to type double for join to match type of %s."
-#~ msgstr "强制转换整数列 %s 为双精度用来与类型 %s 进行联结。"
+#~ msgstr "<possible fragment for fuzzy translation>强制转换整数列 %s 为双精度用来与类型 %s 进行联结。"
 
 #~ msgid "on= matches existing key, using key"
-#~ msgstr "on=和现有键(key)相等,用键"
+#~ msgstr "<possible fragment for fuzzy translation>on=和现有键(key)相等,用键"
 
 #~ msgid "on= matches existing index, using index"
-#~ msgstr "on=和现有索引(index)相等,用索引"
+#~ msgstr "<possible fragment for fuzzy translation>on=和现有索引(index)相等,用索引"
 
 #~ msgid "Calculated ad hoc index in %s"
-#~ msgstr "计算临时索引用了 %s"
+#~ msgstr "<possible fragment for fuzzy translation>计算临时索引用了 %s"
 
 #~ msgid "Non-equi join operators detected ..."
-#~ msgstr "侦测到不等长联结操作符(operator)..."
+#~ msgstr "<possible fragment for fuzzy translation>侦测到不等长联结操作符(operator)..."
 
 #~ msgid "forder took ..."
-#~ msgstr "forder 用了 ..."
+#~ msgstr "<possible fragment for fuzzy translation>forder 用了 ..."
 
 #~ msgid "Generating group lengths ..."
-#~ msgstr "正在生成组的长度。。。"
+#~ msgstr "<possible fragment for fuzzy translation>正在生成组的长度。。。"
 
 #~ msgid "Generating non-equi group ids ..."
-#~ msgstr "正在生成不等长的组标识符 . . . "
+#~ msgstr "<possible fragment for fuzzy translation>正在生成不等长的组标识符 . . . "
 
 #~ msgid "Recomputing forder with non-equi ids ..."
-#~ msgstr "用不等长的组标志符重新计算 forder . . . "
+#~ msgstr "<possible fragment for fuzzy translation>用不等长的组标志符重新计算 forder . . . "
 
 #~ msgid "Found %d non-equi group(s) ..."
-#~ msgstr "找到%d不等长分组 ..."
+#~ msgstr "<possible fragment for fuzzy translation>找到%d不等长分组 ..."
 
 #~ msgid "Starting bmerge ..."
-#~ msgstr "bmerge开始..."
+#~ msgstr "<possible fragment for fuzzy translation>bmerge开始..."
 
 #~ msgid "bmerge done in"
-#~ msgstr "bmerge 用了"
+#~ msgstr "<possible fragment for fuzzy translation>bmerge 用了"
 
 #~ msgid ""
 #~ "cedta decided '%s' wasn't data.table aware. Here is call stack with "
 #~ "[[1L]] applied:"
-#~ msgstr "cedta决定data.table不识别 '%s'。使用[[1L]]后的呼叫堆叠就是:"
+#~ msgstr "<possible fragment for fuzzy translation>cedta决定data.table不识别 '%s'。使用[[1L]]后的呼叫堆叠就是:"
 
 #~ msgid "Object '"
-#~ msgstr "对象 '"
+#~ msgstr "<possible fragment for fuzzy translation>对象 '"
 
 #~ msgid ","
-#~ msgstr ","
+#~ msgstr "<possible fragment for fuzzy translation>,"
 
 #~ msgid "or"
-#~ msgstr "或者"
+#~ msgstr "<possible fragment for fuzzy translation>或者"
 
 #~ msgid "more"
-#~ msgstr "更多"
+#~ msgstr "<possible fragment for fuzzy translation>更多"
 
 #~ msgid "and"
-#~ msgstr "并且"
+#~ msgstr "<possible fragment for fuzzy translation>并且"
 
 #~ msgid "Ignoring by= because j= is not supplied"
-#~ msgstr "因为没有提供 j= ，所以忽略 by= "
+#~ msgstr "<possible fragment for fuzzy translation>因为没有提供 j= ，所以忽略 by= "
 
 #~ msgid "'."
-#~ msgstr "'。"
+#~ msgstr "<possible fragment for fuzzy translation>'。"
 
 #~ msgid "roll is '"
-#~ msgstr "roll 是"
+#~ msgstr "<possible fragment for fuzzy translation>roll 是"
 
 #~ msgid "which=="
-#~ msgstr "which=="
+#~ msgstr "<possible fragment for fuzzy translation>which=="
 
 #~ msgid "Variable '"
-#~ msgstr "变量 '"
+#~ msgstr "<possible fragment for fuzzy translation>变量 '"
 
 #~ msgid "Variable '.."
-#~ msgstr "变量 '.."
+#~ msgstr "<possible fragment for fuzzy translation>变量 '.."
 
 #~ msgid "Both '"
-#~ msgstr "两个都有 '"
+#~ msgstr "<possible fragment for fuzzy translation>两个都有 '"
 
 #~ msgid "' and '.."
-#~ msgstr "' 和 '.."
+#~ msgstr "<possible fragment for fuzzy translation>' 和 '.."
 
 #~ msgid "' exist in calling scope. Please remove the '.."
-#~ msgstr "' 当前存在于调用环境. 请删除 '.."
+#~ msgstr "<possible fragment for fuzzy translation>' 当前存在于调用环境. 请删除 '.."
 
 #~ msgid "' variable in calling scope for clarity."
-#~ msgstr "这个调用环境里的变量以方便理解"
+#~ msgstr "<possible fragment for fuzzy translation>这个调用环境里的变量以方便理解"
 
 #~ msgid "is not found in calling scope"
-#~ msgstr "不存在调用环境里"
+#~ msgstr "<possible fragment for fuzzy translation>不存在调用环境里"
 
 #~ msgid "Joining but 'x' has no key, natural join using"
-#~ msgstr "联结但 'x' 没有键 (key)，自然联结用"
+#~ msgstr "<possible fragment for fuzzy translation>联结但 'x' 没有键 (key)，自然联结用"
 
 #~ msgid ""
 #~ "not-join called with 'by=.EACHI'; Replacing !i with i=setdiff_(x,i) ..."
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "配套使用了 not-join 和 'by=.EACHI' 的命令; 用 !i 取代 i=setdiff_(x,i) ..."
 
 #~ msgid "Constructing irows for '!byjoin || nqbyjoin' ..."
-#~ msgstr "构造 irows 用来对应于 '!byjoin || nqbyjoin' ..."
+#~ msgstr "<possible fragment for fuzzy translation>构造 irows 用来对应于 '!byjoin || nqbyjoin' ..."
 
 #~ msgid "Reorder irows for 'mult==\"all\" && !allGrp1' ..."
-#~ msgstr "对'mult==\"all\" && !allGrp1'再排序irows ..."
+#~ msgstr "<possible fragment for fuzzy translation>对'mult==\"all\" && !allGrp1'再排序irows ..."
 
 #~ msgid "Reordering %d rows after bmerge done in ..."
-#~ msgstr "bmerge 之后再排序%d行用了..."
+#~ msgstr "<possible fragment for fuzzy translation>bmerge 之后再排序%d行用了..."
 
 #~ msgid "i has evaluated to type"
-#~ msgstr "i 运算结果为类型"
+#~ msgstr "<possible fragment for fuzzy translation>i 运算结果为类型"
 
 #~ msgid "i evaluates to a logical vector length"
-#~ msgstr "i 为一个布尔类型向量的长度。"
+#~ msgstr "<possible fragment for fuzzy translation>i 为一个布尔类型向量的长度。"
 
 #~ msgid "but there are"
-#~ msgstr "但是存在"
+#~ msgstr "<possible fragment for fuzzy translation>但是存在"
 
 #~ msgid "Inverting irows for notjoin done in ..."
-#~ msgstr "对 notjoin 求逆 irows 用了 ..."
+#~ msgstr "<possible fragment for fuzzy translation>对 notjoin 求逆 irows 用了 ..."
 
 #~ msgid "of j is"
-#~ msgstr "j 是"
+#~ msgstr "<possible fragment for fuzzy translation>j 是"
 
 #~ msgid "]"
-#~ msgstr "]"
+#~ msgstr "<possible fragment for fuzzy translation>]"
 
 #~ msgid "'by' is a character vector length"
-#~ msgstr "'by' 是一个字符型向量，长度为"
+#~ msgstr "<possible fragment for fuzzy translation>'by' 是一个字符型向量，长度为"
 
 #~ msgid "by index '%s' but that index has 0 length. Ignoring."
-#~ msgstr "by 索引(index) '%s' 但那索引的长度为0。将被忽视。"
+#~ msgstr "<possible fragment for fuzzy translation>by 索引(index) '%s' 但那索引的长度为0。将被忽视。"
 
 #~ msgid "i clause present and columns used in by detected, only these subset:"
-#~ msgstr "有 i 子句和在 by 用的列被侦测, 子集只有这个:"
+#~ msgstr "<possible fragment for fuzzy translation>有 i 子句和在 by 用的列被侦测, 子集只有这个:"
 
 #~ msgid ""
 #~ "i clause present but columns used in by not detected. Having to subset "
 #~ "all columns before evaluating 'by': '"
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "有 i 子句但是在 by 用的列并没有被侦测。于是所有的列将用于接下里的 'by': 运"
 #~ "算。"
 
 #~ msgid ""
 #~ "should work. This is for efficiency so data.table can detect which "
 #~ "columns are needed."
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "应该是可行的。这样做是出于性能考虑，凭此 data.table 可以判断哪些列是需要"
 #~ "的。"
 
 #~ msgid "column or expression"
-#~ msgstr "列或者表达式"
+#~ msgstr "<possible fragment for fuzzy translation>列或者表达式"
 
 #~ msgid "of 'by' or 'keyby' is type"
-#~ msgstr "传递给 'by' 和 'keyby' 参数的类型是"
+#~ msgstr "<possible fragment for fuzzy translation>传递给 'by' 和 'keyby' 参数的类型是"
 
 #~ msgid ""
 #~ ". Do not quote column names. Usage: DT[,sum(colC),by=list(colA,"
 #~ "month(colB))]"
-#~ msgstr "。请勿引用列名。用法：DT[,sum(colC),by=list(colA,month(colB))]"
+#~ msgstr "<possible fragment for fuzzy translation>。请勿引用列名。用法：DT[,sum(colC),by=list(colA,month(colB))]"
 
 #~ msgid ""
 #~ "by-expression '%s' is not named, and the auto-generated name '%s' clashed "
 #~ "with variable(s) in j. Therefore assigning the entire by-expression as "
 #~ "name."
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "by-expression '%s' 没有命名，自动生成的名字 '%s' 与 j 中的变量名冲突。将"
 #~ "用 by-expression 用来命名。"
 
 #~ msgid "items"
-#~ msgstr "项"
+#~ msgstr "<possible fragment for fuzzy translation>项"
 
 #~ msgid ""
 #~ "Different branches of j expression produced different auto-named columns:"
-#~ msgstr "j表达式中的不同分支自动生成的列名不同："
+#~ msgstr "<possible fragment for fuzzy translation>j表达式中的不同分支自动生成的列名不同："
 
 #~ msgid "%s!=%s"
-#~ msgstr "%s!=%s"
+#~ msgstr "<possible fragment for fuzzy translation>%s!=%s"
 
 #~ msgid "; using the most \"last\" names"
-#~ msgstr "；将使用最晚生成的名字"
+#~ msgstr "<possible fragment for fuzzy translation>；将使用最晚生成的名字"
 
 #~ msgid "] at:"
-#~ msgstr "] 的范围:"
+#~ msgstr "<possible fragment for fuzzy translation>] 的范围:"
 
 #~ msgid ""
 #~ "'(m)get' found in j. ansvars being set to all columns. Use .SDcols or a "
 #~ "single j=eval(macro) instead. Both will detect the columns used which is "
 #~ "important for efficiency.\n"
 #~ "Old ansvars: %s"
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "在 j 中检测出 '(m)get'。ansvars 将被设为所以列。请使用 .SDcols 或"
 #~ "j=eval(macro) 来代替。二者均可检测出实际参与运算的列，这对提高运行效率非常"
 #~ "重要。\n"
 #~ "旧的 ansvars：%s"
 
 #~ msgid "New ansvars: %s"
-#~ msgstr "新的 ansvars: %s"
+#~ msgstr "<possible fragment for fuzzy translation>新的 ansvars: %s"
 
 #~ msgid "Detected that j uses these columns:"
-#~ msgstr "侦测 j 用这个列:"
+#~ msgstr "<possible fragment for fuzzy translation>侦测 j 用这个列:"
 
 #~ msgid ""
 #~ "'(m)get' found in j. ansvars being set to all columns. Use .SDcols or a "
 #~ "single j=eval(macro) instead. Both will detect the columns used which is "
 #~ "important for efficiency.\n"
 #~ "Old:"
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "j 中找到了 '(m)get'。ansvars 将应用到所有的列。请考虑使用 .SDcols 或者一个"
 #~ "单独的 j=eval(macro)两个命令都会侦测影响效率的列。\n"
 #~ "旧:"
 
 #~ msgid "New:"
-#~ msgstr "新:"
+#~ msgstr "<possible fragment for fuzzy translation>新:"
 
 #~ msgid ""
 #~ "No rows match i. No new columns to add so not evaluating RHS of :=\n"
 #~ "Assigning to 0 row subset of %d rows"
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "没有找到匹配 i 的行。无法增加新的列所以无法运算 RHS of :=\n"
 #~ "从 %d 行中分配 0 行"
 
@@ -3605,7 +3605,7 @@ msgstr[0] "索引(index): %s\n"
 #~ "not you can safely ignore this. To avoid this message you could "
 #~ "setalloccol() first, deep copy first using copy(), wrap with "
 #~ "suppressWarnings() or increase the 'datatable.alloccol' option."
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "列指针向量从 truelength %d 增加为 %d。浅拷贝已经完成，详见 ?setalloccol。"
 #~ "如果两个变量指向同一个数据 （这个我们无法侦测），会导致潜在的问题。如果并"
 #~ "没有，你可以:忽视这个问题。如果想要避免警告，可以使用以下任一命令，像是 "
@@ -3616,212 +3616,212 @@ msgstr[0] "索引(index): %s\n"
 #~ "Note that the shallow copy will assign to the environment from which := "
 #~ "was called. That means for example that if := was called within a "
 #~ "function, the original table may be unaffected."
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "需要注意的是这个浅拷贝会被指向给调用了 which := 的环境。意思就是说，如果在"
 #~ "函数内部调用了 if :=, 原先的 table 可能不会有任何变化。"
 
 #~ msgid "Internal error -- item '"
-#~ msgstr "内部错误 -- 项目 '"
+#~ msgstr "<possible fragment for fuzzy translation>内部错误 -- 项目 '"
 
 #~ msgid ""
 #~ "j (the 2nd argument inside [...]) is a single symbol but column name '"
-#~ msgstr "j ( [...] 中的第二顺位参数) 是单个符号而列名 '"
+#~ msgstr "<possible fragment for fuzzy translation>j ( [...] 中的第二顺位参数) 是单个符号而列名 '"
 
 #~ msgid "' is not found. Perhaps you intended DT[, .."
-#~ msgstr "' 未被找到，也许你打算 DT[, .."
+#~ msgstr "<possible fragment for fuzzy translation>' 未被找到，也许你打算 DT[, .."
 
 #~ msgid ""
 #~ "]. This difference to data.frame is deliberate and explained in FAQ 1.1."
-#~ msgstr "] ，在FAQ 1.1 中有解释dat.table与data.frame的差别"
+#~ msgstr "<possible fragment for fuzzy translation>] ，在FAQ 1.1 中有解释dat.table与data.frame的差别"
 
 #~ msgid ""
 #~ "Note: forcing units=\"secs\" on implicit difftime by group; call difftime "
 #~ "explicitly to choose custom units"
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "注意：在隐含的 difftime 强制分组使用了 units=\"secs\"; 请明确的调用 "
 #~ "difftime 来选择自定义的单位。"
 
 #~ msgid "Finding groups using forderv ..."
-#~ msgstr "搜寻组中配套使用了 forderv . . . "
+#~ msgstr "<possible fragment for fuzzy translation>搜寻组中配套使用了 forderv . . . "
 
 #~ msgid ""
 #~ "Finding group sizes from the positions (can be avoided to save RAM) ..."
-#~ msgstr "从位置中搜寻组的大小 (避免此举来节省内存) . . ."
+#~ msgstr "<possible fragment for fuzzy translation>从位置中搜寻组的大小 (避免此举来节省内存) . . ."
 
 #~ msgid "Getting back original order ..."
-#~ msgstr "恢复原有的顺序 . . . "
+#~ msgstr "<possible fragment for fuzzy translation>恢复原有的顺序 . . . "
 
 #~ msgid "Finding groups using uniqlist on key ..."
-#~ msgstr "搜寻组并配套使用了将 uniqlist 用在键 (key) ... "
+#~ msgstr "<possible fragment for fuzzy translation>搜寻组并配套使用了将 uniqlist 用在键 (key) ... "
 
 #~ msgid "Finding groups using uniqlist on index '%s' ..."
-#~ msgstr "搜寻组并配套使用了将 uniqlist 用在索引 (index) '%s'... "
+#~ msgstr "<possible fragment for fuzzy translation>搜寻组并配套使用了将 uniqlist 用在索引 (index) '%s'... "
 
 #~ msgid "lapply optimization changed j from '%s' to '%s'"
-#~ msgstr "lapply优化改变j从'%s'成'%s'"
+#~ msgstr "<possible fragment for fuzzy translation>lapply优化改变j从'%s'成'%s'"
 
 #~ msgid "lapply optimization is on, j unchanged as '%s'"
-#~ msgstr "lapply优化打开了, j ('%s')没有区别"
+#~ msgstr "<possible fragment for fuzzy translation>lapply优化打开了, j ('%s')没有区别"
 
 #~ msgid "GForce optimized j to '"
-#~ msgstr "GForce优化 j 到 '"
+#~ msgstr "<possible fragment for fuzzy translation>GForce优化 j 到 '"
 
 #~ msgid "GForce is on, left j unchanged"
-#~ msgstr "GForce打开了, j 没有区别"
+#~ msgstr "<possible fragment for fuzzy translation>GForce打开了, j 没有区别"
 
 #~ msgid "Old mean optimization changed j from '%s' to '%s'"
-#~ msgstr "旧mean优化改变j 从'%s'成'%s'"
+#~ msgstr "<possible fragment for fuzzy translation>旧mean优化改变j 从'%s'成'%s'"
 
 #~ msgid "Old mean optimization is on, left j unchanged."
-#~ msgstr "旧mean优化打开了，j没有区别。"
+#~ msgstr "<possible fragment for fuzzy translation>旧mean优化打开了，j没有区别。"
 
 #~ msgid "All optimizations are turned off"
-#~ msgstr "所有优化关掉了"
+#~ msgstr "<possible fragment for fuzzy translation>所有优化关掉了"
 
 #~ msgid "Optimization is on but left j unchanged (single plain symbol): '%s'"
-#~ msgstr "优化打开了但是并没有改变 j (一个普通符号)：'%s'"
+#~ msgstr "<possible fragment for fuzzy translation>优化打开了但是并没有改变 j (一个普通符号)：'%s'"
 
 #~ msgid "Making each group and running j (GForce %s) ..."
-#~ msgstr "进行分组中，并且运行 j (GForce %s) ..."
+#~ msgstr "<possible fragment for fuzzy translation>进行分组中，并且运行 j (GForce %s) ..."
 
 #~ msgid "setkey() after the := with keyby= ..."
-#~ msgstr "keyby=中，:=后setkey() ..."
+#~ msgstr "<possible fragment for fuzzy translation>keyby=中，:=后setkey() ..."
 
 #~ msgid "but ans is"
-#~ msgstr "但是ans(答案)是"
+#~ msgstr "<possible fragment for fuzzy translation>但是ans(答案)是"
 
 #~ msgid "and bynames is"
-#~ msgstr "同时bynames是"
+#~ msgstr "<possible fragment for fuzzy translation>同时bynames是"
 
 #~ msgid "setkey() afterwards for keyby=.EACHI ..."
-#~ msgstr "keyby=.EACHI中到底setkey() ..."
+#~ msgstr "<possible fragment for fuzzy translation>keyby=.EACHI中到底setkey() ..."
 
 #~ msgid "length(rownames)=="
-#~ msgstr "length(rownames)== (行名长度==)"
+#~ msgstr "<possible fragment for fuzzy translation>length(rownames)== (行名长度==)"
 
 #~ msgid "but nrow(DT)=="
-#~ msgstr "但是nrow(DT)=="
+#~ msgstr "<possible fragment for fuzzy translation>但是nrow(DT)=="
 
 #~ msgid "; taking first column x[,1] as rownames"
-#~ msgstr "； 取第一列, `column x[,1]`, 为rownames"
+#~ msgstr "<possible fragment for fuzzy translation>； 取第一列, `column x[,1]`, 为rownames"
 
 #~ msgid "'"
-#~ msgstr "'"
+#~ msgstr "<possible fragment for fuzzy translation>'"
 
 #~ msgid "as.integer(rownames)=="
-#~ msgstr "as.integer(rownames)=="
+#~ msgstr "<possible fragment for fuzzy translation>as.integer(rownames)=="
 
 #~ msgid "]."
-#~ msgstr "]."
+#~ msgstr "<possible fragment for fuzzy translation>]."
 
 #~ msgid "but should be nrow(x)=="
-#~ msgstr "但应该是nrow(x)=="
+#~ msgstr "<possible fragment for fuzzy translation>但应该是nrow(x)=="
 
 #~ msgid "Can't assign"
-#~ msgstr "无法指定"
+#~ msgstr "<possible fragment for fuzzy translation>无法指定"
 
 #~ msgid "colnames to a"
-#~ msgstr "列名为一个"
+#~ msgstr "<possible fragment for fuzzy translation>列名为一个"
 
 #~ msgid "-column data.table"
-#~ msgstr "-列 data.table"
+#~ msgstr "<possible fragment for fuzzy translation>-列 data.table"
 
 #~ msgid "Processing split.data.table with:"
-#~ msgstr "运行 split.data.table 中使用: "
+#~ msgstr "<possible fragment for fuzzy translation>运行 split.data.table 中使用: "
 
 #~ msgid "x has"
-#~ msgstr "x 有"
+#~ msgstr "<possible fragment for fuzzy translation>x 有"
 
 #~ msgid "Passed a vector of type '"
-#~ msgstr "传递了一个向量，向量类型是；"
+#~ msgstr "<possible fragment for fuzzy translation>传递了一个向量，向量类型是；"
 
 #~ msgid "names to a"
-#~ msgstr "命名"
+#~ msgstr "<possible fragment for fuzzy translation>命名"
 
 #~ msgid "column data.table"
-#~ msgstr "data.table 的纵列"
+#~ msgstr "<possible fragment for fuzzy translation>data.table 的纵列"
 
 #~ msgid "'old' is type"
-#~ msgstr "'old' 的类型是"
+#~ msgstr "<possible fragment for fuzzy translation>'old' 的类型是"
 
 #~ msgid "'old' is length"
-#~ msgstr "'old' 长度为"
+#~ msgstr "<possible fragment for fuzzy translation>'old' 长度为"
 
 #~ msgid "of 'old' is '"
-#~ msgstr "是"
+#~ msgstr "<possible fragment for fuzzy translation>是"
 
 #~ msgid "other items in old that are also duplicated in column names."
-#~ msgstr "old中的其他项在列名中出现重复"
+#~ msgstr "<possible fragment for fuzzy translation>old中的其他项在列名中出现重复"
 
 #~ msgid ". Consider skip_absent=TRUE."
-#~ msgstr "尝试 skip_absent=TRUE"
+#~ msgstr "<possible fragment for fuzzy translation>尝试 skip_absent=TRUE"
 
 #~ msgid "x has some duplicated column name(s):"
-#~ msgstr "x 有多个重复列名:"
+#~ msgstr "<possible fragment for fuzzy translation>x 有多个重复列名:"
 
 #~ msgid "Input is"
-#~ msgstr "输入为"
+#~ msgstr "<possible fragment for fuzzy translation>输入为"
 
 #~ msgid "names, got"
-#~ msgstr "名字,用"
+#~ msgstr "<possible fragment for fuzzy translation>名字,用"
 
 #~ msgid "Cannot convert '"
-#~ msgstr "无法转换'"
+#~ msgstr "<possible fragment for fuzzy translation>无法转换'"
 
 #~ msgid ""
 #~ "' to data.table by reference because binding is locked. It is very likely "
 #~ "that '"
-#~ msgstr "' 为引用形式的 data.table，因为绑定被锁定了。很有可能 '"
+#~ msgstr "<possible fragment for fuzzy translation>' 为引用形式的 data.table，因为绑定被锁定了。很有可能 '"
 
 #~ msgid "Some columns are a multi-column type (such as a matrix column):"
-#~ msgstr "某些列是多重列类型（如矩阵列）："
+#~ msgstr "<possible fragment for fuzzy translation>某些列是多重列类型（如矩阵列）："
 
 #~ msgid "Column"
-#~ msgstr "列"
+#~ msgstr "<possible fragment for fuzzy translation>列"
 
 #~ msgid "%s:%d"
-#~ msgstr "%s:%d"
+#~ msgstr "<possible fragment for fuzzy translation>%s:%d"
 
 #~ msgid "The first entry with fewer than"
-#~ msgstr "第一个长度少于"
+#~ msgstr "<possible fragment for fuzzy translation>第一个长度少于"
 
 #~ msgid "entries is"
-#~ msgstr "的输入项是"
+#~ msgstr "<possible fragment for fuzzy translation>的输入项是"
 
 #~ msgid "Item '"
-#~ msgstr "项 '"
+#~ msgstr "<possible fragment for fuzzy translation>项 '"
 
 #~ msgid ""
 #~ "Subsetting optimization disabled because the cross-product of RHS values "
 #~ "exceeds 1e4, causing memory problems."
-#~ msgstr "筛选子集优化被停止，因为叉积后的RHS值将超过 1e4，会造成内存问题。"
+#~ msgstr "<possible fragment for fuzzy translation>筛选子集优化被停止，因为叉积后的RHS值将超过 1e4，会造成内存问题。"
 
 #~ msgid "Optimized subsetting with key '"
-#~ msgstr "优化的子集用键(key) '"
+#~ msgstr "<possible fragment for fuzzy translation>优化的子集用键(key) '"
 
 #~ msgid "Optimized subsetting with index '"
-#~ msgstr "优化的子集用索引(index) '"
+#~ msgstr "<possible fragment for fuzzy translation>优化的子集用索引(index) '"
 
 #~ msgid "Creating new index '"
-#~ msgstr "造成新索引(index) '"
+#~ msgstr "<possible fragment for fuzzy translation>造成新索引(index) '"
 
 #~ msgid "Creating index %s done in ..."
-#~ msgstr "造成新索引(index) %s 用了 ..."
+#~ msgstr "<possible fragment for fuzzy translation>造成新索引(index) %s 用了 ..."
 
 #~ msgid ". Please specify a single operator."
-#~ msgstr "。请指定单个操作符。"
+#~ msgstr "<possible fragment for fuzzy translation>。请指定单个操作符。"
 
 #~ msgid "'on' contains no column name:"
-#~ msgstr "'on' 中没有列名："
+#~ msgstr "<possible fragment for fuzzy translation>'on' 中没有列名："
 
 #~ msgid "'on' contains more than 2 column names:"
-#~ msgstr "'on' 包含了超过两个列名："
+#~ msgstr "<possible fragment for fuzzy translation>'on' 包含了超过两个列名："
 
 #~ msgid "Invalid operators"
-#~ msgstr "无效的操作符"
+#~ msgstr "<possible fragment for fuzzy translation>无效的操作符"
 
 #~ msgid "."
-#~ msgstr "."
+#~ msgstr "<possible fragment for fuzzy translation>."
 
 #~ msgid ""
 #~ "Git revision is not available. Most likely data.table was installed from "
@@ -3829,51 +3829,51 @@ msgstr[0] "索引(index): %s\n"
 #~ "Git revision is available when installing from our repositories 'https://"
 #~ "Rdatatable.gitlab.io/data.table' and 'https://Rdatatable.github.io/data."
 #~ "table'."
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "Git 修订并不存在。可能是因为 data.table 是从 CRAN 或者是本地档案安装。\n"
 #~ "Git 修订存在的情况只限于从我们资料库 'https://Rdatatable.gitlab.io/data."
 #~ "table' 或者'https://Rdatatable.github.io/data.table'下载。"
 
 #~ msgid "Using '"
-#~ msgstr "使用 '"
+#~ msgstr "<possible fragment for fuzzy translation>使用 '"
 
 #~ msgid "The dcast generic in data.table has been passed a"
-#~ msgstr "data.table 中的 dcast 泛型函数被传递了"
+#~ msgstr "<possible fragment for fuzzy translation>data.table 中的 dcast 泛型函数被传递了"
 
 #~ msgid ""
 #~ ", but data.table::dcast currently only has a method for data.tables. "
 #~ "Please confirm your input is a data.table, with setDT("
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "，但目前 data.table::dcast 仅提供了针对 data.table 的方法。您可通过如下两"
 #~ "种方法确保您的输入为一个 data.table对象，即setDT("
 
 #~ msgid ") or as.data.table("
-#~ msgstr ") 或 as.data.table("
+#~ msgstr "<possible fragment for fuzzy translation>) 或 as.data.table("
 
 #~ msgid ""
 #~ "). If you intend to use a reshape2::dcast, try installing that package "
 #~ "first, but do note that reshape2 is deprecated and you should be "
 #~ "migrating your code away from using it."
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ ")。若您想使用reshape2::dcast，尝试先安装reshape2。但请注意reshape2已经不推"
 #~ "荐使用，您应修改您的代码以不再使用它。"
 
 #~ msgid "). In the next version, this warning will become an error."
-#~ msgstr ")。在下一个版本中，此警告将变成为错误。"
+#~ msgstr "<possible fragment for fuzzy translation>)。在下一个版本中，此警告将变成为错误。"
 
 #~ msgid "value.var values ["
-#~ msgstr "value.var 的值 ["
+#~ msgstr "<possible fragment for fuzzy translation>value.var 的值 ["
 
 #~ msgid "Column ["
-#~ msgstr "列 ["
+#~ msgstr "<possible fragment for fuzzy translation>列 ["
 
 #~ msgid "The melt generic in data.table has been passed a"
-#~ msgstr "data.table 中的 melt 泛型函数被传递了"
+#~ msgstr "<possible fragment for fuzzy translation>data.table 中的 melt 泛型函数被传递了"
 
 #~ msgid ""
 #~ ", but data.table::melt currently only has a method for data.tables. "
 #~ "Please confirm your input is a data.table, with setDT("
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "，然而 data.table::melt 当前只支持输入 data.table 对象。请确保输入的是一"
 #~ "个  data.table 对象，可以用 setDT("
 
@@ -3881,230 +3881,230 @@ msgstr[0] "索引(index): %s\n"
 #~ "). If you intend to use a method from reshape2, try installing that "
 #~ "package first, but do note that reshape2 is deprecated and you should be "
 #~ "migrating your code away from using it."
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ ")。如果确实要使用 reshape2 中的方法，首先要安装这个包。需要注意，reshape2 "
 #~ "已经弃用，你应该将代码迁移并且不再使用它。"
 
 #~ msgid "'value.name' provided in both 'measure.vars'"
-#~ msgstr "'value.name' 同时出现在了 'measure.vars'"
+#~ msgstr "<possible fragment for fuzzy translation>'value.name' 同时出现在了 'measure.vars'"
 
 #~ msgid "and 'value.name argument'; value provided in"
-#~ msgstr "和 'value.name' 参数中；'measure.vars' 中的值"
+#~ msgstr "<possible fragment for fuzzy translation>和 'value.name' 参数中；'measure.vars' 中的值"
 
 #~ msgid "'measure.vars' is given precedence."
-#~ msgstr "将被优先使用。"
+#~ msgstr "<possible fragment for fuzzy translation>将被优先使用。"
 
 #~ msgid ""
 #~ "Duplicate column names found in molten data.table. Setting unique names "
 #~ "using 'make.names'"
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "重复的列名存在于在 molten 之后 data.table。请使用 'make.names' 设置唯一的"
 #~ "列名。"
 
 #~ msgid "The first"
-#~ msgstr "首先"
+#~ msgstr "<possible fragment for fuzzy translation>首先"
 
 #~ msgid "y has some duplicated column name(s):"
-#~ msgstr "y有重复的列名时："
+#~ msgstr "<possible fragment for fuzzy translation>y有重复的列名时："
 
 #~ msgid "NA values in data.table 'x' start column: '"
-#~ msgstr "在data.table的X的初始列的NA值时：'"
+#~ msgstr "<possible fragment for fuzzy translation>在data.table的X的初始列的NA值时：'"
 
 #~ msgid "NA values in data.table 'x' end column: '"
-#~ msgstr "在data.table的'X'的末尾列中NA值时："
+#~ msgstr "<possible fragment for fuzzy translation>在data.table的'X'的末尾列中NA值时："
 
 #~ msgid "All entries in column"
-#~ msgstr "列中所有条目"
+#~ msgstr "<possible fragment for fuzzy translation>列中所有条目"
 
 #~ msgid "in data.table 'x'."
-#~ msgstr "在data.table的'X'部分"
+#~ msgstr "<possible fragment for fuzzy translation>在data.table的'X'部分"
 
 #~ msgid "NA values in data.table 'y' start column: '"
-#~ msgstr "NA值在data.table的'y'起始列时："
+#~ msgstr "<possible fragment for fuzzy translation>NA值在data.table的'y'起始列时："
 
 #~ msgid "NA values in data.table 'y' end column: '"
-#~ msgstr "NA值在data.table的'y'尾列时："
+#~ msgstr "<possible fragment for fuzzy translation>NA值在data.table的'y'尾列时："
 
 #~ msgid "in data.table 'y'."
-#~ msgstr "在data.table的'y'部分"
+#~ msgstr "<possible fragment for fuzzy translation>在data.table的'y'部分"
 
 #~ msgid "unique() + setkey() operations done in ..."
-#~ msgstr "unique() + setkey() 执行用了 ..."
+#~ msgstr "<possible fragment for fuzzy translation>unique() + setkey() 执行用了 ..."
 
 #~ msgid "binary search(es) done in ..."
-#~ msgstr "二进制搜索用了 . . . "
+#~ msgstr "<possible fragment for fuzzy translation>二进制搜索用了 . . . "
 
 #~ msgid "'text=' is type"
-#~ msgstr "'text=' 是类型"
+#~ msgstr "<possible fragment for fuzzy translation>'text=' 是类型"
 
 #~ msgid ""
 #~ "Input URL requires https:// connection for which fread() requires 'curl' "
 #~ "package which cannot be found. Please install 'curl' using 'install."
 #~ "packages('curl')'."
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "输入的URL要求 https:// 连接. 因而 fread() 要求 'curl' 包.请用 'install."
 #~ "packages('curl')' 安装'curl'包."
 
 #~ msgid "Taking input= as a system command ('"
-#~ msgstr "正将 input= 当做系统命令 ('"
+#~ msgstr "<possible fragment for fuzzy translation>正将 input= 当做系统命令 ('"
 
 #~ msgid "File '"
-#~ msgstr "文件'"
+#~ msgstr "<possible fragment for fuzzy translation>文件'"
 
 #~ msgid "data.table"
-#~ msgstr "data.table"
+#~ msgstr "<possible fragment for fuzzy translation>data.table"
 
 #~ msgid "data.frame"
-#~ msgstr "data.frame"
+#~ msgstr "<possible fragment for fuzzy translation>data.frame"
 
 #~ msgid ""
 #~ "Combining a search string as 'skip' and reading a YAML header may not "
 #~ "work as expected -- currently,"
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "读取一个 YAML 文件头 (header) 的同时以 'skip' 为搜索字符可能会引起异常 -- "
 #~ "目前"
 
 #~ msgid ""
 #~ "reading will proceed to search for 'skip' from the beginning of the file, "
 #~ "NOT from the end of"
-#~ msgstr "读取会直接从文件的开头搜索 'skip', 而非从元数据 (metadata) "
+#~ msgstr "<possible fragment for fuzzy translation>读取会直接从文件的开头搜索 'skip', 而非从元数据 (metadata) "
 
 #~ msgid ""
 #~ "the metadata; please file an issue on GitHub if you'd like to see more "
 #~ "intuitive behavior supported."
-#~ msgstr "的尾部开始; 如果你希望更直观的功能, 请在 Github 上提交 issue."
+#~ msgstr "<possible fragment for fuzzy translation>的尾部开始; 如果你希望更直观的功能, 请在 Github 上提交 issue."
 
 #~ msgid "Encountered <"
-#~ msgstr "遇到 <"
+#~ msgstr "<possible fragment for fuzzy translation>遇到 <"
 
 #~ msgid "..."
-#~ msgstr "..."
+#~ msgstr "<possible fragment for fuzzy translation>..."
 
 #~ msgid "> at the first"
-#~ msgstr "> 在第一个"
+#~ msgstr "<possible fragment for fuzzy translation>> 在第一个"
 
 #~ msgid "unskipped line ("
-#~ msgstr "非跳过的行 ("
+#~ msgstr "<possible fragment for fuzzy translation>非跳过的行 ("
 
 #~ msgid "), which does not constitute the start to a valid YAML header"
-#~ msgstr "), 它不含符合要求的 YAML header."
+#~ msgstr "<possible fragment for fuzzy translation>), 它不含符合要求的 YAML header."
 
 #~ msgid "(expecting something matching regex \""
-#~ msgstr "需要符合正则 (regex) \""
+#~ msgstr "<possible fragment for fuzzy translation>需要符合正则 (regex) \""
 
 #~ msgid "\"); please check your input and try again."
-#~ msgstr "\"); 请检查你的输入然后重试."
+#~ msgstr "<possible fragment for fuzzy translation>\"); 请检查你的输入然后重试."
 
 #~ msgid "the regex \""
-#~ msgstr "正则 \""
+#~ msgstr "<possible fragment for fuzzy translation>正则 \""
 
 #~ msgid "\". Please double check the input file is a valid csvy."
-#~ msgstr "从这里开始"
+#~ msgstr "<possible fragment for fuzzy translation>从这里开始"
 
 #~ msgid ""
 #~ "Processed %d lines of YAML metadata with the following top-level fields: "
 #~ "%s"
-#~ msgstr "处理了YAML元数据中的排列最前的 %d 行： %s"
+#~ msgstr "<possible fragment for fuzzy translation>处理了YAML元数据中的排列最前的 %d 行： %s"
 
 #~ msgid ""
 #~ "colClasses dictated by user input and those read from YAML header are in "
 #~ "conflict (specifically, for column"
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "用户输入指定的列类型和从YAML列名中读取的列类型发生冲突（特别是column"
 
 #~ msgid "s"
-#~ msgstr "s"
+#~ msgstr "<possible fragment for fuzzy translation>s"
 
 #~ msgid "["
-#~ msgstr "["
+#~ msgstr "<possible fragment for fuzzy translation>["
 
 #~ msgid "]); the proceeding assumes the user input was"
-#~ msgstr "]); 该过程假定用户输入的是"
+#~ msgstr "<possible fragment for fuzzy translation>]); 该过程假定用户输入的是"
 
 #~ msgid ""
 #~ "an intentional override and will ignore the types implied by the YAML "
 #~ "header; please exclude"
-#~ msgstr "有意覆盖的，因此将忽略YAML表头所指示的列类型；请排除"
+#~ msgstr "<possible fragment for fuzzy translation>有意覆盖的，因此将忽略YAML表头所指示的列类型；请排除"
 
 #~ msgid "these columns"
-#~ msgstr "这些列"
+#~ msgstr "<possible fragment for fuzzy translation>这些列"
 
 #~ msgid "this column from colClasses if this was unintentional."
-#~ msgstr "如果不想覆盖，请将这些列从colClasses中排除"
+#~ msgstr "<possible fragment for fuzzy translation>如果不想覆盖，请将这些列从colClasses中排除"
 
 #~ msgid "Column '"
-#~ msgstr "列"
+#~ msgstr "<possible fragment for fuzzy translation>列"
 
 #~ msgid "' was requested to be '"
-#~ msgstr "被要求为"
+#~ msgstr "<possible fragment for fuzzy translation>被要求为"
 
 #~ msgid "' but fread encountered the following"
-#~ msgstr "但是fread遇到了以下问题"
+#~ msgstr "<possible fragment for fuzzy translation>但是fread遇到了以下问题"
 
 #~ msgid "error"
-#~ msgstr "错误"
+#~ msgstr "<possible fragment for fuzzy translation>错误"
 
 #~ msgid "warning"
-#~ msgstr "警告"
+#~ msgstr "<possible fragment for fuzzy translation>警告"
 
 #~ msgid ":"
-#~ msgstr ":"
+#~ msgstr "<possible fragment for fuzzy translation>:"
 
 #~ msgid "so the column has been left as type '"
-#~ msgstr "所以该列已经被保存为类型"
+#~ msgstr "<possible fragment for fuzzy translation>所以该列已经被保存为类型"
 
 #~ msgid "stringsAsFactors=%s converted %d column(s): %s"
-#~ msgstr "stringsAsFactors=%s 改变 %d 列: %s"
+#~ msgstr "<possible fragment for fuzzy translation>stringsAsFactors=%s 改变 %d 列: %s"
 
 #~ msgid "Appending to existing file so setting bom=FALSE and yaml=FALSE"
-#~ msgstr "并入了已存在的文件，所以设置 bom=FALSE 和 yaml=FALSE"
+#~ msgstr "<possible fragment for fuzzy translation>并入了已存在的文件，所以设置 bom=FALSE 和 yaml=FALSE"
 
 #~ msgid "If you intended to overwrite the file at"
-#~ msgstr "如果你打算覆盖文件"
+#~ msgstr "<possible fragment for fuzzy translation>如果你打算覆盖文件"
 
 #~ msgid "' and exiting."
-#~ msgstr "' 并退出。"
+#~ msgstr "<possible fragment for fuzzy translation>' 并退出。"
 
 #~ msgid ""
 #~ "'sets' contains a duplicate (i.e., equivalent up to sorting) element at "
 #~ "index"
-#~ msgstr "'sets' 的索引含有重复的元素，在做排序时的作用是对等的"
+#~ msgstr "<possible fragment for fuzzy translation>'sets' 的索引含有重复的元素，在做排序时的作用是对等的"
 
 #~ msgid "%s: using %s: %s"
-#~ msgstr "%s: 用 %s: %s"
+#~ msgstr "<possible fragment for fuzzy translation>%s: 用 %s: %s"
 
 #~ msgid "You are trying to join data.tables where"
-#~ msgstr "你正在试图去联结data.table，其中"
+#~ msgstr "<possible fragment for fuzzy translation>你正在试图去联结data.table，其中"
 
 #~ msgid "'x' and 'y' arguments are"
-#~ msgstr "参数'x'和'y'是"
+#~ msgstr "<possible fragment for fuzzy translation>参数'x'和'y'是"
 
 #~ msgid "'y' argument is"
-#~ msgstr "参数'y'的值为"
+#~ msgstr "<possible fragment for fuzzy translation>参数'y'的值为"
 
 #~ msgid "0 columns data.table."
-#~ msgstr "0列的data.table对象。"
+#~ msgstr "<possible fragment for fuzzy translation>0列的data.table对象。"
 
 #~ msgid "column names"
-#~ msgstr "列名"
+#~ msgstr "<possible fragment for fuzzy translation>列名"
 
 #~ msgid "IN DEVELOPMENT built"
-#~ msgstr "在开发版本中"
+#~ msgstr "<possible fragment for fuzzy translation>在开发版本中"
 
 #~ msgid "using"
-#~ msgstr "使用"
+#~ msgstr "<possible fragment for fuzzy translation>使用"
 
 #~ msgid "**********"
-#~ msgstr "**********"
+#~ msgstr "<possible fragment for fuzzy translation>**********"
 
 #~ msgid "sysname"
-#~ msgstr "sysname"
+#~ msgstr "<possible fragment for fuzzy translation>sysname"
 
 #~ msgid "Darwin"
-#~ msgstr "Darwin"
+#~ msgstr "<possible fragment for fuzzy translation>Darwin"
 
 #~ msgid "This is"
-#~ msgstr "这是"
+#~ msgstr "<possible fragment for fuzzy translation>这是"
 
 #~ msgid ""
 #~ "The option 'datatable.nomatch' is being used and is not set to the "
@@ -4113,23 +4113,23 @@ msgstr[0] "索引(index): %s\n"
 #~ "motivation. To specify inner join, please specify `nomatch=NULL` "
 #~ "explicitly in your calls rather than changing the default using this "
 #~ "option."
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "这个选项'datatable.nomatch'正在被使用，没有被设置为默认值NA。该选项目前仍"
 #~ "被使用，但在未来不会被使用。相关的详细信息和动机，请参阅1.12.4的信息。要指"
 #~ "定内部连接，请在调用中明确指定`nomatch = NULL`，而不要使用此选项更改默认"
 #~ "值。"
 
 #~ msgid "This is R"
-#~ msgstr "这是R"
+#~ msgstr "<possible fragment for fuzzy translation>这是R"
 
 #~ msgid "but data.table has been installed using R"
-#~ msgstr "但是data.table安装在R"
+#~ msgstr "<possible fragment for fuzzy translation>但是data.table安装在R"
 
 #~ msgid ""
 #~ "Option 'datatable.old.bywithoutby' has been removed as warned for 2 "
 #~ "years. It is now ignored. Please use by=.EACHI instead and stop using "
 #~ "this option."
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "选项'datatable.old.bywithoutby'已经被移除，警告了2年。它现在被忽略。 请改"
 #~ "用by = .EACHI，然后停止使用这个选项。"
 
@@ -4137,125 +4137,125 @@ msgstr[0] "索引(index): %s\n"
 #~ "Option 'datatable.old.unique.by.key' has been removed as warned for 4 "
 #~ "years. It is now ignored. Please use by=key(DT) instead and stop using "
 #~ "this option."
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "选项'datatable.old.bywithoutby'已经被移除，警告了2年。它现在被忽略。 请改"
 #~ "用by = .EACHI，然后停止使用这个选项。"
 
 #~ msgid ""
 #~ "Reminder to data.table developers: don't use getRversion() internally. "
 #~ "Add a behaviour test to .onLoad instead."
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "提醒data.table开发人员：请勿在内部使用getRversion()。将行为测试添加到."
 #~ "onLoad"
 
 #~ msgid "percent=="
-#~ msgstr "percent=="
+#~ msgstr "<possible fragment for fuzzy translation>percent=="
 
 #~ msgid "Key: <%s>"
-#~ msgstr "键(key): <%s>"
+#~ msgstr "<possible fragment for fuzzy translation>键(key): <%s>"
 
 #~ msgid "Null data.%s (0 rows and 0 cols)"
-#~ msgstr "NULL data.%s (0行，0列)"
+#~ msgstr "<possible fragment for fuzzy translation>NULL data.%s (0行，0列)"
 
 #~ msgid "Empty data.%s (%d rows and %d cols)"
-#~ msgstr "空的 data.%s (%d行，%d列)"
+#~ msgstr "<possible fragment for fuzzy translation>空的 data.%s (%d行，%d列)"
 
 #~ msgid "' is type '"
-#~ msgstr "是类型"
+#~ msgstr "<possible fragment for fuzzy translation>是类型"
 
 #~ msgid "forder took"
-#~ msgstr "forder 用了"
+#~ msgstr "<possible fragment for fuzzy translation>forder 用了"
 
 #~ msgid "setkey on columns %s using existing index '%s'"
-#~ msgstr "setkey到列%s用现有索引(index) '%s'"
+#~ msgstr "<possible fragment for fuzzy translation>setkey到列%s用现有索引(index) '%s'"
 
 #~ msgid "reorder took"
-#~ msgstr "reorder 用了"
+#~ msgstr "<possible fragment for fuzzy translation>reorder 用了"
 
 #~ msgid "x is already ordered by these columns, no need to call reorder"
-#~ msgstr "x 已根据这些列进行了排序，无需调用 reorder"
+#~ msgstr "<possible fragment for fuzzy translation>x 已根据这些列进行了排序，无需调用 reorder"
 
 #~ msgid "Internal error: index '"
-#~ msgstr "内部错误：索引(index) '"
+#~ msgstr "<possible fragment for fuzzy translation>内部错误：索引(index) '"
 
 #~ msgid "' exists but is invalid"
-#~ msgstr "存在但无效"
+#~ msgstr "<possible fragment for fuzzy translation>存在但无效"
 
 #~ msgid "'sorted' is TRUE but element"
-#~ msgstr "'sorted' 为 TRUE 但元素"
+#~ msgstr "<possible fragment for fuzzy translation>'sorted' 为 TRUE 但元素"
 
 #~ msgid "found in x or y:"
-#~ msgstr "存在于 x 或 y 中"
+#~ msgstr "<possible fragment for fuzzy translation>存在于 x 或 y 中"
 
 #~ msgid "of x is '"
-#~ msgstr "对于 x ，是 '"
+#~ msgstr "<possible fragment for fuzzy translation>对于 x ，是 '"
 
 #~ msgid "argument 'fill' ignored, only make sense for type='const'"
-#~ msgstr "参数 'fill' 将被忽略，因其仅当 type='const'时有意义"
+#~ msgstr "<possible fragment for fuzzy translation>参数 'fill' 将被忽略，因其仅当 type='const'时有意义"
 
 #~ msgid "No objects of class data.table exist in %s"
-#~ msgstr "%s中没有 data.table类型的对象"
+#~ msgstr "<possible fragment for fuzzy translation>%s中没有 data.table类型的对象"
 
 #~ msgid "order.col='"
-#~ msgstr "order.col='"
+#~ msgstr "<possible fragment for fuzzy translation>order.col='"
 
 #~ msgid "Total:"
-#~ msgstr "共计:"
+#~ msgstr "<possible fragment for fuzzy translation>共计:"
 
 #~ msgid "test.data.table() running:"
-#~ msgstr "test.data.table() 执行:"
+#~ msgstr "<possible fragment for fuzzy translation>test.data.table() 执行:"
 
 #~ msgid ""
 #~ "**** This R session's language is not English. Each test will still check "
 #~ "that the correct number of errors and/or\n"
 #~ "**** warnings are produced. However, to test the text of each error/"
 #~ "warning too, please restart R with LANGUAGE=en"
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "**** 此 R 会话的语言并非英文。每个测试仍将检查生成的警告或错误的个数是否正"
 #~ "确。**** 然而，若需同时测试警告和错误的文本内容，请用 LANGUAGE=en 重新启"
 #~ "动 R。"
 
 #~ msgid "Failed after test"
-#~ msgstr "错误出现于测试"
+#~ msgstr "<possible fragment for fuzzy translation>错误出现于测试"
 
 #~ msgid "vs"
-#~ msgstr "vs"
+#~ msgstr "<possible fragment for fuzzy translation>vs"
 
 #~ msgid "10 longest running tests took"
-#~ msgstr "最慢10个测试用了"
+#~ msgstr "<possible fragment for fuzzy translation>最慢10个测试用了"
 
 #~ msgid "All %d tests in %s completed ok in %s"
-#~ msgstr "%2$s中每%1$d个测试在%3$s结束了ok"
+#~ msgstr "<possible fragment for fuzzy translation>%2$s中每%1$d个测试在%3$s结束了ok"
 
 #~ msgid "Running test id %s"
-#~ msgstr "执行测试 id %s"
+#~ msgstr "<possible fragment for fuzzy translation>执行测试 id %s"
 
 #~ msgid "Test"
-#~ msgstr "测试"
+#~ msgstr "<possible fragment for fuzzy translation>测试"
 
 #~ msgid "Test id %s is not in increasing order"
-#~ msgstr "测试标识符 %s 不是递增的顺序"
+#~ msgstr "<possible fragment for fuzzy translation>测试标识符 %s 不是递增的顺序"
 
 #~ msgid "Test %s produced %d %ss but expected %d"
-#~ msgstr "测试 %s 生成了%d %ss 但预计生成 %d"
+#~ msgstr "<possible fragment for fuzzy translation>测试 %s 生成了%d %ss 但预计生成 %d"
 
 #~ msgid ""
 #~ "Test %s didn't produce the correct %s:\n"
 #~ "Expected: %s\n"
 #~ "Observed: %s"
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "测试 %s 没有生成正确的 %s:\n"
 #~ "预计生成：%s\n"
 #~ " 实际生成：%s "
 
 #~ msgid "Output captured before unexpected warning/error/message:"
-#~ msgstr "在意外的警告/错误/提示之前，输入已被记录："
+#~ msgstr "<possible fragment for fuzzy translation>在意外的警告/错误/提示之前，输入已被记录："
 
 #~ msgid ""
 #~ "Test %s did not produce the correct output:\n"
 #~ "Expected: <<%s>>\n"
 #~ "Observed <<%s>>"
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "测试 %s 没有生成正确的输入： \n"
 #~ "预计生成: <<%s>>\n"
 #~ "实际生成：<<%s>>"
@@ -4264,44 +4264,44 @@ msgstr[0] "索引(index): %s\n"
 #~ "Test %s produced output but should not have:\n"
 #~ "Expected absent (case insensitive): <<%s>>\n"
 #~ "Observed: <<%s>>"
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "测试 %s 生成输出但是不应当出现以下：\n"
 #~ "预计不存在（不区分大小写）: <<%s>>\n"
 #~ "实际生成：<<%s>>"
 
 #~ msgid "Test %s ran without errors but selfrefok(%s) is FALSE"
-#~ msgstr "测试 %s 可以无报错运行但是 selfrefok(%s) 是否："
+#~ msgstr "<possible fragment for fuzzy translation>测试 %s 可以无报错运行但是 selfrefok(%s) 是否："
 
 #~ msgid "Test %s ran without errors but failed check that x equals y:"
-#~ msgstr "测试 %s 可以无报错运行但是在检查 x 与 y 相同时候有报错："
+#~ msgstr "<possible fragment for fuzzy translation>测试 %s 可以无报错运行但是在检查 x 与 y 相同时候有报错："
 
 #~ msgid "First %d of %d (type '%s'):"
-#~ msgstr "第%d之%d (类型 '%s'):"
+#~ msgstr "<possible fragment for fuzzy translation>第%d之%d (类型 '%s'):"
 
 #~ msgid "make.names='"
-#~ msgstr "make.names='"
+#~ msgstr "<possible fragment for fuzzy translation>make.names='"
 
 #~ msgid "make.names="
-#~ msgstr "make.names="
+#~ msgstr "<possible fragment for fuzzy translation>make.names="
 
 #~ msgid "length(names) (="
-#~ msgstr "length(names) (="
+#~ msgstr "<possible fragment for fuzzy translation>length(names) (="
 
 #~ msgid ") (="
-#~ msgstr ") (="
+#~ msgstr "<possible fragment for fuzzy translation>) (="
 
 #~ msgid ")."
-#~ msgstr ")."
+#~ msgstr "<possible fragment for fuzzy translation>)."
 
 #~ msgid "Pattern"
-#~ msgstr "Pattern"
+#~ msgstr "<possible fragment for fuzzy translation>Pattern"
 
 #~ msgid "not found: ["
-#~ msgstr "未找到: ["
+#~ msgstr "<possible fragment for fuzzy translation>未找到: ["
 
 #~ msgid "%d variable not shown: %s\n"
 #~ msgid_plural "%d variables not shown: %s\n"
 #~ msgstr[0] "%d变量没显示: %s\n"
 
 #~ msgid "'target' and 'current' must both be data.tables"
-#~ msgstr "'target' 和 'current' 都必须是 data.table"
+#~ msgstr "<possible fragment for fuzzy translation>'target' 和 'current' 都必须是 data.table"

--- a/po/R-zh_CN.po
+++ b/po/R-zh_CN.po
@@ -141,7 +141,7 @@ msgstr ""
 msgid ""
 "'between' lower= and upper= are both POSIXct but have different tzone "
 "attributes: %s. Please align their time zones."
-msgstr ""
+msgstr "<fix fuzzy translation>"
 "'between' 中的 lower= 和 upper= 均为 POSIXct 类型但却有不同的时区属性"
 "（tzone）："
 
@@ -152,7 +152,7 @@ msgstr ""
 msgid ""
 "'between' arguments are all POSIXct but have mismatched tzone attributes: "
 "%s. The UTC times will be compared."
-msgstr "'between' 的参数均为 POSIXct 类型但时区属性（tzone）不匹配："
+msgstr "<fix fuzzy translation>'between' 的参数均为 POSIXct 类型但时区属性（tzone）不匹配："
 
 #: between.R:36
 #, c-format
@@ -450,7 +450,7 @@ msgstr ""
 #| "' is not found in calling scope. Looking in calling scope because you "
 #| "used the .. prefix."
 msgid "'%s' is not found in calling scope and it is not a column name either"
-msgstr "' 并没有存在于调用环境中。之所以在调用环境中寻找是因为你使用了..的前缀"
+msgstr "<fix fuzzy translation>' 并没有存在于调用环境中。之所以在调用环境中寻找是因为你使用了..的前缀"
 
 #: data.table.R:419
 #, c-format
@@ -520,7 +520,7 @@ msgstr "逻辑错误。当 i 并非一个 data.table时，不应提供'on'参数
 #, fuzzy, c-format
 #| msgid ". Expecting logical, integer or double."
 msgid "i has evaluated to type %s. Expecting logical, integer or double."
-msgstr "。期望布尔类型，整型或浮点型。"
+msgstr "<fix fuzzy translation>。期望布尔类型，整型或浮点型。"
 
 #: data.table.R:605
 #, c-format
@@ -825,7 +825,7 @@ msgstr ""
 #, fuzzy, c-format
 #| msgid "' not found in names of list"
 msgid "Internal error -- item '%s' not found in names of list"
-msgstr "' 未能在名称列表中找到"
+msgstr "<fix fuzzy translation>' 未能在名称列表中找到"
 
 #: data.table.R:1236 data.table.R:1249
 #, c-format
@@ -852,7 +852,7 @@ msgstr ""
 msgid ""
 "Variable '%s' is not found in calling scope. Looking in calling scope "
 "because this symbol was prefixed with .. in the j= parameter."
-msgstr ""
+msgstr "<fix fuzzy translation>"
 "' 未能在调用范围 (calling scope) 中找到，请查看调用范围因为  j= 的参数以 .. "
 "作为前缀"
 
@@ -955,7 +955,7 @@ msgstr ""
 #, fuzzy, c-format
 #| msgid "Internal error: jvnames is length"
 msgid "Internal error: jvnames is length %d but ans is %d and bynames is %d"
-msgstr "内部错误:jvnames 是长度"
+msgstr "<fix fuzzy translation>内部错误:jvnames 是长度"
 
 #: data.table.R:2020
 #, c-format
@@ -1062,7 +1062,7 @@ msgstr "data.tables没有rownames"
 #, fuzzy, c-format
 #| msgid "Can not cast an empty data.table"
 msgid "Can't assign %d names to a %d-column data.table"
-msgstr "无法转换一个空的data.table"
+msgstr "<fix fuzzy translation>无法转换一个空的data.table"
 
 #: data.table.R:2327
 #, c-format
@@ -1158,7 +1158,7 @@ msgstr "x有%d列，但其列名的长度为%d"
 #, fuzzy, c-format
 #| msgid "'. Needs to be type 'character'."
 msgid "Passed a vector of type '%s'. Needs to be type 'character'."
-msgstr ". 需要是 'character' 类型."
+msgstr "<fix fuzzy translation>. 需要是 'character' 类型."
 
 #: data.table.R:2638
 #, c-format
@@ -1179,7 +1179,7 @@ msgstr "在'old' 中存在重复名称: %s"
 #, fuzzy, c-format
 #| msgid "but should be integer, double or character"
 msgid "'old' is type %s but should be integer, double or character"
-msgstr "应该为整型,浮点型或者字符型"
+msgstr "<fix fuzzy translation>应该为整型,浮点型或者字符型"
 
 #: data.table.R:2644
 #, c-format
@@ -1200,7 +1200,7 @@ msgid ""
 "Item %d of 'old' is '%s' which appears several times in column names. Just "
 "the first will be changed. There are %d other items in 'old' that are also "
 "duplicated in column names."
-msgstr "在列名中重复出现,仅第一个会改动，如下:"
+msgstr "<fix fuzzy translation>在列名中重复出现,仅第一个会改动，如下:"
 
 #: data.table.R:2656
 #, fuzzy, c-format
@@ -1336,7 +1336,7 @@ msgid ""
 "Column %d is of POSIXlt type. Please convert it to POSIXct using as.POSIXct "
 "and run setDT again. We do not recommend use of POSIXlt at all because it "
 "uses 40 bytes to store one date."
-msgstr ""
+msgstr "<fix fuzzy translation>"
 "属于 POSIXlt 类型。请使用 as.POSIXct 转换为 POSIXct 并再次执行setDT。我们非常"
 "不推荐使用 POSIXlt 因为它要用 40 字节来存储一个日期。"
 
@@ -1365,7 +1365,7 @@ msgstr ""
 #, fuzzy, c-format
 #| msgid "' not found in names of input list"
 msgid "Item '%s' not found in names of input list"
-msgstr "' 不存在于输入列表的子项名中"
+msgstr "<fix fuzzy translation>' 不存在于输入列表的子项名中"
 
 #: data.table.R:2951 data.table.R:2976
 #, c-format
@@ -1412,7 +1412,7 @@ msgstr ""
 msgid ""
 "Found more than one operator in one 'on' statement: %s. Please specify a "
 "single operator."
-msgstr "在一个 'on' 语句中出现了多于一个的操作符（operator）："
+msgstr "<fix fuzzy translation>在一个 'on' 语句中出现了多于一个的操作符（operator）："
 
 #: data.table.R:3271
 #, fuzzy, c-format
@@ -1420,7 +1420,7 @@ msgstr "在一个 'on' 语句中出现了多于一个的操作符（operator）�
 msgid ""
 "'on' contains no column name: %s. Each 'on' clause must contain one or two "
 "column names."
-msgstr "。每个'on' 子句必须包含一个或两个列名。"
+msgstr "<fix fuzzy translation>。每个'on' 子句必须包含一个或两个列名。"
 
 #: data.table.R:3273
 #, fuzzy, c-format
@@ -1428,13 +1428,13 @@ msgstr "。每个'on' 子句必须包含一个或两个列名。"
 msgid ""
 "'on' contains more than 2 column names: %s. Each 'on' clause must contain "
 "one or two column names."
-msgstr "。每个'on' 子句必须包含一个或两个列名。"
+msgstr "<fix fuzzy translation>。每个'on' 子句必须包含一个或两个列名。"
 
 #: data.table.R:3278
 #, fuzzy, c-format
 #| msgid ". Only allowed operators are"
 msgid "Invalid join operators %s. Only allowed operators are %s."
-msgstr "。只有这些操作符是有效的"
+msgstr "<fix fuzzy translation>。只有这些操作符是有效的"
 
 #: devel.R:16
 #, c-format
@@ -1618,7 +1618,7 @@ msgstr "<needs translation>"
 #| msgid ""
 #| "Argument 'by' must be a character vector of column names used in grouping."
 msgid "cols must be a character vector of column names"
-msgstr "'by' 参数必须是一个字符向量，向量的元素是列名，用于分组。"
+msgstr "<fix fuzzy translation>'by' 参数必须是一个字符向量，向量的元素是列名，用于分组。"
 
 #: fmelt.R:88
 #, c-format
@@ -1639,7 +1639,7 @@ msgstr "<needs translation>"
 #, fuzzy, c-format
 #| msgid "but must be character."
 msgid "pattern must be character string"
-msgstr "但必须是字符."
+msgstr "<fix fuzzy translation>但必须是字符."
 
 #: fmelt.R:111
 #, c-format
@@ -1658,7 +1658,7 @@ msgstr "<needs translation>"
 #, fuzzy, c-format
 #| msgid "but must be character."
 msgid "sep must be character string"
-msgstr "但必须是字符."
+msgstr "<fix fuzzy translation>但必须是字符."
 
 #: fmelt.R:129
 #, c-format
@@ -1816,7 +1816,7 @@ msgstr "'by.y'应该是具有列名或者数字非空向量"
 msgid ""
 "The first %d columns of y's key must be identical to the columns specified "
 "in by.y."
-msgstr "在'by.y'中，y键(key)的列必须与指定的列相同"
+msgstr "<fix fuzzy translation>在'by.y'中，y键(key)的列必须与指定的列相同"
 
 #: foverlaps.R:42
 #, c-format
@@ -1970,7 +1970,7 @@ msgstr "参数 'encoding' 必须为 'unknown', 'UTF-8' 或 'Latin-1'."
 #, fuzzy, c-format
 #| msgid "but must be character."
 msgid "'text=' is type %s but must be character."
-msgstr "但必须是字符."
+msgstr "<fix fuzzy translation>但必须是字符."
 
 #: fread.R:53
 #, c-format
@@ -2279,7 +2279,7 @@ msgstr "x 的类将强制从 matrix 转变为 data.table"
 msgid ""
 "If you intended to overwrite the file at %s with an empty one, please use "
 "file.remove first."
-msgstr "为空文件，请先使用 file.remove。"
+msgstr "<fix fuzzy translation>为空文件，请先使用 file.remove。"
 
 #: fwrite.R:80
 #, c-format
@@ -2431,13 +2431,13 @@ msgstr "参数 'no.dups' 应为逻辑值 TRUE 或 FALSE"
 #, fuzzy, c-format
 #| msgid "Input data.table must not contain duplicate column names."
 msgid "Neither of the input data.tables to join have columns."
-msgstr "作为输入的 data.table 对象不能含有重复的列名。"
+msgstr "<fix fuzzy translation>作为输入的 data.table 对象不能含有重复的列名。"
 
 #: merge.R:20 merge.R:22
 #, fuzzy, c-format
 #| msgid "Input data.table must not contain duplicate column names."
 msgid "Input data.table '%s' has no columns."
-msgstr "作为输入的 data.table 对象不能含有重复的列名。"
+msgstr "<fix fuzzy translation>作为输入的 data.table 对象不能含有重复的列名。"
 
 #: merge.R:31
 #, c-format
@@ -2628,7 +2628,7 @@ msgstr ""
 msgid ""
 "This is R %s but data.table has been installed using R %s. The major version "
 "must match. Please reinstall data.table."
-msgstr "。主要的版本必须匹配。 请重新安装data.table"
+msgstr "<fix fuzzy translation>。主要的版本必须匹配。 请重新安装data.table"
 
 #: onLoad.R:95
 #, c-format
@@ -2822,7 +2822,7 @@ msgstr "x包含一个叫做'.xi'的列。这与data.table中使用的内部名�
 msgid ""
 "Column '%s' is type '%s' which is not supported as a key column type, "
 "currently."
-msgstr "目前不是一种被支持的键(key)列类型"
+msgstr "<fix fuzzy translation>目前不是一种被支持的键(key)列类型"
 
 #: setkey.R:78 setkey.R:287
 #, c-format
@@ -2835,7 +2835,7 @@ msgstr "内部错误： 目前在setkey中，'cols'应该是字符类型, 请报
 #, fuzzy, c-format
 #| msgid "Internal error: byindex not the index name"
 msgid "Internal error: index '%s' exists but is invalid"
-msgstr "内部错误 : byindex 不是索引(index)名称"
+msgstr "<fix fuzzy translation>内部错误 : byindex 不是索引(index)名称"
 
 #: setkey.R:157
 #, c-format
@@ -2920,7 +2920,7 @@ msgstr ""
 #, fuzzy, c-format
 #| msgid "' which is not supported for ordering currently."
 msgid "Column '%s' is type '%s' which is not supported for ordering currently."
-msgstr "'，该类型目前尚不支持排序。"
+msgstr "<fix fuzzy translation>'，该类型目前尚不支持排序。"
 
 #: setkey.R:329
 #, fuzzy, c-format
@@ -2999,7 +2999,7 @@ msgstr "找到不支持的列类型在 x 或 y: %s"
 #, fuzzy, c-format
 #| msgid "' but the corresponding item of y is '"
 msgid "Item %d of x is '%s' but the corresponding item of y is '%s'."
-msgstr "' 然而 y 中对应的项是：'"
+msgstr "<fix fuzzy translation>' 然而 y 中对应的项是：'"
 
 #: setops.R:55
 #, c-format

--- a/po/R-zh_CN.po
+++ b/po/R-zh_CN.po
@@ -54,10 +54,9 @@ msgstr ""
 "内部错误 -- 不能与IDate类型中减去'difftime'对象但是正确操作应该防止此行为发生"
 
 #: IDateTime.R:309
-#, fuzzy, c-format
-#| msgid "Valid options for ms are 'truncate',"
+#, c-format
 msgid "Valid options for ms are 'truncate', 'nearest', and 'ceil'."
-msgstr "'ms'有效的选项为'truncate'"
+msgstr "'ms'有效的选项为'truncate', 'nearest', 或 'ceil'."
 
 #: as.data.table.R:86
 #, c-format
@@ -90,12 +89,10 @@ msgid "Please provide either 'key' or 'sorted', but not both."
 msgstr "请提供参数'key'或'sorted',但不可同时提供"
 
 #: as.data.table.R:108
-#, fuzzy, c-format
-#| msgid ""
-#| "Argument 'value.name' should not overlap with column names in result:"
+#, c-format
 msgid ""
 "Argument 'value.name' should not overlap with column names in result: %s"
-msgstr "参数'value.name'不能与结果中已有列名重复"
+msgstr "参数'value.name'不能与结果中已有列名重复: %s"
 
 #: as.data.table.R:140
 #, c-format
@@ -128,16 +125,13 @@ msgid "between has been passed an argument x of type logical"
 msgstr "传入 between 的参数 x 为逻辑（logical）型"
 
 #: between.R:13 between.R:15
-#, fuzzy, c-format
-#| msgid ""
-#| "'between' function the 'x' argument is a POSIX class while 'lower' was "
-#| "not, coercion to POSIX failed with:"
+#, c-format
 msgid ""
 "'between' function the 'x' argument is a POSIX class while '%s' was not, "
 "coercion to POSIX failed with: %s"
 msgstr ""
 "'between' 中的 'x' 参数为 POSIX 类，而 'lower' 并不是，将 'lower' 自动转换成 "
-"POSIX 失败："
+"POSIX 失败：%s"
 
 #: between.R:27
 #, fuzzy, c-format
@@ -244,34 +238,29 @@ msgid "key argument of data.table() must be character"
 msgstr "data.table() 的key参数必须是字符"
 
 #: data.table.R:132
-#, fuzzy, c-format
-#| msgid "' not found. Perhaps you intended"
+#, c-format
 msgid "Object '%s' not found. Perhaps you intended %s"
-msgstr "' 不存在， 可能你打算"
+msgstr "对象 '%s' 不存在， 可能你打算 %s"
 
 #: data.table.R:134
-#, fuzzy, c-format
-#| msgid "' not found amongst"
+#, c-format
 msgid "Object '%s' not found amongst %s"
-msgstr "' 不存在"
+msgstr "%2$s 中对象 '%1$s' 不存在"
 
 #: data.table.R:157
-#, fuzzy, c-format
-#| msgid "rollends must be a logical vector"
+#, c-format
 msgid "verbose must be logical or integer"
-msgstr "rollends必须是一个逻辑向量"
+msgstr "verbose必须是一个逻辑向量"
 
 #: data.table.R:158
-#, fuzzy, c-format
-#| msgid "rollends must be length 1 or 2"
+#, c-format
 msgid "verbose must be length 1 non-NA"
-msgstr "rollends 的长度必须是 1 或者 2"
+msgstr "verbose 的长度必须是 1 和不NA"
 
 #: data.table.R:166
-#, fuzzy, c-format
-#| msgid "Ignoring keyby= because j= is not supplied"
+#, c-format
 msgid "Ignoring by/keyby because 'j' is not supplied"
-msgstr "因为没有提供 j= ，所以忽略 keyby= "
+msgstr "因为没有提供 j= ，所以忽略 by/keyby"
 
 #: data.table.R:180
 #, c-format
@@ -279,18 +268,14 @@ msgid "When by and keyby are both provided, keyby must be TRUE or FALSE"
 msgstr ""
 
 #: data.table.R:192
-#, fuzzy, c-format
-#| msgid ""
-#| "When on= is provided but not i=, on= must be a named list or data.table|"
-#| "frame, and a natural join (i.e. join on common names) is invoked. "
-#| "Ignoring on= which is '"
+#, c-format
 msgid ""
 "When on= is provided but not i=, on= must be a named list or data.table|"
 "frame, and a natural join (i.e. join on common names) is invoked. Ignoring "
 "on= which is '%s'."
 msgstr ""
 "当提供 on= 而不提供 i= 的时候， on= 必须是带名称的 list 或者 data.table 或者 "
-"data.frame，并且会调用自然联结（例如，按照共有名称联结），忽略 on= "
+"data.frame，并且会调用自然联结（例如，按照共有名称联结），忽略 on= %s"
 
 #: data.table.R:205
 #, c-format
@@ -314,10 +299,9 @@ msgstr ""
 "+Inf ， -Inf 或 'nearest'"
 
 #: data.table.R:213
-#, fuzzy, c-format
-#| msgid "' (type character). Only valid character value is 'nearest'."
+#, c-format
 msgid "roll is '%s' (type character). Only valid character value is 'nearest'."
-msgstr "'(字符类型)。 唯一有效的字符值是'nearest'。"
+msgstr "roll 是 '%s'(字符类型)。 唯一有效的字符值是'nearest'。"
 
 #: data.table.R:218
 #, c-format
@@ -330,14 +314,11 @@ msgid "rollends must be length 1 or 2"
 msgstr "rollends 的长度必须是 1 或者 2"
 
 #: data.table.R:227
-#, fuzzy, c-format
-#| msgid ""
-#| "nomatch= must be either NA or NULL (or 0 for backwards compatibility "
-#| "which is the same as NULL)"
+#, c-format
 msgid ""
 "nomatch= must be either NA or NULL (or 0 for backwards compatibility which "
 "is the same as NULL but please use NULL)"
-msgstr "nomatch= 必须是 NA 或 NULL (或者在向后兼容的情形下为 0，这等同于 NULL)"
+msgstr "nomatch= 必须是 NA 或 NULL (或者在向后兼容的情形下为 0，这等同于 NULL但是请用 NULL)"
 
 #: data.table.R:230
 #, c-format
@@ -345,28 +326,22 @@ msgid "which= must be a logical vector length 1. Either FALSE, TRUE or NA."
 msgstr "which= 必须是一个长度为 1 的逻辑向量。其取值为 FALSE，TRUE 或者 NA。"
 
 #: data.table.R:231
-#, fuzzy, c-format
-#| msgid ""
-#| "(meaning return row numbers) but j is also supplied. Either you need row "
-#| "numbers or the result of j, but only one type of result can be returned."
+#, c-format
 msgid ""
 "which==%s (meaning return row numbers) but j is also supplied. Either you "
 "need row numbers or the result of j, but only one type of result can be "
 "returned."
 msgstr ""
-"(表示行数会被返回) 但是 j 也被提供了。你可能需要行数或者是 j 的结果，但是只能"
+"which==%s (表示行数会被返回) 但是 j 也被提供了。你可能需要行数或者是 j 的结果，但是只能"
 "返回一种结果。"
 
 #: data.table.R:232
-#, fuzzy, c-format
-#| msgid ""
-#| "which=NA with nomatch=0 would always return an empty vector. Please "
-#| "change or remove either which or nomatch."
+#, c-format
 msgid ""
 "which=NA with nomatch=0|NULL would always return an empty vector. Please "
 "change or remove either which or nomatch."
 msgstr ""
-"同时使用 which=NA 和 nomatch=0 会得到一个空向量。请改变或者是移除 which或 "
+"同时使用 which=NA 和 nomatch=0或NULL 会得到一个空向量。请改变或者是移除 which或 "
 "nomatch 的取值"
 
 #: data.table.R:233
@@ -382,24 +357,18 @@ msgid ""
 msgstr "符号 .. 是无效的。前缀 .. 之后必须要有至少一个字符"
 
 #: data.table.R:276
-#, fuzzy, c-format
-#| msgid ""
-#| "' does exist in calling scope though, so please just removed the .. "
-#| "prefix from that variable name in calling scope."
+#, c-format
 msgid ""
 "Variable '..%s' does exist in calling scope though, so please just removed "
 "the .. prefix from that variable name in calling scope."
-msgstr "' 并不存在于调用环境中。所以请移除在调用环境中那个变量名字的..前缀"
+msgstr "变量 '%s' 并不存在于调用环境中。所以请移除在调用环境中那个变量名字的..前缀"
 
 #: data.table.R:280
-#, fuzzy, c-format
-#| msgid ""
-#| "' is not found in calling scope. Looking in calling scope because you "
-#| "used the .. prefix."
+#, c-format
 msgid ""
 "Variable '%s' is not found in calling scope. Looking in calling scope "
 "because you used the .. prefix.%s"
-msgstr "' 并没有存在于调用环境中。之所以在调用环境中寻找是因为你使用了..的前缀"
+msgstr "变量 '%s' 并没有存在于调用环境中。之所以在调用环境中寻找是因为你使用了..的前缀.%s"
 
 #: data.table.R:282
 #, fuzzy, c-format
@@ -418,16 +387,13 @@ msgid ""
 msgstr "内部错误: DT[, ..var]应该被分支处理中。"
 
 #: data.table.R:290
-#, fuzzy, c-format
-#| msgid ""
-#| "' is not found in calling scope. Looking in calling scope because you set "
-#| "with=FALSE. Also, please use .. symbol prefix and remove with=FALSE."
+#, c-format
 msgid ""
 "Variable '%s' is not found in calling scope. Looking in calling scope "
 "because you set with=FALSE. Also, please use .. symbol prefix and remove "
 "with=FALSE."
 msgstr ""
-"' 并没有存在于调用环境中。之所以在调用环境中搜索是因为你使用了with=FALSE。请"
+"变量 '%s' 并没有存在于调用环境中。之所以在调用环境中搜索是因为你使用了with=FALSE。请"
 "使用 .. 符号前缀并且移除 with=FALSE。"
 
 #: data.table.R:298
@@ -496,15 +462,12 @@ msgid ""
 msgstr ""
 
 #: data.table.R:422
-#, fuzzy, c-format
-#| msgid ""
-#| "When the first argument inside DT[...] is a single symbol (e.g. DT[var]), "
-#| "data.table looks for var in calling scope."
+#, c-format
 msgid ""
 "%s. When the first argument inside DT[...] is a single symbol (e.g. "
 "DT[var]), data.table looks for var in calling scope."
 msgstr ""
-"当DT[...]的第一个参数是一个单个的符号(e.g. DT[var])，data.table会在调用环境中"
+"%s。 当DT[...]的第一个参数是一个单个的符号(e.g. DT[var])，data.table会在调用环境中"
 "搜寻var。"
 
 #: data.table.R:434
@@ -612,16 +575,14 @@ msgstr ""
 "当使用 :=. 的时候，with=FALSE 是多余的，会被忽略。输入 ?':=' 参看例子。"
 
 #: data.table.R:726
-#, fuzzy, c-format
-#| msgid "column(s) not removed because not found:"
+#, c-format
 msgid "column(s) not removed because not found: %s"
-msgstr "列未被删除因为不存在："
+msgstr "列未被删除因为不存在：%s"
 
 #: data.table.R:740
-#, fuzzy, c-format
-#| msgid "column(s) not found:"
+#, c-format
 msgid "column(s) not found: %s"
-msgstr "列不存在"
+msgstr "列不存在: %s"
 
 #: data.table.R:746
 #, fuzzy, c-format
@@ -712,24 +673,19 @@ msgid ""
 msgstr ""
 
 #: data.table.R:906
-#, fuzzy, c-format
-#| msgid ""
-#| "The items in the 'by' or 'keyby' list are length(s) (%s). Each must be "
-#| "length %d; the same length as there are rows in x (after subsetting if i "
-#| "is provided)."
+#, c-format
 msgid ""
 "The items in the 'by' or 'keyby' list are length(s) %s. Each must be length "
 "%d; the same length as there are rows in x (after subsetting if i is "
 "provided)."
 msgstr ""
-"在'by'或'keyby'列表中的项长度为 %s。每一项的长度须均为%d，即应与 x （或经 i "
+"在'by'或'keyby'列表中的项长度为 %s (%s)。每一项的长度须均为%d，即应与 x （或经 i "
 "筛选后的子集）中所包含行数相同。"
 
 #: data.table.R:940
-#, fuzzy, c-format
-#| msgid "Internal error: drop_dot passed"
+#, c-format
 msgid "Internal error: drop_dot passed %d items"
-msgstr "内部错误：drop_dot 传入的参数有"
+msgstr "内部错误：drop_dot 传入的参数有 %d"
 
 #: data.table.R:959
 #, c-format
@@ -756,24 +712,19 @@ msgid ""
 msgstr ""
 
 #: data.table.R:1030
-#, fuzzy, c-format
-#| msgid ""
-#| "When .SDcols is a function, it is applied to each column; the output of "
-#| "this function must be a non-missing boolean scalar signalling inclusion/"
-#| "exclusion of the column. However, these conditions were not met for:"
+#, c-format
 msgid ""
 "When .SDcols is a function, it is applied to each column; the output of this "
 "function must be a non-missing boolean scalar signalling inclusion/exclusion "
 "of the column. However, these conditions were not met for: %s"
 msgstr ""
 "当传入 .SDcols 的参数为一个方程时，该方程将应用于每一列，并须返回单个非缺失值"
-"的布尔值指示该列是否应当被包含/排除。然而上述条件对如下列并不满足："
+"的布尔值指示该列是否应当被包含/排除。然而上述条件对如下列并不满足：%s"
 
 #: data.table.R:1036
-#, fuzzy, c-format
-#| msgid ".SDcols missing at the following indices:"
+#, c-format
 msgid ".SDcols missing at the following indices: %s"
-msgstr ".SDcols 的如下位置为缺失值："
+msgstr ".SDcols 的如下位置为缺失值：%s"
 
 #: data.table.R:1038
 #, c-format
@@ -786,10 +737,9 @@ msgid ".SDcols is numeric but has both +ve and -ve indices"
 msgstr ".SDcols 为数值，但同时具有 +ve 和 -ve 索引"
 
 #: data.table.R:1046
-#, fuzzy, c-format
-#| msgid ".SDcols is numeric but out of bounds [1,"
+#, c-format
 msgid ".SDcols is numeric but out of bounds [1, %d] at: %s"
-msgstr ".SDcols 为数值但超出了 [1,"
+msgstr ".SDcols 为数值但在 %2$s 超出了 [1, %1$d]"
 
 #: data.table.R:1050
 #, c-format
@@ -797,10 +747,9 @@ msgid ".SDcols should be column numbers or names"
 msgstr ".SDcols 应为列数或是列名"
 
 #: data.table.R:1052
-#, fuzzy, c-format
-#| msgid "Some items of .SDcols are not column names:"
+#, c-format
 msgid "Some items of .SDcols are not column names: %s"
-msgstr ".SDcols 中的部份项目不是列名:"
+msgstr ".SDcols 中的部份项目不是列名: %s"
 
 #: data.table.R:1094
 #, c-format
@@ -820,11 +769,9 @@ msgstr ""
 "以供未来使用请直接在 j 中使用 := 依照引用进行分组修改"
 
 #: data.table.R:1118 data.table.R:1130
-#, fuzzy, c-format
-#| msgid ""
-#| "In `:=`(col1=val1, col2=val2, ...) form, all arguments must be named."
+#, c-format
 msgid "In %s(col1=val1, col2=val2, ...) form, all arguments must be named."
-msgstr "在`:=`(col1=val1, col2=val2, ...) 中，所有参数必须被指名"
+msgstr "在 %s(col1=val1, col2=val2, ...) 中，所有参数必须被指名"
 
 #: data.table.R:1135
 #, c-format
@@ -866,16 +813,13 @@ msgstr ""
 "于修复根本原因或改进本讯息"
 
 #: data.table.R:1205
-#, fuzzy, c-format
-#| msgid ""
-#| "Cannot assign to an under-allocated recursively indexed list -- L[[i]][,:"
-#| "=] syntax is only valid when i is length 1, but it's length"
+#, c-format
 msgid ""
 "Cannot assign to an under-allocated recursively indexed list -- L[[i]][,:=] "
 "syntax is only valid when i is length 1, but its length is %d"
 msgstr ""
 "无法指定配置不足的递归索引列表-- L[[i]][,:=] 语法只有在 i 长度为1时有效，但它"
-"的長度"
+"的長度是 %d"
 
 #: data.table.R:1207
 #, fuzzy, c-format
@@ -884,10 +828,9 @@ msgid "Internal error -- item '%s' not found in names of list"
 msgstr "' 未能在名称列表中找到"
 
 #: data.table.R:1236 data.table.R:1249
-#, fuzzy, c-format
-#| msgid "Internal error -- column(s) not found:"
+#, c-format
 msgid "Internal error -- column(s) not found: %s"
-msgstr "内部错误 -- 找不到此列:"
+msgstr "内部错误 -- 找不到此列: %s"
 
 #: data.table.R:1261
 #, c-format
@@ -914,10 +857,9 @@ msgstr ""
 "作为前缀"
 
 #: data.table.R:1290
-#, fuzzy, c-format
-#| msgid "Internal error: xcolAns does not pass checks:"
+#, c-format
 msgid "Internal error: xcolAns does not pass checks: %d/%d/%d/%s"
-msgstr "内部错误 : xcolAns 无法通过检查:"
+msgstr "内部错误 : xcolAns 无法通过检查: %d/%d/%d/%s"
 
 #: data.table.R:1300
 #, c-format
@@ -1021,14 +963,11 @@ msgid "rownames and rownames.value cannot both be used at the same time"
 msgstr "rownames和rownames.value 不能同时使用"
 
 #: data.table.R:2025
-#, fuzzy, c-format
-#| msgid ""
-#| ". The rownames argument specifies a single column name or number. "
-#| "Consider rownames.value= instead."
+#, c-format
 msgid ""
 "length(rownames)==%d but nrow(DT)==%d. The rownames argument specifies a "
 "single column name or number. Consider rownames.value= instead."
-msgstr "。 rownames参数为单一列名或单一数值。请考虑使用`rownames.values=`。"
+msgstr "length(rownames)==%d 但 nrow(DT)==%d。 rownames参数为单一列名或单一数值。请考虑使用`rownames.values=`。"
 
 #: data.table.R:2029
 #, c-format
@@ -1046,24 +985,21 @@ msgid ""
 msgstr "rownames是TRUE但键(key)不只一个列"
 
 #: data.table.R:2043
-#, fuzzy, c-format
-#| msgid "' is not a column of x"
+#, c-format
 msgid "'%s' is not a column of x"
-msgstr "' 不是x的一个列"
+msgstr "'%s' 不是x的一个列"
 
 #: data.table.R:2049
-#, fuzzy, c-format
-#| msgid "which is outside the column number range [1,ncol="
+#, c-format
 msgid ""
 "as.integer(rownames)==%d which is outside the column number range [1,"
 "ncol=%d]."
-msgstr "不在列索引范围内 [1,ncol="
+msgstr "as.integer(rownames)==%d 不在列索引范围内 [1,ncol%d]。"
 
 #: data.table.R:2054
-#, fuzzy, c-format
-#| msgid "length(rownames.value)=="
+#, c-format
 msgid "length(rownames.value)==%d but should be nrow(x)==%d"
-msgstr "length(rownames.value)=="
+msgstr "length(rownames.value)==%d 但应该是 nrow(x)==%d"
 
 #: data.table.R:2116
 #, c-format
@@ -1178,26 +1114,20 @@ msgid "Argument 'by' must refer to column names in x"
 msgstr "参数 'by' 只适用于 x 中的列名"
 
 #: data.table.R:2427
-#, fuzzy, c-format
-#| msgid ""
-#| "Argument 'by' must refer only to atomic-type columns, but the following "
-#| "columns are non-atomic:"
+#, c-format
 msgid ""
 "Argument 'by' must refer only to atomic-type columns, but the following "
 "columns are non-atomic: %s"
-msgstr "参数 'by' 只适用于原子类型的纵列，但现在关联的纵列不是原子类型"
+msgstr "参数 'by' 只适用于原子类型的纵列，但现在关联的纵列不是原子类型: %s"
 
 #: data.table.R:2557
-#, fuzzy, c-format
-#| msgid ""
-#| "x is not a data.table. Shallow copy is a copy of the vector of column "
-#| "pointers (only), so is only meaningful for data.table"
+#, c-format
 msgid ""
 "x is not a data.table|frame. Shallow copy is a copy of the vector of column "
 "pointers (only), so is only meaningful for data.table|frame"
 msgstr ""
-"浅拷贝（shallow copy）只是列指针向量的拷贝，因此仅对 data.table 有意义，而 x "
-"不是 data.table"
+"浅拷贝（shallow copy）只是列指针向量的拷贝，因此仅对 data.table或data.frame 有意义，而 x "
+"不是 data.table或data.frame"
 
 #: data.table.R:2566
 #, c-format
@@ -1220,10 +1150,9 @@ msgid "x is not a data.table or data.frame"
 msgstr "x 不是 data.table 或 data.frame."
 
 #: data.table.R:2618
-#, fuzzy, c-format
-#| msgid "columns but its names are length"
+#, c-format
 msgid "x has %d columns but its names are length %d"
-msgstr " 列，但其列名的数为 "
+msgstr "x有%d列，但其列名的长度为%d"
 
 #: data.table.R:2625
 #, fuzzy, c-format
@@ -1237,16 +1166,14 @@ msgid "'new' is not a character vector or a function"
 msgstr "'new' 既不是特征向量也不是 function"
 
 #: data.table.R:2640
-#, fuzzy, c-format
-#| msgid "NA in 'new' at positions"
+#, c-format
 msgid "NA in 'new' at positions %s"
-msgstr "在 'new' 中有NA值"
+msgstr "在 'new' 中有NA值 %s"
 
 #: data.table.R:2641
-#, fuzzy, c-format
-#| msgid "Some duplicates exist in 'old':"
+#, c-format
 msgid "Some duplicates exist in 'old': %s"
-msgstr "在'old' 中存在重复名称"
+msgstr "在'old' 中存在重复名称: %s"
 
 #: data.table.R:2643
 #, fuzzy, c-format
@@ -1255,16 +1182,14 @@ msgid "'old' is type %s but should be integer, double or character"
 msgstr "应该为整型,浮点型或者字符型"
 
 #: data.table.R:2644
-#, fuzzy, c-format
-#| msgid "but 'new' is length"
+#, c-format
 msgid "'old' is length %d but 'new' is length %d"
-msgstr "'new' 的长度为"
+msgstr "'old' 长度为 %d 但 'new' 的长度为 %d"
 
 #: data.table.R:2645
-#, fuzzy, c-format
-#| msgid "NA (or out of bounds) in 'old' at positions"
+#, c-format
 msgid "NA (or out of bounds) in 'old' at positions %s"
-msgstr "NA(或超出界限)出现在'old' 的位置"
+msgstr "NA(或超出界限)出现在'old' 的位置 %s"
 
 #: data.table.R:2648
 #, fuzzy, c-format
@@ -1298,10 +1223,9 @@ msgid ""
 msgstr "请移除或者重命名重复项并重试"
 
 #: data.table.R:2697
-#, fuzzy, c-format
-#| msgid "Provide either by= or keyby= but not both"
+#, c-format
 msgid "Provide either before= or after= but not both"
-msgstr "提供 by= 或 keyby= ，但两者不能同时存在"
+msgstr "提供 before= 或 after= ，但两者不能同时存在"
 
 #: data.table.R:2699
 #, c-format
@@ -1309,10 +1233,9 @@ msgid "before=/after= accept a single column name or number, not more than one"
 msgstr ""
 
 #: data.table.R:2754
-#, fuzzy, c-format
-#| msgid "but should be a plain list of items to be stacked"
+#, c-format
 msgid "Input is %s but should be a plain list of items to be stacked"
-msgstr "应该叠加普通列表项"
+msgstr "项是 %s 但应该叠加普通列表项"
 
 #: data.table.R:2758
 #, c-format
@@ -1338,15 +1261,12 @@ msgstr ""
 "用表示默认模式详见 ?rbindlist"
 
 #: data.table.R:2780
-#, fuzzy, c-format
-#| msgid ""
-#| "Check that is.data.table(DT) == TRUE. Otherwise, := and `:=`(...) are "
-#| "defined for use in j, once only and in particular ways. See help(\":=\")."
+#, c-format
 msgid ""
 "Check that is.data.table(DT) == TRUE. Otherwise, :=, `:=`(...) and let(...) "
 "are defined for use in j, once only and in particular ways. See help(\":=\")."
 msgstr ""
-"检查是否is.data.table(DT) == TRUE,否则,:= and `:=`(...) 为被界定在j使用，仅一"
+"检查是否is.data.table(DT) == TRUE,否则,:=, `:=`(...), 和 let(...) 为被界定在j使用，仅一"
 "次以特别的方式使用,详见help(\":=\")"
 
 #: data.table.R:2786
@@ -1361,10 +1281,9 @@ msgid "rownames contains duplicates"
 msgstr "行名含有重复"
 
 #: data.table.R:2794 data.table.R:2805 data.table.R:2828
-#, fuzzy, c-format
-#| msgid "rownames incorrect length; expected"
+#, c-format
 msgid "rownames incorrect length; expected %d names, got %d"
-msgstr "行名长度不正确;需要"
+msgstr "行名长度不正确;需要 %d 名 受到 %d"
 
 #: data.table.R:2813
 #, c-format
@@ -1372,10 +1291,9 @@ msgid "All elements in argument 'x' to 'setDF' must be of same length"
 msgstr "'setDF'中的参数'x'的所有元素必须同等长度"
 
 #: data.table.R:2842
-#, fuzzy, c-format
-#| msgid "Cannot find symbol"
+#, c-format
 msgid "Cannot find symbol %s"
-msgstr "无法找到符号"
+msgstr "无法找到符号 %s"
 
 #: data.table.R:2849
 #, fuzzy, c-format

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -477,7 +477,7 @@ msgstr ""
 #: assign.c:690
 #, c-format
 msgid "target vector"
-msgstr ""
+msgstr "<needs translation>"
 
 #: assign.c:690
 #, fuzzy, c-format
@@ -1485,20 +1485,20 @@ msgstr "'variable.name' 必须是长度1的字符/整数向量。"
 msgid ""
 "variable_table attribute of measure.vars should be a data table with at "
 "least one column"
-msgstr ""
+msgstr "<needs translation>"
 
 #: fmelt.c:373
 #, c-format
 msgid ""
 "variable_table attribute of measure.vars should be a data table with same "
 "number of rows as max length of measure.vars vectors =%d"
-msgstr ""
+msgstr "<needs translation>"
 
 #: fmelt.c:377
 msgid ""
 "variable_table attribute of measure.vars should be either NULL or a data "
 "table"
-msgstr ""
+msgstr "<needs translation>"
 
 #: fmelt.c:394
 msgid ""
@@ -2735,11 +2735,11 @@ msgstr "内部错误：coalesce.c 中 'inplaceArg' 参数必须为 TRUE 或 FALS
 #: freadR.c:92
 #, c-format
 msgid "freadR.c has been passed a filename: %s\n"
-msgstr ""
+msgstr "<needs translation>"
 
 #: freadR.c:96
 msgid "freadR.c has been passed the data as text input (not a filename)\n"
-msgstr ""
+msgstr "<needs translation>"
 
 #: freadR.c:102
 msgid ""
@@ -3250,7 +3250,7 @@ msgstr "%zu 通过排除0和1的counts\n"
 msgid ""
 "OpenMP %d did not assign threads to iterations monotonically. Please search "
 "Stack Overflow for this message."
-msgstr ""
+msgstr "<needs translation>"
 
 #: fsort.c:317
 msgid "Unable to allocate working memory"
@@ -3331,7 +3331,7 @@ msgid ""
 "Compression in fwrite uses zlib library. Its header files were not found at "
 "the time data.table was compiled. To enable fwrite compression, please "
 "reinstall data.table and study the output for further guidance."
-msgstr ""
+msgstr "<needs translation>"
 
 #: fwrite.c:704
 #, c-format
@@ -3384,7 +3384,7 @@ msgstr ""
 #: fwrite.c:814
 #, c-format
 msgid "zbuffSize=%d returned from deflateBound\n"
-msgstr ""
+msgstr "<needs translation>"
 
 #: fwrite.c:823
 #, c-format
@@ -3476,7 +3476,7 @@ msgstr "列%d的类型是'%s' - 尚未在fwrite中实施"
 msgid ""
 "input has specific integer rownames but their length (%<PRId64>) != nrow "
 "(%<PRId64>)"
-msgstr ""
+msgstr "<needs translation>"
 
 #: fwriteR.c:282
 msgid ""
@@ -3671,7 +3671,7 @@ msgstr "内部错误：chin 和 chmatchdup 不能同时为真"
 #: gsumm.c:965
 #, c-format
 msgid "Internal error: unanticipated case in gfirstlast first=%d w=%d headw=%d"
-msgstr ""
+msgstr "<needs translation>"
 
 #: gsumm.c:979
 #, fuzzy, c-format
@@ -3874,7 +3874,7 @@ msgstr "指针是%zu个字节，大于8。我们尚未在大于64位的任何体
 
 #: init.c:177
 msgid "... failed. Please forward this message to maintainer('data.table')."
-msgstr ""
+msgstr "<needs translation>"
 
 #: init.c:178
 #, c-format
@@ -4041,7 +4041,7 @@ msgstr "安装的data.table并不是获得OpenMP支持的编译\n"
 #: openmp-utils.c:84
 #, c-format
 msgid "  OpenMP version (_OPENMP)       %d\n"
-msgstr ""
+msgstr "<needs translation>"
 
 #: openmp-utils.c:89
 #, c-format
@@ -4129,7 +4129,7 @@ msgid ""
 "be 'symbol' type when substituting name of the call argument, functions 'as."
 "name' and 'I' can be used to work out proper substitution, see ?substitute2 "
 "examples."
-msgstr ""
+msgstr "<needs translation>"
 
 #: rbindlist.c:8
 msgid "fill= should be TRUE or FALSE"
@@ -4409,7 +4409,7 @@ msgstr "内部错误: setcolorder读取到的dt有 %d 列但是有 %d 个名字�
 msgid ""
 "shift input must not be matrix or array, consider wrapping it into data."
 "table() or c()"
-msgstr ""
+msgstr "<needs translation>"
 
 #: shift.c:17
 #, c-format
@@ -4694,26 +4694,26 @@ msgstr "x不是一个逻辑向量"
 
 #: utils.c:360
 msgid "'x' must not be matrix or array"
-msgstr ""
+msgstr "<needs translation>"
 
 #: utils.c:362
 msgid "input must not be matrix or array"
-msgstr ""
+msgstr "<needs translation>"
 
 #: utils.c:366
 #, c-format
 msgid "copy=false and input already of expected type and class %s[%s]\n"
-msgstr ""
+msgstr "<needs translation>"
 
 #: utils.c:373
 #, c-format
 msgid "Coercing %s[%s] into %s[%s]\n"
-msgstr ""
+msgstr "<needs translation>"
 
 #: utils.c:389
 #, c-format
 msgid "zlib header files were not found when data.table was compiled"
-msgstr ""
+msgstr "<needs translation>"
 
 #: vecseq.c:14
 msgid "len must be an integer vector"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -483,7 +483,7 @@ msgstr "<needs translation>"
 #, fuzzy, c-format
 #| msgid "Column %d of item %d: %s"
 msgid "column %d named '%s'"
-msgstr "第 %2$d 项的第 %1$d 列: %3$s"
+msgstr "<fix fuzzy translation>第 %2$d 项的第 %1$d 列: %3$s"
 
 #: assign.c:706
 #, c-format
@@ -1253,7 +1253,7 @@ msgstr "'na'长度是%<PRId64>但长度必须是1或者等于'test'的长度 (%<
 msgid ""
 "'no' is of type %s but '%s' is %s. Please make all arguments have the same "
 "type."
-msgstr "'yes'是%s类型，但'no'是%s类型。请确认两个参数是同一类型。"
+msgstr "<fix fuzzy translation>'yes'是%s类型，但'no'是%s类型。请确认两个参数是同一类型。"
 
 #: fifelse.c:52
 #, fuzzy, c-format
@@ -1263,7 +1263,7 @@ msgstr "'yes'是%s类型，但'no'是%s类型。请确认两个参数是同一�
 msgid ""
 "'na' is of type %s but '%s' is %s. Please make all arguments have the same "
 "type."
-msgstr "'yes'是%s类型，但'na'是%s类型。请确认两个参数是同一类型。"
+msgstr "<fix fuzzy translation>'yes'是%s类型，但'na'是%s类型。请确认两个参数是同一类型。"
 
 #: fifelse.c:57
 msgid ""
@@ -2730,7 +2730,7 @@ msgstr ""
 #| msgid ""
 #| "Internal error in coalesce.c: argument 'inplaceArg' must be TRUE or FALSE"
 msgid "Internal error: freadR isFileNameArg not TRUE or FALSE"
-msgstr "内部错误：coalesce.c 中 'inplaceArg' 参数必须为 TRUE 或 FALSE"
+msgstr "<fix fuzzy translation>内部错误：coalesce.c 中 'inplaceArg' 参数必须为 TRUE 或 FALSE"
 
 #: freadR.c:92
 #, c-format
@@ -2760,7 +2760,7 @@ msgstr "quote= 必须是单个字符，空白 \"\"，或者 FALSE"
 #| msgid ""
 #| "Internal error: freadR sep not a single character. R level catches this."
 msgid "Internal error: freadR nrows not a single real. R level catches this."
-msgstr "内部错误：freadR sep 不是单个字符。R 中应该捕获此错误。"
+msgstr "<fix fuzzy translation>内部错误：freadR sep 不是单个字符。R 中应该捕获此错误。"
 
 #: freadR.c:141
 msgid "Internal error: skip not integer or string in freadR.c"
@@ -3046,7 +3046,7 @@ msgstr "%s: 使用了 %.3fs\n"
 msgid ""
 "x must be of type numeric or logical, or a list, data.frame or data.table of "
 "such"
-msgstr ""
+msgstr "<fix fuzzy translation>"
 "x 必须是列表 (list), 或由数值或者逻辑类型组成的数据框 (data.frame 或 data."
 "table)"
 
@@ -3090,7 +3090,7 @@ msgstr ""
 msgid ""
 "Internal error: invalid %s argument in %s function should have been caught "
 "earlier. Please report to the data.table issue tracker."
-msgstr ""
+msgstr "<fix fuzzy translation>"
 "内部错误：函数 nafillR 中有无效类型的参数, 该错误理应已被捕获，请向data.table"
 "的issue通道报告"
 
@@ -3978,7 +3978,7 @@ msgstr "PRINTNAME(install(\"integer64\")) 返回了 %s , 而不是 %s"
 #, fuzzy
 #| msgid "rollends must be a length 2 logical vector"
 msgid "verbose option must be length 1 non-NA logical or integer"
-msgstr "rollends 必须是一个长度为2的逻辑向量"
+msgstr "<fix fuzzy translation>rollends 必须是一个长度为2的逻辑向量"
 
 #: init.c:349
 msgid ".Last.value in namespace is not a length 1 integer"
@@ -4002,13 +4002,13 @@ msgstr "参数'x'必须是数字类型，或者是数字类型的list/data.table
 #, fuzzy
 #| msgid "fill must be a vector of length 1"
 msgid "fill must be a vector of length 1 or a list of length of x"
-msgstr "fill 必须是长度为1的向量"
+msgstr "<fix fuzzy translation>fill 必须是长度为1的向量"
 
 #: nafill.c:187
 #, fuzzy
 #| msgid "internal error: 'rho' should be an environment"
 msgid "internal error: 'fill' should be recycled as list already"
-msgstr "内部错误: 'rho' 应该为一个环境 (environment)"
+msgstr "<fix fuzzy translation>内部错误: 'rho' 应该为一个环境 (environment)"
 
 #: nafill.c:226
 #, c-format
@@ -4674,7 +4674,7 @@ msgstr "指定列的参数受到了重复的列"
 #, fuzzy, c-format
 #| msgid "Internal error: type '%s' not caught earlier in fastmean"
 msgid "Internal error: type '%s' not supported in %s"
-msgstr "内部错误：先前fastmean没有侦测到类型 '%s' "
+msgstr "<fix fuzzy translation>内部错误：先前fastmean没有侦测到类型 '%s' "
 
 #: utils.c:234
 #, c-format
@@ -4690,7 +4690,7 @@ msgstr "发现并拷贝了具有相同的内存地址的%d列%s\n"
 #, fuzzy
 #| msgid "x is not a logical vector"
 msgid "'x' is not atomic"
-msgstr "x不是一个逻辑向量"
+msgstr "<fix fuzzy translation>x不是一个逻辑向量"
 
 #: utils.c:360
 msgid "'x' must not be matrix or array"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -37,15 +37,10 @@ msgstr ""
 "行了setDT(), 请报告data.table异常行为到问题跟踪器(issue tracker)\n"
 
 #: assign.c:124
-#, fuzzy
-#| msgid "Internal error: .internal.selfref ptr is not NULL or R_NilValue"
 msgid "Internal error: .internal.selfref ptr is neither NULL nor R_NilValue"
 msgstr "内部错误： .internal.selfref ptr不为NULL或R_NilValue"
 
 #: assign.c:126
-#, fuzzy
-#| msgid ""
-#| "Internal error: .internal.selfref tag isn't NULL or a character vector"
 msgid ""
 "Internal error: .internal.selfref tag is neither NULL nor a character vector"
 msgstr "内部错误： .internal.selfref ptr不为NULL或字符向量"
@@ -139,10 +134,9 @@ msgstr "getOption('datatable.alloc')值为%d, 其必须大于等于零且不能�
 #: assign.c:250 between.c:16 between.c:22 forder.c:459 forder.c:462 frollR.c:40
 #: frollR.c:94 fsort.c:105 gsumm.c:343 gsumm.c:579 gsumm.c:723 gsumm.c:860
 #: gsumm.c:1016 gsumm.c:1108 openmp-utils.c:79 uniqlist.c:354 utils.c:106
-#, fuzzy, c-format
-#| msgid "sort must be TRUE or FALSE"
+#, c-format
 msgid "%s must be TRUE or FALSE"
-msgstr " sort 的参数是逻辑值，必须是 TRUE 或 FALSE"
+msgstr "%s 的参数是逻辑值，必须是 TRUE 或 FALSE"
 
 #: assign.c:298
 msgid "assign has been passed a NULL dt"
@@ -417,10 +411,9 @@ msgstr ""
 "问题追踪器，包含 sessionInfo() 的信息"
 
 #: assign.c:474
-#, fuzzy, c-format
-#| msgid "Internal error: selfrefnames is ok but tl names [%d] != tl [%d]"
+#, c-format
 msgid "Internal error: selfrefnames is ok but tl names [%lld] != tl [%d]"
-msgstr "内部错误: selfrefnames 正确，但 tl 的名称 [%d] != tl [%d]"
+msgstr "内部错误: selfrefnames 正确，但 tl 的名称 [%lld] != tl [%d]"
 
 #: assign.c:493
 msgid ""
@@ -521,24 +514,18 @@ msgstr ""
 "不能将 'factor' 赋值为 '%s' 。因子类型只能赋值为因子，字符或者列表其中的列"
 
 #: assign.c:738
-#, fuzzy, c-format
-#| msgid ""
-#| "Assigning factor numbers to column %d named '%s'. But %d is outside the "
-#| "level range [1,%d]"
+#, c-format
 msgid ""
 "Assigning factor numbers to %s. But %d is outside the level range [1,%d]"
-msgstr "将列 %d 名称为 '%s' 赋值为因子。但是 %d 在层次范围[1,%d]之外"
+msgstr "%s 赋值为因子。但是 %d 在层次范围[1,%d]之外"
 
 #: assign.c:747
-#, fuzzy, c-format
-#| msgid ""
-#| "Assigning factor numbers to column %d named '%s'. But %f is outside the "
-#| "level range [1,%d], or is not a whole number."
+#, c-format
 msgid ""
 "Assigning factor numbers to %s. But %f is outside the level range [1,%d], or "
 "is not a whole number."
 msgstr ""
-"将列 %d 名称为 '%s' 赋值为因子。但是 %f 在层次范围[1,%d]之外，或者不是一个完"
+"%s 赋值为因子。但是 %f 在层次范围[1,%d]之外，或者不是一个完"
 "整的数字"
 
 #: assign.c:753
@@ -555,40 +542,28 @@ msgid ""
 msgstr "内部错误: 目标的层次不是唯一或者长度<0"
 
 #: assign.c:813
-#, fuzzy
-#| msgid ""
-#| "Unable to allocate working memory of %d bytes to combine factor levels"
 msgid "Unable to allocate working memory of %zu bytes to combine factor levels"
-msgstr "不能分配 %d 字节的工作内存来组合因子层次"
+msgstr "不能分配 %zu 字节的工作内存来组合因子层次"
 
 #: assign.c:820
 msgid "Internal error: extra level check sum failed"
 msgstr "内部错误: 额外的层次校验和失败"
 
 #: assign.c:839
-#, fuzzy, c-format
-#| msgid ""
-#| "Coercing 'character' RHS to '%s' to match the type of the target column "
-#| "(column %d named '%s')."
+#, c-format
 msgid "Coercing 'character' RHS to '%s' to match the type of %s."
-msgstr "将'character' RHS 强制转换成 '%s' 来匹配目标列的类型(列 %d 名称 '%s')"
+msgstr "将'character' RHS 强制转换成 '%s' 来匹配目标列 %s 的类型"
 
 #: assign.c:846
-#, fuzzy, c-format
-#| msgid ""
-#| "Cannot coerce 'list' RHS to 'integer64' to match the type of the target "
-#| "column (column %d named '%s')."
+#, c-format
 msgid "Cannot coerce 'list' RHS to 'integer64' to match the type of %s."
 msgstr ""
-"不能将'list' RHS 强制转换成 'integer64' 来匹配目标列的类型(列 %d 名称 '%s')"
+"不能将'list' RHS 强制转换成 'integer64' 来匹配目 %s 的类型"
 
 #: assign.c:851
-#, fuzzy, c-format
-#| msgid ""
-#| "Coercing 'list' RHS to '%s' to match the type of the target column "
-#| "(column %d named '%s')."
+#, c-format
 msgid "Coercing 'list' RHS to '%s' to match the type of %s."
-msgstr "将'list' RHS 强制转换成 '%s' 来匹配目标列的类型(列 %d 名称 '%s')"
+msgstr "将'list' RHS 强制转换成 '%s' 来匹配目 %s 的类型"
 
 #: assign.c:856
 #, fuzzy, c-format
@@ -789,8 +764,7 @@ msgid "typeof x.%s (%s) != typeof i.%s (%s)"
 msgstr "x.%1$s (%2$s) 的数据类型和 i.%3$s (%4$s) 的数据类型并不一致"
 
 #: bmerge.c:70 bmerge.c:380
-#, fuzzy, c-format
-#| msgid "Type '%s' not supported for joining/merging"
+#, c-format
 msgid "Type '%s' is not supported for joining/merging"
 msgstr "'%s' 类型不支持联结/归并"
 
@@ -834,17 +808,13 @@ msgid ""
 msgstr "内部错误: opArg 不是一个长度为 on 的整数向量"
 
 #: bmerge.c:111
-#, fuzzy, c-format
-#| msgid ""
-#| "Internal error in bmerge_r for '%s' column. Unrecognized value op[col]=%d"
+#, c-format
 msgid "Internal error in bmerge_r for x.'%s'. Unrecognized value op[col]=%d"
-msgstr "bmerge_r 针对 '%s' 列的操作出现内部错误。无法识别值 op[col]=%d"
+msgstr "bmerge_r 针对 x 的操作出现内部错误。'%s'。 无法识别值 op[col]=%d"
 
 #: bmerge.c:114
-#, fuzzy
-#| msgid "Only '==' operator is supported for columns of type %s."
 msgid "Only '==' operator is supported for columns of type character."
-msgstr "%s 类型的列仅支持 '==' 操作符。"
+msgstr "字符类型的列仅支持 '==' 操作符。"
 
 #: bmerge.c:118
 msgid "Internal error: nqgrpArg must be an integer vector"
@@ -900,8 +870,7 @@ msgstr ""
 "%1$<PRIu64> 字节的内存空间"
 
 #: cj.c:89
-#, fuzzy, c-format
-#| msgid "Type '%s' not supported by CJ."
+#, c-format
 msgid "Type '%s' is not supported by CJ."
 msgstr "CJ 不支持 '%s' 类型"
 
@@ -970,10 +939,9 @@ msgstr "coalesce 复制了第一项 (inplace=FALSE)\n"
 
 #: coalesce.c:166 fifelse.c:193 fifelse.c:391 shift.c:171 uniqlist.c:98
 #: uniqlist.c:130 uniqlist.c:211 uniqlist.c:248 uniqlist.c:321
-#, fuzzy, c-format
-#| msgid "Type %s is not supported."
+#, c-format
 msgid "Type '%s' is not supported"
-msgstr "不支持类型 %s"
+msgstr "不支持类型 '%s'"
 
 #: dogroups.c:75
 msgid "Internal error: order not integer vector"
@@ -1272,12 +1240,10 @@ msgid ""
 msgstr "'no'长度是%<PRId64>但长度必须是1或者等于'test'的长度 (%<PRId64>)。"
 
 #: fifelse.c:28
-#, fuzzy, c-format
-#| msgid ""
-#| "Length of 'no' is %<PRId64> but must be 1 or length of 'test' (%<PRId64>)."
+#, c-format
 msgid ""
 "Length of 'na' is %<PRId64> but must be 1 or length of 'test' (%<PRId64>)."
-msgstr "'no'长度是%<PRId64>但长度必须是1或者等于'test'的长度 (%<PRId64>)。"
+msgstr "'na'长度是%<PRId64>但长度必须是1或者等于'test'的长度 (%<PRId64>)。"
 
 #: fifelse.c:46
 #, fuzzy, c-format
@@ -1312,14 +1278,10 @@ msgid ""
 msgstr "'yes'的类型与'na'不同。请确认两个参数是同一类型。"
 
 #: fifelse.c:67
-#, fuzzy
-#| msgid ""
-#| "'yes' has different class than 'na'. Please make sure that both arguments "
-#| "have the same class."
 msgid ""
 "'no' has different class than 'na'. Please make sure that both arguments "
 "have the same class."
-msgstr "'yes'的类型与'na'不同。请确认两个参数是同一类型。"
+msgstr "'no'的类型与'na'不同。请确认两个参数是同一类型。"
 
 #: fifelse.c:74
 msgid "'yes' and 'no' are both type factor but their levels are different."
@@ -1330,10 +1292,8 @@ msgid "'yes' and 'na' are both type factor but their levels are different."
 msgstr "'yes'和'na'都是因子类型但他们的因子水平不同"
 
 #: fifelse.c:84
-#, fuzzy
-#| msgid "'yes' and 'na' are both type factor but their levels are different."
 msgid "'no' and 'na' are both type factor but their levels are different."
-msgstr "'yes'和'na'都是因子类型但他们的因子水平不同"
+msgstr "'no'和'na'都是因子类型但他们的因子水平不同"
 
 #: fifelse.c:207
 #, c-format
@@ -1518,8 +1478,6 @@ msgstr ""
 "1的字符/整数向量"
 
 #: fmelt.c:315
-#, fuzzy
-#| msgid "'variable.name' must be a character/integer vector of length=1."
 msgid "'variable.name' must be a character/integer vector of length 1."
 msgstr "'variable.name' 必须是长度1的字符/整数向量。"
 
@@ -1855,10 +1813,9 @@ msgstr "x 必须为浮点数类型"
 
 #: frank.c:9 frank.c:10 frank.c:187 frank.c:188 subset.c:110 subset.c:274
 #: subset.c:287
-#, fuzzy, c-format
-#| msgid "Internal error. Argument 'x' to Cdt_na is type '%s' not 'list'"
+#, c-format
 msgid "Internal error. Argument '%s' to %s is type '%s' not '%s'"
-msgstr "内部错误：参数 'x' 关于 Cdt_na 是 '%s' 类型而不是 'list' 类型"
+msgstr "内部错误：参数 '%s' 关于 %s 是 '%s' 类型而不是 '%s' 类型"
 
 #: frank.c:14 frank.c:192
 #, c-format
@@ -1897,10 +1854,9 @@ msgid ""
 msgstr "fread.c中%d行出现内部错误，请在 data.table 的 GitHub中提交报告："
 
 #: fread.c:150
-#, fuzzy, c-format
-#| msgid "System error %d unmapping view of file\n"
+#, c-format
 msgid "System error %lu unmapping view of file\n"
-msgstr "系统错误 %d 取消映射文件视图\n"
+msgstr "系统错误 %lu 取消映射文件视图\n"
 
 #: fread.c:153
 #, c-format
@@ -2067,10 +2023,9 @@ msgid "  File opened, size = %s.\n"
 msgstr "  文件已打开，大小为 %s.\n"
 
 #: fread.c:1401
-#, fuzzy, c-format
-#| msgid "Unable to open file after %d attempts (error %d): %s"
+#, c-format
 msgid "Unable to open file after %d attempts (error %lu): %s"
-msgstr "经过 %d 次尝试后仍无法打开文件（错误 %d）：%s"
+msgstr "经过 %d 次尝试后仍无法打开文件（错误 %lu）：%s"
 
 #: fread.c:1403
 #, c-format
@@ -2078,10 +2033,9 @@ msgid "GetFileSizeEx failed (returned 0) on file: %s"
 msgstr "GetFileSizeEx 未能成功执行（返回值为0）于文件：%s"
 
 #: fread.c:1408
-#, fuzzy, c-format
-#| msgid "This is Windows, CreateFileMapping returned error %d for file %s"
+#, c-format
 msgid "This is Windows, CreateFileMapping returned error %lu for file %s"
-msgstr "现在在Windows下，CreateFileMapping 返回错误 %d 于文件 %s"
+msgstr "现在在Windows下，CreateFileMapping 返回错误 %lu 于文件 %s"
 
 #: fread.c:1415
 #, c-format
@@ -2391,15 +2345,12 @@ msgid "  Type codes (jump %03d)    : %s  Quote rule %d\n"
 msgstr " 类型码（跳点 %03d）   : %s  引用规则 %d\n"
 
 #: fread.c:1898
-#, fuzzy, c-format
-#| msgid ""
-#| "  'header' determined to be true due to column %d containing a string on "
-#| "row 1 and a lower type (%s) in the rest of the %d sample rows\n"
+#, c-format
 msgid ""
 "  'header' determined to be true due to column %d containing a string on row "
 "1 and a lower type (%s) in the rest of the %<PRId64> sample rows\n"
 msgstr ""
-" 'header' 参数设为真，原因是第%1$d列首行包含字符串，并且在样本中的另外%3$d行"
+" 'header' 参数设为真，原因是第%1$d列首行包含字符串，并且在样本中的另外%3$<PRId64>行"
 "包含有较底层的数据类型(%2$s)\n"
 
 #: fread.c:1910
@@ -3175,10 +3126,8 @@ msgid "fill must be a vector of length 1"
 msgstr "fill 必须是长度为1的向量"
 
 #: frollR.c:147 frollR.c:259
-#, fuzzy
-#| msgid "x must be of type numeric or logical"
 msgid "fill must be numeric or logical"
-msgstr "x 必须是数值或者逻辑类型"
+msgstr "fill 必须是数值或者逻辑类型"
 
 #: frollR.c:168
 #, c-format
@@ -3240,10 +3189,8 @@ msgid "%s: running in parallel for input length %<PRIu64>, hasna %d, narm %d\n"
 msgstr "%s: 正在并行运行, 输入长度 %<PRIu64>, hasna %d, narm %d\n"
 
 #: fsort.c:107
-#, fuzzy
-#| msgid "x must be a vector of type 'double' currently"
 msgid "x must be a vector of type double currently"
-msgstr "x 目前必须是双精度 ('double') 类型的向量"
+msgstr "x 目前必须是双精度 (double) 类型的向量"
 
 #: fsort.c:118
 #, c-format
@@ -3260,10 +3207,9 @@ msgid "Cannot yet handle negatives."
 msgstr "目前无法处理负值。"
 
 #: fsort.c:168
-#, fuzzy, c-format
-#| msgid "maxBit=%d; MSBNbits=%d; shift=%d; MSBsize=%d\n"
+#, c-format
 msgid "maxBit=%d; MSBNbits=%d; shift=%d; MSBsize=%zu\n"
-msgstr "maxBit=%d; MSBNbits=%d; shift=%d; MSBsize=%d\n"
+msgstr "maxBit=%d; MSBNbits=%d; shift=%d; MSBsize=%zu\n"
 
 #: fsort.c:174
 #, c-format
@@ -3279,10 +3225,8 @@ msgid "Internal error: counts[nBatch-1][MSBsize-1] != length(x)"
 msgstr "内部错误：counts[nBatch-1][MSBsize-1] != length(x)"
 
 #: fsort.c:244
-#, fuzzy
-#| msgid "Top 5 MSB counts: "
 msgid "Top 20 MSB counts: "
-msgstr "前5个MSB counts："
+msgstr "前20个MSB counts："
 
 #: fsort.c:244
 #, c-format
@@ -3294,16 +3238,12 @@ msgid "\n"
 msgstr "\n"
 
 #: fsort.c:245
-#, fuzzy
-#| msgid "Reduced MSBsize from %d to "
 msgid "Reduced MSBsize from %zu to "
-msgstr "MSBsize 从 %d 减少到"
+msgstr "MSBsize 从 %zu 减少到"
 
 #: fsort.c:249
-#, fuzzy
-#| msgid "%d by excluding 0 and 1 counts\n"
 msgid "%zu by excluding 0 and 1 counts\n"
-msgstr "%d 通过排除0和1的counts\n"
+msgstr "%zu 通过排除0和1的counts\n"
 
 #: fsort.c:315
 #, c-format
@@ -3346,19 +3286,15 @@ msgid "... "
 msgstr "... "
 
 #: fwrite.c:629
-#, fuzzy, c-format
-#| msgid ""
-#| "\n"
-#| "args.doRowNames=%d args.rowNames=%d doQuote=%d args.nrow=%<PRId64> args."
-#| "ncol=%d eolLen=%d\n"
+#, c-format
 msgid ""
 "\n"
 "args.doRowNames=%d args.rowNames=%p args.rowNameFun=%d doQuote=%d args."
 "nrow=%<PRId64> args.ncol=%d eolLen=%d\n"
 msgstr ""
 "\n"
-"args.doRowNames=%d args.rowNames=%d doQuote=%d args.nrow=%<PRId64> args."
-"ncol=%d eolLen=%d\n"
+"args.doRowNames=%d args.rowNames=%p args.rowNameFun=%d doQuote=%d args."
+"nrow=%<PRId64> args.ncol=%d eolLen=%d\n"
 
 #: fwrite.c:664
 #, c-format
@@ -3403,20 +3339,18 @@ msgid "Writing bom (%s), yaml (%d characters) and column names (%s) ... "
 msgstr "正在写入bom (%s), yaml (%d characters) 和 column names (%s) ..."
 
 #: fwrite.c:717
-#, fuzzy, c-format
-#| msgid "Unable to allocate %d MiB for header: %s"
+#, c-format
 msgid "Unable to allocate %zu MiB for header: %s"
-msgstr "无法为header: %2$s分配%1$d MiB"
+msgstr "无法为header: %2$s分配%1$zu MiB"
 
 #: fwrite.c:748 fwrite.c:812
 msgid "Can't allocate gzip stream structure"
 msgstr "无法分配gzip的流结构"
 
 #: fwrite.c:756
-#, fuzzy, c-format
-#| msgid "Unable to allocate %d MiB for zbuffer: %s"
+#, c-format
 msgid "Unable to allocate %zu MiB for zbuffer: %s"
-msgstr "无法为zbuffer: %2$s分配%1$d MiB"
+msgstr "无法为zbuffer: %2$s分配%1$zu MiB"
 
 #: fwrite.c:772
 #, c-format
@@ -3453,27 +3387,21 @@ msgid "zbuffSize=%d returned from deflateBound\n"
 msgstr ""
 
 #: fwrite.c:823
-#, fuzzy, c-format
-#| msgid ""
-#| "Unable to allocate %d MB * %d thread buffers; '%d: %s'. Please read ?"
-#| "fwrite for nThread, buffMB and verbose options."
+#, c-format
 msgid ""
 "Unable to allocate %zu MB * %d thread buffers; '%d: %s'. Please read ?fwrite "
 "for nThread, buffMB and verbose options."
 msgstr ""
-"无法分配 %d MB * %d 的线程缓存；'%d: %s'。请阅读 ?fwrite 中对 nThread、"
+"无法分配 %zu MB * %d 的线程缓存；'%d: %s'。请阅读 ?fwrite 中对 nThread、"
 "buffMB 和 verbose 选项的说明。"
 
 #: fwrite.c:834
-#, fuzzy, c-format
-#| msgid ""
-#| "Unable to allocate %d MB * %d thread compressed buffers; '%d: %s'. Please "
-#| "read ?fwrite for nThread, buffMB and verbose options."
+#, c-format
 msgid ""
 "Unable to allocate %zu MB * %d thread compressed buffers; '%d: %s'. Please "
 "read ?fwrite for nThread, buffMB and verbose options."
 msgstr ""
-"无法分配 %d MB * %d 的线程压缩缓存；'%d: %s'。请阅读 ?fwrite 中对 nThread、"
+"无法分配 %zu MB * %d 的线程压缩缓存；'%d: %s'。请阅读 ?fwrite 中对 nThread、"
 "buffMB 和 verbose 选项的说明。"
 
 #: fwrite.c:1009
@@ -3599,16 +3527,13 @@ msgid "Internal error: o's maxgrpn attribute mismatches recalculated maxgrpn"
 msgstr "内部错误：o 的 maxgrpn 属性与重新计算的 maxgrpn 不匹配"
 
 #: gsumm.c:89
-#, fuzzy, c-format
-#| msgid ""
-#| "Internal error: nrow=%d  ngrp=%d  nbit=%d  shift=%d  highSize=%d  "
-#| "nBatch=%d  batchSize=%d  lastBatchSize=%d\n"
+#, c-format
 msgid ""
 "Internal error: nrow=%d  ngrp=%d  nbit=%d  bitshift=%d  highSize=%zu  "
 "nBatch=%zu  batchSize=%zu  lastBatchSize=%zu\n"
 msgstr ""
-"内部错误：nrow=%d ngrp=%d  nbit=%d  shift=%d  highSize=%d  nBatch=%d  "
-"batchSize=%d  lastBatchSize=%d\n"
+"内部错误：nrow=%d ngrp=%d  nbit=%d  bitshift=%d  highSize=%zu  nBatch=%zu  "
+"batchSize=%zu  lastBatchSize=%zu\n"
 
 #: gsumm.c:98
 #, c-format
@@ -3645,14 +3570,12 @@ msgid "%.3fs\n"
 msgstr "%.3fs\n"
 
 #: gsumm.c:346 gsumm.c:577 gsumm.c:726 gsumm.c:863 gsumm.c:1019 gsumm.c:1113
-#, fuzzy, c-format
-#| msgid "sum is not meaningful for factors."
+#, c-format
 msgid "%s is not meaningful for factors."
-msgstr "因子的和没有意义。"
+msgstr "对因子的 %s 没有意义。"
 
 #: gsumm.c:350
-#, fuzzy, c-format
-#| msgid "This gsum took (narm=%s) ... "
+#, c-format
 msgid "This gsum (narm=%s) took ... "
 msgstr "gsum 占用了 (narm=%s) ..."
 
@@ -3672,28 +3595,23 @@ msgstr ""
 "故结果被自动转换为数值类型（numeric）"
 
 #: gsumm.c:566 gsumm.c:838 gsumm.c:904 gsumm.c:1090 gsumm.c:1161
-#, fuzzy, c-format
-#| msgid ""
-#| "Type '%s' not supported by GForce sd (gsd). Either add the prefix stats::"
-#| "sd(.) or turn off GForce optimization using options(datatable.optimize=1)"
+#, c-format
 msgid ""
 "Type '%s' is not supported by GForce %s. Either add the prefix %s or turn "
 "off GForce optimization using options(datatable.optimize=1)"
 msgstr ""
-"GForce sd (gsd)不支持类型'%s'，要么添加前缀 stats::sd(.)，要么使用选项"
+"GForce %s 不支持类型'%s'，要么添加前缀 %s，要么使用选项"
 "datatable.optimize=1来关闭GForce优化。"
 
 #: gsumm.c:584
-#, fuzzy, c-format
-#| msgid "This gsum took (narm=%s) ... "
+#, c-format
 msgid "This gmean took (narm=%s) ... "
 msgstr "gsum 占用了 (narm=%s) ..."
 
 #: gsumm.c:619 gsumm.c:676
-#, fuzzy, c-format
-#| msgid "Unable to allocate %d * %d bytes for counts in gmean na.rm=TRUE"
+#, c-format
 msgid "Unable to allocate %d * %zu bytes for non-NA counts in gmean na.rm=TRUE"
-msgstr "无法为 gmean na.rm=TRUE 的计数（counts）分配 %d * %d 字节空间"
+msgstr "无法为 gmean na.rm=TRUE 的不 NA 计数（counts）分配 %d * %zu 字节空间"
 
 #: gsumm.c:712
 #, fuzzy, c-format
@@ -3770,15 +3688,11 @@ msgstr ""
 "options(datatable.optimize=1) 来关掉GForce优化。"
 
 #: gsumm.c:995 gsumm.c:1001
-#, fuzzy
-#| msgid ""
-#| "Internal error, gtail is only implemented for n=1. This should have been "
-#| "caught before. please report to data.table issue tracker."
 msgid ""
 "Internal error, gtail is only implemented for n>0. This should have been "
 "caught before. please report to data.table issue tracker."
 msgstr ""
-"内部错误：gtail仅能应用于n=1的情况。此错误理应已被处理。请在 data.table 的 "
+"内部错误：gtail仅能应用于n>01的情况。此错误理应已被处理。请在 data.table 的 "
 "GitHub中提交报告。"
 
 #: gsumm.c:1007
@@ -3816,34 +3730,26 @@ msgstr ""
 "闭GForce优化。你可以试试'DT[,lapply(.SD,prod),by=,.SDcols=]'"
 
 #: gsumm.c:1119
-#, fuzzy, c-format
-#| msgid "Unable to allocate %d * %d bytes for gprod"
+#, c-format
 msgid "Unable to allocate %d * %zu bytes for gprod"
-msgstr "无法给gprod分配%d * %d 字节"
+msgstr "无法给gprod分配%d * %zu 字节"
 
 #: gsumm.c:1188
-#, fuzzy, c-format
-#| msgid "nrow [%d] != length(x) [%d] in %s"
+#, c-format
 msgid "Internal error: nrow [%d] != length(x) [%d] in %s"
-msgstr "%3$s 中 nrow [%1$d] != length(x) [%2$d]"
+msgstr "内部错误: %3$s 中 nrow [%1$d] != length(x) [%2$d]"
 
 #: gsumm.c:1196 gsumm.c:1201
-#, fuzzy
-#| msgid ""
-#| "Internal error: invalid type for shift(), should have been caught before. "
-#| "please report to data.table issue tracker"
 msgid ""
 "Internal error: invalid type for gshift(), should have been caught before. "
 "please report to data.table issue tracker"
 msgstr ""
-"内部错误：shift() 的类型无效，请提前排查。请向 data.table 提交问题追踪"
+"内部错误：gshift() 的类型无效，请提前排查。请向 data.table 提交问题追踪"
 "（issue tracker）报告"
 
 #: gsumm.c:1207
-#, fuzzy
-#| msgid "Internal error: k must be integer"
 msgid "Internal error: n must be integer"
-msgstr "内部错误：k 必须是整数"
+msgstr "内部错误：n 必须是整数"
 
 #: gsumm.c:1209 shift.c:34
 #, c-format
@@ -3868,27 +3774,19 @@ msgid "x must be an integer vector"
 msgstr "x必须为一个整数向量"
 
 #: idatetime.c:130
-#, fuzzy
-#| msgid ""
-#| "Internal error: invalid type for shift(), should have been caught before. "
-#| "please report to data.table issue tracker"
 msgid ""
 "Internal error: invalid type for convertDate(), should have been caught "
 "before. please report to data.table issue tracker"
 msgstr ""
-"内部错误：shift() 的类型无效，请提前排查。请向 data.table 提交问题追踪"
+"内部错误：convertDate() 的类型无效，请提前排查。请向 data.table 提交问题追踪"
 "（issue tracker）报告"
 
 #: idatetime.c:142
-#, fuzzy
-#| msgid ""
-#| "Internal error: invalid type for shift(), should have been caught before. "
-#| "please report to data.table issue tracker"
 msgid ""
 "Internal error: invalid type for convertDate, should have been caught "
 "before. please report to data.table issue tracker"
 msgstr ""
-"内部错误：shift() 的类型无效，请提前排查。请向 data.table 提交问题追踪"
+"内部错误：convertDate 的类型无效，请提前排查。请向 data.table 提交问题追踪"
 "（issue tracker）报告"
 
 #: ijoin.c:22 ijoin.c:243
@@ -3969,14 +3867,10 @@ msgid "Final step, fetching indices in overlaps ... done in %8.3f seconds\n"
 msgstr "重叠的最后一步：获取索引...在%8.3f秒内完成\n"
 
 #: init.c:163
-#, fuzzy
-#| msgid ""
-#| "Pointers are %d bytes, greater than 8. We have not tested on any "
-#| "architecture greater than 64bit yet."
 msgid ""
 "Pointers are %zu bytes, greater than 8. We have not tested on any "
 "architecture greater than 64bit yet."
-msgstr "指针是%d个字节，大于8。我们尚未在大于64位的任何体系结构上进行测试。"
+msgstr "指针是%zu个字节，大于8。我们尚未在大于64位的任何体系结构上进行测试。"
 
 #: init.c:177
 msgid "... failed. Please forward this message to maintainer('data.table')."
@@ -3994,22 +3888,19 @@ msgstr "检查Checking NA_INTEGER [%d] == NA_LOGICAL [%d] %s"
 
 #: init.c:180 init.c:181 init.c:183 init.c:186 init.c:187 init.c:188 init.c:189
 #: init.c:190 init.c:191 init.c:192
-#, fuzzy, c-format
-#| msgid "Checking sizeof(int) [%d] is 4 %s"
+#, c-format
 msgid "Checking sizeof(%s) [%zu] is %d %s"
-msgstr "检查sizeof（int）[%d]是否为4 %s"
+msgstr "检查sizeof（%s）[%zu]是否为%d %s"
 
 #: init.c:184
-#, fuzzy, c-format
-#| msgid "Checking sizeof(pointer) [%d] is 4 or 8 %s"
+#, c-format
 msgid "Checking sizeof(pointer) [%zu] is 4 or 8 %s"
-msgstr "检查sizeof(pointer) [%d]是否为4 或者 8 %s"
+msgstr "检查sizeof(pointer) [%zu]是否为4 或者 8 %s"
 
 #: init.c:185
-#, fuzzy, c-format
-#| msgid "Checking sizeof(SEXP) [%d] == sizeof(pointer) [%d] %s"
+#, c-format
 msgid "Checking sizeof(SEXP) [%zu] == sizeof(pointer) [%zu] %s"
-msgstr "检查sizeof(SEXP) [%d] == sizeof(pointer) [%d] %s"
+msgstr "检查sizeof(SEXP) [%zu] == sizeof(pointer) [%zu] %s"
 
 #: init.c:195
 #, c-format
@@ -4017,10 +3908,9 @@ msgid "Checking LENGTH(allocVector(INTSXP,2)) [%d] is 2 %s"
 msgstr "检查LENGTH(allocVector(INTSXP,2)) [%d]是否为2 %s"
 
 #: init.c:197
-#, fuzzy, c-format
-#| msgid "Checking TRUELENGTH(allocVector(INTSXP,2)) [%d] is 0 %s"
+#, c-format
 msgid "Checking TRUELENGTH(allocVector(INTSXP,2)) [%lld] is 0 %s"
-msgstr "检查TRUELENGTH(allocVector(INTSXP,2)) [%d]是否为0 %s"
+msgstr "检查TRUELENGTH(allocVector(INTSXP,2)) [%lld]是否为0 %s"
 
 #: init.c:204
 #, c-format
@@ -4460,10 +4350,9 @@ msgid "Column %d of item %d: %s"
 msgstr "第 %2$d 项的第 %1$d 列: %3$s"
 
 #: reorder.c:17
-#, fuzzy, c-format
-#| msgid "Item %d of list is type '%s' which isn't yet supported (SIZEOF=%d)"
+#, c-format
 msgid "Item %d of list is type '%s' which isn't yet supported (SIZEOF=%zu)"
-msgstr "列表的第 %d 项是 '%s' 类型，其尚不被支持 (SIZEOF=%d)"
+msgstr "列表的第 %d 项是 '%s' 类型，其尚不被支持 (SIZEOF=%zu)"
 
 #: reorder.c:19
 #, c-format
@@ -4473,16 +4362,13 @@ msgid ""
 msgstr "列 %d 的长度是 %d ，与列 1 (%d) 的长度不同。数据表无效。"
 
 #: reorder.c:27
-#, fuzzy, c-format
-#| msgid ""
-#| "reorder accepts vectors but this non-VECSXP is type '%s' which isn't yet "
-#| "supported (SIZEOF=%d)"
+#, c-format
 msgid ""
 "reorder accepts vectors but this non-VECSXP is type '%s' which isn't yet "
 "supported (SIZEOF=%zu)"
 msgstr ""
 "重新排序需要输入向量，但输入了 '%s' 类型的非向量对象，目前并不支持 "
-"(SIZEOF=%d)"
+"(SIZEOF=%zu)"
 
 #: reorder.c:28
 msgid ""
@@ -4553,10 +4439,9 @@ msgid "dt_win_snprintf test %d failed: %s"
 msgstr "dt_win_snprintf 测试 %d 失败了: %s"
 
 #: snprintf.c:217
-#, fuzzy, c-format
-#| msgid "dt_win_snprintf test %d failed: %s"
+#, c-format
 msgid "dt_win_snprintf test %d failed: %d"
-msgstr "dt_win_snprintf 测试 %d 失败了: %s"
+msgstr "dt_win_snprintf 测试 %d 失败了: %d"
 
 #: subset.c:7
 #, c-format
@@ -4594,10 +4479,8 @@ msgid "Internal error. max is %d, must be >= 0."
 msgstr "内部错误。最大值是 %d ，且必须 >= 0。"
 
 #: subset.c:140
-#, fuzzy
-#| msgid "Internal error: allowOverMax must be TRUE/FALSE"
 msgid "Internal error: allowNAArg must be TRUE/FALSE"
-msgstr "内部错误：allowOverMax 必须是 TRUE 或 FALSE"
+msgstr "内部错误：allowNAArg 必须是 TRUE 或 FALSE"
 
 #: subset.c:177
 #, c-format
@@ -4722,10 +4605,9 @@ msgid "cols must be an integer vector with length >= 1"
 msgstr "cols必须是一个长度大于等于1的整数向量"
 
 #: uniqlist.c:174
-#, fuzzy, c-format
-#| msgid "Item %d of cols is %d which is outside range of l [1,length(l)=%d]"
+#, c-format
 msgid "Item %d of cols is %d which is outside the range [1,length(l)=%d]"
-msgstr "列的%d项是%d，它超出l的所在区间[1,length(l)=%d]"
+msgstr "列的%d项是%d，它超出所在区间[1,length(l)=%d]"
 
 #: uniqlist.c:177
 #, c-format
@@ -4765,34 +4647,28 @@ msgid ""
 msgstr "指定列的参数是一个双精度类型而其中至少有一个元素不是整数"
 
 #: utils.c:128
-#, fuzzy, c-format
-#| msgid ""
-#| "argument specifying columns specify non existing column(s): cols[%d]=%d"
+#, c-format
 msgid ""
 "argument specifying columns received non-existing column(s): cols[%d]=%d"
-msgstr "指定列的参数指定了不存在的列: cols[%d]=%d"
+msgstr "指定列的参数受到了不存在的列: cols[%d]=%d"
 
 #: utils.c:133
 msgid "'x' argument data.table has no names"
 msgstr "data.table的参数x并没有名字"
 
 #: utils.c:138
-#, fuzzy, c-format
-#| msgid ""
-#| "argument specifying columns specify non existing column(s): cols[%d]='%s'"
+#, c-format
 msgid ""
 "argument specifying columns received non-existing column(s): cols[%d]='%s'"
-msgstr "指定列的参数指定了不存在的列: cols[%d]='%s'"
+msgstr "指定列的参数受到了不存在的列: cols[%d]='%s'"
 
 #: utils.c:141
 msgid "argument specifying columns must be character or numeric"
 msgstr "指定列的参数必须是字符或者是数值"
 
 #: utils.c:144
-#, fuzzy
-#| msgid "argument specifying columns specify duplicated column(s)"
 msgid "argument specifying columns received duplicate column(s)"
-msgstr "指定列的参数指定了重复的列"
+msgstr "指定列的参数受到了重复的列"
 
 #: utils.c:229
 #, fuzzy, c-format

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -4802,191 +4802,191 @@ msgstr ""
 "型"
 
 #~ msgid "verbose must be TRUE or FALSE"
-#~ msgstr "verbose参数必须为TRUE或FALSE"
+#~ msgstr "<possible fragment for fuzzy translation>verbose参数必须为TRUE或FALSE"
 
 #, c-format
 #~ msgid ""
 #~ "Internal error in assign: length of names (%d) is not length of dt (%d)"
-#~ msgstr "赋值的内部错误： names的长度(%d)与dt的长度(%d)不匹配"
+#~ msgstr "<possible fragment for fuzzy translation>赋值的内部错误： names的长度(%d)与dt的长度(%d)不匹配"
 
 #, c-format
 #~ msgid "i[%d] is %d which is out of range [1,nrow=%d]."
-#~ msgstr "i[%d] 为 %d 且超出了范围 [1,nrow=%d]。"
+#~ msgstr "<possible fragment for fuzzy translation>i[%d] 为 %d 且超出了范围 [1,nrow=%d]。"
 
 #~ msgid ""
 #~ "To assign integer64 to a character column, please use as.character() for "
 #~ "clarity."
-#~ msgstr "请使用 as.character() 把 integer64 类型的数值赋值给字符列"
+#~ msgstr "<possible fragment for fuzzy translation>请使用 as.character() 把 integer64 类型的数值赋值给字符列"
 
 #~ msgid "incbounds must be TRUE or FALSE"
-#~ msgstr "incbounds 必须是 TRUE (真) 或者是 FALSE (假)"
+#~ msgstr "<possible fragment for fuzzy translation>incbounds 必须是 TRUE (真) 或者是 FALSE (假)"
 
 #~ msgid "check must be TRUE or FALSE"
-#~ msgstr "check 必须是 TRUE (真) 或者是 FALSE (假)"
+#~ msgstr "<possible fragment for fuzzy translation>check 必须是 TRUE (真) 或者是 FALSE (假)"
 
 #~ msgid "Internal error: xlow!=xupp-1 || xlow<xlowIn || xupp>xuppIn"
-#~ msgstr "内部错误：xlow!=xupp-1 或 xlow<xlowIn 或 xupp>xuppIn"
+#~ msgstr "<possible fragment for fuzzy translation>内部错误：xlow!=xupp-1 或 xlow<xlowIn 或 xupp>xuppIn"
 
 #, c-format
 #~ msgid "Unsupported type: %s"
-#~ msgstr "不支持的类型：%s"
+#~ msgstr "<possible fragment for fuzzy translation>不支持的类型：%s"
 
 #~ msgid "'env' should be an environment"
-#~ msgstr "'env' 应该是一个环境"
+#~ msgstr "<possible fragment for fuzzy translation>'env' 应该是一个环境"
 
 #, c-format
 #~ msgid "Length of 'na' is %<PRId64> but must be 1"
-#~ msgstr "'na'长度是%<PRId64>但必须是长度必须是1"
+#~ msgstr "<possible fragment for fuzzy translation>'na'长度是%<PRId64>但必须是长度必须是1"
 
 #, c-format
 #~ msgid "Unknown 'measure.vars' type %s, must be character or integer vector"
-#~ msgstr "未知'measure.vars'类型 %s，必须是字符或者整数向量"
+#~ msgstr "<possible fragment for fuzzy translation>未知'measure.vars'类型 %s，必须是字符或者整数向量"
 
 #, c-format
 #~ msgid ""
 #~ "The molten data value type is a list at item %d. 'na.rm=TRUE' is "
 #~ "ignored.\n"
-#~ msgstr "在项目%d中，融合后的数值类型是列表，参数'na.rm = TRUE'被自动忽略\n"
+#~ msgstr "<possible fragment for fuzzy translation>在项目%d中，融合后的数值类型是列表，参数'na.rm = TRUE'被自动忽略\n"
 
 #~ msgid "retGrp must be TRUE or FALSE"
-#~ msgstr "retGrp 的参数是逻辑值，必须是 TRUE 或 FALSE"
+#~ msgstr "<possible fragment for fuzzy translation>retGrp 的参数是逻辑值，必须是 TRUE 或 FALSE"
 
 #, c-format
 #~ msgid "Internal error. Argument 'cols' to Cdt_na is type '%s' not 'integer'"
-#~ msgstr "内部错误：参数 'cols' 关于 Cdt_na 是 '%s' 类型而不是 'integer' 类型"
+#~ msgstr "<possible fragment for fuzzy translation>内部错误：参数 'cols' 关于 Cdt_na 是 '%s' 类型而不是 'integer' 类型"
 
 #, c-format
 #~ msgid "Internal error. Argument 'x' to CanyNA is type '%s' not 'list'"
-#~ msgstr "内部错误：参数 'x' 关于 CanyNA 是 '%s' 类型而不是'list'类型"
+#~ msgstr "<possible fragment for fuzzy translation>内部错误：参数 'x' 关于 CanyNA 是 '%s' 类型而不是'list'类型"
 
 #, c-format
 #~ msgid "Internal error. Argument 'cols' to CanyNA is type '%s' not 'integer'"
-#~ msgstr "内部错误：参数 'cols' 关于 CanyNA 是 '%s' 类型而不是'integer'类型"
+#~ msgstr "<possible fragment for fuzzy translation>内部错误：参数 'cols' 关于 CanyNA 是 '%s' 类型而不是'integer'类型"
 
 #, c-format
 #~ msgid "file not found: %s"
-#~ msgstr "文件未找到： %s"
+#~ msgstr "<possible fragment for fuzzy translation>文件未找到： %s"
 
 #~ msgid ""
 #~ "Input contains a \\n or is \")\". Taking this to be text input (not a "
 #~ "filename)\n"
-#~ msgstr "输入中包含 \\n 或者是 \")\"。输入将被当做数据文本（而非文件名）\n"
+#~ msgstr "<possible fragment for fuzzy translation>输入中包含 \\n 或者是 \")\"。输入将被当做数据文本（而非文件名）\n"
 
 #~ msgid "Input contains no \\n. Taking this to be a filename to open\n"
-#~ msgstr "输入中不包含 \\n。输入将被当做文件名打开。\n"
+#~ msgstr "<possible fragment for fuzzy translation>输入中不包含 \\n。输入将被当做文件名打开。\n"
 
 #~ msgid "adaptive must be TRUE or FALSE"
-#~ msgstr "adaptive 必须是 TRUE 或者 FALSE"
+#~ msgstr "<possible fragment for fuzzy translation>adaptive 必须是 TRUE 或者 FALSE"
 
 #~ msgid "na.rm must be TRUE or FALSE"
-#~ msgstr "na.rm 必须是 TRUE 或者 FALSE"
+#~ msgstr "<possible fragment for fuzzy translation>na.rm 必须是 TRUE 或者 FALSE"
 
 #~ msgid ""
 #~ "Internal error: invalid align argument in rolling function, should have "
 #~ "been caught before. please report to data.table issue tracker."
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "内部错误: 在 rolling 函数内无效的 align 参数, 理应在更早阶段排除请向data."
 #~ "table issue tracker报告"
 
 #~ msgid ""
 #~ "Internal error: invalid fun argument in rolling function, should have "
 #~ "been caught before. please report to data.table issue tracker."
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "内部错误: 在 rolling 函数中无效的 fun 参数, 理应在更早阶段排除请向data."
 #~ "table issue tracker报告"
 
 #~ msgid "fill must be numeric"
-#~ msgstr "fill 必须是数值型"
+#~ msgstr "<possible fragment for fuzzy translation>fill 必须是数值型"
 
 #~ msgid ""
 #~ "Internal error: invalid algo argument in rolling function, should have "
 #~ "been caught before. please report to data.table issue tracker."
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "内部错误: 在 rolling 函数内无效的 algo 参数, 理应在更早阶段排除请向data."
 #~ "table issue tracker报告"
 
 #, c-format
 #~ msgid "deflate input stream: %p %d %p %d\n"
-#~ msgstr "deflate (压缩) 输入数据流：%p %d %p %d\n"
+#~ msgstr "<possible fragment for fuzzy translation>deflate (压缩) 输入数据流：%p %d %p %d\n"
 
 #, c-format
 #~ msgid ""
 #~ "deflate returned %d with stream->total_out==%d; Z_FINISH==%d, Z_OK==%d, "
 #~ "Z_STREAM_END==%d\n"
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "deflate (压缩) 返回 %d，stream->total_out==%d; Z_FINISH==%d, Z_OK==%d, "
 #~ "Z_STREAM_END==%d\n"
 
 #, c-format
 #~ msgid "z_stream for header (%d): "
-#~ msgstr "header （%d） 的 z_stream："
+#~ msgstr "<possible fragment for fuzzy translation>header （%d） 的 z_stream："
 
 #, c-format
 #~ msgid "z_stream for data (%d): "
-#~ msgstr "data (%d) 的 z_stream："
+#~ msgstr "<possible fragment for fuzzy translation>data (%d) 的 z_stream："
 
 #, c-format
 #~ msgid ""
 #~ "Type '%s' not supported by GForce sum (gsum). Either add the prefix base::"
 #~ "sum(.) or turn off GForce optimization using options(datatable.optimize=1)"
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "GForce 求和（gsum）不支持类型 '%s'。请使用 base::sum(.) 或者设置 "
 #~ "options(datatable.optimize=1) 关闭 GForce 优化"
 
 #~ msgid ""
 #~ "GForce mean can only be applied to columns, not .SD or similar. Likely "
 #~ "you're looking for 'DT[,lapply(.SD,mean),by=,.SDcols=]'. See ?data.table."
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "GForce 求平均值仅适用于列，而不能用于 .SD 或其它。或许你在查找 'DT[,"
 #~ "lapply(.SD,mean),by=,.SDcols=]'。参见 ?data.table 。"
 
 #~ msgid "mean is not meaningful for factors."
-#~ msgstr "因子的平均值没有意义"
+#~ msgstr "<possible fragment for fuzzy translation>因子的平均值没有意义"
 
 #, c-format
 #~ msgid "Internal error: gsum returned type '%s'. typeof(x) is '%s'"
-#~ msgstr "内部错误：gsum 返回的类型是 '%s'，而 typeof(x) 的结果则是 '%s'"
+#~ msgstr "<possible fragment for fuzzy translation>内部错误：gsum 返回的类型是 '%s'，而 typeof(x) 的结果则是 '%s'"
 
 #, c-format
 #~ msgid "Unable to allocate %d * %d bytes for sum in gmean na.rm=TRUE"
-#~ msgstr "无法为 gmean na.rm=TRUE 的总和（sum）分配 %d * %d 字节空间"
+#~ msgstr "<possible fragment for fuzzy translation>无法为 gmean na.rm=TRUE 的总和（sum）分配 %d * %d 字节空间"
 
 #, c-format
 #~ msgid "Unable to allocate %d * %d bytes for si in gmean na.rm=TRUE"
-#~ msgstr "无法为 gmean na.rm=TRUE 的 si 分配 %d * %d 字节空间"
+#~ msgstr "<possible fragment for fuzzy translation>无法为 gmean na.rm=TRUE 的 si 分配 %d * %d 字节空间"
 
 #, c-format
 #~ msgid ""
 #~ "Type '%s' not supported by GForce mean (gmean) na.rm=TRUE. Either add the "
 #~ "prefix base::mean(.) or turn off GForce optimization using "
 #~ "options(datatable.optimize=1)"
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "GForce 求均值（gmean）不支持类型 '%s'。请使用 base::mean(.) 或者设置 "
 #~ "options(datatable.optimize=1) 关闭 GForce 优化"
 
 #~ msgid "Internal error: unsupported type at the end of gmean"
-#~ msgstr "内部错误：gmean 结尾处存在不支持的类型"
+#~ msgstr "<possible fragment for fuzzy translation>内部错误：gmean 结尾处存在不支持的类型"
 
 #~ msgid "min is not meaningful for factors."
-#~ msgstr "因子的最小值没有意义。"
+#~ msgstr "<possible fragment for fuzzy translation>因子的最小值没有意义。"
 
 #~ msgid ""
 #~ "No non-missing values found in at least one group. Coercing to numeric "
 #~ "type and returning 'Inf' for such groups to be consistent with base"
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "在至少一个分组中没有发现缺失值。为了与 base 保持一致，将这些组强制转换为数"
 #~ "值类型并返回 ‘Inf’。"
 
 #~ msgid ""
 #~ "No non-missing values found in at least one group. Returning 'NA' for "
 #~ "such groups to be consistent with base"
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "在至少一个分组中没有发现缺失值。为了与 base 保持一致，这些组将返回 ‘NA’。"
 
 #~ msgid ""
 #~ "No non-missing values found in at least one group. Returning 'Inf' for "
 #~ "such groups to be consistent with base"
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "在至少一个分组中没有发现缺失值。为了与 base 保持一致，这些组将返回 ‘Inf’。"
 
 #~ msgid ""
@@ -4994,41 +4994,41 @@ msgstr ""
 #~ "max of all items in a list such as .SD, either add the prefix base::max(."
 #~ "SD) or turn off GForce optimization using options(datatable.optimize=1). "
 #~ "More likely, you may be looking for 'DT[,lapply(.SD,max),by=,.SDcols=]'"
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "GForce的max函数只能在应用在数据列上，而不能在.SD或者其他对象上。为了找到某"
 #~ "个list（如.SD）里所有元素的最大值，请使用 base::max(.SD) 或者通过设置 "
 #~ "options(datatable.optimize=1) 来关掉GForce优化。更有可能的是，你真正想要使"
 #~ "用的命令是 'DT[,lapply(.SD,max),by=,.SDcols=]'"
 
 #~ msgid "max is not meaningful for factors."
-#~ msgstr "因子的最大值是没有意义的"
+#~ msgstr "<possible fragment for fuzzy translation>因子的最大值是没有意义的"
 
 #~ msgid ""
 #~ "No non-missing values found in at least one group. Returning '-Inf' for "
 #~ "such groups to be consistent with base"
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "至少有一个子集的值全为缺失值。为保持和base包一致，对这种情况将会返回'-Inf'"
 
 #~ msgid "Type 'complex' has no well-defined max"
-#~ msgstr "类型'complex'没有明确定义的最大值"
+#~ msgstr "<possible fragment for fuzzy translation>类型'complex'没有明确定义的最大值"
 
 #, c-format
 #~ msgid ""
 #~ "Type '%s' not supported by GForce max (gmax). Either add the prefix base::"
 #~ "max(.) or turn off GForce optimization using options(datatable.optimize=1)"
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "GForce的max (gmax)函数不支持类型 '%s'。请使用 base::max(.) 或者设置 "
 #~ "options(datatable.optimize=1) 来关掉GForce优化"
 
 #~ msgid "median is not meaningful for factors."
-#~ msgstr "因子的中位值没有意义。"
+#~ msgstr "<possible fragment for fuzzy translation>因子的中位值没有意义。"
 
 #, c-format
 #~ msgid ""
 #~ "Type '%s' not supported by GForce median (gmedian). Either add the prefix "
 #~ "stats::median(.) or turn off GForce optimization using options(datatable."
 #~ "optimize=1)"
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "GForce函数median (gmedian)不支持类型'%s'。请使用 stats::tail(.) 或者设置 "
 #~ "options(datatable.optimize=1) 来关掉GForce优化。"
 
@@ -5037,14 +5037,14 @@ msgstr ""
 #~ "Type '%s' not supported by GForce tail (gtail). Either add the prefix "
 #~ "utils::tail(.) or turn off GForce optimization using options(datatable."
 #~ "optimize=1)"
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "GForce函数tail (gtail)不支持类型'%s'。请使用 utils::tail(.) 或者设置 "
 #~ "options(datatable.optimize=1) 来关掉GForce优化。"
 
 #~ msgid ""
 #~ "Internal error, ghead is only implemented for n=1. This should have been "
 #~ "caught before. please report to data.table issue tracker."
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "内部错误：ghead仅能应用于n=1的情况。此错误理应已被处理。请在 data.table "
 #~ "的 GitHub中提交报告。"
 
@@ -5053,108 +5053,108 @@ msgstr ""
 #~ "Type '%s' not supported by GForce subset `[` (gnthvalue). Either add the "
 #~ "prefix utils::head(.) or turn off GForce optimization using "
 #~ "options(datatable.optimize=1)"
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "GForce取子集运算符`[` (gnthvalue)尚不支持'%s'类型。。请添加前缀stats::"
 #~ "var(.)，或使用options(datatable.optimize=1) 关闭 GForce优化"
 
 #~ msgid "var/sd is not meaningful for factors."
-#~ msgstr "无法对因子类型使用 var/sd。"
+#~ msgstr "<possible fragment for fuzzy translation>无法对因子类型使用 var/sd。"
 
 #, c-format
 #~ msgid ""
 #~ "Type '%s' not supported by GForce var (gvar). Either add the prefix "
 #~ "stats::var(.) or turn off GForce optimization using options(datatable."
 #~ "optimize=1)"
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "GForce var (gvar) 尚不支持 '%s'类型。请添加前缀stats::var(.)，或使用"
 #~ "options(datatable.optimize=1) 关闭 GForce优化"
 
 #~ msgid "prod is not meaningful for factors."
-#~ msgstr "prod对于因子是没有意义的"
+#~ msgstr "<possible fragment for fuzzy translation>prod对于因子是没有意义的"
 
 #, c-format
 #~ msgid ""
 #~ "Type '%s' not supported by GForce prod (gprod). Either add the prefix "
 #~ "base::prod(.) or turn off GForce optimization using options(datatable."
 #~ "optimize=1)"
-#~ msgstr ""
+#~ msgstr "<possible fragment for fuzzy translation>"
 #~ "GForce prod (gprod)不支持类型'%s'，要么添加前缀 base::prod(.)，要么使用选"
 #~ "项datatable.optimize=1来关闭GForce优化。"
 
 #, c-format
 #~ msgid "Checking sizeof(double) [%d] is 8 %s"
-#~ msgstr "检查 sizeof(double) [%d]是否为8 %s"
+#~ msgstr "<possible fragment for fuzzy translation>检查 sizeof(double) [%d]是否为8 %s"
 
 #, c-format
 #~ msgid "Checking sizeof(long long) [%d] is 8 %s"
-#~ msgstr "检查sizeof(long long) [%d]是否为8 %s"
+#~ msgstr "<possible fragment for fuzzy translation>检查sizeof(long long) [%d]是否为8 %s"
 
 #, c-format
 #~ msgid "Checking sizeof(uint64_t) [%d] is 8 %s"
-#~ msgstr "检查 sizeof(uint64_t) [%d]是否为8 %s"
+#~ msgstr "<possible fragment for fuzzy translation>检查 sizeof(uint64_t) [%d]是否为8 %s"
 
 #, c-format
 #~ msgid "Checking sizeof(int64_t) [%d] is 8 %s"
-#~ msgstr "检查sizeof(int64_t) [%d]是否为8 %s"
+#~ msgstr "<possible fragment for fuzzy translation>检查sizeof(int64_t) [%d]是否为8 %s"
 
 #, c-format
 #~ msgid "Checking sizeof(signed char) [%d] is 1 %s"
-#~ msgstr "检查sizeof(signed char) [%d]是否为1 %s"
+#~ msgstr "<possible fragment for fuzzy translation>检查sizeof(signed char) [%d]是否为1 %s"
 
 #, c-format
 #~ msgid "Checking sizeof(int8_t) [%d] is 1 %s"
-#~ msgstr "检查sizeof(int8_t) [%d]是否为1 %s"
+#~ msgstr "<possible fragment for fuzzy translation>检查sizeof(int8_t) [%d]是否为1 %s"
 
 #, c-format
 #~ msgid "Checking sizeof(uint8_t) [%d] is 1 %s"
-#~ msgstr "检查sizeof(uint8_t) [%d]是否为1 %s"
+#~ msgstr "<possible fragment for fuzzy translation>检查sizeof(uint8_t) [%d]是否为1 %s"
 
 #, c-format
 #~ msgid "Checking sizeof(int16_t) [%d] is 2 %s"
-#~ msgstr "检查sizeof(int16_t) [%d]是否为2 %s"
+#~ msgstr "<possible fragment for fuzzy translation>检查sizeof(int16_t) [%d]是否为2 %s"
 
 #, c-format
 #~ msgid "Checking sizeof(uint16_t) [%d] is 2 %s"
-#~ msgstr "检查sizeof(uint16_t) [%d]是否为2 %s"
+#~ msgstr "<possible fragment for fuzzy translation>检查sizeof(uint16_t) [%d]是否为2 %s"
 
 #~ msgid "'verbose' must be TRUE or FALSE"
-#~ msgstr "'verbose'必须是TRUE或者FALSE"
+#~ msgstr "<possible fragment for fuzzy translation>'verbose'必须是TRUE或者FALSE"
 
 #~ msgid ""
 #~ "use.names= cannot be FALSE when fill is TRUE. Setting use.names=TRUE."
-#~ msgstr "当fill是TRUE时，use.names= 不能是FALSE . 正在设置 use.names=TRUE."
+#~ msgstr "<possible fragment for fuzzy translation>当fill是TRUE时，use.names= 不能是FALSE . 正在设置 use.names=TRUE."
 
 #, c-format
 #~ msgid "Unsupported type '%s'"
-#~ msgstr "不支持 '%s' 类型"
+#~ msgstr "<possible fragment for fuzzy translation>不支持 '%s' 类型"
 
 #, c-format
 #~ msgid "Internal error. Argument 'x' to CsubsetDT is type '%s' not 'list'"
-#~ msgstr "内部错误：CsubsetDT 的参数 'x' 是 '%s' 类型而非列表"
+#~ msgstr "<possible fragment for fuzzy translation>内部错误：CsubsetDT 的参数 'x' 是 '%s' 类型而非列表"
 
 #, c-format
 #~ msgid ""
 #~ "Internal error. Argument 'cols' to Csubset is type '%s' not 'integer'"
-#~ msgstr "内部错误：CsubsetDT 的参数 'cols' 是 '%s' 类型而非整数"
+#~ msgstr "<possible fragment for fuzzy translation>内部错误：CsubsetDT 的参数 'cols' 是 '%s' 类型而非整数"
 
 #, c-format
 #~ msgid "Type '%s' not supported"
-#~ msgstr "类型 '%s' 不被支持"
+#~ msgstr "<possible fragment for fuzzy translation>类型 '%s' 不被支持"
 
 #~ msgid "cols must be an integer vector of positive length"
-#~ msgstr "cols必须是一个长度大于零的整数向量"
+#~ msgstr "<possible fragment for fuzzy translation>cols必须是一个长度大于零的整数向量"
 
 #~ msgid "'check_dups' argument must be TRUE or FALSE"
-#~ msgstr "参数'check_dups'必须为TRUE或者是FALSE"
+#~ msgstr "<possible fragment for fuzzy translation>参数'check_dups'必须为TRUE或者是FALSE"
 
 #, c-format
 #~ msgid "%s: fill argument must be length 1"
-#~ msgstr "%s：fill参数的长度必须为1"
+#~ msgstr "<possible fragment for fuzzy translation>%s：fill参数的长度必须为1"
 
 #, c-format
 #~ msgid "%s: fill argument must be numeric"
-#~ msgstr "%s：fill参数必须为数值类型"
+#~ msgstr "<possible fragment for fuzzy translation>%s：fill参数必须为数值类型"
 
 #, c-format
 #~ msgid "Internal error: unsupported type '%s' passed to copyAsPlain()"
-#~ msgstr "内部错误：copyAsPlain()不支持类型为'%s'的参数"
+#~ msgstr "<possible fragment for fuzzy translation>内部错误：copyAsPlain()不支持类型为'%s'的参数"


### PR DESCRIPTION
A lot is due to being more intentional about using `stopf()` to ensure full messages are included (#5068), not fragments, so a lot of the fuzzed translations just require adding a `%s` or `%d`.

On the C side, a lot of the fuzz is due to #5790 -related fixes, just requires changing the format template specifier.

I got things started here but there's still a lot of fuzzy translations left.

Would appreciate if @hongyuanjia or any other Mandarin speakers could take over from here (as well as copy-edit my own attempts) 🙏