### PR TITLE
Clarify Integer Key Behavior in `setkey.Rd`

### DIFF
--- a/man/setkey.Rd
+++ b/man/setkey.Rd
@@ -23,7 +23,7 @@ There are three reasons \code{setkey} is desirable:
 
 \code{NA}s are always first because:
 \itemize{
-  \item \code{NA} is internally \code{INT_MIN} (a large negative number) in R. Keys and indexes are always in increasing order so if \code{NA}s are first, no special treatment or branch is needed in many \code{data.table} internals involving binary search. It is not optional to place \code{NA}s last for speed, simplicity and rubustness of internals at C level.
+  \item \code{NA} is internally \code{INT_MIN} (a large negative number) in R. Keys and indexes are always in increasing order so if \code{NA}s are first, no special treatment or branch is needed in many \code{data.table} internals involving binary search. It is not optional to place \code{NA}s last for speed, simplicity and robustness of internals at C level.
   \item if any \code{NA}s are present then we believe it is better to display them up front (rather than hiding them at the end) to reduce the risk of not realizing \code{NA}s are present.
 }
 
@@ -87,7 +87,9 @@ required.)
 If you really wish to use column numbers, it is possible but
 deliberately a little harder; e.g., \code{setkeyv(DT,names(DT)[1:2])}.
 
-If you use integer columns as keys, it's crucial to ensure correct behavior in subsetting and joining operations. Integer keys should be used with the dot (\code{.}) syntax to explicitly match values against the key rather than interpreting them as indices.
+If you use integer columns as keys, it's crucial to ensure correct behavior in subsetting and joining operations.
+Integer keys should be used with the dot (\code{.}) syntax to explicitly match values against the key 
+rather than interpreting them as indices. see examples for better understanding.
 
 If you wanted to use \code{\link[base]{grep}} to select key columns according to
 a pattern, note that you can just set \code{value = TRUE} to return a character vector instead of the default integer indices.

--- a/man/setkey.Rd
+++ b/man/setkey.Rd
@@ -89,7 +89,7 @@ deliberately a little harder; e.g., \code{setkeyv(DT,names(DT)[1:2])}.
 
 If you use integer columns as keys, it's crucial to ensure correct behavior in subsetting and joining operations.
 Integer keys should be used with the dot (\code{.}) syntax to explicitly match values against the key 
-rather than interpreting them as indices. see examples for better understanding.
+rather than interpreting them as indices. See examples for better understanding.
 
 If you wanted to use \code{\link[base]{grep}} to select key columns according to
 a pattern, note that you can just set \code{value = TRUE} to return a character vector instead of the default integer indices.

--- a/man/setkey.Rd
+++ b/man/setkey.Rd
@@ -145,11 +145,11 @@ indices(DT)           # get indices single vector
 indices(DT, vectors = TRUE) # get indices list
 
 # Example illustrating the importance of using the dot (`.`) syntax with integer keys:
-DT <- data.table(id = 1:5, B = letters[5:1])
+DT <- data.table(id = 2:1)
 
 # Incorrect Usage:
 setkey(DT, id)
-subset_value <- 3
+subset_value <- 1
 DT[subset_value]  # Incorrect: treats `subset_value` as an index
 
 # Correct Usage:

--- a/man/setkey.Rd
+++ b/man/setkey.Rd
@@ -148,9 +148,9 @@ indices(DT, vectors = TRUE) # get indices list
 DT = data.table(id = 2:1)
 setkey(DT, id)
 subset_value <- 1
-DT[subset_value]  # Incorrect: treats `subset_value` as an row number
+DT[subset_value]  # treats `subset_value` as an row number
 # To correctly subset based on the key column `id`, use the dot (`.`) syntax:
-DT[.(subset_value)]  # Correct: matches `subset_value` against `id`
+DT[.(subset_value)]  # matches `subset_value` against `id`
 
 }
 \keyword{ data }

--- a/man/setkey.Rd
+++ b/man/setkey.Rd
@@ -87,6 +87,8 @@ required.)
 If you really wish to use column numbers, it is possible but
 deliberately a little harder; e.g., \code{setkeyv(DT,names(DT)[1:2])}.
 
+If you use integer columns as keys, it's crucial to ensure correct behavior in subsetting and joining operations. Integer keys should be used with the dot (\code{.}) syntax to explicitly match values against the key rather than interpreting them as indices.
+
 If you wanted to use \code{\link[base]{grep}} to select key columns according to
 a pattern, note that you can just set \code{value = TRUE} to return a character vector instead of the default integer indices.
 }
@@ -139,5 +141,18 @@ setindex(DT, A)
 setindex(DT, B)
 indices(DT)           # get indices single vector
 indices(DT, vectors = TRUE) # get indices list
