### PR TITLE
Subset Copy Documentation

### DIFF
--- a/man/assign.Rd
+++ b/man/assign.Rd
@@ -85,11 +85,9 @@ Unlike \code{<-} for \code{data.frame}, the (potentially large) LHS is not coerc
 Since \code{[.data.table} incurs overhead to check the existence and type of arguments (for example), \code{set()} provides direct (but less flexible) assignment by reference with low overhead, appropriate for use inside a \code{for} loop. See examples. \code{:=} is more powerful and flexible than \code{set()} because \code{:=} is intended to be combined with \code{i} and \code{by} in single queries on large datasets.
 }
 \note{
-    \code{DT[a > 4, b := c]} is different from \code{DT[a > 4][, b := c]}. The first expression updates (or adds) column \code{b} with the value \code{c} on those rows where \code{a > 4} evaluates to \code{TRUE}. \code{X} is updated \emph{by reference}, therefore no assignment needed.
+    \code{DT[a > 4, b := c]} is different from \code{DT[a > 4][, b := c]}. The first expression updates (or adds) column \code{b} with the value \code{c} on those rows where \code{a > 4} evaluates to \code{TRUE}. \code{X} is updated \emph{by reference}, therefore no assignment needed.  Note that this does not apply when `i` is missing, i.e. \code{DT[]}.
 
     The second expression on the other hand updates a \emph{new} \code{data.table} that's returned by the subset operation. Since the subsetted data.table is ephemeral (it is not assigned to a symbol), the result would be lost; unless the result is assigned, for example, as follows: \code{ans <- DT[a > 4][, b := c]}.
-
-    Regarding subset operations: \code{data.table} only creates a copy of its subset when the subset operation is non-empty. For example, \code{DT[a > 4]} returns a copy of \code{DT} where \code{a > 4} is \code{TRUE}. However, \code{DT[]} returns a reference to the original \code{DT}.
 }
 \value{
 \code{DT} is modified by reference and returned invisibly. If you require a copy, take a \code{\link{copy}} first (using \code{DT2 = copy(DT)}).

--- a/man/assign.Rd
+++ b/man/assign.Rd
@@ -89,7 +89,7 @@ Since \code{[.data.table} incurs overhead to check the existence and type of arg
 
     The second expression on the other hand updates a \emph{new} \code{data.table} that's returned by the subset operation. Since the subsetted data.table is ephemeral (it is not assigned to a symbol), the result would be lost; unless the result is assigned, for example, as follows: \code{ans <- DT[a > 4][, b := c]}.
 
-    About subset operations: \code{data.table} only returns a copy of the subset when the subset operation is non-empty. For example, \code{DT[a > 4]} returns a copy of \code{DT} where \code{a > 4} is \code{TRUE}. However, \code{DT[]} returns a reference to the original \code{DT}.
+    About subset operations: \code{data.table} only creates a copy of its subset when the subset operation is non-empty. For example, \code{DT[a > 4]} returns a copy of \code{DT} where \code{a > 4} is \code{TRUE}. However, \code{DT[]} returns a reference to the original \code{DT}.
 }
 \value{
 \code{DT} is modified by reference and returned invisibly. If you require a copy, take a \code{\link{copy}} first (using \code{DT2 = copy(DT)}).

--- a/man/assign.Rd
+++ b/man/assign.Rd
@@ -89,7 +89,7 @@ Since \code{[.data.table} incurs overhead to check the existence and type of arg
 
     The second expression on the other hand updates a \emph{new} \code{data.table} that's returned by the subset operation. Since the subsetted data.table is ephemeral (it is not assigned to a symbol), the result would be lost; unless the result is assigned, for example, as follows: \code{ans <- DT[a > 4][, b := c]}.
 
-    About subset operations: \code{data.table} only creates a copy of its subset when the subset operation is non-empty. For example, \code{DT[a > 4]} returns a copy of \code{DT} where \code{a > 4} is \code{TRUE}. However, \code{DT[]} returns a reference to the original \code{DT}.
+    Regarding subset operations: \code{data.table} only creates a copy of its subset when the subset operation is non-empty. For example, \code{DT[a > 4]} returns a copy of \code{DT} where \code{a > 4} is \code{TRUE}. However, \code{DT[]} returns a reference to the original \code{DT}.
 }
 \value{
 \code{DT} is modified by reference and returned invisibly. If you require a copy, take a \code{\link{copy}} first (using \code{DT2 = copy(DT)}).

--- a/man/assign.Rd
+++ b/man/assign.Rd
@@ -88,6 +88,8 @@ Since \code{[.data.table} incurs overhead to check the existence and type of arg
     \code{DT[a > 4, b := c]} is different from \code{DT[a > 4][, b := c]}. The first expression updates (or adds) column \code{b} with the value \code{c} on those rows where \code{a > 4} evaluates to \code{TRUE}. \code{X} is updated \emph{by reference}, therefore no assignment needed.
 
     The second expression on the other hand updates a \emph{new} \code{data.table} that's returned by the subset operation. Since the subsetted data.table is ephemeral (it is not assigned to a symbol), the result would be lost; unless the result is assigned, for example, as follows: \code{ans <- DT[a > 4][, b := c]}.
+
+    About subset operations: \code{data.table} only returns a copy of the subset when the subset operation is non-empty. For example, \code{DT[a > 4]} returns a copy of \code{DT} where \code{a > 4} is \code{TRUE}. However, \code{DT[]} returns a reference to the original \code{DT}.
 }
 \value{
 \code{DT} is modified by reference and returned invisibly. If you require a copy, take a \code{\link{copy}} first (using \code{DT2 = copy(DT)}).

--- a/vignettes/datatable-reference-semantics.Rmd
+++ b/vignettes/datatable-reference-semantics.Rmd
@@ -78,6 +78,8 @@ A *shallow* copy is just a copy of the vector of column pointers (corresponding 
 
 A *deep* copy on the other hand copies the entire data to another location in memory.
 
+When subsetting a *data.table* using `i` (e.g., `DT[1:10]`), a *deep* copy is made. However, when `i` is not provided or equals `TRUE`, a *shallow* copy is made.
+
 #
 With *data.table's* `:=` operator, absolutely no copies are made in *both* (1) and (2), irrespective of R version you are using. This is because `:=` operator updates *data.table* columns *in-place* (by reference).
 


### PR DESCRIPTION
Closes #5411 

Current `:=` documentation states: 
>`DT[a > 4, b := c]` is different from `DT[a > 4][, b := c]`. The first expression updates (or adds) column `b` with the value `c` on those rows where `a > 4` evaluates to `TRUE`. `X` is updated by reference, therefore no assignment needed.

>The second expression on the other hand updates a new `data.table` that's returned by the subset operation. Since the subsetted `data.table` is ephemeral (it is not assigned to a symbol), the result would be lost; unless the result is assigned, for example, as follows: `ans <- DT[a > 4][, b := c]`.

While mostly correct about copying the `data.table` when using the subset operation, it doesn't mention that a copy isn't made when subset is empty, and instead we return a reference to the original `data.table`:

```R
DT = data.table(a = 1:5)
DT[, address(a)]
# 0x55dd1a8e3758

dt1 = DT[] # doesn't create a copy, same as 'dt1 = DT'
dt1[, address(a)]
# 0x55dd1a8e3758

dt1[, a := 2] # updates dt1 AND DT
dt1[, address(a)]
# 0x55dd1a8e3758

all.equal(DT, dt1) # since dt1 isn't a copy, DT is also updated by reference when using ':='
# TRUE

# --------------------------------------- Copies when subset is non-empty

dt2 = DT[1:.N] # copies rows 1 - nrow(DT)
dt2[, address(a)]
# 0x55dd16ebbdd8

dt2[, a := 2] # only updates dt2
dt2[, address(a)]
# 0x55dd16ebbdd8

all.equal(DT, dt2) # dt2 is a copy, therefore DT isn't updated by reference
# Column \'a\': Mean relative difference: 0.5384615
```

Updated documentation of `:=` under `Notes` section as this section states that a new `data.table` is made when doing subset operations, which it is, except when the subset operation is empty. 

`assign.Rd` is the only place I found talking about copying with subset, LMK if there's another area where this information would be useful to the user. (Maybe, `data.table.Rd`?), also happy to add the above code as examples in docs if we find the need.

Related: https://github.com/Rdatatable/data.table/blob/ff900d1e6a8bcfaa0385bd1304af7b90657d3c4d/NEWS.0.md?plain=1#L1772