### PR TITLE
Need importClassesFrom(methods, "[") after removing blanket import(methods)

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,7 @@ useDynLib("data_table", .registration=TRUE)
 
 ## For S4-ization
 importFrom(methods, "S3Part<-", slotNames)
+importMethodsFrom(methods, "[")
 exportClasses(data.table, IDate, ITime)
 ##
 

--- a/R/AllS4.R
+++ b/R/AllS4.R
@@ -3,21 +3,21 @@ if ("package:data.table" %in% search()) stopf("data.table package loaded. When d
 
 ## Allows data.table to be defined as an object of an S4 class,
 ## or even have data.table be a super class of an S4 class.
-setOldClass(c('data.frame'))
-setOldClass(c('data.table', 'data.frame'))
+methods::setOldClass(c('data.frame'))
+methods::setOldClass(c('data.table', 'data.frame'))
 
 ## as(some.data.frame, "data.table")
-setAs("data.frame", "data.table", function(from) {
+methods::setAs("data.frame", "data.table", function(from) {
   as.data.table(from)
 })
 
 ## as(some.data.table, "data.frame")
-setAs("data.table", "data.frame", function(from) {
+methods::setAs("data.table", "data.frame", function(from) {
   as.data.frame(from)
 })
 
-setOldClass("IDate")
-setOldClass("ITime")
+methods::setOldClass("IDate")
+methods::setOldClass("ITime")
 
-setAs("character", "IDate", function(from) as.IDate(from))
-setAs("character", "ITime", function(from) as.ITime(from))
+methods::setAs("character", "IDate", function(from) as.IDate(from))
+methods::setAs("character", "ITime", function(from) as.ITime(from))

--- a/R/AllS4.R
+++ b/R/AllS4.R
@@ -3,21 +3,21 @@ if ("package:data.table" %in% search()) stopf("data.table package loaded. When d
 
 ## Allows data.table to be defined as an object of an S4 class,
 ## or even have data.table be a super class of an S4 class.
-methods::setOldClass(c('data.frame'))
-methods::setOldClass(c('data.table', 'data.frame'))
+setOldClass(c('data.frame'))
+setOldClass(c('data.table', 'data.frame'))
 
 ## as(some.data.frame, "data.table")
-methods::setAs("data.frame", "data.table", function(from) {
+setAs("data.frame", "data.table", function(from) {
   as.data.table(from)
 })
 
 ## as(some.data.table, "data.frame")
-methods::setAs("data.table", "data.frame", function(from) {
+setAs("data.table", "data.frame", function(from) {
   as.data.frame(from)
 })
 
-methods::setOldClass("IDate")
-methods::setOldClass("ITime")
+setOldClass("IDate")
+setOldClass("ITime")
 
-methods::setAs("character", "IDate", function(from) as.IDate(from))
-methods::setAs("character", "ITime", function(from) as.ITime(from))
+setAs("character", "IDate", function(from) as.IDate(from))
+setAs("character", "ITime", function(from) as.ITime(from))


### PR DESCRIPTION
Closes #6000 

I'm still not convinced {do} should be allowed to "import" this "virtual object", but anyway this unbreaks them for now.