### PR TITLE
do not eval vignette chunks which should error (use purl=FALSE)

### DIFF
--- a/vignettes/datatable-programming.Rmd
+++ b/vignettes/datatable-programming.Rmd
@@ -49,7 +49,7 @@ The problem with this kind of interface is that we cannot easily parameterize th
 
 ### Example
 
-```{r subset_error, error=0}
+```{r subset_error, eval = FALSE}
 my_subset = function(data, col, val) {
   subset(data, col == val)
 }
@@ -288,7 +288,7 @@ DT[, j,  # the same as above but accepts character vector
 
 Now let's try to pass a list of symbols, rather than list call to those symbols. We'll use `I()` to escape automatic _enlist_-ing but, as this will also turn off character to symbol conversion, we also have to use `as.name`.
 
-```{r splice_not, error=0}
+```{r splice_not, eval = FALSE}
 DT[, j,  # list of symbols
    env = I(list(j = lapply(cols, as.name))),
    verbose = TRUE]

--- a/vignettes/datatable-programming.Rmd
+++ b/vignettes/datatable-programming.Rmd
@@ -49,12 +49,11 @@ The problem with this kind of interface is that we cannot easily parameterize th
 
 ### Example
 
-```{r subset_error, eval = FALSE}
+```{r subset_error, error = TRUE, purl = FALSE}
 my_subset = function(data, col, val) {
   subset(data, col == val)
 }
 my_subset(iris, Species, "setosa")
-# Error in eval(e, x, parent.frame()): object 'Species' not found
 ```
 
 ### Approaches to the problem
@@ -289,15 +288,11 @@ DT[, j,  # the same as above but accepts character vector
 
 Now let's try to pass a list of symbols, rather than list call to those symbols. We'll use `I()` to escape automatic _enlist_-ing but, as this will also turn off character to symbol conversion, we also have to use `as.name`.
 
-```{r splice_not, eval = FALSE}
+```{r splice_not, eval = TRUE, purl = FALSE}
 DT[, j,  # list of symbols
    env = I(list(j = lapply(cols, as.name))),
    verbose = TRUE]
-# Argument 'j' after substitute: list(Sepal.Length, Sepal.Width)
-# Error: When with=FALSE, j-argument should be of type logical/character/integer indicating the columns to select.
-```
 
-```{r splice_not_proper}
 DT[, j,  # again the proper way, enlist list to list call automatically
    env = list(j = as.list(cols)),
    verbose = TRUE]

--- a/vignettes/datatable-programming.Rmd
+++ b/vignettes/datatable-programming.Rmd
@@ -288,7 +288,7 @@ DT[, j,  # the same as above but accepts character vector
 
 Now let's try to pass a list of symbols, rather than list call to those symbols. We'll use `I()` to escape automatic _enlist_-ing but, as this will also turn off character to symbol conversion, we also have to use `as.name`.
 
-```{r splice_not, eval = TRUE, purl = FALSE}
+```{r splice_not, error = TRUE, purl = FALSE}
 DT[, j,  # list of symbols
    env = I(list(j = lapply(cols, as.name))),
    verbose = TRUE]

--- a/vignettes/datatable-programming.Rmd
+++ b/vignettes/datatable-programming.Rmd
@@ -49,7 +49,7 @@ The problem with this kind of interface is that we cannot easily parameterize th
 
 ### Example
 
-```{r subset_error, error = TRUE, purl = FALSE}
+```{r subset_error, error=TRUE, purl=FALSE}
 my_subset = function(data, col, val) {
   subset(data, col == val)
 }
@@ -288,7 +288,7 @@ DT[, j,  # the same as above but accepts character vector
 
 Now let's try to pass a list of symbols, rather than list call to those symbols. We'll use `I()` to escape automatic _enlist_-ing but, as this will also turn off character to symbol conversion, we also have to use `as.name`.
 
-```{r splice_not, error = TRUE, purl = FALSE}
+```{r splice_not, error=TRUE, purl=FALSE}
 DT[, j,  # list of symbols
    env = I(list(j = lapply(cols, as.name))),
    verbose = TRUE]

--- a/vignettes/datatable-programming.Rmd
+++ b/vignettes/datatable-programming.Rmd
@@ -49,11 +49,12 @@ The problem with this kind of interface is that we cannot easily parameterize th
 
 ### Example
 
-```{r subset_error, error = TRUE, purl = TRUE}
+```{r subset_error, eval = FALSE}
 my_subset = function(data, col, val) {
   subset(data, col == val)
 }
 my_subset(iris, Species, "setosa")
+# Error in eval(e, x, parent.frame()): object 'Species' not found
 ```
 
 ### Approaches to the problem
@@ -288,11 +289,15 @@ DT[, j,  # the same as above but accepts character vector
 
 Now let's try to pass a list of symbols, rather than list call to those symbols. We'll use `I()` to escape automatic _enlist_-ing but, as this will also turn off character to symbol conversion, we also have to use `as.name`.
 
-```{r splice_not, error = TRUE, purl = TRUE}
+```{r splice_not, eval = FALSE}
 DT[, j,  # list of symbols
    env = I(list(j = lapply(cols, as.name))),
    verbose = TRUE]
+# Argument 'j' after substitute: list(Sepal.Length, Sepal.Width)
+# Error: When with=FALSE, j-argument should be of type logical/character/integer indicating the columns to select.
+```
 
+```{r splice_not_proper}
 DT[, j,  # again the proper way, enlist list to list call automatically
    env = list(j = as.list(cols)),
    verbose = TRUE]

--- a/vignettes/datatable-programming.Rmd
+++ b/vignettes/datatable-programming.Rmd
@@ -49,7 +49,7 @@ The problem with this kind of interface is that we cannot easily parameterize th
 
 ### Example
 
-```{r subset_error, eval = FALSE}
+```{r subset_error, error = TRUE, purl = TRUE}
 my_subset = function(data, col, val) {
   subset(data, col == val)
 }
@@ -288,7 +288,7 @@ DT[, j,  # the same as above but accepts character vector
 
 Now let's try to pass a list of symbols, rather than list call to those symbols. We'll use `I()` to escape automatic _enlist_-ing but, as this will also turn off character to symbol conversion, we also have to use `as.name`.
 
-```{r splice_not, eval = FALSE}
+```{r splice_not, error = TRUE, purl = TRUE}
 DT[, j,  # list of symbols
    env = I(list(j = lapply(cols, as.name))),
    verbose = TRUE]

--- a/vignettes/datatable-programming.Rmd
+++ b/vignettes/datatable-programming.Rmd
@@ -49,7 +49,7 @@ The problem with this kind of interface is that we cannot easily parameterize th
 
 ### Example
 
-```{r subset_error, error=TRUE}
+```{r subset_error, error=0}
 my_subset = function(data, col, val) {
   subset(data, col == val)
 }
@@ -288,7 +288,7 @@ DT[, j,  # the same as above but accepts character vector
 
 Now let's try to pass a list of symbols, rather than list call to those symbols. We'll use `I()` to escape automatic _enlist_-ing but, as this will also turn off character to symbol conversion, we also have to use `as.name`.
 
-```{r splice_not, error=TRUE}
+```{r splice_not, error=0}
 DT[, j,  # list of symbols
    env = I(list(j = lapply(cols, as.name))),
    verbose = TRUE]


### PR DESCRIPTION
Currently our CI pipelines are erroring, since they error on parts of the vignettes where they are supposed to error.

According to [knitr doc](https://yihui.org/knitr/options/#chunk_options) setting `error=0` should be the right
> 0 will keep evaluating after errors as if you had pasted the text into a terminal;

but these will still result in `R CMD check` erroring, hence, `purl=FALSE`