### PR TITLE
New linter for test(symbol)

### DIFF
--- a/.ci/linters/dt_test_literal_linter.R
+++ b/.ci/linters/dt_test_literal_linter.R
@@ -1,0 +1,10 @@
+# Avoid test(SYMBOL) and test(SYMBOL+...) except in rare cases.
+#   in the latter case, prefer test(NUMBER+expr).
+dt_test_literal_linter <- lintr::make_linter_from_xpath(
+  "
+    //SYMBOL_FUNCTION_CALL[text() = 'test']
+      /parent::expr
+      /following-sibling::expr[1][SYMBOL or expr[1]/SYMBOL]
+  ",
+  "Prefer test's 'num' argument to start with a numeric literal except in rare cases, e.g. test(123, ...) or test(123+x/6, ...)"
+)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -9769,7 +9769,7 @@ nqjoin_test <- function(x, y, k=1L, test_no, mult="all") {
     ans1 = nq(x, y, thiscols, thisops, 0L, mult=mult)
     ans2 = check(x, y, thiscols, thisops, mult=mult)
     test_no = test_no + .001
-    test(test_no, ans1, ans2)
+    test(test_no, ans1, ans2) # nolint: dt_test_literal_linter.
   }
   gc()  # no longer needed but left in place just in case, no harm
 }


### PR DESCRIPTION
This is a follow-up to #6041 that will prevent regression on that front going forward.