### PR TITLE
New option env= for test()

### DIFF
--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -303,7 +303,19 @@ gc_mem = function() {
   # nocov end
 }
 
-test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,notOutput=NULL,ignore.warning=NULL,options=NULL) {
+test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,notOutput=NULL,ignore.warning=NULL,options=NULL,env=NULL) {
+  if (!is.null(env)) {
+    old = Sys.getenv(names(env), names=TRUE, unset=NA)
+    to_unset = !lengths(env)
+    # NB: Sys.setenv() (no arguments) errors
+    if (!all(to_unset)) do.call(Sys.setenv, as.list(env[!to_unset]))
+    Sys.unsetenv(names(env)[to_unset])
+    on.exit(add=TRUE, {
+      is_preset = !is.na(old)
+      if (any(is_preset)) do.call(Sys.setenv, as.list(old[is_preset]))
+      Sys.unsetenv(names(old)[!is_preset])
+    })
+  }
   if (!is.null(options)) {
     old_options <- do.call('options', as.list(options)) # as.list(): allow passing named character vector for convenience
     on.exit(options(old_options), add=TRUE)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -14290,35 +14290,24 @@ test(1997.06, setDTthreads(percent=NULL), error="but is length 0")
 test(1997.07, setDTthreads(percent=1:2), error="but is length 2")
 test(1997.08, setDTthreads(restore_after_fork=21), error="must be TRUE, FALSE, or NULL")
 old = getDTthreads()   # (1)
-oldenv1 = Sys.getenv("R_DATATABLE_NUM_PROCS_PERCENT")
-oldenv2 = Sys.getenv("R_DATATABLE_NUM_THREADS")
-Sys.setenv(R_DATATABLE_NUM_THREADS="")  # in case user has this set, so we can test PROCS_PERCENT
-Sys.setenv(R_DATATABLE_NUM_PROCS_PERCENT="3.0")
-test(1997.09, setDTthreads(), old, ignore.warning="Ignoring invalid.*Please remove any.*not a digit")
+test(1997.09, env = c(R_DATATABLE_NUM_THREADS="", R_DATATABLE_NUM_PROCS_PERCENT="3.0"), setDTthreads(), old, ignore.warning="Ignoring invalid.*Please remove any.*not a digit")
 new = getDTthreads()  # old above at (1) may not have been default. new now is.
 test(1997.10, getDTthreads(), new)
-Sys.setenv(R_DATATABLE_NUM_PROCS_PERCENT="1")
-test(1997.11, setDTthreads(), new, ignore.warning="Ignoring invalid.*integer between 2 and 100")
+test(1997.11, env=c(R_DATATABLE_NUM_PROCS_PERCENT="1"), setDTthreads(), new, ignore.warning="Ignoring invalid.*integer between 2 and 100")
 test(1997.12, getDTthreads(), new)
-Sys.setenv(R_DATATABLE_NUM_PROCS_PERCENT="75")
-test(1997.13, setDTthreads(), new)
+test(1997.13, env=c(R_DATATABLE_NUM_PROCS_PERCENT="75"), setDTthreads(), new)
 new = getDTthreads()
 setDTthreads(percent=75)
 test(1997.14, getDTthreads(), new)
-Sys.setenv(R_DATATABLE_NUM_PROCS_PERCENT="100")
-setDTthreads()
+test(1997.15, env=c(R_DATATABLE_NUM_PROCS_PERCENT="100"), setDTthreads(), new)
 allcpu = getDTthreads()
-Sys.setenv(R_DATATABLE_NUM_PROCS_PERCENT="75")
-Sys.setenv(R_DATATABLE_NUM_THREADS=allcpu)
-setDTthreads()
-test(1997.15, getDTthreads(), allcpu)
-Sys.setenv(R_DATATABLE_NUM_PROCS_PERCENT=oldenv1)
-Sys.setenv(R_DATATABLE_NUM_THREADS=oldenv2)
-test(1997.16, setDTthreads(old), allcpu)
-test(1997.17, getDTthreads(), old)
-test(1997.18, setDTthreads(throttle=NA), error="throttle.*must be a single number, non-NA, and >=1")
+test(1997.16, env=c(R_DATATABLE_NUM_PROCS_PERCENT="75", R_DATATABLE_NUM_THREADS=allcpu), setDTthreads(), allcpu)
+test(1997.17, getDTthreads(), allcpu)
+test(1997.18, setDTthreads(old), allcpu)
+test(1997.19, getDTthreads(), old)
+test(1997.20, setDTthreads(throttle=NA), error="throttle.*must be a single number, non-NA, and >=1")
 setDTthreads(throttle=65536)
-test(1997.19, getDTthreads(TRUE), output="throttle==65536")
+test(1997.21, getDTthreads(TRUE), output="throttle==65536")
 setDTthreads(throttle=1024)
 
 # test that a copy is being made and output is printed, #3385 after partial revert of #3281
@@ -16429,14 +16418,9 @@ test(2122.2, DT, data.table(V3=5:6))
 dt = data.table(SomeNumberA=c(1,1,1),SomeNumberB=c(1,1,1))
 test(2123, dt[, .(.N, TotalA=sum(SomeNumberA), TotalB=sum(SomeNumberB)), by=SomeNumberA], data.table(SomeNumberA=1, N=3L, TotalA=1, TotalB=3))
 
-# system timezone is not usually UTC, so as.ITime.POSIXct shouldn't assume so, #4085
-oldtz=Sys.getenv('TZ', unset=NA)
-Sys.setenv(TZ='Asia/Jakarta') # UTC+7
-t0 = as.POSIXct('2019-10-01')
-test(2124.1, format(as.ITime(t0)), '00:00:00')
-test(2124.2, format(as.IDate(t0)), '2019-10-01')
-if (is.na(oldtz)) Sys.unsetenv("TZ") else Sys.setenv(TZ=oldtz)
-# careful to unset because TZ="" means UTC whereas unset TZ means local, #4261 and #4464
+# system timezone is not usually UTC, so as.ITime.POSIXct shouldn't assume so, #4085, #4261, #4464
+test(2124.1, env=c(TZ='Asia/Jakarta'), format(as.ITime(as.POSIXct('2019-10-01'))), '00:00:00')
+test(2124.2, env=c(TZ='Asia/Jakarta'), format(as.IDate(as.POSIXct('2019-10-01'))), '2019-10-01')
 
 # trunc.cols in print.data.table, #4074
 old_width = options("width" = 40L)
@@ -16799,20 +16783,12 @@ if (.Platform$OS.type=="windows") local({
   )
   x_old = Map(Sys.getlocale, names(x))
   invisible(Map(Sys.setlocale, names(x), x))
-  old = Sys.getenv('LANGUAGE')
-  Sys.setenv('LANGUAGE' = 'zh_CN')
-  on.exit({
-    if (nzchar(old))
-      Sys.setenv('LANGUAGE' = old)
-    else
-      Sys.unsetenv('LANGUAGE')
-    invisible(Map(Sys.setlocale, names(x_old), x_old))
-  }, add = TRUE)
+  on.exit(Map(Sys.setlocale, names(x_old), x_old))
   # triggered segfault here in #4402, Windows-only under translation.
   # test that the argument order changes correctly (the 'item 2' moves to the beginning of the message)
   # since the argument order changes in this example (and that was the crash) we don't need to test
   # the display of the Chinese characters here. Thanks to @shrektan for all his help on this.
-  test(2143, rbind(DT,list(c=4L,a=7L)), error="2.*1.*c.*1")
+  test(2143, env=c(LANGUAGE='zh_CN'), rbind(DT,list(c=4L,a=7L)), error="2.*1.*c.*1")
 })
 # test back to English (the argument order is back to 1,c,2,1)
 test(2144, rbind(DT,list(c=4L,a=7L)), error="Column 1 ['c'] of item 2 is missing in item 1")
@@ -16871,18 +16847,13 @@ tmp = tempfile()
 fwrite(DT, tmp)
 test(2150.01, fread(tmp), DT)   # defaults for fwrite/fread simple and preserving
 fwrite(DT, tmp, dateTimeAs='write.csv')  # as write.csv, writes the UTC times as-is not local because the time column has tzone=="UTC", but without the Z marker
-oldtz = Sys.getenv("TZ", unset=NA)
-Sys.unsetenv("TZ")
-test(2150.021, sapply(fread(tmp,tz=""), typeof), c(dates="integer", times="character"))  # from v1.14.0 tz="" needed to read datetime as character
-test(2150.022, fread(tmp,tz="UTC"), DT)  # user can tell fread to interpet the unmarked datetimes as UTC
-Sys.setenv(TZ="UTC")
-test(2150.023, fread(tmp), DT)  # TZ environment variable is also recognized
+test(2150.021, env=list(TZ=NULL), sapply(fread(tmp,tz=""), typeof), c(dates="integer", times="character"))  # from v1.14.0 tz="" needed to read datetime as character
+test(2150.022, env=list(TZ=NULL), fread(tmp,tz="UTC"), DT)  # user can tell fread to interpet the unmarked datetimes as UTC
+test(2150.023, env=c(TZ='UTC'), fread(tmp), DT)  # TZ environment variable is also recognized
 if (.Platform$OS.type!="windows") {
-  Sys.setenv(TZ="")  # on Windows this unsets TZ, see ?Sys.setenv
-  test(2150.024, fread(tmp), DT)
+  test(2150.024, env=c(TZ=''), fread(tmp), DT) # on Windows this unsets TZ, see ?Sys.setenv
   # blank TZ env variable on non-Windows is recognized as UTC consistent with C and R; but R's tz= argument is the opposite and uses "" for local
 }
-Sys.unsetenv("TZ")
 # Notes:
 #  - from v1.14.0 tz="" needed
 #  - as.POSIXct puts "" on the result (testing the write.csv version here with missing tzone)
@@ -16891,11 +16862,11 @@ Sys.unsetenv("TZ")
 #    as.POSIXct() failure means 'times' is returned as a character, hence no 'tzone' attribute.
 #    fread() will also throw a warning, one substring of which will be the reproduced base R error.
 test(2150.025,
+     env=list(TZ=NULL),
      attr(fread(tmp, colClasses=list(POSIXct="times"), tz="")$times, "tzone"),
      if (is.null(base_messages$maybe_invalid_old_posixct)) "" else NULL,
      warning=base_messages$maybe_invalid_old_posixct)
 # the times will be different though here because as.POSIXct read them as local time.
-if (is.na(oldtz)) Sys.unsetenv("TZ") else Sys.setenv(TZ=oldtz)
 fwrite(copy(DT)[ , times := format(times, '%FT%T+00:00')], tmp)
 test(2150.03, fread(tmp), DT)
 fwrite(copy(DT)[ , times := format(times, '%FT%T+0000')], tmp)

--- a/man/test.Rd
+++ b/man/test.Rd
@@ -8,7 +8,7 @@
 test(num, x, y = TRUE,
      error = NULL, warning = NULL, message = NULL,
      output = NULL, notOutput = NULL, ignore.warning = NULL,
-     options = NULL)
+     options = NULL, env = NULL)
 }
 \arguments{
 \item{num}{ A unique identifier for a test, helpful in identifying the source of failure when testing is not working. Currently, we use a manually-incremented system with tests formatted as \code{n.m}, where essentially \code{n} indexes an issue and \code{m} indexes aspects of that issue. For the most part, your new PR should only have one value of \code{n} (scroll to the end of \code{inst/tests/tests.Rraw} to see the next available ID) and then index the tests within your PR by increasing \code{m}. Note -- \code{n.m} is interpreted as a number, so \code{123.4} and \code{123.40} are actually the same -- please \code{0}-pad as appropriate. Test identifiers are checked to be in increasing order at runtime to prevent duplicates being possible. }
@@ -21,6 +21,7 @@ test(num, x, y = TRUE,
 \item{notOutput}{ Or if you are testing that a feature does \emph{not} print particular console output. Case insensitive (unlike output) so that the test does not incorrectly pass just because the string is not found due to case. }
 \item{ignore.warning}{ A single character string. Any warnings emitted by \code{x} that contain this string are dropped. Remaining warnings are compared to the expected \code{warning} as normal. }
 \item{options}{ A named list of options to set for the duration of the test. Any code evaluated during this call to `test()` (usually, `x`, or maybe `y`) will run with the named options set, and the original options will be restored on return. This is a named list since different options can have different types in general, but in typical usage, only one option is set at a time, in which case a named vector is also accepted. }
+\item{env}{ A named list of environment variables to set for the duration of the test, much like \code{options}. A list entry set to \code{NULL} will unset (i.e., \code{\link{Sys.unsetenv}}) the corresponding variable. }
 }
 \note{
    \code{NA_real_} and \code{NaN} are treated as equal, use \code{identical} if distinction is needed. See examples below.


### PR DESCRIPTION
Closes #5848.

Also apply it to our tests, since most of the usage is in one set of tests about `{set,get}DTthreads()`.