### PR TITLE
Try an explicit R_LIBS_USER to avoid losing packages between steps

### DIFF
--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -1,6 +1,6 @@
 on:
   schedule:
-   - cron: '17 13 12 * *' # 12th of month at 13:17 UTC
+   - cron: '17 13 13 * *' # 13th of month at 13:17 UTC
 
 # A more complete suite of checks to run monthly; each PR/merge need not pass all these, but they should pass before CRAN release
 name: R-CMD-check-occasional
@@ -42,6 +42,7 @@ jobs:
             r: '4.1'
 
     env:
+      R_LIBS_USER: /home/runner/work/r-lib
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
@@ -157,5 +158,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@main
         with:
-          name: ${{ runner.os }}-r${{ matrix.r }}-results
+          name: ${{ runner.os }}-r${{ matrix.r }}-l${{ matrix.locale }}results
           path: check


### PR DESCRIPTION
Related: #6250. This will work if only `_temp` is wiped between steps, if this path is also wiped I guess we'll have to just combine the deps+check steps into one to avoid losing the installed packages from one to the next.