### PR TITLE
Update fifelse documentation to reflect evaluation behavior

### DIFF
--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -1,6 +1,6 @@
 on:
   schedule:
-   - cron: '17 13 22 * *' # 22nd of month at 13:17 UTC
+   - cron: '17 13 23 * *' # 22nd of month at 13:17 UTC
 
 # A more complete suite of checks to run monthly; each PR/merge need not pass all these, but they should pass before CRAN release
 name: R-CMD-check-occasional
@@ -45,7 +45,6 @@ jobs:
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      TEST_DATA_TABLE_WITH_OTHER_PACKAGES: true
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
@@ -85,20 +84,6 @@ jobs:
         if: matrix.os == 'macOS-latest'
         run: brew install gdal proj
 
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Restore R package cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
-
       - name: Install system dependencies
         if: runner.os == 'Linux'
         run: |
@@ -109,12 +94,12 @@ jobs:
 
       - name: Install dependencies
         run: |
-          remotes::install_deps(dependencies = TRUE)
+          remotes::install_deps(dependencies=TRUE, force=TRUE)
           other_deps_expr = parse('inst/tests/other.Rraw', n=1L)
           eval(other_deps_expr)
           pkgs <- get(as.character(other_deps_expr[[1L]][[2L]]))
           # May not install on oldest R versions
-          try(remotes::install_cran(c(pkgs, "rcmdcheck")))
+          try(remotes::install_cran(c(pkgs, "rcmdcheck"), force=TRUE))
         shell: Rscript {0}
 
       - name: Check
@@ -137,12 +122,13 @@ jobs:
 
           other_deps_expr = parse('inst/tests/other.Rraw', n=1L)
           eval(other_deps_expr)
