### PR TITLE
PROTECT() as= input to coerceAs()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -62,7 +62,7 @@
 
 10. `dt[,,by=año]` (i.e., using a column name containing a non-ASCII character in `by` as a plain symbol) no longer errors with "object 'año' not found", #4708. Thanks @pfv07 for the report, and Michael Chirico for the fix.
 
-11. Fix some memory management issues in the C routine backing `melt()`, as identified by `rchk`. Thanks Tomas Kalibera and the CRAN team for setting up the `rchk` system, and @MichaelChirico for the fix.
+11. Fix some memory management issues in the C routines backing `melt()`, `froll()`, and GForce `mean()`, as identified by `rchk`. Thanks Tomas Kalibera and the CRAN team for setting up the `rchk` system, and @MichaelChirico for the fix.
 
 ## NOTES
 

--- a/src/frollR.c
+++ b/src/frollR.c
@@ -15,8 +15,8 @@ SEXP coerceToRealListR(SEXP obj) {
     SEXP this_obj = VECTOR_ELT(obj, i);
     if (!(isReal(this_obj) || isInteger(this_obj) || isLogical(this_obj)))
       error(_("x must be of type numeric or logical, or a list, data.frame or data.table of such"));
-    SET_VECTOR_ELT(x, i, coerceAs(this_obj, PROTECT(ScalarReal(NA_REAL)), /*copyArg=*/PROTECT(ScalarLogical(false)))); // copyArg=false will make type-class match to return as-is, no copy
-    UNPROTECT(2); // scalar arguments to coerceAs()
+    SET_VECTOR_ELT(x, i, coerceAs(this_obj, PROTECT(ScalarReal(NA_REAL)), /*copyArg=*/ScalarLogical(false))); // copyArg=false will make type-class match to return as-is, no copy
+    UNPROTECT(1); // as= input to coerceAs()
   }
   UNPROTECT(protecti);
   return x;
@@ -146,8 +146,8 @@ SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEX
     error(_("fill must be a vector of length 1"));
   if (!isInteger(fill) && !isReal(fill) && !isLogical(fill))
     error(_("fill must be numeric or logical"));
-  double dfill = REAL(PROTECT(coerceAs(fill, PROTECT(ScalarReal(NA_REAL)), PROTECT(ScalarLogical(true)))))[0]; protecti++;
-  UNPROTECT(2); // Scalar* inputs to coerceAs()
+  double dfill = REAL(PROTECT(coerceAs(fill, PROTECT(ScalarReal(NA_REAL)), ScalarLogical(true))))[0]; protecti++;
+  UNPROTECT(1); // as= input to coerceAs()
 
   bool bnarm = LOGICAL(narm)[0];
 
