### PR TITLE
Trigger GHA on any PR

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -3,12 +3,8 @@
 on:
   push:
     branches:
-      - main
       - master
   pull_request:
-    branches:
-      - main
-      - master
 
 name: R-CMD-check
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,12 +1,8 @@
 on:
   push:
     branches:
-      - main
       - master
   pull_request:
-    branches:
-      - main
-      - master
 
 name: test-coverage
 


### PR DESCRIPTION
Per docs:

https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#example-including-branches

Our current config is set up to _only_ run GHA on PRs that target `master` (or `main`, which we don't use). But I think we don't need that restriction, especially given recent experience with chained PRs targeting each other instead of `master` directly.