### PR TITLE
Next round of ci-occasional fixes

### DIFF
--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -155,6 +155,8 @@ jobs:
             system2(Rbin, c("CMD", "build", ".", vignette_args))
             dt_tar <- list.files(pattern = "^data[.]table_.*[.]tar[.]gz$")
             if (!length(dt_tar)) stop("Built tar.gz not found among: ", toString(list.files()))
+            # --no-build-vignettes is not enough for R CMD check
+            if (!do_vignettes) args <- c(args, "--ignore-vignettes")
             res = system2(Rbin, c("CMD", "check", dt_tar[1L], args), stdout=TRUE)
             if (!is.null(attr(res, "status")) || grep("^Status:.*(ERROR|WARNING)", res)) {
               writeLines(res)

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -84,20 +84,6 @@ jobs:
         if: matrix.os == 'macOS-latest'
         run: brew install gdal proj
 
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Restore R package cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
-
       - name: Install system dependencies
         if: runner.os == 'Linux'
         run: |
@@ -108,12 +94,12 @@ jobs:
 
       - name: Install dependencies
         run: |
-          remotes::install_deps(dependencies = TRUE)
+          remotes::install_deps(dependencies=TRUE, force=TRUE)
           other_deps_expr = parse('inst/tests/other.Rraw', n=1L)
           eval(other_deps_expr)
           pkgs <- get(as.character(other_deps_expr[[1L]][[2L]]))
           # May not install on oldest R versions
-          try(remotes::install_cran(c(pkgs, "rcmdcheck")))
+          try(remotes::install_cran(c(pkgs, "rcmdcheck"), force=TRUE))
         shell: Rscript {0}
 
       - name: Check

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -45,7 +45,6 @@ jobs:
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      TEST_DATA_TABLE_WITH_OTHER_PACKAGES: true
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
@@ -137,12 +136,13 @@ jobs:
 
           other_deps_expr = parse('inst/tests/other.Rraw', n=1L)
           eval(other_deps_expr)
-          pkgs <- get(as.character(other_deps_expr[[1L]][[2L]]))
-          has_pkg <- sapply(pkgs, requireNamespace, quietly=TRUE)
-          if (!all(has_pkg)) {
+          pkgs = get(as.character(other_deps_expr[[1L]][[2L]]))
+          has_pkg = sapply(pkgs, requireNamespace, quietly=TRUE)
+          run_other = all(has_pkg)
+          if (!run_other) {
             cat(sprintf("Skipping other.Rraw since some required packages are not available: %s\n", toString(pkgs[!has_pkg])))
-            Sys.unsetenv("TEST_DATA_TABLE_WITH_OTHER_PACKAGES")
           }
+          Sys.setenv(TEST_DATA_TABLE_WITH_OTHER_PACKAGES=as.character(run_other))
 
           do_vignettes <- requireNamespace("knitr", quietly=TRUE)
 

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -1,6 +1,6 @@
 on:
   schedule:
-   - cron: '17 13 22 * *' # 22nd of month at 13:17 UTC
+   - cron: '17 13 23 * *' # 22nd of month at 13:17 UTC
 
 # A more complete suite of checks to run monthly; each PR/merge need not pass all these, but they should pass before CRAN release
 name: R-CMD-check-occasional


### PR DESCRIPTION
Latest errors:

https://github.com/Rdatatable/data.table/actions/runs/9192169760

Based on this observed error:

```
  Here's all installed packages:
    bit,bit64,commonmark,data.table,evaluate,highr,knitr,markdown,R.methodsS3,R.oo,R.utils,xfun,xts,yaml,zoo,base,boot,class,cluster,codetools,compiler,datasets,foreign,graphics,grDevices,grid,KernSmooth,lattice,MASS,Matrix,methods,mgcv,nlme,nnet,parallel,rpart,spatial,splines,stats,stats4,survival,tcltk,tools,utils
  Here's the search() path:
    .GlobalEnv->package:R.oo->package:R.methodsS3->package:bit->package:data.table->package:stats->package:graphics->package:grDevices->package:utils->package:datasets->package:methods->Autoloads->package:zoo->package:bit64->package:xts->package:R.utils->package:knitr->package:parallel->package:yaml->package:base
  If you can't install them and this is R CMD check, please set environment variable TEST_DATA_TABLE_WITH_OTHER_PACKAGES back to the default, false; it's currently true.
```

It appears the `env` setting is overriding our `Sys.unsetenv()` call when referred in the subprocess. Hopefully setting it here is enough, otherwise we'll need to pass it to `system2`.

Also:

 - It appears we need `--ignore-vignettes` passed to `R CMD check` in addition to `--no-build-vignettes`
 - I think package caching is broken, which could explain why even the newest versions of R are not finding the right packages for other.Rraw. This test will only be run monthly, so I think caching can be skipped anyway.