### PR TITLE
print.data.table Gets New Argument "indices"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -98,7 +98,7 @@
 
 15. `dcast()` now issues a warning when `fun.aggregate` is used but not provided by the user. `fun.aggregate` defaults to `length` in this case. Previously, only a message was issued. However, relying on this default often signals unexpected duplicates in the data. Therefore, a stricter class of signal was deemed more appropriate, [#5386](https://github.com/Rdatatable/data.table/issues/5386). The warning is classed as `dt_missing_fun_aggregate_warning`, allowing for more targeted handling in user code. Thanks @MichaelChirico for the suggestion and @Nj221102 for the fix.
 
-16. `print.data.table` gains new argument `indices` that allows the user to print a `data.table`'s indices without having to modify the `data.table` itself. Thanks @MichaelChirico for the report and @joshhwuu for the PR.
+16. `print.data.table` gains new argument `show.indices` and option `datatable.show.indices` that allows the user to print a `data.table`'s indices as columns without having to modify the `data.table` itself. Thanks @MichaelChirico for the report and @joshhwuu for the PR.
 
 ## TRANSLATIONS
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -98,7 +98,7 @@
 
 15. `dcast()` now issues a warning when `fun.aggregate` is used but not provided by the user. `fun.aggregate` defaults to `length` in this case. Previously, only a message was issued. However, relying on this default often signals unexpected duplicates in the data. Therefore, a stricter class of signal was deemed more appropriate, [#5386](https://github.com/Rdatatable/data.table/issues/5386). The warning is classed as `dt_missing_fun_aggregate_warning`, allowing for more targeted handling in user code. Thanks @MichaelChirico for the suggestion and @Nj221102 for the fix.
 
-16. `print.data.table` gains new argument `indices` that print a `data.table`'s indices without having to modify the `data.table` itself. Thanks @MichaelChirico for the report and @joshhwuu for the PR.
+16. `print.data.table` gains new argument `indices` that allows the user to print a `data.table`'s indices without having to modify the `data.table` itself. Thanks @MichaelChirico for the report and @joshhwuu for the PR.
 
 ## TRANSLATIONS
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -98,6 +98,8 @@
 
 15. `dcast()` now issues a warning when `fun.aggregate` is used but not provided by the user. `fun.aggregate` defaults to `length` in this case. Previously, only a message was issued. However, relying on this default often signals unexpected duplicates in the data. Therefore, a stricter class of signal was deemed more appropriate, [#5386](https://github.com/Rdatatable/data.table/issues/5386). The warning is classed as `dt_missing_fun_aggregate_warning`, allowing for more targeted handling in user code. Thanks @MichaelChirico for the suggestion and @Nj221102 for the fix.
 
+16. `print.data.table` gains new argument `indices` that print a `data.table`'s indices without having to modify the `data.table` itself. Thanks @MichaelChirico for the report and @joshhwuu for the PR.
+
 ## TRANSLATIONS
 
 1. Fix a typo in a Mandarin translation of an error message that was hiding the actual error message, [#6172](https://github.com/Rdatatable/data.table/issues/6172). Thanks @trafficfan for the report and @MichaelChirico for the fix.

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -79,6 +79,7 @@
        "datatable.print.colnames"="'auto'",    # for print.data.table
        "datatable.print.keys"="TRUE",          # for print.data.table
        "datatable.print.trunc.cols"="FALSE",   # for print.data.table
+       "datatable.print.indices"="FALSE",      # for print.data.table
        "datatable.allow.cartesian"="FALSE",    # datatable.<argument name>
        "datatable.dfdispatchwarn"="TRUE",                   # not a function argument
        "datatable.warnredundantby"="TRUE",                  # not a function argument

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -79,7 +79,7 @@
        "datatable.print.colnames"="'auto'",    # for print.data.table
        "datatable.print.keys"="TRUE",          # for print.data.table
        "datatable.print.trunc.cols"="FALSE",   # for print.data.table
-       "datatable.print.indices"="FALSE",      # for print.data.table
+       "datatable.show.indices"="FALSE",       # for print.data.table
        "datatable.allow.cartesian"="FALSE",    # datatable.<argument name>
        "datatable.dfdispatchwarn"="TRUE",                   # not a function argument
        "datatable.warnredundantby"="TRUE",                  # not a function argument

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -80,7 +80,9 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
     toprint = rbindlist(list(head(x, topn), tail(x, topn)), use.names=FALSE)  # no need to match names because head and tail of same x, and #3306
     rn = c(seq_len(topn), seq.int(to=n_x, length.out=topn))
     printdots = TRUE
-    if (show.indices) toprint = cbind(toprint, rbindlist(list(head(index_dt, topn), tail(index_dt, topn)), use.names=FALSE))
+    idx = c(seq_len(topn), seq(to=nrow(x), length.out=topn))
+    toprint = x[idx, ]
+    if (show.indices) toprint = cbind(toprint, index_dt[idx, ])
   } else {
     toprint = x
     rn = seq_len(n_x)

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -71,7 +71,7 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
       show.indices = FALSE
     } else {
       index_dt <- as.data.table(attributes(attr(x, 'index')))
-      print_names <- paste0("index", if (ncol(index_dt) > 1L) seq_len(ncol(index_dt)) else "", ":", sub("^__", "", names(index_dt), fixed=TRUE))
+      print_names <- paste0("index", if (ncol(index_dt) > 1L) seq_len(ncol(index_dt)) else "", ":", sub("^__", "", names(index_dt)))
       setnames(index_dt, print_names)
     }
   }

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -7,10 +7,10 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
                col.names=getOption("datatable.print.colnames"),
                print.keys=getOption("datatable.print.keys"),
                trunc.cols=getOption("datatable.print.trunc.cols"),
+               print.indices=getOption("datatable.print.indices"),
                quote=FALSE,
                na.print=NULL,
-               timezone=FALSE,
-               indices=FALSE, ...) {
+               timezone=FALSE, ...) {
   # topn  - print the top topn and bottom topn rows with '---' inbetween (5)
   # nrows - under this the whole (small) table is printed, unless topn is provided (100)
   # class - should column class be printed underneath column name? (FALSE)
@@ -65,12 +65,23 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
     }
     return(invisible(x))
   }
