### PR TITLE
fix: mutable dt alias from unique.data.table 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,10 @@
 
 3. Namespace-qualifying `data.table::shift()`, `data.table::first()`, or `data.table::last()` will not deactivate GForce, [#5942](https://github.com/Rdatatable/data.table/issues/5942). Thanks @MichaelChirico for the proposal and fix. Namespace-qualifying other calls like `stats::sum()`, `base::prod()`, etc., continue to work as an escape valve to avoid GForce, e.g. to ensure S3 method dispatch.
 
+## BUG FIXES
+
+1. `unique()` returns a copy the case when `nrows(x) <= 1` instead of a mutable alias, [#5932](https://github.com/Rdatatable/data.table/pull/5932). This is consistent with existing `unique()` behavior when the input has no duplicates but more than one row. Thanks to @brookslogan for the report and @dshemetov for the fix.
+
 ## NOTES
 
 1. `transform` method for data.table sped up substantially when creating new columns on large tables. Thanks to @OfekShilon for the report and PR. The implemented solution was proposed by @ColeMiller1.
@@ -589,8 +593,6 @@
 55. `fread(URL)` with `https:` and `ftps:` could timeout if proxy settings were not guessed right by `curl::curl_download`, [#1686](https://github.com/Rdatatable/data.table/issues/1686). `fread(URL)` now uses `download.file()` as default for downloading files from urls. Thanks to @cderv for the report and Benjamin Schwendinger for the fix.
 
 56. `split.data.table()` works for downstream methods that don't implement `DT[i]` form (i.e., requiring `DT[i, j]` form, like plain `data.frame`s), for example `sf`'s `[.sf`, [#5365](https://github.com/Rdatatable/data.table/issues/5365). Thanks @barryrowlingson for the report and @michaelchirico for the fix.
-
-57. `unique()` returns a copy the case when `nrows(x) <= 1` instead of a mutable alias, [#5932](https://github.com/Rdatatable/data.table/pull/5932). This is consistent with existing `unique()` behavior when the input has no duplicates but more than one row. Thanks to @brookslogan for the report and @dshemetov for the fix.
 
 ## NOTES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -590,7 +590,7 @@
 
 56. `split.data.table()` works for downstream methods that don't implement `DT[i]` form (i.e., requiring `DT[i, j]` form, like plain `data.frame`s), for example `sf`'s `[.sf`, [#5365](https://github.com/Rdatatable/data.table/issues/5365). Thanks @barryrowlingson for the report and @michaelchirico for the fix.
 
-57. `unique()` no longer returns a mutable alias in the case when `nrows(x) <= 1`, [#5932](https://github.com/Rdatatable/data.table/pull/5932). Thanks to @brookslogan for the report and @dshemetov for the fix.
+57. `unique()` returns a copy the case when `nrows(x) <= 1` instead of a mutable alias, [#5932](https://github.com/Rdatatable/data.table/pull/5932). This is consistent with existing `unique()` behavior when the input has no duplicates but more than one row. Thanks to @brookslogan for the report and @dshemetov for the fix.
 
 ## NOTES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -590,7 +590,7 @@
 
 56. `split.data.table()` works for downstream methods that don't implement `DT[i]` form (i.e., requiring `DT[i, j]` form, like plain `data.frame`s), for example `sf`'s `[.sf`, [#5365](https://github.com/Rdatatable/data.table/issues/5365). Thanks @barryrowlingson for the report and @michaelchirico for the fix.
 
-57. `unique()` no longer returns a mutable alias in the case when `nrows(x) <= 1`, [#5960](https://github.com/Rdatatable/data.table/pull/5960). Thanks to @brookslogan for the report and @dshemetov for the fix.
+57. `unique()` no longer returns a mutable alias in the case when `nrows(x) <= 1`, [#5932](https://github.com/Rdatatable/data.table/pull/5932). Thanks to @brookslogan for the report and @dshemetov for the fix.
 
 ## NOTES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -590,6 +590,8 @@
 
 56. `split.data.table()` works for downstream methods that don't implement `DT[i]` form (i.e., requiring `DT[i, j]` form, like plain `data.frame`s), for example `sf`'s `[.sf`, [#5365](https://github.com/Rdatatable/data.table/issues/5365). Thanks @barryrowlingson for the report and @michaelchirico for the fix.
 
+57. `unique()` no longer returns a mutable alias in the case when `nrows(x) <= 1`, [#5960](https://github.com/Rdatatable/data.table/pull/5960). Thanks to @brookslogan for the report and @dshemetov for the fix.
+
 ## NOTES
 
 1. New feature 29 in v1.12.4 (Oct 2019) introduced zero-copy coercion. Our thinking is that requiring you to get the type right in the case of `0` (type double) vs `0L` (type integer) is too inconvenient for you the user. So such coercions happen in `data.table` automatically without warning. Thanks to zero-copy coercion there is no speed penalty, even when calling `set()` many times in a loop, so there's no speed penalty to warn you about either. However, we believe that assigning a character value such as `"2"` into an integer column is more likely to be a user mistake that you would like to be warned about. The type difference (character vs integer) may be the only clue that you have selected the wrong column, or typed the wrong variable to be assigned to that column. For this reason we view character to numeric-like coercion differently and will warn about it. If it is correct, then the warning is intended to nudge you to wrap the RHS with `as.<type>()` so that it is clear to readers of your code that a coercion from character to that type is intended. For example :
@@ -637,7 +639,7 @@
 
 14. The options `datatable.print.class` and `datatable.print.keys` are now `TRUE` by default. They have been available since v1.9.8 (Nov 2016) and v1.11.0 (May 2018) respectively.
 
-15. Thanks to @ssh352, Václav Tlapák, Cole Miller, András Svraka and Toby Dylan Hocking for reporting and bisecting a significant performance regression in dev. This was fixed before release thanks to a PR by Jan Gorecki, [#5463](https://github.com/Rdatatable/data.table/pull/5463). 
+15. Thanks to @ssh352, Václav Tlapák, Cole Miller, András Svraka and Toby Dylan Hocking for reporting and bisecting a significant performance regression in dev. This was fixed before release thanks to a PR by Jan Gorecki, [#5463](https://github.com/Rdatatable/data.table/pull/5463).
 
 16. `key(x) <- value` is now fully deprecated (from warning to error). Use `setkey()` to set a table's key. We started warning not to use this approach in 2012, with a stronger warning starting in 2019 (1.12.2). This function will be removed in the next release.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -639,7 +639,7 @@
 
 14. The options `datatable.print.class` and `datatable.print.keys` are now `TRUE` by default. They have been available since v1.9.8 (Nov 2016) and v1.11.0 (May 2018) respectively.
 
-15. Thanks to @ssh352, Václav Tlapák, Cole Miller, András Svraka and Toby Dylan Hocking for reporting and bisecting a significant performance regression in dev. This was fixed before release thanks to a PR by Jan Gorecki, [#5463](https://github.com/Rdatatable/data.table/pull/5463).
+15. Thanks to @ssh352, Václav Tlapák, Cole Miller, András Svraka and Toby Dylan Hocking for reporting and bisecting a significant performance regression in dev. This was fixed before release thanks to a PR by Jan Gorecki, [#5463](https://github.com/Rdatatable/data.table/pull/5463). 
 
 16. `key(x) <- value` is now fully deprecated (from warning to error). Use `setkey()` to set a table's key. We started warning not to use this approach in 2012, with a stronger warning starting in 2019 (1.12.2). This function will be removed in the next release.
 

--- a/R/duplicated.R
+++ b/R/duplicated.R
@@ -28,7 +28,7 @@ unique.data.table = function(x, incomparables=FALSE, fromLast=FALSE, by=seq_alon
   if (!isFALSE(incomparables)) {
     .NotYetUsed("incomparables != FALSE")
   }
-  if (nrow(x) <= 1L) return(x)
+  if (nrow(x) <= 1L) return(copy(x))
   if (!length(by)) by = NULL  #4594
   o = forderv(x, by=by, sort=FALSE, retGrp=TRUE)
   if (!is.null(cols)) {

--- a/R/duplicated.R
+++ b/R/duplicated.R
@@ -28,7 +28,7 @@ unique.data.table = function(x, incomparables=FALSE, fromLast=FALSE, by=seq_alon
   if (!isFALSE(incomparables)) {
     .NotYetUsed("incomparables != FALSE")
   }
-  if (nrow(x) <= 1L) return(copy(x))
+  if (nrow(x) <= 1L) return(copy(x)) # unique(x)[, col := val] should not alter x, #5932
   if (!length(by)) by = NULL  #4594
   o = forderv(x, by=by, sort=FALSE, retGrp=TRUE)
   if (!is.null(cols)) {

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18184,7 +18184,7 @@ test(2241.04, set(DT, j="D", value=2), data.table(A=1:3, b=4:6, C=1, D=2, key="A
 test(2241.05, colnames(DT)[2]<-"B", "B")
 test(2241.06, DT, data.table(A=1:3, B=4:6, C=1, D=2, key="A"))
 test(2241.07, set(DT, j="E", value=3), data.table(A=1:3, B=4:6, C=1, D=2, E=3, key="A"))
-test(2241.08, names(DT)<-letters[1:5], letters[1:5])  # R doesn't copy *tmp* when assigning to all names
+test(2241.08, names(DT)<-letters[1:5], letters[1:5])  # R doesn't copy *tmp* when assigning to all names 
 test(2241.09, DT, data.table(a=1:3, b=4:6, c=1, d=2, e=3, key="a"))
 test(2241.10, set(DT, j="f", value=4), data.table(a=1:3, b=4:6, c=1, d=2, e=3, f=4, key="a"))
 
@@ -18287,16 +18287,16 @@ test(2246.2, DT[, data.table::first(b), by=a], DT[, first(b), by=a], output="GFo
 test(2246.3, DT[, data.table::last(b), by=a], DT[, last(b), by=a], output="GForce TRUE")
 options(old)
 
-# unique.data.table doesn't return a mutable alias, #5960
+# unique.data.table doesn't return a mutable alias, #5932
 # unique nrows > 1 should return different address object (even before this fix)
 DT1 = data.table(a = 1:2, b = 3:4)
 DT2 = unique(DT1)
-test(2247.1, address(DT1) != address(DT2), TRUE)
+test(2247.1, address(DT1) != address(DT2))
 # unique nrows == 1 should return different address object (after this fix)
 DT1 = data.table(a = 1, b = 3)
 DT2 = unique(DT1)
-test(2247.2, address(DT1) != address(DT2), TRUE)
+test(2247.2, address(DT1) != address(DT2))
 # unique nrows == 0 should return different address object (after this fix)
 DT1 = data.table()
 DT2 = unique(DT1)
-test(2247.3, address(DT1) != address(DT2), TRUE)
+test(2247.3, address(DT1) != address(DT2))

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18184,7 +18184,7 @@ test(2241.04, set(DT, j="D", value=2), data.table(A=1:3, b=4:6, C=1, D=2, key="A
 test(2241.05, colnames(DT)[2]<-"B", "B")
 test(2241.06, DT, data.table(A=1:3, B=4:6, C=1, D=2, key="A"))
 test(2241.07, set(DT, j="E", value=3), data.table(A=1:3, B=4:6, C=1, D=2, E=3, key="A"))
-test(2241.08, names(DT)<-letters[1:5], letters[1:5])  # R doesn't copy *tmp* when assigning to all names 
+test(2241.08, names(DT)<-letters[1:5], letters[1:5])  # R doesn't copy *tmp* when assigning to all names
 test(2241.09, DT, data.table(a=1:3, b=4:6, c=1, d=2, e=3, key="a"))
 test(2241.10, set(DT, j="f", value=4), data.table(a=1:3, b=4:6, c=1, d=2, e=3, f=4, key="a"))
 
@@ -18286,3 +18286,17 @@ test(2246.1, DT[, data.table::shift(b), by=a], DT[, shift(b), by=a], output="GFo
 test(2246.2, DT[, data.table::first(b), by=a], DT[, first(b), by=a], output="GForce TRUE")
 test(2246.3, DT[, data.table::last(b), by=a], DT[, last(b), by=a], output="GForce TRUE")
 options(old)
+
+# unique.data.table doesn't return a mutable alias, #5960
+# unique nrows > 1 should return different address object (even before this fix)
+DT1 = data.table(a = 1:2, b = 3:4)
+DT2 = unique(DT1)
+test(2247.1, address(DT1) != address(DT2), TRUE)
+# unique nrows == 1 should return different address object (after this fix)
+DT1 = data.table(a = 1, b = 3)
+DT2 = unique(DT1)
+test(2247.2, address(DT1) != address(DT2), TRUE)
+# unique nrows == 0 should return different address object (after this fix)
+DT1 = data.table()
+DT2 = unique(DT1)
+test(2247.3, address(DT1) != address(DT2), TRUE)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -12231,7 +12231,12 @@ test(1860, fread("A,B\n "), data.table(A=logical(), B=logical()))  # 2543
 # That unique(DT) returns DT when there are no dups, #2013
 # #3383 fix for unique.data.table returning copy(x)
 DT = data.table(A=c(1L,1L,2L), B=c(3L,4L,4L))
-test(1861, address(unique(DT)) != address(DT), TRUE)
+test(1861.1, address(unique(DT)) != address(DT))
+# Ditto when nrow(x) is 0 or 1, where there can never be duplicates
+DT = data.table(a = 1, b = 3)
+test(1861.2, address(unique(DT)) != address(DT))
+DT = data.table()
+test(1861.3, address(unique(DT)) != address(DT))
 
 # New warning for deprecated old behaviour option
 setkey(DT,A)
@@ -18289,17 +18294,3 @@ test(2246.1, DT[, data.table::shift(b), by=a], DT[, shift(b), by=a], output="GFo
 test(2246.2, DT[, data.table::first(b), by=a], DT[, first(b), by=a], output="GForce TRUE")
 test(2246.3, DT[, data.table::last(b), by=a], DT[, last(b), by=a], output="GForce TRUE")
 options(old)
-
-# unique.data.table doesn't return a mutable alias, #5932
-# unique nrows > 1 should return different address object (even before this fix)
-DT1 = data.table(a = 1:2, b = 3:4)
-DT2 = unique(DT1)
-test(2247.1, address(DT1) != address(DT2))
-# unique nrows == 1 should return different address object (after this fix)
-DT1 = data.table(a = 1, b = 3)
-DT2 = unique(DT1)
-test(2247.2, address(DT1) != address(DT2))
-# unique nrows == 0 should return different address object (after this fix)
-DT1 = data.table()
-DT2 = unique(DT1)
-test(2247.3, address(DT1) != address(DT2))


### PR DESCRIPTION
Thanks to @brookslogan for the original bug report.

Fixes #5932.