### PR TITLE
Optionally skip test relying on R>=4.1.0 behavior

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18337,8 +18337,10 @@ dt = data.table(x=1:4, y=factor(letters[1:2]))
 test(2247.1, split(dt, ~y), split(dt, dt$y))
 dt = data.table(x=1:4, y=1:2)
 test(2247.2, split(dt, ~y), list(`1`=data.table(x=c(1L,3L), y=1L), `2`=data.table(x=c(2L, 4L), y=2L)))
-# Closely match the original MRE from the issue
-test(2247.3, do.call(rbind, split(dt, ~y)), setDT(do.call(rbind, split(as.data.frame(dt), ~y))))
+if (!inherits(tryCatch(split(mtcars, ~cyl), error=identity), "error")) { # R>=4.1.0
+  # Closely match the original MRE from the issue
+  test(2247.3, do.call(rbind, split(dt, ~y)), setDT(do.call(rbind, split(as.data.frame(dt), ~y))))
+}
 dt = data.table(x=1:4, y=factor(letters[1:2]), z=factor(c(1,1,2,2), labels=c("c", "d")))
 test(2247.4, split(dt, ~y+z), list("a.c"=dt[1], "b.c"=dt[2], "a.d"=dt[3], "b.d"=dt[4]))
 


### PR DESCRIPTION
That's causing this observed issue:

```
Test 2247.3 ran without errors but failed check that x equals y:
> x = do.call(rbind, split(dt, ~y)) 
   x y  [Key= Types=int,int Classes=int,int]
1: 1 1                                      
2: 3 1                                      
3: 2 2                                      
4: 4 2                                      
> y = setDT(do.call(rbind, split(as.data.frame(dt), ~y))) 
First 1 of 1 (type 'character'): 
[1] "Error in unique.default(x, nmax = nmax) : \n  unique() applies only to vectors\n"
```

The error is from `~y` being coerced to factor, c.f. `as.factor(~y)`.

https://github.com/Rdatatable/data.table/actions/runs/9957719789/job/27510350948