### PR TITLE
Remove rraw from lint

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -28,7 +28,7 @@ jobs:
           needs: lint
 
       - name: Lint
-        run: lintr::lint_package(pattern = "(?i)[.](r|rmd|rraw)$") # TODO(#5830): use the default pattern
+        run: lintr::lint_package(pattern = "(?i)[.](r|rmd)$") # TODO(#5830): use the default pattern
         shell: Rscript {0}
         env:
           LINTR_ERROR_ON_LINT: true


### PR DESCRIPTION
This GHA has been timing out lately, I assume because linting of .Rraw files is too slow (not sure what changed though). To be investigated as a follow-up: #6266 