-  if (indices) {
+  index_dt = NULL
+  if (print.indices) {
     if (is.null(indices(x))) {
-      indices = FALSE
+      print.indices = FALSE
     } else {
-      index_col_name = paste0("index__", indices(x))
-      index_col = attr(attr(x, 'index'), paste0('__', indices(x)))
+      index_dt = data.table()
+      index_names = indices(x)
+      if (length(index_names) > 1L) {
+        count = 1L
+        for (index_name in index_names) {
+          index_col = attr(attr(x, 'index'), paste0('__', index_name))
+          index_dt[, paste0("index", count, "__", index_name) := index_col]
+          count = count + 1L
+        }
+      } else {
+        index_dt[, paste0("index__", index_names) := attr(attr(x, 'index'), paste0('__', index_names))]
+      }
     }
   }
   n_x = nrow(x)
@@ -78,12 +89,12 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
     toprint = rbindlist(list(head(x, topn), tail(x, topn)), use.names=FALSE)  # no need to match names because head and tail of same x, and #3306
     rn = c(seq_len(topn), seq.int(to=n_x, length.out=topn))
     printdots = TRUE
-    if (indices) set(toprint, j=index_col_name, value=c(head(index_col, topn), tail(index_col, topn)))
+    if (print.indices) toprint = cbind(toprint, rbindlist(list(head(index_dt, topn), tail(index_dt, topn)), use.names=FALSE))
   } else {
     toprint = x
     rn = seq_len(n_x)
     printdots = FALSE
-    if (indices) set(toprint, j=index_col_name, value=index_col)
+    if (print.indices) toprint = cbind(toprint, index_dt)
   }
   toprint=format.data.table(toprint, na.encode=FALSE, timezone = timezone, ...)  # na.encode=FALSE so that NA in character cols print as <NA>
   require_bit64_if_needed(x)
