### PR TITLE
add one level of additional revdeps to mirror packages in CI

### DIFF
--- a/.ci/ci.R
+++ b/.ci/ci.R
@@ -64,6 +64,12 @@ function(file = "DESCRIPTION",
     which <- c("Depends", "Imports", "LinkingTo", "Suggests")
   if (!is.character(which) || !length(which) || !all(which %in% which_all))
     stop("which argument accept only valid dependency relation: ", paste(which_all, collapse=", "))
+  x <- unlist(lapply(file, function(f, which) {
+      dcf <- tryCatch(read.dcf(f, fields = which), error = identity)
+      if (inherits(dcf, "error") || !length(dcf))
+          warning(gettextf("error reading file '%s'", f), domain = NA, call. = FALSE)
+      else dcf[!is.na(dcf)]
+  }, which = which), use.names = FALSE)
   local.extract_dependency_package_names = function (x) {
     ## do not filter out R like tools:::.extract_dependency_package_names, used for web/$pkg/index.html
     if (is.na(x))
@@ -72,12 +78,6 @@ function(file = "DESCRIPTION",
     x <- sub("[[:space:]]*([[:alnum:].]+).*", "\\1", x)
     x[nzchar(x)]
   }
-  x <- unlist(lapply(file, function(f, which) {
-      dcf <- tryCatch(read.dcf(f, fields = which), error = identity)
-      if (inherits(dcf, "error") || !length(dcf))
-          warning(gettextf("error reading file '%s'", f), domain = NA, call. = FALSE)
-      else dcf[!is.na(dcf)]
-  }, which = which), use.names = FALSE)
   x <- unlist(lapply(x, local.extract_dependency_package_names))
   except <- if (length(except.priority)) c("R", unlist(tools:::.get_standard_package_names()[except.priority], use.names = FALSE))
   x = setdiff(x, except)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,7 +54,7 @@ mirror-packages:
   script:
     - echo 'source(".ci/ci.R")' >> .Rprofile
     - mkdir -p bus/$CI_JOB_NAME/cran/src/contrib
-    - Rscript -e 'mirror.packages(dcf.dependencies("DESCRIPTION", "all"), repos=Sys.getenv("CRAN_MIRROR"), repodir="bus/mirror-packages/cran")'
+    - Rscript -e 'mirror.packages(dcf.dependencies("DESCRIPTION", "all", revdeps=TRUE), repos=Sys.getenv("CRAN_MIRROR"), repodir="bus/mirror-packages/cran")'
     - Rscript -e 'sapply(simplify=FALSE, setNames(nm=Sys.getenv(c("R_REL_VERSION","R_DEV_VERSION","R_OLD_VERSION"))), function(binary.ver) mirror.packages(type="win.binary", dcf.dependencies("DESCRIPTION", "all"), repos=Sys.getenv("CRAN_MIRROR"), repodir="bus/mirror-packages/cran", binary.ver=binary.ver))'
   <<: *artifacts
 


### PR DESCRIPTION
Currently we already mirror reverse dependencies, but these might also have reverse dependencies etc.

This results in that our CI reports things like `also installing the dependencies ‘R.oo’, ‘R.methodsS3’, ‘evaluate’, ‘highr’, ‘xfun’, ‘commonmark’`

This PR adds one extra level of mirroring also the `c("Imports", "Depends")` of the mirrored reverse dependencies (no recursion yet).