### PR TITLE
change tags for windows

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -209,7 +209,7 @@ test-lin-310-cran:
 .test-win-template: &test-win
   <<: *test
   tags:
-    - shared-windows
+    - saas-windows-medium-amd64
   before_script:
     - curl.exe -s -o ../R-win.exe $R_BIN --fail; if (!(Test-Path -Path ..\R-win.exe)) {Write-Error "R-win.exe not found, download failed?"}
     - Start-Process -FilePath ..\R-win.exe -ArgumentList "/VERYSILENT /DIR=C:\R" -NoNewWindow -Wait


### PR DESCRIPTION
Follow-up to #6211

Makes the same change of tags for [windows](https://docs.gitlab.com/ee/ci/runners/hosted_runners/windows.html)