### PR TITLE
Fix typo in redirect template of error message in Chinese translation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -98,6 +98,10 @@
 
 15. `dcast()` now issues a warning when `fun.aggregate` is used but not provided by the user. `fun.aggregate` defaults to `length` in this case. Previously, only a message was issued. However, relying on this default often signals unexpected duplicates in the data. Therefore, a stricter class of signal was deemed more appropriate, [#5386](https://github.com/Rdatatable/data.table/issues/5386). The warning is classed as `dt_missing_fun_aggregate_warning`, allowing for more targeted handling in user code. Thanks @MichaelChirico for the suggestion and @Nj221102 for the fix.
 
+## TRANSLATIONS
+
+1. Fix a typo in a Mandarin translation of an error message that was hiding the actual error message, [#6172](https://github.com/Rdatatable/data.table/issues/6172). Thanks @trafficfan for the report and @MichaelChirico for the fix.
+
 # data.table [v1.15.0](https://github.com/Rdatatable/data.table/milestone/29)  (30 Jan 2024)
 
 ## BREAKING CHANGE

--- a/po/R-zh_CN.po
+++ b/po/R-zh_CN.po
@@ -371,7 +371,7 @@ msgstr "变量 '%s' 并没有存在于调用环境中。之所以在调用环境
 msgid ""
 "Both '%1$s' and '..%1$s' exist in calling scope. Please remove the '..%1$s' "
 "variable in calling scope for clarity."
-msgstr "'%1%s'和'..%1$s'均在当前调用环境中。为清晰起见，请移除在调用环境中名为"
+msgstr "'%1$s'和'..%1$s'均在当前调用环境中。为清晰起见，请移除在调用环境中名为"
 "..%1$s' 的变量。"
 
 #: data.table.R:288


### PR DESCRIPTION
Closes #6172.

I checked that `tools::checkPoFile()` does _not_ identify this .po file issue, but also that there are no other CRAN packages with the mistake:

https://github.com/search?q=org%3Acran+%2F%25%5B0-9%5D%25%2F+path%3A.po&type=code

So, it's probably not worth filing a fix upstream with r-devel.

@trafficfan I will not update the .mo file for now, which means the issue will persist in the installed package. Since it's a code error, the fix is to fix the error first :) The fixed translation will be compiled to .mo as part of our regular release process and land on CRAN in 1.16.0.