### PR TITLE
Make test robust to R configuration/version/platform issue

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -135,12 +135,17 @@ if (!test_longdouble) {
 # generate simple error messages from base that are checked against in our tests. this helps
 #   protect us against these messages evolving in base in the future, and against these messages
 #   potentially not being produced in English.
+# If the target condition only appears on certain platforms/R versions, this will return NULL
+#   whenever the code succeeds, or the message matcher wherever it fails. Thus we can flexibly
+#   pass e.g. 'warning = NULL | warning = <warning>' concisely as 'test(., warning = get_msg())'.
 # Three use cases:
 #   (1) match message exactly [missing delim]
 #   (2) match message pattern after dropping anything between delimeters [delim, fmt=FALSE]
 #   (3) function factory for matching messages exactly by substituting anything between delimeters [delim, fmt=TRUE]
 get_msg = function(e, delim, fmt=FALSE) {
-  msg = tryCatch(e, error=identity, warning=identity)$message
+  condition = tryCatch({e; NULL}, error=identity, warning=identity)
+  if (is.null(condition)) return(condition)
+  msg = condition$message
   if (missing(delim)) return(msg)
   if (length(delim) == 1L) delim[2L] = delim[1L]
   msg = gsub(
@@ -165,7 +170,8 @@ base_messages = list(
   missing_file = get_msg({tmp <- tempfile(tmpdir=tempfile("xxx")); file(tmp, "w")}, "'"),
   # gives both error & warning but tryCatch returns the warning first, so suppress
   cant_open_file = get_msg(suppressWarnings({con<-file(tempfile()); open(con, 'r')})),
-  mixed_subscripts = get_msg(letters[-1:1])
+  mixed_subscripts = get_msg(letters[-1:1]),
+  maybe_invalid_old_posixct = get_msg(as.POSIXct("1893-12-28 05:15:36", tz = ""))
 )
 
 ##########################
@@ -16847,8 +16853,17 @@ if (.Platform$OS.type!="windows") {
   # blank TZ env variable on non-Windows is recognized as UTC consistent with C and R; but R's tz= argument is the opposite and uses "" for local
 }
 Sys.unsetenv("TZ")
-tt = fread(tmp, colClasses=list(POSIXct="times"), tz="")   # from v1.14.0 tz="" needed
-test(2150.025, attr(tt$times, "tzone"), "") # as.POSIXct puts "" on the result (testing the write.csv version here with missing tzone)
+# Notes:
+#  - from v1.14.0 tz="" needed
+#  - as.POSIXct puts "" on the result (testing the write.csv version here with missing tzone)
+#  - Per #5866, this test is complicated by some interaction with very specific builds of R where
+#    as.POSIXct() might fail for very old timestamps when 'tz=""' is used. On such systems,
+#    as.POSIXct() failure means 'times' is returned as a character, hence no 'tzone' attribute.
+#    fread() will also throw a warning, one substring of which will be the reproduced base R error.
+test(2150.025,
+     attr(fread(tmp, colClasses=list(POSIXct="times"), tz="")$times, "tzone"),
+     if (is.null(base_messages$maybe_invalid_old_posixct)) "" else NULL,
+     warning=base_messages$maybe_invalid_old_posixct)
 # the times will be different though here because as.POSIXct read them as local time.
 if (is.na(oldtz)) Sys.unsetenv("TZ") else Sys.setenv(TZ=oldtz)
 fwrite(copy(DT)[ , times := format(times, '%FT%T+00:00')], tmp)


### PR DESCRIPTION
Closes #5866

@jameslamb are you able to test the conda build against this PR? Would be great to confirm it's WAI on your end. If so we can merge and try to have this shipped in CRAN version 1.15.0.