### PR TITLE
Run GHA jobs on 1-15-99 dev branch

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -3,12 +3,12 @@
 on:
   push:
     branches:
-      - main
       - master
+      - 1-15-99
   pull_request:
     branches:
-      - main
       - master
+      - 1-15-99
 
 name: R-CMD-check
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,12 +1,12 @@
 on:
   push:
     branches:
-      - main
       - master
+      - 1-15-99
   pull_request:
     branches:
-      - main
       - master
+      - 1-15-99
 
 name: test-coverage
 


### PR DESCRIPTION
Also, we don't use `main`, may as well drop it from the config.

Currently it looks like only Appveyor is running on PRs to `1-15-99`, intent is to keep running more jobs during dev waiting for CRAN release.