### PR TITLE
ignore any project-specific Rprofile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ Rplots.pdf
 data.table_*.tar.gz
 data.table.Rcheck
 src/Makevars
+.Rprofile
 
 # Package install
 inst/cc


### PR DESCRIPTION
.dev/.Rprofile discusses setting it as a _global_ profile, but this may interfere with development of other packages, or with scripting work. So some developers (e.g. me) might want to put it in the data.table project folder instead to run `cc()`, in which case we should ignore it in git.