@@ -282,4 +293,8 @@ trunc_cols_message = function(not_printed, abbs, class, col.names){
     "%d variable(s) not shown: %s\n",
     n, brackify(paste0(not_printed, classes))
   )
+}
+
+hello = function(x) {
+  print(names(x))
 }

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -294,7 +294,3 @@ trunc_cols_message = function(not_printed, abbs, class, col.names){
     n, brackify(paste0(not_printed, classes))
   )
 }
-
-hello = function(x) {
-  print(names(x))
-}

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -9,7 +9,8 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
                trunc.cols=getOption("datatable.print.trunc.cols"),
                quote=FALSE,
                na.print=NULL,
-               timezone=FALSE, ...) {
+               timezone=FALSE,
+               indices=FALSE, ...) {
   # topn  - print the top topn and bottom topn rows with '---' inbetween (5)
   # nrows - under this the whole (small) table is printed, unless topn is provided (100)
   # class - should column class be printed underneath column name? (FALSE)
@@ -64,15 +65,25 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
     }
     return(invisible(x))
   }
+  if (indices) {
+    if (is.null(indices(x))) {
+      indices = FALSE
+    } else {
+      index_col_name = paste0("index__", indices(x))
+      index_col = attr(attr(x, 'index'), paste0('__', indices(x)))
+    }
+  }
   n_x = nrow(x)
   if ((topn*2L+1L)<n_x && (n_x>nrows || !topnmiss)) {
     toprint = rbindlist(list(head(x, topn), tail(x, topn)), use.names=FALSE)  # no need to match names because head and tail of same x, and #3306
     rn = c(seq_len(topn), seq.int(to=n_x, length.out=topn))
     printdots = TRUE
+    if (indices) set(toprint, j=index_col_name, value=c(head(index_col, topn), tail(index_col, topn)))
   } else {
     toprint = x
     rn = seq_len(n_x)
     printdots = FALSE
+    if (indices) set(toprint, j=index_col_name, value=index_col)
   }
   toprint=format.data.table(toprint, na.encode=FALSE, timezone = timezone, ...)  # na.encode=FALSE so that NA in character cols print as <NA>
   require_bit64_if_needed(x)

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -70,7 +70,6 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
     if (is.null(indices(x))) {
       show.indices = FALSE
     } else {
-      index_dt = data.table()
       index_names = indices(x)
       index_dt <- as.data.table(attributes(attr(x, 'index')))
       print_names <- paste0("index", if (ncol(index_dt) > 1L) seq_along(index_names) else "", ":", sub("__", "", names(index_dt)))

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -70,9 +70,8 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
     if (is.null(indices(x))) {
       show.indices = FALSE
     } else {
-      index_names = indices(x)
       index_dt <- as.data.table(attributes(attr(x, 'index')))
-      print_names <- paste0("index", if (ncol(index_dt) > 1L) seq_along(index_names) else "", ":", sub("__", "", names(index_dt)))
+      print_names <- paste0("index", if (ncol(index_dt) > 1L) seq_len(ncol(index_dt)) else "", ":", sub("^__", "", names(index_dt), fixed=TRUE))
       setnames(index_dt, print_names)
     }
   }

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -65,7 +65,6 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
     }
     return(invisible(x))
   }
