### PR TITLE
Updated documentation of `new` in setattr.rd

### DIFF
--- a/man/setattr.Rd
+++ b/man/setattr.Rd
@@ -14,7 +14,7 @@ setnames(x,old,new,skip_absent=FALSE)
   \item{name}{ The character attribute name. }
   \item{value}{ The value to assign to the attribute or \code{NULL} removes the attribute, if present. }
   \item{old}{ When \code{new} is provided, character names or numeric positions of column names to change. When \code{new} is not provided, a function or the new column names (i.e., it's implicitly treated as \code{new}; excluding \code{old} and explicitly naming \code{new} is equivalent). If a function, it will be called with the current column names and is supposed to return the new column names. The new column names must be the same length as the number of columns. See examples. }
-  \item{new}{ Optional. It can be a function or the new column names. If a function, it will be called with \code{old} and expected to return the new column names. The new column names must be the same length as columns provided to \code{old} argument. }
+  \item{new}{ Optional. It can be a function or the new column names. If a function, it will be called with \code{old} and expected to return the new column names. The new column names must be the same length as columns provided to \code{old} argument. Missing values in \code{new} mean to not rename that column, note: missing values are only allowed when \code{old} is not provided.}
   \item{skip_absent}{ Skip items in \code{old} that are missing (i.e. absent) in `names(x)`. Default \code{FALSE} halts with error if any are missing. }
 }
 


### PR DESCRIPTION
**Summary:**
This pull request aims to clarify the behavior of `setnames` when missing values are provided, and update the documentation accordingly. This will help users understand how missing values are treated and maintain back-compatibility.

closes #6236