### PR TITLE
build and check args consistently handled in occasional check

### DIFF
--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -1,6 +1,6 @@
 on:
   schedule:
-   - cron: '17 13 14 * *' # 14th of month at 13:17 UTC
+   - cron: '17 13 16 * *' # 16th of month at 13:17 UTC
 
 # A more complete suite of checks to run monthly; each PR/merge need not pass all these, but they should pass before CRAN release
 name: R-CMD-check-occasional

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -106,7 +106,7 @@ jobs:
           remotes::install_deps(dependencies=TRUE, force=TRUE)
           other_deps_expr = parse('inst/tests/other.Rraw', n=1L)
           eval(other_deps_expr)
-          pkgs <- get(as.character(other_deps_expr[[1L]][[2L]]))
+          pkgs = get(as.character(other_deps_expr[[1L]][[2L]]))
           # Many will not install on oldest R versions
           try(remotes::install_cran(c(pkgs, "rcmdcheck"), force=TRUE))
 
@@ -126,20 +126,19 @@ jobs:
           }
           Sys.setenv(TEST_DATA_TABLE_WITH_OTHER_PACKAGES=as.character(run_other))
 
-          do_vignettes <- requireNamespace("knitr", quietly=TRUE)
+          do_vignettes = requireNamespace("knitr", quietly=TRUE)
 
-          vignette_args <- if (!do_vignettes) "--no-build-vignettes"
-          args <- c("--no-manual", "--as-cran", vignette_args)
+          build_args = if (!do_vignettes) "--no-build-vignettes"
+          check_args = c("--no-manual", "--as-cran")
+          if (!do_vignettes) check_args = c(check_args, "--no-build-vignettes", "--ignore-vignettes")
           if (requireNamespace("rcmdcheck", quietly=TRUE)) {
-            rcmdcheck::rcmdcheck(args = args, error_on = "warning", check_dir = "check")
+            rcmdcheck::rcmdcheck(args = check_args, build_args = build_args, error_on = "warning", check_dir = "check")
           } else {
             Rbin = if (.Platform$OS.type == "windows") "R.exe" else "R"
-            system2(Rbin, c("CMD", "build", ".", vignette_args))
-            dt_tar <- list.files(pattern = "^data[.]table_.*[.]tar[.]gz$")
+            system2(Rbin, c("CMD", "build", ".", build_args))
+            dt_tar = list.files(pattern = "^data[.]table_.*[.]tar[.]gz$")
             if (!length(dt_tar)) stop("Built tar.gz not found among: ", toString(list.files()))
-            # --no-build-vignettes is not enough for R CMD check
-            if (!do_vignettes) args <- c(args, "--ignore-vignettes")
-            res = system2(Rbin, c("CMD", "check", dt_tar[1L], args), stdout=TRUE)
+            res = system2(Rbin, c("CMD", "check", dt_tar[1L], check_args), stdout=TRUE)
             if (!is.null(attr(res, "status")) || grep("^Status:.*(ERROR|WARNING)", res)) {
               writeLines(res)
               stop("R CMD check failed")


### PR DESCRIPTION
Based on the latest failure: https://github.com/Rdatatable/data.table/actions/runs/9928261825/job/27424314989

Where it's observed the check keeps trying to build the vignettes even though {knitr} is not available. Turns out we forgot to ignore vignette stuff on the {rcmdcheck} branch; I'm tempted to just drop {rcmdcheck} but the output formatting _is_ nice when possible.