### PR TITLE
Add a 'name' to pkgup workflow

### DIFF
--- a/.github/workflows/pkgup.yaml
+++ b/.github/workflows/pkgup.yaml
@@ -12,6 +12,8 @@ on:
     branches:
       - 'master'
 
+name: pkgdown-deploy
+
 jobs:
   build:
     name: data.table


### PR DESCRIPTION
Currently, we get a somewhat ugly default name:

![image](https://github.com/user-attachments/assets/0cba527f-2dae-4644-acbc-4322a7d7d427)
