### PR TITLE
Clean up getRversion overwrite to avoid cc() error on re-run

### DIFF
--- a/.dev/cc.R
+++ b/.dev/cc.R
@@ -38,6 +38,7 @@ sourceImports = function(path=getwd(), quiet=FALSE) {
     if (!quiet) warning("No NAMESPACE file found, required to guarantee imports resolve correctly")
     return(invisible())
   }
+  suppressWarnings(rm("getRversion", envir=.GlobalEnv)) # clean up from previous cc() because parseNamespaceFile() run getRversion() in NAMESPACE in .GlobalEnv
   nsParsedImports = parseNamespaceFile(basename(path), "..")$imports # weird signature to this function
   if (!quiet && length(nsParsedImports)) cat(sprintf("Ensuring objects from %d import entries in NAMESPACE resolve correctly\n", length(nsParsedImports)))
   for (ii in seq_along(nsParsedImports)) {


### PR DESCRIPTION
Follow-up to #6061.

We overwrite `getRversion()` to discourage its use in R code:

https://github.com/Rdatatable/data.table/blob/a7a12a93f1c56eae339d74ee82f2f7f2a2ccd6d7/R/onLoad.R#L131

However the new `parseNamespaceFile()` usage evaluates the directives in NAMESPACE in `.GlobalEnv`:

https://github.com/r-devel/r-svn/blob/9613ea171aec3c53f283ff2b4d5785f7c4f98027/src/library/base/R/namespace.R#L1336

https://github.com/Rdatatable/data.table/blob/a7a12a93f1c56eae339d74ee82f2f7f2a2ccd6d7/NAMESPACE#L87
https://github.com/Rdatatable/data.table/blob/a7a12a93f1c56eae339d74ee82f2f7f2a2ccd6d7/NAMESPACE#L141

Causing the error.

An alternative is to use `base::getRversion()` even in the NAMESPACE file, but I think this approach is preferable.