### PR TITLE
Be sure to test 'other' in occasional suite

### DIFF
--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -22,6 +22,7 @@ jobs:
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      TEST_DATA_TABLE_WITH_OTHER_PACKAGES: true
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:


### PR DESCRIPTION
Follow-up to #6090 -- adding another site where we're sure 'other.Rraw' will run with regularity.