### PR TITLE
adding an atime test case Performance Regression with .N and := #PR5426

### DIFF
--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -119,6 +119,23 @@ test.list <- atime::atime_test_list(
       data.table:::setDT(L)
     },
     Slow = "c4a2085e35689a108d67dacb2f8261e4964d7e12", # Parent of the first commit in the PR that fixes the issue (https://github.com/Rdatatable/data.table/commit/7cc4da4c1c8e568f655ab5167922dcdb75953801)
-    Fast = "1872f473b20fdcddc5c1b35d79fe9229cd9a1d15") # Last commit in the PR that fixes the issue (https://github.com/Rdatatable/data.table/pull/5427/commits)
+    Fast = "1872f473b20fdcddc5c1b35d79fe9229cd9a1d15"),
+  # Last commit in the PR that fixes the issue (https://github.com/Rdatatable/data.table/pull/5427/commits)
+  
+  "Performance Regression with .N and := #5463" = atime::atime_test(
+   N=10^seq(1,20),
+  setup={ 
+    set.seed(108)
+    d <- data.table(
+      id3 = sample(c(seq.int(N*0.9), sample(N*0.9, N*0.1, TRUE))),
+      v1 = sample(5L, N, TRUE),
+      v2 = sample(5L, N, TRUE))
+  },
+  system.time(d[, max(v1)-min(v2), by=id3])
+  expr=data.table:::`[.data.table`(d, , (max(v1)-min(v2)), by = id3),
+  Before = "793f8545c363d222de18ac892bc7abb80154e724",#parent of the PR that introduced the regression(https://github.com/Rdatatable/data.table/commit/4aadde8f5a51cd7c8f3889964e7280432ec65bbc) as stated here (https://github.com/Rdatatable/data.table/issues/4200#issuecomment-646111420) https://github.com/Rdatatable/data.table/commit/793f8545c363d222de18ac892bc7abb80154e724
+  Regression = "c152ced0e5799acee1589910c69c1a2c6586b95d", #praent of the first commit in the PR (https://github.com/Rdatatable/data.table/commit/15f0598b9828d3af2eb8ddc9b38e0356f42afe4f)
+  Fixed = "f750448a2efcd258b3aba57136ee6a95ce56b302")#second commit in the PR that fixes the regression(https://github.com/Rdatatable/data.table/pull/4558/commits)
 )
+
 # nolint end: undesirable_operator_linter.


### PR DESCRIPTION

This atime test case discusses the issue of [Performance Regression with .N and := (https://github.com/Rdatatable/data.table/issues/5424) 


The cause of the regression is related to the addition of the snprintf function in the assign.c. https://github.com/Rdatatable/data.table/pull/4491


The Regression was fixed by creating targetDesc function and adding snprintf in assign.c [Fixes Regression](https://github.com/Rdatatable/data.table/commit/e793f53466d99f86e70fc2611b708ae8c601a451)