### PR TITLE
Add .libPaths() to the test.data.table() diagnostic

### DIFF
--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -235,6 +235,7 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
     ", Sys.getlocale()=='", Sys.getlocale(), "'",
     ", l10n_info()=='", paste0(names(l10n_info()), "=", l10n_info(), collapse="; "), "'",
     ", getDTthreads()=='", paste(gsub("[ ][ ]+","==",gsub("^[ ]+","",capture.output(invisible(getDTthreads(verbose=TRUE))))), collapse="; "), "'",
+    ", .libPaths()==", paste0("'", .libPaths(), "'", collapse = ","),
     ", ", .Call(Cdt_zlib_version),
     "\n", sep="")
 


### PR DESCRIPTION
Motivated by `r-cmd-check-occasional` still failing, which I no longer understand why. See `ubuntu-latest` log here:

https://github.com/Rdatatable/data.table/actions/runs/9908622817/job/27374799289

We get:

> test.data.table('other.Rraw') failed to attach required package(s): ggplot2, hexbin, plyr, dplyr, caret, gdata, nlme, sf, nanotime.

And indeed these packages are missing from "all installed packages". But the previous step (`Install dependencies`) has those packages installing without error, e.g.

> `* DONE (ggplot2)`

So now I'm wondering if it installed to a different library than is used by the subsequent step (?), otherwise that installed path is removed in between steps (it has `_temp` in it after all: `/home/runner/work/_temp/Library`). Anyway this diagnostic seems useful to include.