-  index_dt = NULL
   if (show.indices) {
     if (is.null(indices(x))) {
       show.indices = FALSE

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18619,60 +18619,80 @@ set.seed(2024)
 DT = data.table(
  grp1 = sample(100, NN, TRUE),
  grp2 = sample(90, NN, TRUE),
- grp3 = sample(80, NN, TRUE)
-)
+ grp3 = sample(80, NN, TRUE))
 setkey(DT, grp1, grp2)
 setindex(DT, grp1, grp3)
 ans = c(
- "     grp1 grp2 grp3 index__grp1__grp3",
- "  1:    1    5   15                 1",
- "  2:    1   24   60                 2",
- "  3:    2   26   32                 5",
- "  4:    2   36   57                 3",
- "  5:    2   51   30                 4",
- " ---                                 ",
- "196:   98   77   45               195",
- "197:   98   87   70               197",
- "198:  100   18   21               198",
- "199:  100   36   51               199",
- "200:  100   38   56               200")
+ "     grp1 grp2 grp3 index:grp1__grp3",
+ "  1:    1    5   15                1",
+ "  2:    1   24   60                2",
+ "  3:    2   26   32                5",
+ "  4:    2   36   57                3",
+ "  5:    2   51   30                4",
+ " ---                                ",
+ "196:   98   77   45              195",
+ "197:   98   87   70              197",
+ "198:  100   18   21              198",
+ "199:  100   36   51              199",
+ "200:  100   38   56              200")
 # test printing with 1 index column, no markers for order
-test(2264.1, print(DT, print.indices=TRUE), output=ans)
+test(2264.1, print(DT, show.indices=TRUE), output=ans)
 # test that options work as well
-test(2264.2, options=list(datatable.print.indices=TRUE), print(DT), output=ans)
+test(2264.2, options=list(datatable.show.indices=TRUE), print(DT), output=ans)
 setindex(DT, grp3, grp1)
 ans = c(
- "     grp1 grp2 grp3 index1__grp1__grp3 index2__grp3__grp1",
- "  1:    1    5   15                  1                 10",
- "  2:    1   24   60                  2                119",
- "  3:    2   26   32                  5                164",
- "  4:    2   36   57                  3                192",
- "  5:    2   51   30                  4                 63",
- " ---                                                     ",
- "196:   98   77   45                195                 11",
- "197:   98   87   70                197                 66",
- "198:  100   18   21                198                 31",
- "199:  100   36   51                199                139",
- "200:  100   38   56                200                159")
+ "     grp1 grp2 grp3 index1:grp1__grp3 index2:grp3__grp1",
+ "  1:    1    5   15                 1                10",
+ "  2:    1   24   60                 2               119",
+ "  3:    2   26   32                 5               164",
+ "  4:    2   36   57                 3               192",
+ "  5:    2   51   30                 4                63",
+ " ---                                                   ",
+ "196:   98   77   45               195                11",
+ "197:   98   87   70               197                66",
+ "198:  100   18   21               198                31",
+ "199:  100   36   51               199               139",
+ "200:  100   38   56               200               159")
 # test for two indices, with markers to show order
-test(2264.3, print(DT, print.indices=TRUE), output=ans)
-test(2264.4, options=list(datatable.print.indices=TRUE), print(DT), output=ans)
+test(2264.3, print(DT, show.indices=TRUE), output=ans)
+test(2264.4, options=list(datatable.show.indices=TRUE), print(DT), output=ans)
 setindex(DT, NULL) # clear indices
 # if no indices are set, simply ignore
