### PR TITLE
remove cc_dir, use normalizePath() on default

### DIFF
--- a/.dev/cc.R
+++ b/.dev/cc.R
@@ -54,11 +54,7 @@ sourceImports = function(path=getwd(), quiet=FALSE) {
   return(invisible())
 }
 
-cc = function(test=FALSE, clean=FALSE, debug=FALSE, omp=!debug, cc_dir, path=Sys.getenv("PROJ_PATH", unset="."), CC="gcc", quiet=FALSE) {
-  if (!missing(cc_dir)) {
-    warning("'cc_dir' arg is deprecated, use 'path' argument or 'PROJ_PATH' env var instead")
-    path = cc_dir
-  }
+cc = function(test=FALSE, clean=FALSE, debug=FALSE, omp=!debug, path=Sys.getenv("PROJ_PATH", unset=normalizePath(".")), CC="gcc", quiet=FALSE) {
   stopifnot(is.character(CC), length(CC)==1L, !is.na(CC), nzchar(CC))
   gc()
 


### PR DESCRIPTION
`.` doesn't work as it remains relative when it should be absolute, so materialize the absolute path ASAP.

Also remove `cc_dir` which has been "marked as deprecated" in this dev-only script for >5 years.