### PR TITLE
Don't attempt locale-gen except on Ubuntu

### DIFF
--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Set locale
-        if: matrix.locale == 'en_US.utf8'
+        if: matrix.os == 'ubuntu-latest' && matrix.locale == 'en_US.utf8'
         run: |
           sudo locale-gen en_US
           echo "LC_ALL=en_US.utf8" >> $GITHUB_ENV


### PR DESCRIPTION
Should fix the issue encountered here:

https://github.com/Rdatatable/data.table/actions/runs/9002635140

The problem is that, while the other locales are only run on `ubuntu-latest`, this `locale-gen` step is nonetheless attempted on Mac/Windows because the condition (`locale == 'en_US'`) is true there.

Submitting without review.