-          pkgs <- get(as.character(other_deps_expr[[1L]][[2L]]))
-          has_pkg <- sapply(pkgs, requireNamespace, quietly=TRUE)
-          if (!all(has_pkg)) {
+          pkgs = get(as.character(other_deps_expr[[1L]][[2L]]))
+          has_pkg = sapply(pkgs, requireNamespace, quietly=TRUE)
+          run_other = all(has_pkg)
+          if (!run_other) {
             cat(sprintf("Skipping other.Rraw since some required packages are not available: %s\n", toString(pkgs[!has_pkg])))
-            Sys.unsetenv("TEST_DATA_TABLE_WITH_OTHER_PACKAGES")
           }
+          Sys.setenv(TEST_DATA_TABLE_WITH_OTHER_PACKAGES=as.character(run_other))
 
           do_vignettes <- requireNamespace("knitr", quietly=TRUE)
 
@@ -155,6 +141,8 @@ jobs:
             system2(Rbin, c("CMD", "build", ".", vignette_args))
             dt_tar <- list.files(pattern = "^data[.]table_.*[.]tar[.]gz$")
             if (!length(dt_tar)) stop("Built tar.gz not found among: ", toString(list.files()))
+            # --no-build-vignettes is not enough for R CMD check
+            if (!do_vignettes) args <- c(args, "--ignore-vignettes")
             res = system2(Rbin, c("CMD", "check", dt_tar[1L], args), stdout=TRUE)
             if (!is.null(attr(res, "status")) || grep("^Status:.*(ERROR|WARNING)", res)) {
               writeLines(res)

--- a/man/fcase.Rd
+++ b/man/fcase.Rd
@@ -63,8 +63,7 @@ fcase(
 # fcase can be used for recursion, unlike fifelse
 gcd_dt = function(x,y) {
   r = x\%\%y
-  # Recursive call must be in the last when-value pair
-  return(fcase(!r, y, r, gcd_dt(x, y)))
+  fcase(!r, y, r, gcd_dt(x, y)) # Recursive call must be in the last when-value pair
 }
 gcd_dt(10L, 1L)
 }

--- a/man/fcase.Rd
+++ b/man/fcase.Rd
@@ -12,9 +12,9 @@
 \item{default}{ Default return value, \code{NA} by default, for when all of the logical conditions \code{when1, when2, ..., whenN} are \code{FALSE} or missing for some entries. }
 }
 \details{
-	\code{fcase} evaluates each when-value pair in order, until it finds a \code{when} that is \code{TRUE}. It then returns the corresponding \code{value}. During evaluation, \code{value} will be evaluated regardless of whether the corresponding \code{when} is \code{TRUE} or not, which means recursive calls should be placed in the last when-value pair, see \code{Examples}.
+\code{fcase} evaluates each when-value pair in order, until it finds a \code{when} that is \code{TRUE}. It then returns the corresponding \code{value}. During evaluation, \code{value} will be evaluated regardless of whether the corresponding \code{when} is \code{TRUE} or not, which means recursive calls should be placed in the last when-value pair, see \code{Examples}.
 
-	\code{default} is always evaluated, regardless of whether it is returned or not.
+\code{default} is always evaluated, regardless of whether it is returned or not.
 }
 \value{
   Vector with the same length as the logical conditions (\code{when}) in \code{...}, filled with the corresponding values (\code{value}) from \code{...}, or eventually \code{default}. Attributes of output values \code{value1, value2, ...valueN} in \code{...} are preserved.

--- a/man/fcase.Rd
+++ b/man/fcase.Rd
@@ -61,10 +61,11 @@ fcase(
 )
 
 # fcase can be used for recursion, unlike fifelse
-gcd_dt <- function(x,y) {
-  r <- x%%y;
-  return(fcase(!r, y, r, gcd_dt(x, y))) # Recursive call must be in the last when-value pair
+gcd_dt = function(x,y) {
+  r = x\%\%y
+  # Recursive call must be in the last when-value pair
+  return(fcase(!r, y, r, gcd_dt(x, y)))
 }
-gcd_dt(10, 1)
+gcd_dt(10L, 1L)
 }
 \keyword{ data }

--- a/man/fcase.Rd
+++ b/man/fcase.Rd
@@ -11,6 +11,11 @@
 \item{...}{ A sequence consisting of logical condition (\code{when})-resulting value (\code{value}) \emph{pairs} in the following order \code{when1, value1, when2, value2, ..., whenN, valueN}. Logical conditions \code{when1, when2, ..., whenN} must all have the same length, type and attributes. Each \code{value} may either share length with \code{when} or be length 1. Please see Examples section for further details.}
 \item{default}{ Default return value, \code{NA} by default, for when all of the logical conditions \code{when1, when2, ..., whenN} are \code{FALSE} or missing for some entries. }
 }
+\details{
+	\code{fcase} evaluates each when-value pair in order, until it finds a \code{when} that is \code{TRUE}. It then returns the corresponding \code{value}. During evaluation, \code{value} will be evaluated regardless of whether the corresponding \code{when} is \code{TRUE} or not, which means recursive calls should be placed in the last when-value pair, see \code{Examples}.
+
+	\code{default} is always evaluated, regardless of whether it is returned or not.
+}
 \value{
   Vector with the same length as the logical conditions (\code{when}) in \code{...}, filled with the corresponding values (\code{value}) from \code{...}, or eventually \code{default}. Attributes of output values \code{value1, value2, ...valueN} in \code{...} are preserved.
 }
@@ -54,5 +59,12 @@ fcase(
 	x > 5L, 3L,
 	default = 5L
 )
+
+# fcase can be used for recursion, unlike fifelse
+gcd_dt <- function(x,y) {
+  r <- x%%y;
+  return(fcase(!r, y, r, gcd_dt(x, y))) # Recursive call must be in the last when-value pair
+}
+gcd_dt(10, 1)
 }
 \keyword{ data }

--- a/man/fcase.Rd
+++ b/man/fcase.Rd
@@ -61,6 +61,7 @@ fcase(
 )
 
 # fcase can be used for recursion, unlike fifelse
