### PR TITLE
Better test failure with non-ASCII characters

### DIFF
--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -395,6 +395,10 @@ test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,no
       catf("Test %s did not produce correct output:\n", numStr)
       catf("Expected: <<%s>>\n", encodeString(output))  # \n printed as '\\n' so the two lines of output can be compared vertically
       catf("Observed: <<%s>>\n", encodeString(out))
+      if (anyNonAscii(output) || anyNonAscii((out))) {
+        catf("Expected (raw): <<%s>>\n", paste(charToRaw(output), collapse = " "))
+        catf("Observed (raw): <<%s>>\n", paste(charToRaw(out), collapse = " "))
+      }
       fail = TRUE
       # nocov end
     }
@@ -403,6 +407,10 @@ test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,no
       catf("Test %s produced output but should not have:\n", numStr)
       catf("Expected absent (case insensitive): <<%s>>\n", encodeString(notOutput))
       catf("Observed: <<%s>>\n", encodeString(out))
+      if (anyNonAscii(notOutput) || anyNonAscii((out))) {
+        catf("Expected absent (raw): <<%s>>\n", paste(charToRaw(notOutput), collapse = " "))
+        catf("Observed (raw): <<%s>>\n", paste(charToRaw(out), collapse = " "))
+      }
       fail = TRUE
       # nocov end
     }
@@ -448,6 +456,10 @@ test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,no
           # head.matrix doesn't restrict columns
           if (length(d <- dim(x))) do.call(`[`, c(list(x, drop = FALSE), lapply(pmin(d, 6L), seq_len)))
           else print(head(x))
+          if (typeof(x) == 'character' && anyNonAscii(x)) {
+            cat("Non-ASCII string detected, raw representation:\n")
+            print(lapply(head(x), charToRaw))
+          }
         }
       }
       failPrint(x, deparse(xsub))
@@ -466,3 +478,4 @@ test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,no
   invisible(!fail)
 }
 
+anyNonAscii = function(x) anyNA(iconv(x, to="ASCII"))

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -478,4 +478,4 @@ test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,no
   invisible(!fail)
 }
 
-anyNonAscii = function(x) anyNA(iconv(x, to="ASCII"))
+anyNonAscii = function(x) anyNA(iconv(x, to="ASCII")) # nocov

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18350,10 +18350,3 @@ if (test_bit64) {
   apple = data.table(id = c("a", "b", "b"), time = c(1L, 1L, 2L), y = i64v[1:3])
   test(2248, dcast(apple, id ~ time, value.var = "y"), data.table(id = c('a', 'b'), `1` = i64v[1:2], `2` = i64v[4:3], key='id'))
 }
-
-test(9999, '\u1234', 'abc')
-test(99999, '\u1234', '\u2345')
-test(999999, 'abc', '\u1234')
-test(9999999, '\u1234', output='abc')
-test(99999999, '\u1234', output='\u2345')
-test(999999999, 'abc', output='\u1234')

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18350,3 +18350,10 @@ if (test_bit64) {
   apple = data.table(id = c("a", "b", "b"), time = c(1L, 1L, 2L), y = i64v[1:3])
   test(2248, dcast(apple, id ~ time, value.var = "y"), data.table(id = c('a', 'b'), `1` = i64v[1:2], `2` = i64v[4:3], key='id'))
 }
+
+test(9999, '\u1234', 'abc')
+test(99999, '\u1234', '\u2345')
+test(999999, 'abc', '\u1234')
+test(9999999, '\u1234', output='abc')
+test(99999999, '\u1234', output='\u2345')
+test(999999999, 'abc', output='\u1234')


### PR DESCRIPTION
Should help with situations like #5995 where it's hard to figure out from CI output alone what the issue might be. Byte representation will always be the "truest" way to look at why string comparison fails in a platform-robust way, in my experience.

Tested manually:

```r
test(9999, '\u1234', 'abc')
test(99999, '\u1234', '\u2345')
test(999999, 'abc', '\u1234')
test(9999999, '\u1234', output='abc')
test(99999999, '\u1234', output='\u2345')
test(999999999, 'abc', output='\u1234')
```

with output:

```
Test 9999 ran without errors but failed check that x equals y:
> x = "ሴ" 
First 1 of 1 (type 'character'): 
[1] "ሴ"
Non-ASCII string detected, raw representation:
[[1]]
[1] e1 88 b4

> y = "abc" 
First 1 of 1 (type 'character'): 
[1] "abc"
1 string mismatch
Test 99999 ran without errors but failed check that x equals y:
> x = "ሴ" 
First 1 of 1 (type 'character'): 
[1] "ሴ"
Non-ASCII string detected, raw representation:
[[1]]
[1] e1 88 b4

> y = "⍅" 
First 1 of 1 (type 'character'): 
[1] "⍅"
Non-ASCII string detected, raw representation:
[[1]]
[1] e2 8d 85

1 string mismatch
Test 999999 ran without errors but failed check that x equals y:
> x = "abc" 
First 1 of 1 (type 'character'): 
[1] "abc"
> y = "ሴ" 
First 1 of 1 (type 'character'): 
[1] "ሴ"
Non-ASCII string detected, raw representation:
[[1]]
[1] e1 88 b4

1 string mismatch
Test 9999999 did not produce correct output:
Expected: <<abc>>
Observed: <<[1] "ሴ">>
Expected (raw): <<61 62 63>>
Observed (raw): <<5b 31 5d 20 22 e1 88 b4 22>>
Test 99999999 did not produce correct output:
Expected: <<⍅>>
Observed: <<[1] "ሴ">>
Expected (raw): <<e2 8d 85>>
Observed (raw): <<5b 31 5d 20 22 e1 88 b4 22>>
Test 1e+09 did not produce correct output:
Expected: <<ሴ>>
Observed: <<[1] "abc">>
Expected (raw): <<e1 88 b4>>
Observed (raw): <<5b 31 5d 20 22 61 62 63 22>>
```