### PR TITLE
fix names_sd rev dep issue 6033

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1122,6 +1122,11 @@ replace_dot_alias = function(e) {
           if (is.name(lhs)) {
             lhs = as.character(lhs)
           } else {
+            #6033 revdev. Slowly deprecate in 1.17. Caller has given us `dt[, substitute(names(.SD))]` which means 
+            # jsub is actually substitute(names(.SD)) instead of just names(.SD)
+            if (lhs %iscall% 'substitute') 
+              lhs = eval(lhs, parent.frame(), parent.frame())
+
             # lhs is e.g. (MyVar) or get("MyVar") or names(.SD) || setdiff(names(.SD), cols)
             lhs = eval(lhs, list(.SD = setNames(logical(length(sdvars)), sdvars)), parent.frame())
           }

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1122,9 +1122,9 @@ replace_dot_alias = function(e) {
           if (is.name(lhs)) {
             lhs = as.character(lhs)
           } else {
-            #6033 revdev. Slowly deprecate in 1.17.0. Caller has given us `dt[, substitute(names(.SD))]` which means 
+            #6033 revdev. Slowly deprecate in 1.17.0. Caller has given us `dt[, substitute(names(.SD))]` which means
             # jsub is actually substitute(names(.SD)) instead of just names(.SD)
-            if (lhs %iscall% 'substitute') 
+            if (lhs %iscall% 'substitute')
               lhs = eval(lhs, parent.frame(), parent.frame())
 
             # lhs is e.g. (MyVar) or get("MyVar") or names(.SD) || setdiff(names(.SD), cols)

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1122,7 +1122,7 @@ replace_dot_alias = function(e) {
           if (is.name(lhs)) {
             lhs = as.character(lhs)
           } else {
-            #6033 revdev. Slowly deprecate in 1.17. Caller has given us `dt[, substitute(names(.SD))]` which means 
+            #6033 revdev. Slowly deprecate in 1.17.0. Caller has given us `dt[, substitute(names(.SD))]` which means 
             # jsub is actually substitute(names(.SD)) instead of just names(.SD)
             if (lhs %iscall% 'substitute') 
               lhs = eval(lhs, parent.frame(), parent.frame())

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1121,7 +1121,7 @@ replace_dot_alias = function(e) {
           if (is.name(lhs)) {
             lhs = as.character(lhs)
           } else {
-            #6033 revdev. Slowly deprecate in 1.17.0. Caller has given us `dt[, substitute(names(.SD))]` which means
+            #6033 revdep. Slowly deprecate in 1.17.0. Caller has given us `dt[, substitute(names(.SD))]` which means
             # jsub is actually substitute(names(.SD)) instead of just names(.SD)
             if (lhs %iscall% 'substitute')
               lhs = eval(lhs, parent.frame(), parent.frame())

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18386,7 +18386,7 @@ test(2250.12, dt[, names(.SD) := lapply(.SD, function(x) x + b), .SDcols = "a"],
 dt = data.table(a = 1L, b = 2L, c = 3L, d = 4L, e = 5L, f = 6L)
 test(2250.13, dt[, names(.SD)[1:5] := sum(.SD)], data.table(a = 21L, b = 21L, c = 21L, d = 21L, e = 21L, f = 6L))
 
-dt = data.table(a = 1) #6033 revdev follow-up
+dt = data.table(a = 1) #6033 revdep follow-up
 my_col = "a"
 test(2250.14, dt[, substitute(my_col) := .(3)], data.table(a = 3))
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18393,9 +18393,11 @@ test(2250.11, dt[, names(.SD(2)) := lapply(.SD, .I)], error=base_messages$missin
 dt = data.table(a = 1:3, b = 5:7, grp = c('a', 'a', 'b'))
 test(2250.12, dt[, names(.SD) := lapply(.SD, function(x) x + b), .SDcols = "a"], data.table(a = 1:3 + 5:7, b = 5:7, grp = c('a', 'a', 'b')))
 
-
 dt = data.table(a = 1L, b = 2L, c = 3L, d = 4L, e = 5L, f = 6L)
 test(2250.13, dt[, names(.SD)[1:5] := sum(.SD)], data.table(a = 21L, b = 21L, c = 21L, d = 21L, e = 21L, f = 6L))
+
+dt = data.table(a = 1:4, b = 5:8) #6033 revdev follow-up
+test(2250.14, dt[, substitute(names(.SD)) := lapply(.SD, `*`, 2), .SDcols = 1L], data.table(a = 1:4 * 2, b = 5:8))
 
 # fread(...,fill) can also be used to specify a guess on the maximum number of columns #2691 #1812 #4130 #3436 #2727
 dt_str = paste(rep(c("1,2\n", "1,2,3\n"), each=100), collapse="")

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18396,8 +18396,9 @@ test(2250.12, dt[, names(.SD) := lapply(.SD, function(x) x + b), .SDcols = "a"],
 dt = data.table(a = 1L, b = 2L, c = 3L, d = 4L, e = 5L, f = 6L)
 test(2250.13, dt[, names(.SD)[1:5] := sum(.SD)], data.table(a = 21L, b = 21L, c = 21L, d = 21L, e = 21L, f = 6L))
 
-dt = data.table(a = 1:4, b = 5:8) #6033 revdev follow-up
-test(2250.14, dt[, substitute(names(.SD)) := lapply(.SD, `*`, 2), .SDcols = 1L], data.table(a = 1:4 * 2, b = 5:8))
+dt = data.table(a = 1) #6033 revdev follow-up
+my_col = "a"
+test(2250.14, dt[, substitute(my_col) := .(3)], data.table(a = 3))
 
 # fread(...,fill) can also be used to specify a guess on the maximum number of columns #2691 #1812 #4130 #3436 #2727
 dt_str = paste(rep(c("1,2\n", "1,2,3\n"), each=100), collapse="")


### PR DESCRIPTION
Closes #6033 . 

The root cause was that the caller would make a call as `dt[, substitute(col)]`. This meant our `jsub` would be `substitute(col)` which would only evaluate to the name `col` instead of the value of `col`. I was unable to figure out why #4163 caused this issue to come to light. 

This is a quick fix meant for follow-up. The plan would be to:

1) Make PRs at rev deps that have similar issues. There are less than 10 that Michael spotted in GitHub.
2) Upgrade to a warning in 1.17.0
3) Upgrade to an error in 1.18.0.
4) Remove logic in 1.19.0.

I will start looking at rev deps again to fix.