### PR TITLE
Updated CODEOWNERS for GHA-based performance testing

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -52,3 +52,7 @@
 
 # utils
 /src/utils.c @HughParsonage
+
+# performance testing
+/.ci/atime/tests.R @tdhock @Anirban166
+/.github/workflows/performance-tests.yaml @Anirban166


### PR DESCRIPTION
Since @tdhock mentioned it earlier this week (for reviewing or the general purpose of being automatically assigned and notified for changes to the relevant files)