### PR TITLE
better locale robustness

### DIFF
--- a/inst/tests/nafill.Rraw
+++ b/inst/tests/nafill.Rraw
@@ -290,7 +290,7 @@ test(10.16, coerceAs(1:2, xy_factor), xy_factor, output="integer[integer] into i
 test(10.17, coerceAs(1:3, xy_factor), output="integer[integer] into integer[factor]", error="factor numbers.*3 is outside the level range")
 test(10.18, coerceAs(c(1,2,3), xy_factor), output="double[numeric] into integer[factor]", error="factor numbers.*3.000000 is outside the level range")
 test(10.19, coerceAs(factor("x"), xy_factor), factor("x", levels=c("x","y")), output="integer[factor] into integer[factor]")
-test(10.20, coerceAs(factor("x"), xy_factor), copy=FALSE), factor("x", levels=c("x","y")), output="input already of expected type and class") ## copy=F has copyMostAttrib
+test(10.20, coerceAs(factor("x"), xy_factor, copy=FALSE), factor("x", levels=c("x","y")), output="input already of expected type and class") ## copy=F has copyMostAttrib
 a = structure("a", class="a")
 b = structure("b", class="b")
 test(10.21, coerceAs(a, b), structure("a", class="b"), output="character[a] into character[b]")

--- a/inst/tests/nafill.Rraw
+++ b/inst/tests/nafill.Rraw
@@ -269,6 +269,8 @@ if (test_bit64) {
 # coerceAs verbose
 options(datatable.verbose=2L)
 input = 1
+# use levels= explicitly to avoid locale-related sorting of letters
+xy_factor = factor(c("x", "y"), levels=c("x", "y"))
 test(10.01, ans<-coerceAs(input, 1), 1, output="double[numeric] into double[numeric]")
 test(10.02, address(input)!=address(ans))
 test(10.03, ans<-coerceAs(input, 1, copy=FALSE), 1, output="copy=false and input already of expected type and class double[numeric]")
@@ -284,11 +286,11 @@ test(10.12, coerceAs("a", factor()), factor("a"), output="character[character] i
 test(10.13, coerceAs(1, factor("x")), factor("x"), output="double[numeric] into integer[factor]")
 test(10.14, coerceAs(1, factor("x", levels=c("x","y"))), factor("x", levels=c("x","y")), output="double[numeric] into integer[factor]")
 test(10.15, coerceAs(2, factor("x", levels=c("x","y"))), factor("y", levels=c("x","y")), output="double[numeric] into integer[factor]")
-test(10.16, coerceAs(1:2, factor(c("x","y"))), factor(c("x","y")), output="integer[integer] into integer[factor]")
-test(10.17, coerceAs(1:3, factor(c("x","y"))), output="integer[integer] into integer[factor]", error="factor numbers.*3 is outside the level range")
-test(10.18, coerceAs(c(1,2,3), factor(c("x","y"))), output="double[numeric] into integer[factor]", error="factor numbers.*3.000000 is outside the level range")
-test(10.19, coerceAs(factor("x"), factor(c("x","y"))), factor("x", levels=c("x","y")), output="integer[factor] into integer[factor]")
-test(10.20, coerceAs(factor("x"), factor(c("x","y")), copy=FALSE), factor("x", levels=c("x","y")), output="input already of expected type and class") ## copy=F has copyMostAttrib
+test(10.16, coerceAs(1:2, xy_factor), xy_factor, output="integer[integer] into integer[factor]")
+test(10.17, coerceAs(1:3, xy_factor), output="integer[integer] into integer[factor]", error="factor numbers.*3 is outside the level range")
+test(10.18, coerceAs(c(1,2,3), xy_factor), output="double[numeric] into integer[factor]", error="factor numbers.*3.000000 is outside the level range")
+test(10.19, coerceAs(factor("x"), xy_factor), factor("x", levels=c("x","y")), output="integer[factor] into integer[factor]")
+test(10.20, coerceAs(factor("x"), xy_factor), copy=FALSE), factor("x", levels=c("x","y")), output="input already of expected type and class") ## copy=F has copyMostAttrib
 a = structure("a", class="a")
 b = structure("b", class="b")
 test(10.21, coerceAs(a, b), structure("a", class="b"), output="character[a] into character[b]")


### PR DESCRIPTION
Closes #6140; follow-up to #6074

Looking more carefully, `coerceAs()` will receive a factor as-is from R unless it's doing some lazy evaluation. It's only job is to map what its input into the factor structure it receives.

So I don't think `coerceAs()` is doing anything wrong, rather, the test is poorly structured:

```r
# return a vector where the first element is the first level of the factor, the second is the second level
coerceAs(1:2, factor(c("x","y")))
# coerce c("x", "y") to a factor, picking up levels automatically
factor(c("x","y"))
```

i.e. in the second case, 'x' will always come first regardless of which level it is, while in the first, the first level always comes first.

Therefore I think the proposed edit (to always supply levels explicitly) is appropriate -- it abstracts the base-owned logic of generating levels away.

An uglier alternative is to use `coerceAs(order(c('x', 'y')), factor(c('x', 'y')))`. I don't see any real advantage of this approach.