### PR TITLE
Updated warning for referencing a non-existent value during creation of new column

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -1012,7 +1012,7 @@ test(313, DT[,a:=1:3], data.table(a=1:3))    # test changed in 1.12.2; can now a
 DT = data.table(a=20:22)
 test(314, {DT[,b:=23:25];DT[,c:=26:28]}, data.table(a=20:22,b=23:25,c=26:28))   # add in series
 test(315, DT[,c:=NULL], data.table(a=20:22,b=23:25))   # delete last
-test(316, DT[,c:=NULL], data.table(a=20:22,b=23:25), warning="Tried to assign NULL to column 'c', but column 'c' does not exist to remove")
+test(316, DT[,c:=NULL], data.table(a=20:22,b=23:25), warning="Tried to assign NULL to column 'c', but this column does not exist to remove")
 
 # Test adding, removing and updating columns via [<- in one step
 DT = data.table(a=1:6,b=1:6,c=1:6)
@@ -2809,9 +2809,9 @@ test(943, merge(X,Y,all.y=TRUE,by="a"), data.table(a=2:4,b=INT(5:6,NA),"d 1"=5:7
 
 # Test error message about NULL type
 DT = data.table(NULL)
-test(944.1, DT[, foo:=NULL], DT, warning="Tried to assign NULL to column 'foo', but column 'foo' does not exist to remove")
+test(944.1, DT[, foo:=NULL], DT, warning="Tried to assign NULL to column 'foo', but this column does not exist to remove")
 test(944.2, DT[,a:=1L], data.table(a=1L))  # can now add columns to an empty data.table from v1.12.2
-test(944.3, DT[,aa:=NULL], data.table(a=1L), warning="Tried to assign NULL to column 'aa', but column 'aa' does not exist to remove")
+test(944.3, DT[,aa:=NULL], data.table(a=1L), warning="Tried to assign NULL to column 'aa', but this column does not exist to remove")
 test(944.4, DT[,a:=NULL], data.table(NULL))
 if (base::getRversion() >= "3.4.0") {
   test(944.5, typeof(structure(NULL, class=c("data.table","data.frame"))), 'list', warning="deprecated, as NULL cannot have attributes")  # R warns which is good and we like

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -1012,7 +1012,7 @@ test(313, DT[,a:=1:3], data.table(a=1:3))    # test changed in 1.12.2; can now a
 DT = data.table(a=20:22)
 test(314, {DT[,b:=23:25];DT[,c:=26:28]}, data.table(a=20:22,b=23:25,c=26:28))   # add in series
 test(315, DT[,c:=NULL], data.table(a=20:22,b=23:25))   # delete last
-test(316, DT[,c:=NULL], data.table(a=20:22,b=23:25), warning="Column 'c' does not exist to remove")
+test(316, DT[,c:=NULL], data.table(a=20:22,b=23:25), warning="Tried to assign NULL to column 'c', but column 'c' does not exist to remove")
 
 # Test adding, removing and updating columns via [<- in one step
 DT = data.table(a=1:6,b=1:6,c=1:6)
@@ -2809,9 +2809,9 @@ test(943, merge(X,Y,all.y=TRUE,by="a"), data.table(a=2:4,b=INT(5:6,NA),"d 1"=5:7
 
 # Test error message about NULL type
 DT = data.table(NULL)
-test(944.1, DT[, foo:=NULL], DT, warning="Column 'foo' does not exist to remove")
+test(944.1, DT[, foo:=NULL], DT, warning="Tried to assign NULL to column 'foo', but column 'foo' does not exist to remove")
 test(944.2, DT[,a:=1L], data.table(a=1L))  # can now add columns to an empty data.table from v1.12.2
-test(944.3, DT[,aa:=NULL], data.table(a=1L), warning="Column 'aa' does not exist to remove")
+test(944.3, DT[,aa:=NULL], data.table(a=1L), warning="Tried to assign NULL to column 'aa', but column 'aa' does not exist to remove")
 test(944.4, DT[,a:=NULL], data.table(NULL))
 if (base::getRversion() >= "3.4.0") {
   test(944.5, typeof(structure(NULL, class=c("data.table","data.frame"))), 'list', warning="deprecated, as NULL cannot have attributes")  # R warns which is good and we like

--- a/src/assign.c
+++ b/src/assign.c
@@ -430,7 +430,7 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values)
       if (newcolnum<0 || newcolnum>=length(newcolnames))
         error(_("Internal error in assign.c: length(newcolnames)=%d, length(names)=%d, coln=%d"), length(newcolnames), length(names), coln); // # nocov
       if (isNull(thisvalue)) {
-        warning(_("Column '%s' does not exist to remove"),CHAR(STRING_ELT(newcolnames,newcolnum)));
+        warning(_("Tried to assign NULL to column '%s', but column '%s' does not exist to remove"),CHAR(STRING_ELT(newcolnames,newcolnum)),CHAR(STRING_ELT(newcolnames,newcolnum)));
         continue;
       }
       // RHS of assignment to new column is zero length but we'll use its type to create all-NA column of that type

--- a/src/assign.c
+++ b/src/assign.c
@@ -430,7 +430,7 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values)
       if (newcolnum<0 || newcolnum>=length(newcolnames))
         error(_("Internal error in assign.c: length(newcolnames)=%d, length(names)=%d, coln=%d"), length(newcolnames), length(names), coln); // # nocov
       if (isNull(thisvalue)) {
-        warning(_("Tried to assign NULL to column '%s', but column '%s' does not exist to remove"),CHAR(STRING_ELT(newcolnames,newcolnum)),CHAR(STRING_ELT(newcolnames,newcolnum)));
+        warning(_("Tried to assign NULL to column '%s', but column '%s' does not exist to remove"), CHAR(STRING_ELT(newcolnames,newcolnum)), CHAR(STRING_ELT(newcolnames,newcolnum)));
         continue;
       }
       // RHS of assignment to new column is zero length but we'll use its type to create all-NA column of that type

--- a/src/assign.c
+++ b/src/assign.c
@@ -430,7 +430,7 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values)
       if (newcolnum<0 || newcolnum>=length(newcolnames))
         error(_("Internal error in assign.c: length(newcolnames)=%d, length(names)=%d, coln=%d"), length(newcolnames), length(names), coln); // # nocov
       if (isNull(thisvalue)) {
-        warning(_("Tried to assign NULL to column '%s', but column '%s' does not exist to remove"), CHAR(STRING_ELT(newcolnames,newcolnum)), CHAR(STRING_ELT(newcolnames,newcolnum)));
+        warning(_("Tried to assign NULL to column '%s', but this column does not exist to remove"), CHAR(STRING_ELT(newcolnames,newcolnum)));
         continue;
       }
       // RHS of assignment to new column is zero length but we'll use its type to create all-NA column of that type


### PR DESCRIPTION
Closes #5648 

This PR changes the old warning message when referencing a value that doesn't exist:

> ```r
> library(data.table)
> 
> foo<-data.table(col1=letters[1:10])
> 
> foo[,col3:=foo[col1=="a",]$col2]
> 
> # Warning message:
> # In `[.data.table`(foo, , `:=`(col3, foo[col1 == "a", ]$col2)) :
> # Column 'col3' does not exist to remove
> ```

The above issue may be easy to spot when isolated but the previous warning message isn't very helpful when someone just accidentally loses track of what order they put things in, especially within a larger context.

The new warning message:

https://github.com/Rdatatable/data.table/blob/ac9943998fb66a618ad0921583fe7f0046825ebc/src/assign.c#L433
```r
# Tried to assign NULL to column 'col3', but this column does not exist to remove.
```
should be clearer and more helpful in debugging.

Also, I updated tests 316, 944.1, and 944.3 to test for this new warning message.