### PR TITLE
Update Imports from Blanket to Selective Import for Improved Code Maintainability

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -82,5 +82,6 @@ Authors@R: c(
   person("Josh","O'Brien",         role="ctb"),
   person("Dereck","de Mezquita",   role="ctb"),
   person("Michael","Czekanski",    role="ctb"),
-  person("Dmitry", "Shemetov",     role="ctb")
+  person("Dmitry", "Shemetov",     role="ctb"),
+  person("Nitish", "Jha",          role="ctb")
   )

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -134,7 +134,7 @@ importFrom(utils, capture.output, contrib.url, download.file, flush.console, get
 export(update_dev_pkg)
 S3method(tail, data.table)
 S3method(head, data.table)
-importFrom(stats, as.formula, na.omit, setNames, terms, time)
+importFrom(stats, as.formula, na.omit, setNames, terms)
 S3method(na.omit, data.table)
 
 S3method(as.data.table, xts)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -130,11 +130,11 @@ S3method(melt, default)
 # and many packges on CRAN call dcast.data.table() and/or melt.data.table() directly. See #3082.
 export(melt.data.table, dcast.data.table)
 
-importFrom(utils, tail, head, packageVersion, capture.output, contrib.url, download.file, flush.console, getS3method, untar, unzip)
+importFrom(utils, capture.output, contrib.url, download.file, flush.console, getS3method, head, packageVersion, tail, untar, unzip)
 export(update_dev_pkg)
 S3method(tail, data.table)
 S3method(head, data.table)
-importFrom(stats, na.omit, as.formula, setNames, terms, time)
+importFrom(stats, as.formula, na.omit, setNames, terms, time)
 S3method(na.omit, data.table)
 
 S3method(as.data.table, xts)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,7 +1,7 @@
 useDynLib("data_table", .registration=TRUE)
 
 ## For S4-ization
-importFrom("methods", "S3Part<-", "slotNames")
+importFrom(methods, "S3Part<-", slotNames)
 exportClasses(data.table, IDate, ITime)
 ##
 
@@ -130,11 +130,11 @@ S3method(melt, default)
 # and many packges on CRAN call dcast.data.table() and/or melt.data.table() directly. See #3082.
 export(melt.data.table, dcast.data.table)
 
-importFrom("utils", "tail", "head", "packageVersion", "capture.output", "contrib.url", "download.file", "flush.console", "getS3method", "untar", "unzip")
+importFrom(utils, tail, head, packageVersion, capture.output, contrib.url, download.file, flush.console, getS3method, untar, unzip)
 export(update_dev_pkg)
 S3method(tail, data.table)
 S3method(head, data.table)
-importFrom("stats", "na.omit", "as.formula", "setNames", "terms", "time")
+importFrom(stats, na.omit, as.formula, setNames, terms, time)
 S3method(na.omit, data.table)
 
 S3method(as.data.table, xts)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,7 +1,7 @@
 useDynLib("data_table", .registration=TRUE)
 
 ## For S4-ization
-import(methods)
+importFrom("methods", "S3Part<-", "slotNames")
 exportClasses(data.table, IDate, ITime)
 ##
 
@@ -130,11 +130,11 @@ S3method(melt, default)
 # and many packges on CRAN call dcast.data.table() and/or melt.data.table() directly. See #3082.
 export(melt.data.table, dcast.data.table)
 
-import(utils)
+importFrom("utils", "tail", "head", "packageVersion", "capture.output", "contrib.url", "download.file", "flush.console", "getS3method", "untar", "unzip")
 export(update_dev_pkg)
 S3method(tail, data.table)
 S3method(head, data.table)
-import(stats)
+importFrom("stats", "na.omit", "as.formula", "setNames", "terms", "time")
 S3method(na.omit, data.table)
 
 S3method(as.data.table, xts)

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -7,7 +7,7 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
   if (length(memtest.id)) {
     if (length(memtest.id)==1L) memtest.id = rep(memtest.id, 2L)  # for convenience of supplying one id rather than always a range
     stopifnot(length(memtest.id)<=2L,  # conditions quoted to user when false so "<=2L" even though following conditions rely on ==2L
-                     !anyNA(memtest.id), memtest.id[1L]<=memtest.id[2L])
+                     !anyNA(memtest.id), memtest.id[1L]<=memtest.id[2L]) 
     if (memtest==0L) memtest=1L  # using memtest.id implies memtest
   }
   if (exists("test.data.table", .GlobalEnv, inherits=FALSE)) {
@@ -132,7 +132,7 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
 
   owd = setwd(tempdir()) # ensure writeable directory; e.g. tests that plot may write .pdf here depending on device option and/or batch mode; #5190
   on.exit(setwd(owd))
-
+  
   if (memtest) {
     catf("\n***\n*** memtest=%d. This should be the first call in a fresh R_GC_MEM_GROW=0 R session for best results. Ctrl-C now if not.\n***\n\n", memtest)
     if (is.na(rss())) stopf("memtest intended for Linux. Step through data.table:::rss() to see what went wrong.")

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -7,7 +7,7 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
   if (length(memtest.id)) {
     if (length(memtest.id)==1L) memtest.id = rep(memtest.id, 2L)  # for convenience of supplying one id rather than always a range
     stopifnot(length(memtest.id)<=2L,  # conditions quoted to user when false so "<=2L" even though following conditions rely on ==2L
-                     !anyNA(memtest.id), memtest.id[1L]<=memtest.id[2L]) 
+                     !anyNA(memtest.id), memtest.id[1L]<=memtest.id[2L])
     if (memtest==0L) memtest=1L  # using memtest.id implies memtest
   }
   if (exists("test.data.table", .GlobalEnv, inherits=FALSE)) {
@@ -132,7 +132,7 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
 
   owd = setwd(tempdir()) # ensure writeable directory; e.g. tests that plot may write .pdf here depending on device option and/or batch mode; #5190
   on.exit(setwd(owd))
-  
+
   if (memtest) {
     catf("\n***\n*** memtest=%d. This should be the first call in a fresh R_GC_MEM_GROW=0 R session for best results. Ctrl-C now if not.\n***\n\n", memtest)
     if (is.na(rss())) stopf("memtest intended for Linux. Step through data.table:::rss() to see what went wrong.")
@@ -191,7 +191,7 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
   }
 
   # There aren't any errors, so we can use up 11 lines for the timings table
-  nTest = RSS = NULL  # to avoid 'no visible binding' note
+  time = nTest = RSS = NULL  # to avoid 'no visible binding' note
   timings = env$timings[nTest>0]
   if (!memtest) {
     ans = head(timings[if (dev) -1L else TRUE][order(-time)], 10L)[,RSS:=NULL]   # exclude id 1 in dev as that includes JIT


### PR DESCRIPTION
**Summary:**
This pull request updates the imports in the codebase to use selective imports instead of blanket imports for better maintainability and reduced risk of conflicts.

**Changes Made:**
- Replaced `import(methods)` with `importFrom("methods", "S3Part<-", "slotNames")`.
- Replaced `import(utils)` with `importFrom("utils", "tail", "head", "packageVersion", "capture.output", "contrib.url", "download.file", "flush.console", "getS3method", "untar", "unzip")`.
- Replaced `import(stats)` with `importFrom("stats", "na.omit", "as.formula", "setNames", "terms", "time")`.

This PR Closes #5970 
