### PR TITLE
Comment Out Definitions of `J` and `.` to Fix Test 715 in cc() Environment

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2778,6 +2778,8 @@ address = function(x) .Call(Caddress, eval(substitute(x), parent.frame()))
 # . = function(...) {
 #   stopf(".() called outside of [.data.table. .() is only intended as an alias for list() inside DT[...].")
 # }
+# Commented out to prevent test failures caused by non-exported functions being attached during the clear and compile (cc()) process,
+# which alters the expected output(i.e error message in this case).
 
 let = function(...) `:=`(...)
 

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2771,13 +2771,13 @@ address = function(x) .Call(Caddress, eval(substitute(x), parent.frame()))
 }
 
 # TODO(#6197): Export these.
-J = function(...) {
-  stopf("J() called outside of [.data.table. J() is only intended for use in i.")
-}
+# J = function(...) {
+#   stopf("J() called outside of [.data.table. J() is only intended for use in i.")
+# }
 
-. = function(...) {
-  stopf(".() called outside of [.data.table. .() is only intended as an alias for list() inside DT[...].")
-}
+# . = function(...) {
+#   stopf(".() called outside of [.data.table. .() is only intended as an alias for list() inside DT[...].")
+# }
 
 let = function(...) `:=`(...)
 


### PR DESCRIPTION
#### Description

This PR addresses the issue where test 715 fails in the `cc()` environment. The failure is due to the `J` function being inadvertently included in the namespace when `cc()` is used, which attaches the full `data.table` namespace, including non-exported functions.

#### Changes Made

1. **Commented Out Definitions**:
    - Commented out the definitions of the `J` and `.` functions in `R/data.table.R` to prevent them from being used or causing conflicts within the `cc()` environment.
    
#### Related PR : #6198 

