### PR TITLE
force loading bit64 earlier in print()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -104,6 +104,7 @@
 
     We plan to export similar placeholders for `.` and `J` in roughly one year (e.g. data.table 1.18.0), but excluded them from this release to avoid back-compatibility issues. Specifically, some packages doing `import(plyr)` _and_ `import(data.table)`, and/or with those packages in `Depends`, will error when data.table starts exporting `.` (and similarly for a potential conflict with `rJava::J()`). We discourage using data.table (or any package, really) in Depends; blanket `import()` of package is also generally best avoided. See `vignette("datatable-importing")`.
 
+18. `integer64` columns print well even if {bit64} has not yet been loaded, [#6224](https://github.com/Rdatatable/data.table/issues/6224). Thanks @renkun-ken for the report and @MichaelChirico for the fix.
 
 ## TRANSLATIONS
 

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -88,8 +88,8 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
     printdots = FALSE
     if (show.indices) toprint = cbind(toprint, index_dt)
   }
-  toprint=format.data.table(toprint, na.encode=FALSE, timezone = timezone, ...)  # na.encode=FALSE so that NA in character cols print as <NA>
   require_bit64_if_needed(x)
+  toprint=format.data.table(toprint, na.encode=FALSE, timezone = timezone, ...)  # na.encode=FALSE so that NA in character cols print as <NA>
 
   # FR #353 - add row.names = logical argument to print.data.table
   if (isTRUE(row.names)) rownames(toprint)=paste0(format(rn,right=TRUE,scientific=FALSE),":") else rownames(toprint)=rep.int("", nrow(toprint))
@@ -193,7 +193,7 @@ format_list_item = function(x, ...) {
 
 has_format_method = function(x) {
   f = function(y) !is.null(getS3method("format", class=y, optional=TRUE))
-  any(sapply(class(x), f))
+  any(vapply_1b(class(x), f))
 }
 
 format_col.default = function(x, ...) {

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18701,3 +18701,11 @@ ans = c(
  "10:   83   64   41                 9                 9")
 # test where topn isn't necessary
 test(2264.8, print(DT, show.indices=TRUE), output=ans)
+
+# integer64 columns print even when bit64 isn't loaded
+if (test_bit64) local({
+  DT = data.table(a = 'abc', b = as.integer64(1))
+  unloadNamespace("bit64")
+  on.exit(library(bit64))
+  test(2265, DT, output="abc\\s*1$")
+})


### PR DESCRIPTION
Closes #6224

My first thought was to add a `format_col.integer64` method, but it turns out the fix is much easier, just need to force loading {bit64} one line earlier.