### PR TITLE
bump master to 1.15.99

### DIFF
--- a/.dev/CRAN_Release.cmd
+++ b/.dev/CRAN_Release.cmd
@@ -598,13 +598,18 @@ Rdevel -q -e "packageVersion('xml2')"   # ensure installed
 Rdevel CMD check data.table_1.16.0.tar.gz --as-cran  # use latest Rdevel as it may have extra checks
 bunzip2 inst/tests/*.Rraw.bz2  # decompress *.Rraw again so as not to commit compressed *.Rraw to git
 
+#
+# Final Release steps
+#
 # Resubmit to winbuilder (R-release, R-devel and R-oldrelease)
+# Submit to R-Hub
+# If RESUBMISSION, update date in NEWS file
 # Submit to CRAN. Message template :
 # ------------------------------------------------------------
 # Hello,
-# 1,016 CRAN revdeps checked. None are impacted.
+# XXXX CRAN revdeps checked. None are impacted.
 # Many thanks!
-# Best, Matt
+# Best, Tyson
 # ------------------------------------------------------------
 # DO NOT commit or push to GitHub. Leave 4 files (.dev/CRAN_Release.cmd, DESCRIPTION, NEWS and init.c) edited and not committed. Include these in a single and final bump commit below.
 # DO NOT even use a PR. Because PRs build binaries and we don't want any binary versions of even release numbers available from anywhere other than CRAN.
@@ -624,20 +629,20 @@ bunzip2 inst/tests/*.Rraw.bz2  # decompress *.Rraw again so as not to commit com
 # 5. Bump 3 minor version numbers in Makefile
 # 6. Search and replace this .dev/CRAN_Release.cmd to update 1.14.99 to 1.15.99 inc below, 1.15.0 to 1.16.0 above, 1.14.0 to 1.15.0 below
 # 7. Another final gd to view all diffs using meld. (I have `alias gd='git difftool &> /dev/null'` and difftool meld: http://meldmerge.org/)
-# 8. Push to master with this consistent commit message: "1.15.0 on CRAN. Bump to 1.14.10"
+# 8. Push to master with this consistent commit message: "1.15.0 on CRAN. Bump to 1.15.99"
 # 9. Take sha from step 8 and run `git tag 1.15.0 96c..sha..d77` then `git push origin 1.15.0` (not `git push --tags` according to https://stackoverflow.com/a/5195913/403310)
 ######
 
 ###### Bump dev for PATCH RELEASE
-## WARNING: review this process during the next first patch release (x.y.2) from a regular release (x,y,0), possibly during 1.15.2 release.
+## WARNING: review this process during the next first patch release (x.y.2) from a regular release (x.y.0), possibly during 1.15.2 release.
 # 0. Close milestone to prevent new issues being tagged with it. The final 'release checks' issue can be left open in a closed milestone.
 # 1. Check that 'git status' shows 4 files in modified and uncommitted state: DESCRIPTION, NEWS.md, init.c and this .dev/CRAN_Release.cmd
 # 2. Bump patch version in DESCRIPTION to next odd number. Note that DESCRIPTION was in edited and uncommitted state so even number never appears in git.
 # 3. Add new heading in NEWS for the next dev PATCH version. Add "(submitted to CRAN on <today>)" on the released heading.
 # 4. Bump patch version in dllVersion() in init.c
 # 5. Bump 3 patch version numbers in Makefile
-# 6. Search and replace this .dev/CRAN_Release.cmd to update 1.14.9 to 1.14.11 inc below, 1.14.10 to 1.14.12 above, 1.14.8 to 1.14.10 below
+# 6. Search and replace this .dev/CRAN_Release.cmd to update 1.14.99 to 1.15.99
 # 7. Another final gd to view all diffs using meld. (I have `alias gd='git difftool &> /dev/null'` and difftool meld: http://meldmerge.org/)
-# 8. Push to master with this consistent commit message: "1.14.8 on CRAN. Bump to 1.14.10"
+# 8. Push to master with this consistent commit message: "1.15.0 on CRAN. Bump to 1.15.99"
 # 9. Take sha from step 8 and run `git tag 1.14.8 96c..sha..d77` then `git push origin 1.14.8` (not `git push --tags` according to https://stackoverflow.com/a/5195913/403310)
 ######

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: data.table
-Version: 1.14.99
+Version: 1.15.99
 Title: Extension of `data.frame`
 Depends: R (>= 3.1.0)
 Imports: methods

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 **If you are viewing this file on CRAN, please check [latest news on GitHub](https://github.com/Rdatatable/data.table/blob/master/NEWS.md) where the formatting is also better.**
 
-# data.table [v1.14.99](https://github.com/Rdatatable/data.table/milestone/29)  (in development)
+# data.table [v1.15.99](https://github.com/Rdatatable/data.table/milestone/30)  (in development)
+
+# data.table [v1.15.0](https://github.com/Rdatatable/data.table/milestone/29)  (14 Jan 2024)
 
 ## BREAKING CHANGE
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 # data.table [v1.15.99](https://github.com/Rdatatable/data.table/milestone/30)  (in development)
 
-# data.table [v1.15.0](https://github.com/Rdatatable/data.table/milestone/29)  (14 Jan 2024)
+# data.table [v1.15.0](https://github.com/Rdatatable/data.table/milestone/29)  (30 Jan 2024)
 
 ## BREAKING CHANGE
 

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1015,7 +1015,7 @@ replace_dot_alias = function(e) {
           } else negate_sdcols = FALSE
           # fix for #1216, make sure the parentheses are peeled from expr of the form (((1:4)))
           while(colsub %iscall% "(") colsub = as.list(colsub)[[-1L]]
-          if (colsub %iscall% ':' && length(colsub)==3L && !is.call(colsub[[2L]]) && !is.call(colsub[[3]])) {
+          if (colsub %iscall% ':' && length(colsub)==3L && !is.call(colsub[[2L]]) && !is.call(colsub[[3L]])) {
             # .SDcols is of the format a:b, ensure none of : arguments is a call data.table(V1=-1L, V2=-2L, V3=-3L)[,.SD,.SDcols=-V2:-V1] #4231
             .SDcols = eval(colsub, setattr(as.list(seq_along(x)), 'names', names_x), parent.frame())
           } else {
@@ -2747,7 +2747,7 @@ setcolorder = function(x, neworder=key(x), before=NULL, after=NULL)  # before/af
     stopf("x has some duplicated column name(s): %s. Please remove or rename the duplicate(s) and try again.", brackify(unique(names(x)[duplicated(names(x))])))
   if (!is.null(before) && !is.null(after))
     stopf("Provide either before= or after= but not both")
-  if (length(before)>1 || length(after)>1)
+  if (length(before)>1L || length(after)>1L)
     stopf("before=/after= accept a single column name or number, not more than one")
   neworder = colnamesInt(x, neworder, check_dups=FALSE)  # dups are now checked inside Csetcolorder below
   if (length(before))

--- a/src/init.c
+++ b/src/init.c
@@ -353,6 +353,6 @@ SEXP initLastUpdated(SEXP var) {
 
 SEXP dllVersion(void) {
   // .onLoad calls this and checks the same as packageVersion() to ensure no R/C version mismatch, #3056
-  return(ScalarString(mkChar("1.14.99")));
+  return(ScalarString(mkChar("1.15.99")));
 }
 


### PR DESCRIPTION
Closes https://github.com/Rdatatable/data.table/issues/5931 
Closes https://github.com/Rdatatable/data.table/issues/5924

Hi @MichaelChirico @TysonStanley @ben-schwen @jangorecki 
This is my attempt to clarify what I meant by "I thought we did not want 1.15.0 (or any even number release version) to get on master branch?" https://github.com/Rdatatable/data.table/pull/5925#discussion_r1471723523
Is this OK with you all? If so I suggest we merge this PR and close #5925 

Thanks!
