### PR TITLE
Enhance Error Message for using `:=` or `let` in Non-data.table-aware Environment

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -147,7 +147,7 @@ replace_dot_alias = function(e) {
     # Fix for #500 (to do)
     if (substitute(j) %iscall% c(":=", "let")) {
         # Throw a specific error message
-        stopf("[ was called on a data.table in an environment that is not data.table-aware (i.e. cedta()), but '%s' was used, implying the owner of this call really intended for data.table methods to be called. See vignette('datatable-importing') for details on properly importing data.table.", substitute(j)[[1L]])
+        stopf("[ was called on a data.table in an environment that is not data.table-aware (i.e. cedta()), but '%s' was used, implying the owner of this call really intended for data.table methods to be called. See vignette('datatable-importing') for details on properly importing data.table.", as.character(substitute(j)[[1L]]))
     }
     Nargs = nargs() - (!missing(drop))
     ans = if (Nargs<3L) { `[.data.frame`(x,i) }  # drop ignored anyway by DF[i]

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -145,7 +145,7 @@ replace_dot_alias = function(e) {
   # the drop=NULL is to sink drop argument when dispatching to [.data.frame; using '...' stops test 147
   if (!cedta()) {
     # Fix for #500 (to do)
-    if (substitute(j) %iscall% c(":=", "let")){
+    if (substitute(j) %iscall% c(":=", "let")) {
         # Throw a specific error message
         stopf("[ was called on a data.table in an environment that is not data.table-aware (i.e. cedta()), but ':=' or 'let' was used, implying the owner of this call really intended for data.table methods to be called. See vignette('datatable-importing') for details on properly importing data.table.")
     }

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -145,6 +145,10 @@ replace_dot_alias = function(e) {
   # the drop=NULL is to sink drop argument when dispatching to [.data.frame; using '...' stops test 147
   if (!cedta()) {
     # Fix for #500 (to do)
+    if (any(grepl(":=|let", substitute(j)))) {
+        # Throw a specific error message
+        stopf("[ was called on a data.table in an environment that is not data.table-aware (i.e. cedta()), but ':=' or 'let' was used, implying the owner of this call really intended for data.table methods to be called. See vignette('datatable-importing') for details on properly importing data.table.")
+    }
     Nargs = nargs() - (!missing(drop))
     ans = if (Nargs<3L) { `[.data.frame`(x,i) }  # drop ignored anyway by DF[i]
         else if (missing(drop)) `[.data.frame`(x,i,j)

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -145,7 +145,7 @@ replace_dot_alias = function(e) {
   # the drop=NULL is to sink drop argument when dispatching to [.data.frame; using '...' stops test 147
   if (!cedta()) {
     # Fix for #500 (to do)
-    if (any(grepl(":=|let", substitute(j)))) {
+    if (substitute(j) %iscall% c(":=", "let")){
         # Throw a specific error message
         stopf("[ was called on a data.table in an environment that is not data.table-aware (i.e. cedta()), but ':=' or 'let' was used, implying the owner of this call really intended for data.table methods to be called. See vignette('datatable-importing') for details on properly importing data.table.")
     }

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -147,7 +147,7 @@ replace_dot_alias = function(e) {
     # Fix for #500 (to do)
     if (substitute(j) %iscall% c(":=", "let")) {
         # Throw a specific error message
-        stopf("[ was called on a data.table in an environment that is not data.table-aware (i.e. cedta()), but ':=' or 'let' was used, implying the owner of this call really intended for data.table methods to be called. See vignette('datatable-importing') for details on properly importing data.table.")
+        stopf("[ was called on a data.table in an environment that is not data.table-aware (i.e. cedta()), but '%s' was used, implying the owner of this call really intended for data.table methods to be called. See vignette('datatable-importing') for details on properly importing data.table.", substitute(j)[[1L]])
     }
     Nargs = nargs() - (!missing(drop))
     ans = if (Nargs<3L) { `[.data.frame`(x,i) }  # drop ignored anyway by DF[i]

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18419,3 +18419,8 @@ test(2251.10, dim(fread(text, fill=TRUE)), c(9L, 9L))
 test(2251.11, dim(fread(text, fill=7)), c(9L, 9L))
 test(2251.12, dim(fread(text, fill=9)), c(9L, 9L))
 test(2251.13, dim(fread(text, fill=20)), c(9L, 20L)) # clean up currently only kicks in if sep!=' '
+
+.datatable.aware = FALSE
+dt = data.table(a = 1L)
+test(2252.1, dt[, b:=2L], error = "^\\[ was called on a data.table in an environment that is not data.table-aware.*")
+test(2252.2, dt[, b:=2L], error = "^\\[ was called on a data.table in an environment that is not data.table-aware.*")

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18423,4 +18423,4 @@ test(2251.13, dim(fread(text, fill=20)), c(9L, 20L)) # clean up currently only k
 .datatable.aware = FALSE
 dt = data.table(a = 1L)
 test(2252.1, dt[, b:=2L], error = "^\\[ was called on a data.table in an environment that is not data.table-aware.*")
-test(2252.2, dt[, b:=2L], error = "^\\[ was called on a data.table in an environment that is not data.table-aware.*")
+test(2252.2, dt[, let(b=2L)], error = "^\\[ was called on a data.table in an environment that is not data.table-aware.*")

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18422,5 +18422,6 @@ test(2251.13, dim(fread(text, fill=20)), c(9L, 20L)) # clean up currently only k
 
 .datatable.aware = FALSE
 dt = data.table(a = 1L)
-test(2252.1, dt[, b:=2L], error = "^\\[ was called on a data.table in an environment that is not data.table-aware.*")
-test(2252.2, dt[, let(b=2L)], error = "^\\[ was called on a data.table in an environment that is not data.table-aware.*")
+test(2252.1, dt[, b:=2L], error = "\\[ was called on a data.table.*not data.table-aware.*':='")
+test(2252.2, dt[, let(b=2L)], error = "\\[ was called on a data.table.*not data.table-aware.*'let'")
+rm(.datatable.aware)


### PR DESCRIPTION
**Description:**

This PR addresses issue #5721. The current error message generated when `:=` is used directly in an environment not aware of data.table (`cedta()` returns `FALSE`) can be misleading. This PR enhances the error message to provide more specific guidance to the user.

**Changes Made:**
- Added a check in the `[.data.table` function to detect the presence of `:=` or `let` in the `j` argument.
- If `:=` or `let` is detected, a more specific error message is thrown, advising the user to ensure that data.table is imported and used explicitly in their package.

**Proposed Error Message:**

```
"[ was called on a data.table in an environment that is not data.table-aware (i.e. cedta()), but ':=' or 'let' was used, implying the owner of this call really intended for data.table methods to be called. See vignette('datatable-importing') for details on properly importing data.table."
```


Closes #5721
