### PR TITLE
Better pipeline failure when curl fails on Windows

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -211,8 +211,10 @@ test-lin-310-cran:
   tags:
     - shared-windows
   before_script:
-    - curl.exe -s -o ../R-win.exe $R_BIN --fail; if (Test-Path -Path ..\R-win.exe) { Start-Process -FilePath ..\R-win.exe -ArgumentList "/VERYSILENT /DIR=C:\R" -NoNewWindow -Wait } else { Write-Error "R-win.exe not found, download failed?" }
-    - curl.exe -s -o ../rtools.exe $RTOOLS_BIN --fail; if (Test-Path -Path ..\rtools.exe) { Start-Process -FilePath ..\rtools.exe -ArgumentList "/VERYSILENT /DIR=C:\rtools" -NoNewWindow -Wait } else { Write-Error "rtools.exe not found, download failed?" }
+    - curl.exe -s -o ../R-win.exe $R_BIN --fail; if (!(Test-Path -Path ..\R-win.exe)) {Write-Error "R-win.exe not found, download failed?"}
+    - Start-Process -FilePath ..\R-win.exe -ArgumentList "/VERYSILENT /DIR=C:\R" -NoNewWindow -Wait
+    - curl.exe -s -o ../rtools.exe $RTOOLS_BIN --fail; if (!(Test-Path -Path ..\rtools.exe)) {Write-Error "rtools.exe not found, download failed?"}
+    - Start-Process -FilePath ..\rtools.exe -ArgumentList "/VERYSILENT /DIR=C:\rtools" -NoNewWindow -Wait
     - $env:PATH = "C:\R\bin;C:\rtools\usr\bin;$env:PATH"
     - Rscript.exe -e "source('.ci/ci.R'); install.packages(dcf.dependencies('DESCRIPTION', which='all'), repos=file.path('file://',getwd(),'bus/mirror-packages/cran'), quiet=TRUE)"
     - cp.exe $(ls.exe -1t bus/build/data.table_*.tar.gz | head.exe -n 1) .

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -211,8 +211,8 @@ test-lin-310-cran:
   tags:
     - shared-windows
   before_script:
-    - curl.exe -s -o ../R-win.exe $R_BIN; Start-Process -FilePath ..\R-win.exe -ArgumentList "/VERYSILENT /DIR=C:\R" -NoNewWindow -Wait
-    - curl.exe -s -o ../rtools.exe $RTOOLS_BIN; Start-Process -FilePath ..\rtools.exe -ArgumentList "/VERYSILENT /DIR=C:\rtools" -NoNewWindow -Wait
+    - curl.exe -s -o ../R-win.exe $R_BIN --fail; if (Test-Path -Path ..\R-win.exe) { Start-Process -FilePath ..\R-win.exe -ArgumentList "/VERYSILENT /DIR=C:\R" -NoNewWindow -Wait } else { Write-Error "R-win.exe not found, download failed?" }
+    - curl.exe -s -o ../rtools.exe $RTOOLS_BIN --fail; if (Test-Path -Path ..\rtools.exe) { Start-Process -FilePath ..\rtools.exe -ArgumentList "/VERYSILENT /DIR=C:\rtools" -NoNewWindow -Wait } else { Write-Error "rtools.exe not found, download failed?" }
     - $env:PATH = "C:\R\bin;C:\rtools\usr\bin;$env:PATH"
     - Rscript.exe -e "source('.ci/ci.R'); install.packages(dcf.dependencies('DESCRIPTION', which='all'), repos=file.path('file://',getwd(),'bus/mirror-packages/cran'), quiet=TRUE)"
     - cp.exe $(ls.exe -1t bus/build/data.table_*.tar.gz | head.exe -n 1) .


### PR DESCRIPTION
Related to #5979. The pipeline failed with a pretty unhelpful error message that required some guesswork.

I don't know much about PowerShell so there was some guesswork involved. I iterated a few times over on GitLab; since that history is lost here on GitHub, I'll write out some learnings for future reference here:

 - `curl --fail` is needed for the `Test-Path` approach to work, otherwise a corrupted file is created and `Test-Path` gives a related error (cannot run on corrupted file).
 - [This page](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_pipeline_chain_operators?view=powershell-7.4) implied that we could use `&&` and `||` similar to Linux, but I think that might be available only on certain PowerShell versions. I didn't easily see what version of PowerShell GLCI runs. So instead I switched to the `CMD1; if (...) CMD2 else FAIL` approach.

Here is the job that shows we're getting the intended error:

https://gitlab.com/Rdatatable/data.table/-/jobs/6337145911

Commit e137bb01b8581252f9ca22fc7b2fcebd4379de72 is purely stylistic, I didn't test it on GLCI. Not 100% sure it's still correct, so we can remove that commit if needed.