### PR TITLE
More fixes to occasional CI

### DIFF
--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -79,7 +79,7 @@ jobs:
         if: matrix.os != 'windows-latest' && matrix.os != 'macOS-latest'
         run: |
             sudo apt-get update
-            sudo apt-get install -y libcurl4-openssl-dev libudunits2-dev
+            sudo apt-get install -y libcurl4-openssl-dev libudunits2-dev libgdal-dev libgeos-dev libproj-dev
 
       - name: Query dependencies
         run: |

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -75,11 +75,15 @@ jobs:
         with:
           r-version: ${{ matrix.r }}
 
-      - name: Install check dependencies
-        if: matrix.os != 'windows-latest' && matrix.os != 'macOS-latest'
+      - name: Install check dependencies (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
         run: |
             sudo apt-get update
             sudo apt-get install -y libcurl4-openssl-dev libudunits2-dev libgdal-dev libgeos-dev libproj-dev
+
+      - name: Install check dependencies (macOS)
+        if: matrix.os == 'macOS-latest'
+        run: brew install gdal proj
 
       - name: Query dependencies
         run: |

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -115,6 +115,8 @@ jobs:
 
       - name: Check
         env:
+          # several Suggests dependencies have R dependencies more recent than ours
+          _R_CHECK_FORCE_SUGGESTS_: false
           _R_CHECK_CRAN_INCOMING_REMOTE_: false
         run: |
           options(crayon.enabled = TRUE)

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -1,6 +1,6 @@
 on:
   schedule:
-   - cron: '17 13 18 * *' # 18th of month at 13:17 UTC
+   - cron: '17 13 19 * *' # 18th of month at 13:17 UTC
 
 # A more complete suite of checks to run monthly; each PR/merge need not pass all these, but they should pass before CRAN release
 name: R-CMD-check-occasional

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -122,6 +122,7 @@ jobs:
           # several Suggests dependencies have R dependencies more recent than ours
           _R_CHECK_FORCE_SUGGESTS_: false
           _R_CHECK_CRAN_INCOMING_REMOTE_: false
+          _R_CHECK_TESTS_NLINES_: 0
         run: |
           options(crayon.enabled = TRUE)
 


### PR DESCRIPTION
Today's failures:

https://github.com/Rdatatable/data.table/actions/runs/9140204969

 - Use `_R_CHECK_FORCE_SUGGESTS_=false` for e.g. `xts` which now has a R>=3.6.0 dependency