-test(2264.5, capture.output(print(DT, print.indices=TRUE)), capture.output(print(DT, print.indices=FALSE)))
-test(2264.6, options=list(datatable.print.indices=TRUE), capture.output(print(DT, print.indices=TRUE)), capture.output(print(DT, print.indices=FALSE)))
+test(2264.5, print(DT, show.indices=TRUE), notOutput="index:grp1__grp3")
+test(2264.6, options=list(datatable.show.indices=TRUE), print(DT, show.indices=TRUE), notOutput="index:grp1__grp3")
 setindex(DT, grp3)
 ans = c(
- "     grp1 grp2 grp3 index__grp3",
- "  1:    1    5   15          10",
- "  2:    1   24   60         119",
- "  3:    2   26   32         164",
- "  4:    2   36   57         192",
- "  5:    2   51   30          63",
- " ---                           ",
- "196:   98   77   45          11",
- "197:   98   87   70          66",
- "198:  100   18   21          31",
- "199:  100   36   51         139",
- "200:  100   38   56         159")
-test(2264.7, print(DT, print.indices=TRUE), output=ans)
+ "     grp1 grp2 grp3 index:grp3",
+ "  1:    1    5   15         10",
+ "  2:    1   24   60        119",
+ "  3:    2   26   32        164",
+ "  4:    2   36   57        192",
+ "  5:    2   51   30         63",
+ " ---                          ",
+ "196:   98   77   45         11",
+ "197:   98   87   70         66",
+ "198:  100   18   21         31",
+ "199:  100   36   51        139",
+ "200:  100   38   56        159")
+test(2264.7, print(DT, show.indices=TRUE), output=ans)
+NN = 10
+DT = data.table(
+ grp1 = sample(100, NN, TRUE),
+ grp2 = sample(90, NN, TRUE),
+ grp3 = sample(80, NN, TRUE))
+setindex(DT, grp1, grp3)
+setindex(DT, grp3, grp1)
+ans = c(
+ "    grp1 grp2 grp3 index1:grp1__grp3 index2:grp3__grp1",
+ " 1:   77   61   53                 3                 5",
+ " 2:   80   66   37                 8                 4",
+ " 3:   27   42    8                 5                 3",
+ " 4:   66   37    7                 4                 7",
+ " 5:   38   69    5                 6                 2",
+ " 6:   72   89   69                 1                10",
+ " 7:   86   52   16                 2                 1",
+ " 8:   28   35   62                10                 8",
+ " 9:   95   82   80                 7                 6",
+ "10:   83   64   41                 9                 9")
+# test where topn isn't necessary
+test(2264.8, print(DT, show.indices=TRUE), output=ans)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18623,7 +18623,6 @@ DT = data.table(
 )
 setkey(DT, grp1, grp2)
 setindex(DT, grp1, grp3)
-dt2 = copy(DT)
 ans = c(
  "     grp1 grp2 grp3 index__grp1__grp3",
  "  1:    1    5   15                 1",
@@ -18636,12 +18635,32 @@ ans = c(
  "197:   98   87   70               197",
  "198:  100   18   21               198",
  "199:  100   36   51               199",
- "200:  100   38   56               200"
- )
-test(2264.1, print(DT, indices=TRUE), output=ans)
+ "200:  100   38   56               200")
+# test printing with 1 index column, no markers for order
+test(2264.1, print(DT, print.indices=TRUE), output=ans)
+# test that options work as well
+test(2264.2, options=list(datatable.print.indices=TRUE), print(DT), output=ans)
+setindex(DT, grp3, grp1)
+ans = c(
+ "     grp1 grp2 grp3 index1__grp1__grp3 index2__grp3__grp1",
+ "  1:    1    5   15                  1                 10",
+ "  2:    1   24   60                  2                119",
+ "  3:    2   26   32                  5                164",
+ "  4:    2   36   57                  3                192",
+ "  5:    2   51   30                  4                 63",
+ " ---                                                     ",
+ "196:   98   77   45                195                 11",
+ "197:   98   87   70                197                 66",
+ "198:  100   18   21                198                 31",
+ "199:  100   36   51                199                139",
+ "200:  100   38   56                200                159")
+# test for two indices, with markers to show order
+test(2264.3, print(DT, print.indices=TRUE), output=ans)
+test(2264.4, options=list(datatable.print.indices=TRUE), print(DT), output=ans)
 setindex(DT, NULL) # clear indices
 # if no indices are set, simply ignore
