### PR TITLE
Set GHA jobs to auto-cancel when new commits are pushed to the same branch

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -12,6 +12,10 @@ on:
 
 name: R-CMD-check
 
+concurrency:
+  group: ${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}


### PR DESCRIPTION
This doesn't bother wasting CI resources finishing up tests for commits that are often in error (if a new commit is pushed while CI is still in progress, most often that means a "silly" mistake was noticed & fixed)