### PR TITLE
Set me + Jan as the default owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-* @mattdowle
+* @jangorecki @michaelchirico
 
 # melt
 /R/fmelt.R @tdhock


### PR DESCRIPTION
This should reduce the noise in PRs of always assigning Matt. I think Jan and I have the most context on the repo to be able to delegate PRs to an appropriate reviewer, so I put us as the default owners. Over time, this will be less relevant as we get more file-level ownership built up.

cc other committers: @tdhock @mattdowle @arunsrinivasan for viz.