-test(2264.2, capture.output(print(DT, indices=TRUE)), capture.output(print(DT, indices=FALSE)))
+test(2264.5, capture.output(print(DT, print.indices=TRUE)), capture.output(print(DT, print.indices=FALSE)))
+test(2264.6, options=list(datatable.print.indices=TRUE), capture.output(print(DT, print.indices=TRUE)), capture.output(print(DT, print.indices=FALSE)))
 setindex(DT, grp3)
 ans = c(
  "     grp1 grp2 grp3 index__grp3",
@@ -18655,6 +18674,5 @@ ans = c(
  "197:   98   87   70          66",
  "198:  100   18   21          31",
  "199:  100   36   51         139",
- "200:  100   38   56         159"
- )
-test(2264.3, print(DT, indices=TRUE), output=ans)
+ "200:  100   38   56         159")
+test(2264.7, print(DT, print.indices=TRUE), output=ans)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18612,3 +18612,49 @@ test(2263.3, options=list(datatable.verbose=TRUE, datatable.optimize=0L), names(
 test(2263.4, options=list(datatable.verbose=TRUE, datatable.optimize=Inf), dt[, .N, b], data.table(b=dt$b, N=1L), output="GForce optimized j to")
 test(2263.5, options=list(datatable.verbose=TRUE, datatable.optimize=Inf), dt[, .N, .(b,c)], data.table(b=dt$b, c=dt$c, N=1L), output="GForce optimized j to")
 test(2263.6, options=list(datatable.verbose=TRUE, datatable.optimize=Inf), names(attributes(dt[, .N, b]$b)), c("class", "att"), output="GForce optimized j to")
+
+# tests for printing indices alongside data.tables
+NN = 200
+set.seed(2024)
+DT = data.table(
+ grp1 = sample(100, NN, TRUE),
+ grp2 = sample(90, NN, TRUE),
+ grp3 = sample(80, NN, TRUE)
+)
+setkey(DT, grp1, grp2)
+setindex(DT, grp1, grp3)
+dt2 = copy(DT)
+ans = c(
+ "     grp1 grp2 grp3 index__grp1__grp3",
+ "  1:    1    5   15                 1",
+ "  2:    1   24   60                 2",
+ "  3:    2   26   32                 5",
+ "  4:    2   36   57                 3",
+ "  5:    2   51   30                 4",
+ " ---                                 ",
+ "196:   98   77   45               195",
+ "197:   98   87   70               197",
+ "198:  100   18   21               198",
+ "199:  100   36   51               199",
+ "200:  100   38   56               200"
+ )
+test(2264.1, print(DT, indices=TRUE), output=ans)
+setindex(DT, NULL) # clear indices
+# if no indices are set, simply ignore
+test(2264.2, capture.output(print(DT, indices=TRUE)), capture.output(print(DT, indices=FALSE)))
+setindex(DT, grp3)
+ans = c(
+ "     grp1 grp2 grp3 index__grp3",
+ "  1:    1    5   15          10",
+ "  2:    1   24   60         119",
+ "  3:    2   26   32         164",
+ "  4:    2   36   57         192",
+ "  5:    2   51   30          63",
+ " ---                           ",
+ "196:   98   77   45          11",
+ "197:   98   87   70          66",
+ "198:  100   18   21          31",
+ "199:  100   36   51         139",
+ "200:  100   38   56         159"
+ )
+test(2264.3, print(DT, indices=TRUE), output=ans)

--- a/man/print.data.table.Rd
+++ b/man/print.data.table.Rd
@@ -27,7 +27,8 @@
     trunc.cols=getOption("datatable.print.trunc.cols"), # default: FALSE
     quote=FALSE,
     na.print=NULL,
-    timezone=FALSE, \dots)
+    timezone=FALSE,
+    indices=FALSE, \dots)
 
   format_col(x, \dots)
   \method{format_col}{default}(x, \dots)
