### PR TITLE
Don't use function string matching for do.call(what=) or lapply(FUN=)

### DIFF
--- a/.dev/cc.R
+++ b/.dev/cc.R
@@ -62,8 +62,8 @@ cc = function(test=FALSE, clean=FALSE, debug=FALSE, omp=!debug, cc_dir, path=Sys
 
   xx = try(getDLLRegisteredRoutines("data_table",TRUE), silent=TRUE)
   if (!inherits(xx, "try-error")) {
-    remove(list=sapply(xx$.Call,'[[',"name"), pos=.GlobalEnv)
-    remove(list=sapply(xx$.External,'[[',"name"), pos=.GlobalEnv)
+    remove(list=sapply(xx$.Call, `[[`, "name"), pos=.GlobalEnv)
+    remove(list=sapply(xx$.External, `[[`, "name"), pos=.GlobalEnv)
     # if these objects aren't there to remove it's correctly an error (should always be there)
   }
 

--- a/.dev/cc.R
+++ b/.dev/cc.R
@@ -68,7 +68,7 @@ cc = function(test=FALSE, clean=FALSE, debug=FALSE, omp=!debug, cc_dir, path=Sys
   }
 
   # Make sure library .so is not loaded (neither installed package nor from dev)
-  dll = unlist(do.call("rbind",getLoadedDLLs())[,"path"])
+  dll = unlist(do.call(rbind,getLoadedDLLs())[,"path"])
   dll = grep("data_table.so", dll, fixed=TRUE, value=TRUE)
   sapply(dll, dyn.unload)
   gc()

--- a/R/cedta.R
+++ b/R/cedta.R
@@ -65,7 +65,7 @@ cedta = function(n=2L) {
   if (!ans && getOption("datatable.verbose")) {
     # nocov start
     catf("cedta decided '%s' wasn't data.table aware. Here is call stack with [[1L]] applied:\n", nsname)
-    print(sapply(sys.calls(), "[[", 1L))
+    print(sapply(sys.calls(), `[[`, 1L))
     # nocov end
     # so we can trace the namespace name that may need to be added (very unusually)
   }

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2374,8 +2374,8 @@ which_ = function(x, bool = TRUE) {
 }
 
 is.na.data.table = function(x) {
-  if (!cedta()) return(`is.na.data.frame`(x))
-  do.call("cbind", lapply(x, "is.na"))
+  if (!cedta()) return(is.na.data.frame(x))
+  do.call(cbind, lapply(x, is.na))
 }
 
 # not longer needed as inherits ...

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1938,7 +1938,7 @@ replace_dot_alias = function(e) {
     return(suppPrint(x))
   }
   if (is.null(ans)) {
-    ans = as.data.table.list(lapply(groups,"[",0L))  # side-effects only such as test 168
+    ans = as.data.table.list(lapply(groups, `[`, 0L))  # side-effects only such as test 168
     setnames(ans,seq_along(bynames),bynames)   # TO DO: why doesn't groups have bynames in the first place?
     return(ans)
   }

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2423,7 +2423,7 @@ split.data.table = function(x, f, drop = FALSE, by, sorted = FALSE, keep.by = TR
       factor(.x_lev, levels = .x_lev)
       }
     })
