### PR TITLE
change tags for linux

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,7 +46,7 @@ stages:
 mirror-packages:
   stage: dependencies
   tags:
-    - linux
+    - saas-linux-medium-amd64
   image: registry.gitlab.com/jangorecki/dockerfiles/r-base-minimal
   cache:
     paths:
@@ -68,7 +68,7 @@ mirror-packages:
 build:
   stage: build
   tags:
-    - linux
+    - saas-linux-medium-amd64
   image: registry.gitlab.com/jangorecki/dockerfiles/r-base-gcc
   needs: ["mirror-packages"]
   before_script:
@@ -91,7 +91,7 @@ build:
 .test-lin-template: &test-lin
   <<: *test
   tags:
-    - linux
+    - saas-linux-medium-amd64
   before_script:
     - cp $(ls -1t bus/build/data.table_*.tar.gz | head -n 1) .
     - mkdir -p ~/.R
@@ -292,7 +292,7 @@ integration:
   stage: integration
   image: registry.gitlab.com/jangorecki/dockerfiles/r-pkgdown
   tags:
-    - linux
+    - saas-linux-medium-amd64
   only:
     - master
   needs: ["mirror-packages","build","test-lin-rel","test-lin-rel-cran","test-lin-dev-gcc-strict-cran","test-lin-dev-clang-cran","test-lin-rel-vanilla","test-lin-310-cran","test-win-rel","test-win-dev" ,"test-win-old"]
@@ -381,7 +381,7 @@ pages:
   stage: deploy
   environment: production
   tags:
-    - linux
+    - saas-linux-medium-amd64
   only:
     - master
   image: ubuntu


### PR DESCRIPTION
Closes #6209 

Apparently, our used tag `linux` is not available anymore at the [hosted runners](https://docs.gitlab.com/ee/ci/runners/hosted_runners/linux.html)

This PR changes the tag from `linux` to `saas-linux-medium-amd64`. Another option would be to remove the tags which then uses the default of `saas-linux-small-amd64`