@@ -259,8 +259,8 @@ SEXP frollapplyR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP align, SEXP rho) {
     error(_("fill must be a vector of length 1"));
   if (!isInteger(fill) && !isReal(fill) && !isLogical(fill))
     error(_("fill must be numeric or logical"));
-  double dfill = REAL(PROTECT(coerceAs(fill, PROTECT(ScalarReal(NA_REAL)), PROTECT(ScalarLogical(true)))))[0]; protecti++;
-  UNPROTECT(2); // Scalar* inputs to coerceAs()
+  double dfill = REAL(PROTECT(coerceAs(fill, PROTECT(ScalarReal(NA_REAL)), ScalarLogical(true))))[0]; protecti++;
+  UNPROTECT(1); // as= input to coerceAs()
 
   SEXP ans = PROTECT(allocVector(VECSXP, nk * nx)); protecti++;
   if (verbose)

--- a/src/frollR.c
+++ b/src/frollR.c
@@ -15,7 +15,8 @@ SEXP coerceToRealListR(SEXP obj) {
     SEXP this_obj = VECTOR_ELT(obj, i);
     if (!(isReal(this_obj) || isInteger(this_obj) || isLogical(this_obj)))
       error(_("x must be of type numeric or logical, or a list, data.frame or data.table of such"));
-    SET_VECTOR_ELT(x, i, coerceAs(this_obj, ScalarReal(NA_REAL), /*copyArg=*/ScalarLogical(false))); // copyArg=false will make type-class match to return as-is, no copy
+    SET_VECTOR_ELT(x, i, coerceAs(this_obj, PROTECT(ScalarReal(NA_REAL)), /*copyArg=*/PROTECT(ScalarLogical(false)))); // copyArg=false will make type-class match to return as-is, no copy
+    UNPROTECT(2); // scalar arguments to coerceAs()
   }
   UNPROTECT(protecti);
   return x;

--- a/src/frollR.c
+++ b/src/frollR.c
@@ -146,7 +146,8 @@ SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEX
     error(_("fill must be a vector of length 1"));
   if (!isInteger(fill) && !isReal(fill) && !isLogical(fill))
     error(_("fill must be numeric or logical"));
-  double dfill = REAL(PROTECT(coerceAs(fill, ScalarReal(NA_REAL), ScalarLogical(true))))[0]; protecti++;
+  double dfill = REAL(PROTECT(coerceAs(fill, PROTECT(ScalarReal(NA_REAL)), PROTECT(ScalarLogical(true)))))[0]; protecti++;
+  UNPROTECT(2); // Scalar* inputs to coerceAs()
 
   bool bnarm = LOGICAL(narm)[0];
 
@@ -258,7 +259,8 @@ SEXP frollapplyR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP align, SEXP rho) {
     error(_("fill must be a vector of length 1"));
   if (!isInteger(fill) && !isReal(fill) && !isLogical(fill))
     error(_("fill must be numeric or logical"));
-  double dfill = REAL(PROTECT(coerceAs(fill, ScalarReal(NA_REAL), ScalarLogical(true))))[0]; protecti++;
+  double dfill = REAL(PROTECT(coerceAs(fill, PROTECT(ScalarReal(NA_REAL)), PROTECT(ScalarLogical(true)))))[0]; protecti++;
+  UNPROTECT(2); // Scalar* inputs to coerceAs()
 
   SEXP ans = PROTECT(allocVector(VECSXP, nk * nx)); protecti++;
   if (verbose)

--- a/src/gsumm.c
+++ b/src/gsumm.c
@@ -591,8 +591,8 @@ SEXP gmean(SEXP x, SEXP narmArg)
     x = PROTECT(coerceVector(x, REALSXP)); protecti++;
   case REALSXP: {
     if (INHERITS(x, char_integer64)) {
-      x = PROTECT(coerceAs(x, /*as=*/PROTECT(ScalarReal(1)), /*copyArg=*/PROTECT(ScalarLogical(TRUE)))); protecti++;
-      UNPROTECT(2); // Scalar* inputs to coerceAs()
+      x = PROTECT(coerceAs(x, /*as=*/PROTECT(ScalarReal(1)), /*copyArg=*/ScalarLogical(TRUE))); protecti++;
+      UNPROTECT(1); // as= input to coerceAs()
     }
     const double *restrict gx = gather(x, &anyNA);
     ans = PROTECT(allocVector(REALSXP, ngrp)); protecti++;

--- a/src/gsumm.c
+++ b/src/gsumm.c
@@ -591,7 +591,8 @@ SEXP gmean(SEXP x, SEXP narmArg)
     x = PROTECT(coerceVector(x, REALSXP)); protecti++;
   case REALSXP: {
     if (INHERITS(x, char_integer64)) {
-      x = PROTECT(coerceAs(x, /*as=*/ScalarReal(1), /*copyArg=*/ScalarLogical(TRUE))); protecti++;
+      x = PROTECT(coerceAs(x, /*as=*/PROTECT(ScalarReal(1)), /*copyArg=*/PROTECT(ScalarLogical(TRUE)))); protecti++;
+      UNPROTECT(2); // Scalar* inputs to coerceAs()
     }
     const double *restrict gx = gather(x, &anyNA);
     ans = PROTECT(allocVector(REALSXP, ngrp)); protecti++;


### PR DESCRIPTION
As identified by `rchk` on CRAN:

https://raw.githubusercontent.com/kalibera/cran-checks/master/rchk/results/data.table.out

```
Function coerceToRealListR
  [UP] calling allocating function coerceAs(?,V,?) with argument allocated using Rf_ScalarReal data.table/src/frollR.c:18

Function frollapplyR
  [UP] calling allocating function coerceAs(?,V,?) with argument allocated using Rf_ScalarReal data.table/src/frollR.c:260

Function frollfunR
  [UP] calling allocating function coerceAs(?,V,?) with argument allocated using Rf_ScalarReal data.table/src/frollR.c:148

Function gmean
  [UP] calling allocating function coerceAs(?,V,?) with argument allocated using Rf_ScalarReal data.table/src/gsumm.c:594
```

I'm a bit surprised about how conservative we need to be here, but I _do_ see R's own sources `PROTECT()`ing the output of `Scalar*`:

https://github.com/search?q=repo%3Ar-devel%2Fr-svn%20%2FPROTECT%5B(%5D(Rf_)%3FScalar%2F&type=code

I don't understand well why the `as=` argument in particular needs to be protected here...