-    r = do.call("CJ", c(ul, sorted=sorted, unique=TRUE))
+    r = do.call(CJ, c(ul, sorted=sorted, unique=TRUE))
     if (!sorted && nrow(by.order)) {
       ii = r[by.order, on=cols, which=TRUE]
       r = rbindlist(list(

--- a/R/fcast.R
+++ b/R/fcast.R
@@ -203,7 +203,7 @@ dcast.data.table = function(data, formula, fun.aggregate = NULL, sep = "_", ...,
     o[idx] # subsetVector retains attributes, using R's subset for now
   }
   cj_uniq = function(DT) {
-    do.call("CJ", lapply(DT, function(x)
+    do.call(CJ, lapply(DT, function(x)
       if (is.factor(x)) {
         xint = seq_along(levels(x))
         setattr(xint, 'levels', levels(x))
@@ -236,16 +236,16 @@ dcast.data.table = function(data, formula, fun.aggregate = NULL, sep = "_", ...,
       lhs = lhs_; rhs = rhs_
     }
     maplen = lengths(mapunique)
-    idx = do.call("CJ", mapunique)[map, 'I' := .I][["I"]] # TO DO: move this to C and avoid materialising the Cross Join.
+    idx = do.call(CJ, mapunique)[map, 'I' := .I][["I"]] # TO DO: move this to C and avoid materialising the Cross Join.
     some_fill = anyNA(idx)
     fill.default = if (run_agg_funs && is.null(fill) && some_fill) dat_for_default_fill[, maybe_err(eval(fun.call))]
     if (run_agg_funs && is.null(fill) && some_fill) {
       fill.default = dat_for_default_fill[0L][, maybe_err(eval(fun.call))]
     }
     ans = .Call(Cfcast, lhs, val, maplen[[1L]], maplen[[2L]], idx, fill, fill.default, is.null(fun.call), some_fill)
-    allcols = do.call("paste", c(rhs, sep=sep))
+    allcols = do.call(paste, c(rhs, sep=sep))
     if (length(valnames) > 1L)
-      allcols = do.call("paste", if (identical(".", allcols)) list(valnames, sep=sep)
+      allcols = do.call(paste, if (identical(".", allcols)) list(valnames, sep=sep)
             else c(CJ(valnames, allcols, sorted=FALSE), sep=sep))
       # removed 'setcolorder()' here, #1153
     setattr(ans, 'names', c(lhsnames, allcols))

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -155,7 +155,7 @@ format.data.table = function(x, ..., justify="none") {
 
     stopf("Internal structure doesn't seem to be a list. Possibly corrupt data.table.")
   }
-  do.call("cbind", lapply(x, format_col, ..., justify=justify))
+  do.call(cbind, lapply(x, format_col, ..., justify=justify))
 }
 
 mimicsAutoPrint = c("knit_print.default")

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -211,10 +211,10 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
     if (is.na(oldEnv[i]))
       Sys.unsetenv(names(oldEnv)[i])
     else
-      do.call("Sys.setenv", as.list(oldEnv[i])) # nocov
+      do.call(Sys.setenv, as.list(oldEnv[i])) # nocov
   }
   # Sys.setlocale("LC_CTYPE", oldlocale)
-  suppressWarnings(do.call("RNGkind",as.list(oldRNG)))
+  suppressWarnings(do.call(RNGkind,as.list(oldRNG)))
   # suppressWarnings for the unlikely event that user selected sample='Rounding' themselves before calling test.data.table()
 
   setNumericRounding(userNumericRounding)  # Restore the user's numeric rounding value
@@ -331,8 +331,8 @@ test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,no
     })
   }
   if (!is.null(options)) {
-    old_options <- do.call('options', as.list(options)) # as.list(): allow passing named character vector for convenience
-    on.exit(options(old_options), add=TRUE)
+    old_options <- do.call(base::options, as.list(options)) # as.list(): allow passing named character vector for convenience
+    on.exit(base::options(old_options), add=TRUE)
   }
   # Usage:
   # i) tests that x equals y when both x and y are supplied, the most common usage

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -5623,7 +5623,7 @@ test(1360.2, copy(dt)[sample, N := c(.N), by = .EACHI], copy(dt)[sample, N := .N
 
 # Fix for #500 - `lapply` call shouldn't redirect to `[.data.frame`.
 L <- list(data.table(BOD), data.table(BOD))
-test(1361, lapply(L, "[", Time==3L), list(L[[1L]][Time == 3L], L[[2L]][Time == 3L]))
+test(1361, lapply(L, `[`, Time==3L), list(L[[1L]][Time == 3L], L[[2L]][Time == 3L]))
 
 # Feature #735, first two cases: 1) .SD, and 2) DT[, c(.SD, lapply(.SD, ...)), by=...] optimisation:
 # Don't set options(datatable.verbose=TRUE) here because the "running test 1362.1 ..." messages cause output to scroll away errors on CRAN checks last 13 lines
@@ -18369,10 +18369,10 @@ test(2249.4, indices(DT[, .SD]), c('x', 'y'))
 
 # make names(.SD) work - issue #795
 dt = data.table(a = 1:4, b = 5:8)
-test(2250.01, dt[, names(.SD) := lapply(.SD, '*', 2), .SDcols = 1L], data.table(a = 1:4 * 2, b = 5:8))
-test(2250.02, dt[, names(.SD) := lapply(.SD, '*', 2), .SDcols = 2L], data.table(a = 1:4 * 2, b = 5:8 * 2))
+test(2250.01, dt[, names(.SD) := lapply(.SD, `*`, 2), .SDcols = 1L], data.table(a = 1:4 * 2, b = 5:8))
+test(2250.02, dt[, names(.SD) := lapply(.SD, `*`, 2), .SDcols = 2L], data.table(a = 1:4 * 2, b = 5:8 * 2))
 test(2250.03, dt[, names(.SD) := lapply(.SD, as.integer)], data.table(a = as.integer(1:4 * 2), b = as.integer(5:8 * 2)))
-test(2250.04, dt[1L, names(.SD) := lapply(.SD, '+', 2L)], data.table(a = as.integer(c(4, 2:4 * 2)), b = as.integer(c(12, 6:8 * 2))))
+test(2250.04, dt[1L, names(.SD) := lapply(.SD, `+`, 2L)], data.table(a = as.integer(c(4, 2:4 * 2)), b = as.integer(c(12, 6:8 * 2))))
 test(2250.05, dt[, setdiff(names(.SD), 'a') := NULL], data.table(a = as.integer(c(4, 2:4 * 2))))
 test(2250.06, dt[, c(names(.SD)) := NULL], null.data.table())
 

--- a/man/rbindlist.Rd
+++ b/man/rbindlist.Rd
@@ -4,7 +4,7 @@
 \alias{rbind}
 \title{ Makes one data.table from a list of many }
 \description{
-  Same as \code{do.call("rbind", l)} on \code{data.frame}s, but much faster.
+  Same as \code{do.call(rbind, l)} on \code{data.frame}s, but much faster.
 }
 \usage{
 rbindlist(l, use.names="check", fill=FALSE, idcol=NULL)


### PR DESCRIPTION
Related: #6192. First caught my eye because I know this makes it harder for static analyzers, e.g. any code looking for `cbind()` usage will have to special-case the possibility that `cbind` is passed as a string, in an appropriate context, etc.

This is not a terribly big deal for base functions but is best practice when using dependencies since it can be hard to tell if downstreams get broken, statically.

It's also a bit slower -- `match.fun()` exits immediately when passed a function, takes an extra step when passed a string. That core part of function matching in `lapply()` is 10x slower. `do.call()` is roughly the same:

```r
microbenchmark(times=1e6, match.fun("is.na"), match.fun(is.na))
# Unit: nanoseconds
#                expr  min   lq     mean median   uq       max neval cld
#  match.fun("is.na") 6892 7183 8837.238   7290 7696 127587928 1e+06   b
#    match.fun(is.na)  575  677 1073.283    730  832  64672336 1e+06  a 
```

```r
l=list(1)
microbenchmark(times=1e6, do.call("identity", l), do.call(identity, l))
# Unit: microseconds
#                    expr   min    lq     mean median    uq      max neval cld
#  do.call("identity", l) 1.885 2.010 2.910809  2.094 2.451 42517.85 1e+06   a
#    do.call(identity, l) 1.850 1.966 2.915019  2.049 2.417 77993.08 1e+06   a
```

PS Shouldn't we use `NextMethod()`, rather than call the S3 method explicitly?