### PR TITLE
More fixes for occasional CI test based on new failures

### DIFF
--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -101,8 +101,11 @@ jobs:
       - name: Install dependencies
         run: |
           remotes::install_deps(dependencies = TRUE)
+          other_deps_expr = parse('inst/tests/other.Rraw', n=1L)
+          eval(other_deps_expr)
+          pkgs <- get(as.character(other_deps_expr[[1L]][[2L]]))
           # May not install on oldest R versions
-          try(remotes::install_cran("rcmdcheck"))
+          try(remotes::install_cran(c(pkgs, "rcmdcheck")))
         shell: Rscript {0}
 
       - name: Check
@@ -110,13 +113,23 @@ jobs:
           _R_CHECK_CRAN_INCOMING_REMOTE_: false
         run: |
           options(crayon.enabled = TRUE)
+
+          other_deps_expr = parse('inst/tests/other.Rraw', n=1L)
+          eval(other_deps_expr)
+          pkgs <- get(as.character(other_deps_expr[[1L]][[2L]]))
+          has_pkg <- sapply(pkgs, requireNamespace, quietly=TRUE)
+          if (!all(has_pkg)) {
+            cat(sprintf("Skipping other.Rraw since some required packages are not available: %s\n", toString(pkgs[!has_pkg])))
+            Sys.unsetenv("TEST_DATA_TABLE_WITH_OTHER_PACKAGES")
+          }
+
           args <- c("--no-manual", "--as-cran")
           if (requireNamespace("rcmdcheck", quietly=TRUE)) {
             rcmdcheck::rcmdcheck(args = args, error_on = "warning", check_dir = "check")
           } else {
-            Rbin <- if (.Platform$OS.type == "windows") "R.exe" else "R"
+            Rbin = if (.Platform$OS.type == "windows") "R.exe" else "R"
             system2(Rbin, c("CMD", "build", "."))
-            res <- system2(Rbin, c("CMD", "check", "data.table_*.tar.gz", args), stdout=TRUE)
+            res = system2(Rbin, c("CMD", "check", "data.table_*.tar.gz", args), stdout=TRUE)
             if (!is.null(attr(res, "status")) || grep("^Status:.*(ERROR|WARNING)", res)) {
               writeLines(res)
               stop("R CMD check failed")

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -85,15 +85,27 @@ jobs:
       - name: Install dependencies
         run: |
           remotes::install_deps(dependencies = TRUE)
-          remotes::install_cran("rcmdcheck")
+          # May not install on oldest R versions
+          try(remotes::install_cran("rcmdcheck"))
         shell: Rscript {0}
 
-      - name: Check
+      - name: Check (with rcmdcheck)
         env:
           _R_CHECK_CRAN_INCOMING_REMOTE_: false
         run: |
           options(crayon.enabled = TRUE)
-          rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
+          args <- c("--no-manual", "--as-cran")
+          if (requireNamespace("rcmdcheck", quietly=TRUE)) {
+            rcmdcheck::rcmdcheck(args = args, error_on = "warning", check_dir = "check")
+          } else {
+            Rbin <- ifelse(.Platform$OS.type == "windows", "R.exe", "R")
+            system2(Rbin, c("CMD", "build", "."))
+            res <- system2(Rbin, c("CMD", "check", "data.table_*.tar.gz", args), stdout=TRUE)
+            if (!is.null(attr(res, "status")) || grep("^Status:.*(ERROR|WARNING)", res)) {
+              writeLines(res)
+              stop("R CMD check failed")
+            }
+          }
         shell: Rscript {0}
 
       - name: Upload check results

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -17,7 +17,8 @@ jobs:
         os: [macOS-latest, windows-latest, ubuntu-latest]
         r: ['devel', 'release', '3.2', '3.3', '3.4', '3.5', '3.6', '4.0', '4.1', '4.2', '4.3']
         locale: ['en_US.utf8', 'zh_CN.utf8', 'lv_LV.utf8'] # Chinese for translations, Latvian for collate order (#3502)
-        exclude: # only run non-English locale CI on Ubuntu
+        exclude:
+          # only run non-English locale CI on Ubuntu
           - os: macOS-latest
             locale: 'zh_CN.utf8'
           - os: macOS-latest
@@ -26,6 +27,21 @@ jobs:
             locale: 'zh_CN.utf8'
           - os: windows-latest
             locale: 'lv_LV.utf8'
+          # macOS/arm64 only available for R>=4.1.0
+          - os: macOS-latest
+            r: '3.2'
+          - os: macOS-latest
+            r: '3.3'
+          - os: macOS-latest
+            r: '3.4'
+          - os: macOS-latest
+            r: '3.5'
+          - os: macOS-latest
+            r: '3.6'
+          - os: macOS-latest
+            r: '4.0'
+          - os: macOS-latest
+            r: '4.1'
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -42,14 +42,14 @@ jobs:
       - name: Set locale
         if: matrix.locale == 'zh_CN.utf8'
         run: |
-          sudo locale-gen zh_CN
+          sudo locale-gen 'zh_CN.utf8'
           echo "LC_ALL=zh_CN.utf8" >> $GITHUB_ENV
           echo "LANGUAGE=zh_CN" >> $GITHUB_ENV
 
       - name: Set locale
         if: matrix.locale == 'lv_LV.utf8'
         run: |
-          sudo locale-gen lv_LV
+          sudo locale-gen 'lv_LV.utf8'
           echo "LC_ALL=lv_LV.utf8" >> $GITHUB_ENV
           echo "LANGUAGE=lv_LV" >> $GITHUB_ENV
 

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -75,6 +75,11 @@ jobs:
         with:
           r-version: ${{ matrix.r }}
 
+      - name: Install check dependencies
+        if: matrix.os != 'windows-latest' && matrix.os != 'macOS-latest'
+        run: |
+            sudo apt-get update
+            sudo apt-get install -y libcurl4-openssl-dev
 
       - name: Query dependencies
         run: |

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -89,7 +89,7 @@ jobs:
           try(remotes::install_cran("rcmdcheck"))
         shell: Rscript {0}
 
-      - name: Check (with rcmdcheck)
+      - name: Check
         env:
           _R_CHECK_CRAN_INCOMING_REMOTE_: false
         run: |

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -98,7 +98,7 @@ jobs:
           if (requireNamespace("rcmdcheck", quietly=TRUE)) {
             rcmdcheck::rcmdcheck(args = args, error_on = "warning", check_dir = "check")
           } else {
-            Rbin <- ifelse(.Platform$OS.type == "windows", "R.exe", "R")
+            Rbin <- if (.Platform$OS.type == "windows") "R.exe" else "R"
             system2(Rbin, c("CMD", "build", "."))
             res <- system2(Rbin, c("CMD", "check", "data.table_*.tar.gz", args), stdout=TRUE)
             if (!is.null(attr(res, "status")) || grep("^Status:.*(ERROR|WARNING)", res)) {


### PR DESCRIPTION
Based on latest failures: https://github.com/Rdatatable/data.table/actions/runs/9032914230

 - plain `locale-gen lv_LV` picks a different default encoding:

    ```shell
    sudo locale-gen lv_LV
    # Generating locales (this might take a while)...
    #   lv_LV.ISO-8859-13... done
    # Generation complete.
    ```

 - Need to be robust to {rcmdcheck} being unavailable, https://github.com/r-lib/rcmdcheck/issues/220
 - Need to specifically install some packages for other.Rraw. Previously, this was done by a dummy DESCRIPTION file, however I find we can pretty easily just parse the file itself since the required packages are on the first line.
 - Need to install system curl manually for {curl} to install, not sure why this doesn't affect the other GHA CI...