### PR TITLE
Consistent Error Handling for `setnames()` with `NA_character_`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -62,6 +62,8 @@
 
 10. `dt[,,by=año]` (i.e., using a column name containing a non-ASCII character in `by` as a plain symbol) no longer errors with "object 'año' not found", #4708. Thanks @pfv07 for the report, and Michael Chirico for the fix.
 
+11. `setnames` now errors if provided `NA_character_` as a name in both partial and full assignments, maintaining consistency, [#6236](https://github.com/Rdatatable/data.table/issues/6236). Previously, an error would occur in partial assignments but was silently ignored in full assignments, leading to unexpected behavior. This update ensures consistent error handling. Thanks to @MichaelChirico for identifying the issue and @Nj221102 for the fix.
+
 ## NOTES
 
 1. `transform` method for data.table sped up substantially when creating new columns on large tables. Thanks to @OfekShilon for the report and PR. The implemented solution was proposed by @ColeMiller1.

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2619,6 +2619,7 @@ setnames = function(x,old,new,skip_absent=FALSE) {
     } else {
       w = which(names(x) != old | (Encoding(names(x)) != Encoding(old)))
     }
+    if (anyNA(old)) stopf("NA in 'new' at positions %s", brackify(which(is.na(old))))
     if (!length(w)) return(invisible(x))  # no changes
     new = old[w]
     i = w

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18705,3 +18705,8 @@ DT = data.table(a = rep(1:3, 2))
 # NB: recall we can't use non-ASCII symbols here. the text is a-<n-tilde>-o (year in Spanish)
 setnames(DT, "a", "a\U00F1o")
 test(2266, eval(parse(text="DT[ , .N, a\U00F1o]$N[1L]")), 2L)
+
+# checks for error when NA names are provided in setnames
+DT = data.table(a=1, b=2)
+test(2267.1, setnames(DT, 'b', NA_character_), error="NA in 'new' at positions [1]")
+test(2267.2, setnames(DT, c('c', NA_character_)), error="NA in 'new' at positions [2]")


### PR DESCRIPTION
closes #6236 

**Summary:**
This pull request addresses the inconsistency in the `setnames()` function when handling `NA_character_` in column renaming. Previously, `setnames()` would error on partial assignments with `NA_character_` but silently ignore the same in full assignments. This update ensures consistent error handling for both cases, providing a clear error message when `NA_character_` is used as a new column name.

**Changes Made:**
1. Modified `setnames()` to error if `NA_character_` is provided as a name in both partial and full assignments.
2. Added tests to ensure consistent behavior and proper error handling.

