### PR TITLE
Issues with memory management in fmelt

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -62,6 +62,8 @@
 
 10. `dt[,,by=año]` (i.e., using a column name containing a non-ASCII character in `by` as a plain symbol) no longer errors with "object 'año' not found", #4708. Thanks @pfv07 for the report, and Michael Chirico for the fix.
 
+11. Fix some memory management issues in the C routine backing `melt()`, as identified by `rchk`. Thanks Tomas Kalibera and the CRAN team for setting up the `rchk` system, and @MichaelChirico for the fix.
+
 ## NOTES
 
 1. `transform` method for data.table sped up substantially when creating new columns on large tables. Thanks to @OfekShilon for the report and PR. The implemented solution was proposed by @ColeMiller1.

--- a/src/fmelt.c
+++ b/src/fmelt.c
@@ -197,8 +197,9 @@ SEXP uniq_diff(SEXP int_or_list, int ncol, bool is_measure) {
       INTEGER(unique_col_numbers)[unique_i++] = INTEGER(int_vec)[i];
     }
   }
+  SEXP out = set_diff(unique_col_numbers, ncol)
   UNPROTECT(3);
-  return set_diff(unique_col_numbers, ncol);
+  return out;
 }
 
 SEXP cols_to_int_or_list(SEXP cols, SEXP dtnames, bool is_measure) {

--- a/src/fmelt.c
+++ b/src/fmelt.c
@@ -247,7 +247,7 @@ SEXP checkVars(SEXP DT, SEXP id, SEXP measure, Rboolean verbose) {
       if (length(value_col)) Rprintf(_("Assigned 'measure.vars' are [%s].\n"), concat(dtnames, value_col));
     }
   } else if (isNull(id) && !isNull(measure)) {
-    SEXP measure_int_or_list = cols_to_int_or_list(measure, dtnames, true);
+    SEXP measure_int_or_list = PROTECT(cols_to_int_or_list(measure, dtnames, true)); protecti++;
     idcols = PROTECT(uniq_diff(measure_int_or_list, ncol, true)); protecti++;
     if (isNewList(measure)) valuecols = measure_int_or_list;
     else {

--- a/src/fmelt.c
+++ b/src/fmelt.c
@@ -197,7 +197,7 @@ SEXP uniq_diff(SEXP int_or_list, int ncol, bool is_measure) {
       INTEGER(unique_col_numbers)[unique_i++] = INTEGER(int_vec)[i];
     }
   }
-  SEXP out = set_diff(unique_col_numbers, ncol)
+  SEXP out = set_diff(unique_col_numbers, ncol);
   UNPROTECT(3);
   return out;
 }


### PR DESCRIPTION
As identified by `rchk` on CRAN:

https://raw.githubusercontent.com/kalibera/cran-checks/master/rchk/results/data.table.out

```
Function checkVars
  [UP] allocating function uniq_diff may destroy its unprotected argument (measure_int_or_list <arg 1>), which is later used. data.table/src/fmelt.c:251
Function uniq_diff
  [UP] calling allocating function set_diff(V,?) with a fresh pointer (unique_col_numbers <arg 1>) data.table/src/fmelt.c:201
```

Note that the `cols_to_int_or_list()` output is indeed `PROTECT()`'d properly in other nearby branches. This makes sense because `measure_int_or_list` is a new `SEXP` not yet on the stack that must be marked against gc removal.