@@ -49,6 +50,7 @@
   \item{quote}{ If \code{TRUE}, all output will appear in quotes, as in \code{print.default}. }
   \item{timezone}{ If \code{TRUE}, time columns of class POSIXct or POSIXlt will be printed with their timezones (if attribute is available). }
   \item{na.print}{ The string to be printed in place of \code{NA} values, as in \code{print.default}. }
+  \item{indices}{ If \code{TRUE}, the row indices will be printed alongside \code{x}. }
   \item{\dots}{ Other arguments ultimately passed to \code{format}. }
 }
 \value{
@@ -115,6 +117,17 @@
   format_col.complex = function(x, ...) sprintf('(\%.1f, \%.1fi)', Re(x), Im(x))
   x = data.table(z = c(1 + 3i, 2 - 1i, pi + 2.718i))
   print(x)
+
+  NN = 200
+  set.seed(2024)
+  DT = data.table(
+    grp1 = sample(100, NN, TRUE),
+    grp2 = sample(90, NN, TRUE),
+    grp3 = sample(80, NN, TRUE)
+  )
+  setkey(DT, grp1, grp2)
+  setindex(DT, grp1, grp3)
+  print(DT, indices = TRUE)
 
   iris = as.data.table(iris)
   iris_agg = iris[ , .(reg = list(lm(Sepal.Length ~ Petal.Length))), by = Species]

--- a/man/print.data.table.Rd
+++ b/man/print.data.table.Rd
@@ -25,7 +25,7 @@
     col.names=getOption("datatable.print.colnames"),    # default: "auto"
     print.keys=getOption("datatable.print.keys"),       # default: TRUE
     trunc.cols=getOption("datatable.print.trunc.cols"), # default: FALSE
-    print.indices=getOption("datatable.print.indices"), # default: FALSE
+    show.indices=getOption("datatable.show.indices"),   # default: FALSE
     quote=FALSE,
     na.print=NULL,
     timezone=FALSE, \dots)