+
+# Example illustrating the importance of using the dot (`.`) syntax with integer keys:
+DT <- data.table(id = 1:5, B = letters[5:1])
+
+# Incorrect Usage:
+setkey(DT, id)
+subset_value <- 3
+DT[subset_value]  # Incorrect: treats `subset_value` as an index
+
+# Correct Usage:
+# To correctly subset based on the key column `id`, use the dot (`.`) syntax:
+DT[.(subset_value)]  # Correct: explicitly matches `subset_value` against `id`
+
 }
 \keyword{ data }

--- a/man/setkey.Rd
+++ b/man/setkey.Rd
@@ -154,7 +154,7 @@ DT[subset_value]  # Incorrect: treats `subset_value` as an row number
 
 # Correct Usage:
 # To correctly subset based on the key column `id`, use the dot (`.`) syntax:
-DT[.(subset_value)]  # Correct: explicitly matches `subset_value` against `id`
+DT[.(subset_value)]  # Correct: matches `subset_value` against `id`
 
 }
 \keyword{ data }

--- a/man/setkey.Rd
+++ b/man/setkey.Rd
@@ -145,14 +145,10 @@ indices(DT)           # get indices single vector
 indices(DT, vectors = TRUE) # get indices list
 
 # Example illustrating the importance of using the dot (`.`) syntax with integer keys:
-DT <- data.table(id = 2:1)
-
-# Incorrect Usage:
+DT = data.table(id = 2:1)
 setkey(DT, id)
 subset_value <- 1
 DT[subset_value]  # Incorrect: treats `subset_value` as an row number
-
-# Correct Usage:
 # To correctly subset based on the key column `id`, use the dot (`.`) syntax:
 DT[.(subset_value)]  # Correct: matches `subset_value` against `id`
 

--- a/man/setkey.Rd
+++ b/man/setkey.Rd
@@ -89,7 +89,7 @@ deliberately a little harder; e.g., \code{setkeyv(DT,names(DT)[1:2])}.
 
 If you use integer columns as keys, it's crucial to ensure correct behavior in subsetting and joining operations.
 Integer keys should be used with the dot (\code{.}) syntax to explicitly match values against the key 
-rather than interpreting them as indices. See examples for better understanding.
+rather than interpreting them as row numbers. See examples for better understanding.
 
 If you wanted to use \code{\link[base]{grep}} to select key columns according to
 a pattern, note that you can just set \code{value = TRUE} to return a character vector instead of the default integer indices.
@@ -150,7 +150,7 @@ DT <- data.table(id = 2:1)
 # Incorrect Usage:
 setkey(DT, id)
 subset_value <- 1
-DT[subset_value]  # Incorrect: treats `subset_value` as an index
+DT[subset_value]  # Incorrect: treats `subset_value` as an row number
 
 # Correct Usage:
 # To correctly subset based on the key column `id`, use the dot (`.`) syntax:

--- a/man/setkey.Rd
+++ b/man/setkey.Rd
@@ -87,9 +87,7 @@ required.)
 If you really wish to use column numbers, it is possible but
 deliberately a little harder; e.g., \code{setkeyv(DT,names(DT)[1:2])}.
 
-If you use integer columns as keys, it's crucial to ensure correct behavior in subsetting and joining operations.
-Integer keys should be used with the dot (\code{.}) syntax to explicitly match values against the key 
-rather than interpreting them as row numbers. See examples for better understanding.
+If you want to subset rows based on values of an integer key column, it should be done with the dot (\code{.}) syntax, because integers are otherwise interpreted as row numbers (see example). 
 
 If you wanted to use \code{\link[base]{grep}} to select key columns according to
 a pattern, note that you can just set \code{value = TRUE} to return a character vector instead of the default integer indices.
@@ -144,13 +142,12 @@ setindex(DT, B)
 indices(DT)           # get indices single vector
 indices(DT, vectors = TRUE) # get indices list
 
-# Example illustrating the importance of using the dot (`.`) syntax with integer keys:
+# Use the dot .(subset_value) syntax with integer keys:
 DT = data.table(id = 2:1)
 setkey(DT, id)
 subset_value <- 1
-DT[subset_value]  # treats `subset_value` as an row number
-# To correctly subset based on the key column `id`, use the dot (`.`) syntax:
-DT[.(subset_value)]  # matches `subset_value` against `id`
+DT[subset_value]  # treats subset_value as an row number
+DT[.(subset_value)]  # matches subset_value against key column (id)
 
 }
 \keyword{ data }


### PR DESCRIPTION
closes #5074 

### Description

This PR updates the documentation of `setkey.Rd` to emphasize the importance of using the dot (`.`) syntax when employing integer columns as keys. The documentation now explicitly advises users to use `.[(subset_value)]` instead of `[subset_value]` to ensure correct behavior in subsetting operations. This clarification aims to prevent potential issues where integers are misinterpreted as indices rather than values against the key column.

