### PR TITLE
Added `freadR.c` to Documentation for OpenMP Directives

### DIFF
--- a/man/openmp-utils.Rd
+++ b/man/openmp-utils.Rd
@@ -41,7 +41,7 @@
     \item\file{cj.c} - \code{\link{CJ}()}
     \item\file{coalesce.c} - \code{\link{fcoalesce}()}
     \item\file{fifelse.c} - \code{\link{fifelse}()}
-    \item\file{fread.c} - \code{\link{fread}()}
+    \item\file{fread.c}, \file{freadR.c} - \code{\link{fread}()}
     \item\file{forder.c}, \file{fsort.c}, and \file{reorder.c} - \code{\link{forder}()} and related
     \item\file{froll.c}, \file{frolladaptive.c}, and \file{frollR.c} - \code{\link{froll}()} and family
     \item\file{fwrite.c} - \code{\link{fwrite}()}


### PR DESCRIPTION
This PR addresses issue #5265 by adding the missing `freadR.c` file to the list of files in the `data.table/man/openmp-utils.Rd` documentation that contain OpenMP directives.

**Changes:**
- Added an entry for `freadR.c` in the `data.table/man/openmp-utils.Rd` file to document that it contains OpenMP directives associated with the `fread` function.

This update ensures that all relevant files with OpenMP directives are accurately documented.

closes #5265 
