### PR TITLE
 adding an atime test case Performance Regression with .N and := #PR5463

### DIFF
--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -121,8 +121,8 @@ test.list <- atime::atime_test_list(
     Slow = "c4a2085e35689a108d67dacb2f8261e4964d7e12", # Parent of the first commit in the PR that fixes the issue (https://github.com/Rdatatable/data.table/commit/7cc4da4c1c8e568f655ab5167922dcdb75953801)
     Fast = "1872f473b20fdcddc5c1b35d79fe9229cd9a1d15"),# Last commit in the PR that fixes the issue (https://github.com/Rdatatable/data.table/pull/5427/commits)
 
-  #issue reported in: https://github.com/Rdatatable/data.table/issues/5424
-  #Fixed in: https://github.com/Rdatatable/data.table/pull/5463
+   # Issue reported in: https://github.com/Rdatatable/data.table/issues/5424
+   # Fixed in: https://github.com/Rdatatable/data.table/pull/5463
    ".N and := regression fixed in #5463" = atime::atime_test(
      N = 10^seq(1, 4),
      setup = {
@@ -133,8 +133,8 @@ test.list <- atime::atime_test_list(
        dt
      },
      expr = data.table:::`[.data.table`(dt, , .(vs = (sum(val))), by = .(id)),
-     Before = "be2f72e6f5c90622fe72e1c315ca05769a9dc854",
-     Regression = "e793f53466d99f86e70fc2611b708ae8c601a451",
-     Fixed = "58409197426ced4714af842650b0cc3b9e2cb842")
+     Before = "be2f72e6f5c90622fe72e1c315ca05769a9dc854", # Parent of the regression causing commit (https://github.com/Rdatatable/data.table/commit/e793f53466d99f86e70fc2611b708ae8c601a451) in the PR that introduced the issue (https://github.com/Rdatatable/data.table/pull/4491/commits)
+     Regression = "e793f53466d99f86e70fc2611b708ae8c601a451", # Commit responsible for regression in the PR that introduced the issue (https://github.com/Rdatatable/data.table/pull/4491/commits)
+     Fixed = "58409197426ced4714af842650b0cc3b9e2cb842") # Last commit in the PR that fixed the regression (https://github.com/Rdatatable/data.table/pull/5463/commits)
 )
 # nolint end: undesirable_operator_linter.

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -123,7 +123,7 @@ test.list <- atime::atime_test_list(
 
   #issue reported in: https://github.com/Rdatatable/data.table/issues/5424
   #Fixed in: https://github.com/Rdatatable/data.table/pull/5463
-   "Performance Regression with .N and := #PR5463" = atime::atime_test(
+   ".N and := regression fixed in #5463" = atime::atime_test(
      N = 10^seq(1, 4),
      setup = {
        set.seed(123L)

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -119,6 +119,22 @@ test.list <- atime::atime_test_list(
       data.table:::setDT(L)
     },
     Slow = "c4a2085e35689a108d67dacb2f8261e4964d7e12", # Parent of the first commit in the PR that fixes the issue (https://github.com/Rdatatable/data.table/commit/7cc4da4c1c8e568f655ab5167922dcdb75953801)
-    Fast = "1872f473b20fdcddc5c1b35d79fe9229cd9a1d15") # Last commit in the PR that fixes the issue (https://github.com/Rdatatable/data.table/pull/5427/commits)
+    Fast = "1872f473b20fdcddc5c1b35d79fe9229cd9a1d15"),# Last commit in the PR that fixes the issue (https://github.com/Rdatatable/data.table/pull/5427/commits)
+
+  #issue reported in: https://github.com/Rdatatable/data.table/issues/5424
+  #Fixed in: https://github.com/Rdatatable/data.table/pull/5463
+   "Performance Regression with .N and := #PR5463" = atime::atime_test(
+     N = 10^seq(1, 4),
+     setup = {
+       set.seed(123L)
+       dt <- data.table(
+         id = seq_len(N),
+         val = rnorm(N))
+       dt
+     },
+     expr = data.table:::`[.data.table`(dt, , .(vs = (sum(val))), by = .(id)),
+     Before = "be2f72e6f5c90622fe72e1c315ca05769a9dc854",
+     Regression = "e793f53466d99f86e70fc2611b708ae8c601a451",
+     Fixed = "58409197426ced4714af842650b0cc3b9e2cb842")
 )
 # nolint end: undesirable_operator_linter.

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -130,7 +130,6 @@ test.list <- atime::atime_test_list(
        dt <- data.table(
          id = seq_len(N),
          val = rnorm(N))
-       dt
      },
      expr = data.table:::`[.data.table`(dt, , .(vs = (sum(val))), by = .(id)),
      Before = "be2f72e6f5c90622fe72e1c315ca05769a9dc854", # Parent of the regression causing commit (https://github.com/Rdatatable/data.table/commit/e793f53466d99f86e70fc2611b708ae8c601a451) in the PR that introduced the issue (https://github.com/Rdatatable/data.table/pull/4491/commits)

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -132,8 +132,9 @@ test.list <- atime::atime_test_list(
          val = rnorm(N))
      },
      expr = data.table:::`[.data.table`(dt, , .(vs = (sum(val))), by = .(id)),
-     Before = "be2f72e6f5c90622fe72e1c315ca05769a9dc854", # Parent of the regression causing commit (https://github.com/Rdatatable/data.table/commit/e793f53466d99f86e70fc2611b708ae8c601a451) in the PR that introduced the issue (https://github.com/Rdatatable/data.table/pull/4491/commits)
-     Regression = "e793f53466d99f86e70fc2611b708ae8c601a451", # Commit responsible for regression in the PR that introduced the issue (https://github.com/Rdatatable/data.table/pull/4491/commits)
-     Fixed = "58409197426ced4714af842650b0cc3b9e2cb842") # Last commit in the PR that fixed the regression (https://github.com/Rdatatable/data.table/pull/5463/commits)
+     Before = "fda7fd9dbcac939df33769193eebd44731ee59b9", # Parent of the regression commit (https://github.com/Rdatatable/data.table/commit/c4a2085e35689a108d67dacb2f8261e4964d7e12)  
+     Regression = "c4a2085e35689a108d67dacb2f8261e4964d7e12", # Parent of the first commit (https://github.com/Rdatatable/data.table/commit/ade6e57984f9e7f898a638d2049039cd886f2369) in the PR (https://github.com/Rdatatable/data.table/pull/5463/commits) that fixed the issue
+     Fixed = "58409197426ced4714af842650b0cc3b9e2cb842") # Last commit in the PR (https://github.com/Rdatatable/data.table/pull/5463) that fixed the regression 
 )
+
 # nolint end: undesirable_operator_linter.


### PR DESCRIPTION
This atime test case discusses the issue of [Performance Regression with .N and := (https://github.com/https://github.com/https://github.com/Rdatatable/data.table/issues/5424)

The cause of the regression is related to the addition of the snprintf function in the assign.c. https://github.com/Rdatatable/data.table/pull/4491

The Regression was fixed by creating targetDesc function and adding snprintf in assign.c [Fixes Regression](https://github.com/Rdatatable/data.table/commit/e793f53466d99f86e70fc2611b708ae8c601a451)