+# Recursive function to calculate the Greatest Common Divisor
 gcd_dt = function(x,y) {
   r = x\%\%y
   fcase(!r, y, r, gcd_dt(x, y)) # Recursive call must be in the last when-value pair

--- a/man/fifelse.Rd
+++ b/man/fifelse.Rd
@@ -16,7 +16,7 @@
 \details{
 In contrast to \code{\link[base]{ifelse}} attributes are copied from the first non-\code{NA} argument to the output. This is useful when returning \code{Date}, \code{factor} or other classes.
 
-Unlike \code{\link[base]{ifelse}}, \code{fifelse} evaluates both \code{yes} and \code{no} arguments for type checking regardless of the result of \code{test}. This means that neither \code{yes} nor \code{no} should be recursive function calls. For recursiveness, use \code{fcase} instead.
+Unlike \code{\link[base]{ifelse}}, \code{fifelse} evaluates both \code{yes} and \code{no} arguments for type checking regardless of the result of \code{test}. This means that neither \code{yes} nor \code{no} should be recursive function calls. For recursion, use \code{fcase} instead.
 }
 \value{
 A vector of the same length as \code{test} and attributes as \code{yes}. Data values are taken from the values of \code{yes} and \code{no}, eventually \code{na}.

--- a/man/fifelse.Rd
+++ b/man/fifelse.Rd
@@ -16,7 +16,7 @@
 \details{
 In contrast to \code{\link[base]{ifelse}} attributes are copied from the first non-\code{NA} argument to the output. This is useful when returning \code{Date}, \code{factor} or other classes.
 
-\code{fifelse}, contrary to \code{\link[base]{ifelse}}, evalutes both \code{yes} and \code{no} arguments for type checking regardless the result of \code{test}. This means that neither \code{yes} nor \code{no} should be recursive function calls, use \code{fcase} instead.
+Unlike \code{\link[base]{ifelse}}, \code{fifelse} evaluates both \code{yes} and \code{no} arguments for type checking regardless of the result of \code{test}. This means that neither \code{yes} nor \code{no} should be recursive function calls; use \code{fcase} instead.
 }
 \value{
 A vector of the same length as \code{test} and attributes as \code{yes}. Data values are taken from the values of \code{yes} and \code{no}, eventually \code{na}.

--- a/man/fifelse.Rd
+++ b/man/fifelse.Rd
@@ -16,7 +16,7 @@
 \details{
 In contrast to \code{\link[base]{ifelse}} attributes are copied from the first non-\code{NA} argument to the output. This is useful when returning \code{Date}, \code{factor} or other classes.
 
-Unlike \code{\link[base]{ifelse}}, \code{fifelse} evaluates both \code{yes} and \code{no} arguments for type checking regardless of the result of \code{test}. This means that neither \code{yes} nor \code{no} should be recursive function calls; use \code{fcase} instead.
+Unlike \code{\link[base]{ifelse}}, \code{fifelse} evaluates both \code{yes} and \code{no} arguments for type checking regardless of the result of \code{test}. This means that neither \code{yes} nor \code{no} should be recursive function calls. For recursiveness, use \code{fcase} instead.
 }
 \value{
 A vector of the same length as \code{test} and attributes as \code{yes}. Data values are taken from the values of \code{yes} and \code{no}, eventually \code{na}.

--- a/man/fifelse.Rd
+++ b/man/fifelse.Rd
@@ -15,12 +15,16 @@
 }
 \details{
 In contrast to \code{\link[base]{ifelse}} attributes are copied from the first non-\code{NA} argument to the output. This is useful when returning \code{Date}, \code{factor} or other classes.
+
+\code{fifelse}, contrary to \code{\link[base]{ifelse}}, evalutes both \code{yes} and \code{no} arguments for type checking regardless the result of \code{test}. This means that neither \code{yes} nor \code{no} should be recursive function calls, use \code{fcase} instead.
 }
 \value{
 A vector of the same length as \code{test} and attributes as \code{yes}. Data values are taken from the values of \code{yes} and \code{no}, eventually \code{na}.
 }
 \seealso{
   \code{\link{fcoalesce}}
+
+  \code{\link{fcase}}
 }
 \examples{
 x = c(1:4, 3:2, 1:4)
@@ -37,5 +41,9 @@ fifelse(c(TRUE,FALSE,TRUE), yes, no)
 
 # Example of using the 'na' argument
 fifelse(test = c(-5L:5L < 0L, NA), yes = 1L, no = 0L, na = 2L)
+
+# Example showing both 'yes' and 'no' arguments are evaluated, unlike ifelse
+fifelse(1 == 1, print("yes"), print("no"))
+ifelse(1 == 1, print("yes"), print("no"))
 }
 \keyword{ data }


### PR DESCRIPTION
Closes #4549

`fifelse` evaluates both `yes` and `no` arguments, regardless of the value of `test`. This makes it unfit for recursive functions as the evaluation will cause an infinite loop of calls.

Changed documentation to better reflect this behavior, along with a simple example to showcase the difference against base `ifelse`:

```R
ifelse(1 == 1, print("yes"), print("no"))
# [1] "yes"
fifelse(1 == 1, print("yes"), print("no"))
# [1] "yes"
# [1] "no"
```
Also mentioned that `fcase` can be used instead for recursive calls. Does `fcase` documentation also need updating? I noticed that the `when` and `value` pair is evaluated, even if the `when` doesn't bind, which means:

```R
gcd_dt <- function(x,y) {
  r <- x%%y;
  return(data.table::fcase(!r, y, r, gcd_dt(x, y)))
}
```
works, but

```R
gcd_dt <- function(x,y) {
  r <- x%%y;
  return(data.table::fcase(!r, y, r, gcd_dt(x, y))) # (when value pair swapped)
}
```
doesn't, due to the same reason that `fifelse` doesn't.
