### PR TITLE
Bump run date for occasional CI

### DIFF
--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -1,6 +1,6 @@
 on:
   schedule:
-   - cron: '17 13 23 * *' # 22nd of month at 13:17 UTC
+   - cron: '17 13 28 * *' # 28th of month at 13:17 UTC
 
 # A more complete suite of checks to run monthly; each PR/merge need not pass all these, but they should pass before CRAN release
 name: R-CMD-check-occasional


### PR DESCRIPTION
Latest failure again makes no sense to me :)

https://github.com/Rdatatable/data.table/actions/runs/9208833561

But possibly it was a transient issue of {remotes} being unavailable?

Otherwise it's `force=TRUE` causing some other issue...