### PR TITLE
Force installing remotes

### DIFF
--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -1,6 +1,6 @@
 on:
   schedule:
-   - cron: '17 13 28 * *' # 28th of month at 13:17 UTC
+   - cron: '17 13 9 * *' # 9th of month at 13:17 UTC
 
 # A more complete suite of checks to run monthly; each PR/merge need not pass all these, but they should pass before CRAN release
 name: R-CMD-check-occasional
@@ -83,6 +83,10 @@ jobs:
       - name: Install check dependencies (macOS)
         if: matrix.os == 'macOS-latest'
         run: brew install gdal proj
+
+      - name: Install remotes
+        run: install.packages("remotes")
+        shell: Rscript {0}
 
       - name: Install system dependencies
         if: runner.os == 'Linux'


### PR DESCRIPTION
Based on latest batch of failures:

https://github.com/Rdatatable/data.table/actions/runs/9713547074/job/26810574606#step:10:19

Not sure why this is only emerging now, I got the impression the `r-lib` runners came bundled with {remotes}... but I do see some other workflows in the `r-lib` org running something similar. Possibly due to package caching earlier? 