### PR TITLE
Resolve Rd Line Width Issues in transpose.Rd and print.data.table.Rd Files

### DIFF
--- a/man/print.data.table.Rd
+++ b/man/print.data.table.Rd
@@ -100,7 +100,8 @@
   print(DT, trunc.cols=TRUE)
   options(old_width)
 
-  # `char.trunc` will truncate the strings if their lengths exceed the given limit: `datatable.prettyprint.char`
+  # `char.trunc` will truncate the strings,
+  # if their lengths exceed the given limit: `datatable.prettyprint.char`
   # For example:
 
   old = options(datatable.prettyprint.char=5L)

--- a/man/transpose.Rd
+++ b/man/transpose.Rd
@@ -6,7 +6,8 @@
 }
 
 \usage{
-transpose(l, fill=NA, ignore.empty=FALSE, keep.names=NULL, make.names=NULL, list.cols=FALSE)
+transpose(l, fill=NA, ignore.empty=FALSE, keep.names=NULL,
+          make.names=NULL, list.cols=FALSE)
 }
 \arguments{
   \item{l}{ A list, data.frame or data.table. }


### PR DESCRIPTION
**Description:**

This pull request addresses the NOTE generated during the package check process for the `data.table` package regarding line widths in the Rd files. The changes made ensure that the lines in the Rd files adhere to the specified width limits.

**Changes Made:**

- In the 'transpose.Rd' file, adjusted the `\usage` section to break lines , ensuring that each line is no wider than 90 characters.
- In the 'print.data.table.Rd' file, modified the `\examples` section to keep the example within the 100-character limit.

This PR Closes #6009 
