### PR TITLE
 **Clarify distinction between week() and isoweek() functions in IDateTime documentation**

### DIFF
--- a/man/IDateTime.Rd
+++ b/man/IDateTime.Rd
@@ -175,6 +175,13 @@ They can round or truncate to hours and minutes.
 Note for ITime's with 30 seconds, rounding is inconsistent due to rounding off a 5.
 See 'Details' in \code{\link{round}} for more information.
 
+Functions like \code{week()} and \code{isoweek()} provide week numbering functionality.
+\code{week()} computes completed or fractional weeks within the year,
+while \code{isoweek()} calculates week numbers according to ISO 8601 standards,
+which specify that the first week of the year is the one containing the first Thursday.
+This convention ensures that week boundaries align consistently with year boundaries,
+accounting for both year transitions and varying day counts per week.
+
 }
 
 \value{


### PR DESCRIPTION
**Description:**

### Issue Addressed
This PR closes #3065, which suggests adding clarification to the `IDateTime` documentation regarding the distinction between the `week()` and `isoweek()` functions.

### Proposed Changes
- Added a new paragraph in the value section of the `IDateTime` documentation to explicitly differentiate between the `week()` and `isoweek()` functions.
- Clarified that `week()` computes completed or fractional weeks within the year, whereas `isoweek()` adheres to ISO 8601 standards for week numbering, ensuring consistent alignment with year boundaries based on the first Thursday rule.

