### PR TITLE
remove unneeded step to uninstall data.table under cc()

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -1,10 +1,6 @@
 require(methods)
 
 if (exists("test.data.table", .GlobalEnv, inherits=FALSE)) {
-  if (!identical(suppressWarnings(packageDescription("data.table")), NA)) {
-    remove.packages("data.table")
-    stop("This is dev mode but data.table was installed. Uninstalled it. Please q() this R session and try cc() again. The installed namespace causes problems in dev mode for the S4 tests.\n")
-  }
   if ((tt<-compiler::enableJIT(-1))>0)
     cat("This is dev mode and JIT is enabled (level ", tt, ") so there will be a brief pause around the first test.\n", sep="")
   rm_all = function() {}


### PR DESCRIPTION
Split off from #6053. I can run `cc()` twice in a row with no problem -- per https://github.com/Rdatatable/data.table/commit/335368b3ec54d585c30d04f95949e773a0e7f87b, bad interaction with S4 seems to stem from bad clean-up of tests that can be fixed by improving the test suite rather than uninstalling data.table.