### PR TITLE
Updating C API Entry Points: isFrame -> isDataFrame

### DIFF
--- a/src/data.table.h
+++ b/src/data.table.h
@@ -10,6 +10,9 @@
 #if !defined(R_VERSION) || R_VERSION < R_Version(3, 4, 0)
 #  define SET_GROWABLE_BIT(x)  // #3292
 #endif
+#if !defined(R_VERSION) || R_VERSION < R_Version(4, 5, 0)
+# define isDataFrame(x) isFrame(x)
+#endif
 #include <Rinternals.h>
 #define SEXPPTR_RO(x) ((const SEXP *)DATAPTR_RO(x))  // to avoid overhead of looped STRING_ELT and VECTOR_ELT
 #include <stdint.h>    // for uint64_t rather than unsigned long long

--- a/src/dogroups.c
+++ b/src/dogroups.c
@@ -276,7 +276,7 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
       for (int j=0; j<LENGTH(jval); ++j) {
         thiscol = VECTOR_ELT(jval,j);
         if (isNull(thiscol)) continue;
-        if (!isVector(thiscol) || isFrame(thiscol))
+        if (!isVector(thiscol) || isDataFrame(thiscol))
           error(_("Entry %d for group %d in j=list(...) should be atomic vector or list. If you are trying something like j=list(.SD,newcol=mean(colA)) then use := by group instead (much quicker), or cbind or merge afterwards."), j+1, i+1);
         if (isArray(thiscol)) {
           SEXP dims = PROTECT(getAttrib(thiscol, R_DimSymbol));


### PR DESCRIPTION
This is starting a PR with some of the C API changes as reported in #6180. This is likely a growing list but current NOTEs

```
Found non-API calls to R: ‘LEVELS’, ‘NAMED’, ‘SETLENGTH’,
    ‘SET_GROWABLE_BIT’, ‘SET_S4_OBJECT’, ‘SET_TRUELENGTH’,
    ‘SET_TYPEOF’, ‘STRING_PTR’, ‘TRUELENGTH’, ‘UNSET_S4_OBJECT’
```

- [x] `isFrame` to `isDataFrame`: Easy first one (not on the notes but in WRE 6.21.8 Some backports)
- [ ]  `LEVELS`:
- [ ]  `NAMED`:
- [ ]  `SETLENGTH`:
- [ ]  `SET_GROWABLE_BIT`:
- [ ]  `SET_S4_OBJECT`:
- [ ]  `SET_TRUELENGTH`:
- [ ]  `SET_TYPEOF`:
- [ ]  `STRING_PTR`:
- [ ]  `TRUELENGTH`:
- [ ] `UNSET_S4_OBJECT`:

We can keep adding to this list as others come up in the notes. WRE 6.21 "Moving into C API compliance" says  "This section is a work in progress and will be adjusted as changes are made to the API."

Based on Kurt's useR! 2024 talk, they are aware this is a work in progress so I don't believe this should hold up any releases if we can't get to each of these right away.