### PR TITLE
Revert "Updating C API Entry Points: isFrame -> isDataFrame"

### DIFF
--- a/src/data.table.h
+++ b/src/data.table.h
@@ -10,9 +10,6 @@
 #if !defined(R_VERSION) || R_VERSION < R_Version(3, 4, 0)
 #  define SET_GROWABLE_BIT(x)  // #3292
 #endif
-#if !defined(R_VERSION) || R_VERSION < R_Version(4, 5, 0)
-# define isDataFrame(x) isFrame(x)
-#endif
 #include <Rinternals.h>
 #define SEXPPTR_RO(x) ((const SEXP *)DATAPTR_RO(x))  // to avoid overhead of looped STRING_ELT and VECTOR_ELT
 #include <stdint.h>    // for uint64_t rather than unsigned long long

--- a/src/dogroups.c
+++ b/src/dogroups.c
@@ -276,7 +276,7 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
       for (int j=0; j<LENGTH(jval); ++j) {
         thiscol = VECTOR_ELT(jval,j);
         if (isNull(thiscol)) continue;
-        if (!isVector(thiscol) || isDataFrame(thiscol))
+        if (!isVector(thiscol) || isFrame(thiscol))
           error(_("Entry %d for group %d in j=list(...) should be atomic vector or list. If you are trying something like j=list(.SD,newcol=mean(colA)) then use := by group instead (much quicker), or cbind or merge afterwards."), j+1, i+1);
         if (isArray(thiscol)) {
           SEXP dims = PROTECT(getAttrib(thiscol, R_DimSymbol));


### PR DESCRIPTION
Reverts #6235. Closes #6244.

This is not generating a NOTE and `isDataFrame()` is not available in any _released_ version of R yet, so I think we can hold off on this given #6244. It will be easier to figure out how to proceed once we have `isDataFrame()` in a release.