### PR TITLE
call correct which= in sys.call()

### DIFF
--- a/R/translation.R
+++ b/R/translation.R
@@ -5,7 +5,7 @@ catf = function(fmt, ..., sep=" ", domain="R-data.table") {
 }
 
 raise_condition = function(signal, message, classes, immediate=FALSE, appendLF=FALSE) {
-  obj = list(message=message, call=sys.call(2))
+  obj = list(message=message, call=sys.call(sys.nframe()-2L))
   # NB: append _after_ translation
   if (appendLF) obj$message = paste0(obj$message, "\n")
   setattr(obj, "class", classes)


### PR DESCRIPTION
`sys.call(1)` actually pulls from the _top_ of the stack (i.e., equivalent to `sys.calls()[[1]]`), but we need to pull from the bottom, hence `sys.nframe()`.

Before:

```r
DT=data.table(a=1, b=2)
setnames(DT, c(NA, 'b'), c('c', 'd'))
# Error in stopf("NA (or out of bounds) in 'old' at positions %s", brackify(which(is.na(old)))) : 
#   NA (or out of bounds) in 'old' at positions [1]

foo = function() {
  setnames(DT, c(NA, 'b'), c('c', 'd'))
}
foo()
# Error in setnames(DT, c(NA, "b"), c("c", "d")) : 
#   NA (or out of bounds) in 'old' at positions [1]
```

After:

```r
DT=data.table(a=1, b=2)
setnames(DT, c(NA, 'b'), c('c', 'd'))
# Error in setnames(DT, c(NA, "b"), c("c", "d")) : 
#   NA (or out of bounds) in 'old' at positions [1]

foo = function() {
  setnames(DT, c(NA, 'b'), c('c', 'd'))
}
foo()
# Error in setnames(DT, c(NA, "b"), c("c", "d")) : 
#   NA (or out of bounds) in 'old' at positions [1]
```