### PR TITLE
Refactor calls to "print.default" within "print.data.table"

### DIFF
--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -111,6 +111,7 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
     #   function below adds those back when necessary
     toprint = toprint_subset(toprint, cols_to_print)
   }
+  print_args = list(right = TRUE, quote = quote, na.print = na.print)
   if (printdots) {
     if (isFALSE(row.names)) {
       toprint = rbind(head(toprint, topn + isTRUE(class)), "---", tail(toprint, topn)) # 4083
@@ -119,9 +120,9 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
     }
     rownames(toprint) = format(rownames(toprint), justify="right")
     if (col.names == "none") {
-      cut_colnames(print_default(toprint, quote, na.print))
+      cut_colnames(do.call(print, c(list(toprint), print_args)))
     } else {
-      print_default(toprint, quote, na.print)
+      do.call(print, c(list(toprint), print_args))
     }
     if (trunc.cols && length(not_printed) > 0L)
       # prints names of variables not shown in the print
@@ -134,9 +135,9 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
     #   option to shut this off per request of Oleg Bondar on SO, #1482
     toprint=rbind(toprint, matrix(if (quote) old else colnames(toprint), nrow=1L)) # fixes bug #97
   if (col.names == "none") {
-    cut_colnames(print_default(toprint, quote, na.print))
+    cut_colnames(do.call(print, c(list(toprint), print_args)))
   } else {
-    print_default(toprint, quote, na.print)
+    do.call(print, c(list(toprint), print_args))
   }
   if (trunc.cols && length(not_printed) > 0L)
     # prints names of variables not shown in the print
@@ -280,10 +281,5 @@ trunc_cols_message = function(not_printed, abbs, class, col.names){
     "%d variable(s) not shown: %s\n",
     n, brackify(paste0(not_printed, classes))
   )
-}
-
-# refactoring calls to print.default, #6089
-print_default = function(x, quote, na.print) {
-  print(x, right=TRUE, quote=quote, na.print=na.print)
 }
 

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -119,9 +119,9 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
     }
     rownames(toprint) = format(rownames(toprint), justify="right")
     if (col.names == "none") {
-      cut_colnames(print(toprint, right=TRUE, quote=quote, na.print=na.print))
+      cut_colnames(print_default(toprint, quote, na.print))
     } else {
-      print(toprint, right=TRUE, quote=quote, na.print=na.print)
+      print_default(toprint, quote, na.print)
     }
     if (trunc.cols && length(not_printed) > 0L)
       # prints names of variables not shown in the print
@@ -134,9 +134,9 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
     #   option to shut this off per request of Oleg Bondar on SO, #1482
     toprint=rbind(toprint, matrix(if (quote) old else colnames(toprint), nrow=1L)) # fixes bug #97
   if (col.names == "none") {
-    cut_colnames(print(toprint, right=TRUE, quote=quote, na.print=na.print))
+    cut_colnames(print_default(toprint, quote, na.print))
   } else {
-    print(toprint, right=TRUE, quote=quote, na.print=na.print)
+    print_default(toprint, quote, na.print)
   }
   if (trunc.cols && length(not_printed) > 0L)
     # prints names of variables not shown in the print
@@ -280,5 +280,10 @@ trunc_cols_message = function(not_printed, abbs, class, col.names){
     "%d variable(s) not shown: %s\n",
     n, brackify(paste0(not_printed, classes))
   )
+}
+
+# refactoring calls to print.default, #6089
+print_default = function(x, quote, na.print) {
+  print(x, right=TRUE, quote=quote, na.print=na.print)
 }
 

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -113,7 +113,7 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
     trunc.cols <- length(not_printed) > 0L
   }
   print_default = function(x) {
-    if (col.names != "none") { cut_colnames = identity }
+    if (col.names != "none") cut_colnames = identity
     cut_colnames(print(x, right=TRUE, quote=quote, na.print=na.print))
     # prints names of variables not shown in the print
     if (trunc.cols) trunc_cols_message(not_printed, abbs, class, col.names)

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -110,12 +110,13 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
     # When nrow(toprint) = 1, attributes get lost in the subset,
     #   function below adds those back when necessary
     toprint = toprint_subset(toprint, cols_to_print)
+    trunc.cols <- length(not_printed) > 0L
   }
   print_default = function(x) {
     if (col.names != "none") { cut_colnames = identity }
     cut_colnames(print(x, right=TRUE, quote=quote, na.print=na.print))
     # prints names of variables not shown in the print
-    if (trunc.cols && length(not_printed) > 0L) trunc_cols_message(not_printed, abbs, class, col.names)
+    if (trunc.cols) trunc_cols_message(not_printed, abbs, class, col.names)
   }
   if (printdots) {
     if (isFALSE(row.names)) {

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -111,7 +111,12 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
     #   function below adds those back when necessary
     toprint = toprint_subset(toprint, cols_to_print)
   }
-  print_args = list(right = TRUE, quote = quote, na.print = na.print)
+  print_default = function(x) {
+    if (col.names != "none") { cut_colnames = identity }
+    cut_colnames(print(x, right=TRUE, quote=quote, na.print=na.print))
+    # prints names of variables not shown in the print
+    if (trunc.cols && length(not_printed) > 0L) trunc_cols_message(not_printed, abbs, class, col.names)
+  }
   if (printdots) {
     if (isFALSE(row.names)) {
       toprint = rbind(head(toprint, topn + isTRUE(class)), "---", tail(toprint, topn)) # 4083
@@ -119,30 +124,14 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
       toprint = rbind(head(toprint, topn + isTRUE(class)), "---"="", tail(toprint, topn))
     }
     rownames(toprint) = format(rownames(toprint), justify="right")
-    if (col.names == "none") {
-      cut_colnames(do.call(print, c(list(toprint), print_args)))
-    } else {
-      do.call(print, c(list(toprint), print_args))
-    }
-    if (trunc.cols && length(not_printed) > 0L)
-      # prints names of variables not shown in the print
-      trunc_cols_message(not_printed, abbs, class, col.names)
-
+    print_default(toprint)
     return(invisible(x))
   }
   if (nrow(toprint)>20L && col.names == "auto")
     # repeat colnames at the bottom if over 20 rows so you don't have to scroll up to see them
     #   option to shut this off per request of Oleg Bondar on SO, #1482
-    toprint=rbind(toprint, matrix(if (quote) old else colnames(toprint), nrow=1L)) # fixes bug #97
-  if (col.names == "none") {
-    cut_colnames(do.call(print, c(list(toprint), print_args)))
-  } else {
-    do.call(print, c(list(toprint), print_args))
-  }
-  if (trunc.cols && length(not_printed) > 0L)
-    # prints names of variables not shown in the print
-    trunc_cols_message(not_printed, abbs, class, col.names)
-
+    toprint = rbind(toprint, matrix(if (quote) old else colnames(toprint), nrow=1L)) # fixes bug #97
+  print_default(toprint)
   invisible(x)
 }
 


### PR DESCRIPTION
Closes #6089

Need discussion on what to name the factored function, currently `print_default()`, and whether to put it inside the `print.data.table` body or outside as a helper