### PR TITLE
Suppress output of computing 'y' in test()

### DIFF
--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -418,7 +418,7 @@ test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,no
     }
   }
   if (!fail && !length(error) && (!length(output) || !missing(y))) {   # TODO test y when output=, too
-    y = try(y,TRUE)
+    capture.output(y <- try(y, silent=TRUE)) # y might produce verbose output, just toss it
     if (identical(x,y)) return(invisible(TRUE))
     all.equal.result = TRUE
     if (is.data.frame(x) && is.data.frame(y)) {


### PR DESCRIPTION
Started noticing this lately, not sure how this hasn't come up before.

For example these tests, where `verbose=TRUE` is set and we are using a `data.table::`-less version to check equality, `y` will also produce the verbose output:

https://github.com/Rdatatable/data.table/blob/61d40246c8cff85e46f969e7cdfa00e928a71b50/inst/tests/tests.Rraw#L18292-L18297

So I wouldn't change the test, suppressing output seems the easiest+best approach.

Will merge since it's been quite annoying in dev to deal with this & it's test-only.