@@ -47,7 +47,7 @@
   \item{col.names}{ One of three flavours for controlling the display of column names in output. \code{"auto"} includes column names above the data, as well as below the table if \code{nrow(x) > 20}. \code{"top"} excludes this lower register when applicable, and \code{"none"} suppresses column names altogether (as well as column classes if \code{class = TRUE}. }
   \item{print.keys}{ If \code{TRUE}, any \code{\link{key}} and/or \code{\link[=indices]{index}} currently assigned to \code{x} will be printed prior to the preview of the data. }
   \item{trunc.cols}{ If \code{TRUE}, only the columns that can be printed in the console without wrapping the columns to new lines will be printed (similar to \code{tibbles}). }
-  \item{print.indices}{ If \code{TRUE}, indices will be printed as columns alongside \code{x}. }
+  \item{show.indices}{ If \code{TRUE}, indices will be printed as columns alongside \code{x}. }
   \item{quote}{ If \code{TRUE}, all output will appear in quotes, as in \code{print.default}. }
   \item{timezone}{ If \code{TRUE}, time columns of class POSIXct or POSIXlt will be printed with their timezones (if attribute is available). }
   \item{na.print}{ The string to be printed in place of \code{NA} values, as in \code{print.default}. }
@@ -118,7 +118,7 @@
   x = data.table(z = c(1 + 3i, 2 - 1i, pi + 2.718i))
   print(x)
 
-  old = options(datatable.print.indices=TRUE)
+  old = options(datatable.show.indices=TRUE)
   NN = 200
   set.seed(2024)
   DT = data.table(

--- a/man/print.data.table.Rd
+++ b/man/print.data.table.Rd
@@ -47,7 +47,7 @@
   \item{col.names}{ One of three flavours for controlling the display of column names in output. \code{"auto"} includes column names above the data, as well as below the table if \code{nrow(x) > 20}. \code{"top"} excludes this lower register when applicable, and \code{"none"} suppresses column names altogether (as well as column classes if \code{class = TRUE}. }
   \item{print.keys}{ If \code{TRUE}, any \code{\link{key}} and/or \code{\link[=indices]{index}} currently assigned to \code{x} will be printed prior to the preview of the data. }
   \item{trunc.cols}{ If \code{TRUE}, only the columns that can be printed in the console without wrapping the columns to new lines will be printed (similar to \code{tibbles}). }
-  \item{print.indices}{ If \code{TRUE}, indices will be printed alongside \code{x}. }
+  \item{print.indices}{ If \code{TRUE}, indices will be printed as columns alongside \code{x}. }
   \item{quote}{ If \code{TRUE}, all output will appear in quotes, as in \code{print.default}. }
   \item{timezone}{ If \code{TRUE}, time columns of class POSIXct or POSIXlt will be printed with their timezones (if attribute is available). }
   \item{na.print}{ The string to be printed in place of \code{NA} values, as in \code{print.default}. }

--- a/man/print.data.table.Rd
+++ b/man/print.data.table.Rd
@@ -25,10 +25,10 @@
     col.names=getOption("datatable.print.colnames"),    # default: "auto"
     print.keys=getOption("datatable.print.keys"),       # default: TRUE
     trunc.cols=getOption("datatable.print.trunc.cols"), # default: FALSE
+    print.indices=getOption("datatable.print.indices"), # default: FALSE
     quote=FALSE,
     na.print=NULL,
-    timezone=FALSE,
-    indices=FALSE, \dots)
+    timezone=FALSE, \dots)
 
   format_col(x, \dots)
   \method{format_col}{default}(x, \dots)
@@ -47,10 +47,10 @@
   \item{col.names}{ One of three flavours for controlling the display of column names in output. \code{"auto"} includes column names above the data, as well as below the table if \code{nrow(x) > 20}. \code{"top"} excludes this lower register when applicable, and \code{"none"} suppresses column names altogether (as well as column classes if \code{class = TRUE}. }
   \item{print.keys}{ If \code{TRUE}, any \code{\link{key}} and/or \code{\link[=indices]{index}} currently assigned to \code{x} will be printed prior to the preview of the data. }
   \item{trunc.cols}{ If \code{TRUE}, only the columns that can be printed in the console without wrapping the columns to new lines will be printed (similar to \code{tibbles}). }
+  \item{print.indices}{ If \code{TRUE}, indices will be printed alongside \code{x}. }
   \item{quote}{ If \code{TRUE}, all output will appear in quotes, as in \code{print.default}. }
   \item{timezone}{ If \code{TRUE}, time columns of class POSIXct or POSIXlt will be printed with their timezones (if attribute is available). }
   \item{na.print}{ The string to be printed in place of \code{NA} values, as in \code{print.default}. }
-  \item{indices}{ If \code{TRUE}, the row indices will be printed alongside \code{x}. }
   \item{\dots}{ Other arguments ultimately passed to \code{format}. }
 }
 \value{
@@ -118,6 +118,7 @@
   x = data.table(z = c(1 + 3i, 2 - 1i, pi + 2.718i))
   print(x)
 
+  old = options(datatable.print.indices=TRUE)
   NN = 200
   set.seed(2024)
   DT = data.table(
@@ -127,7 +128,8 @@
   )
   setkey(DT, grp1, grp2)
   setindex(DT, grp1, grp3)
-  print(DT, indices = TRUE)
+  print(DT)
+  options(old)
 
   iris = as.data.table(iris)
   iris_agg = iris[ , .(reg = list(lm(Sepal.Length ~ Petal.Length))), by = Species]


### PR DESCRIPTION
Closes #4280

`print.data.table` gains a new argument to allow users to print its indices as a column without actually assigning a new column to the `data.table`. 

Note: does `set.seed()` work differently in the test script? for some reason I don't get the same values when using `sample` vs in my vscode or R in Windows