### PR TITLE
MacOS: fix linker flags for SHLIB feature test

### DIFF
--- a/configure
+++ b/configure
@@ -111,7 +111,7 @@ detect_openmp () {
 
     # https://mac.r-project.org/openmp
     printf "%s" "* checking if R installation supports OpenMP with \"-Xclang -fopenmp\" ... "
-    if CPPFLAGS="${CPPFLAGS} -Xclang -fopenmp" LDFLAGS="${LDFLAGS} -lomp" "${R_HOME}/bin/R" CMD SHLIB test-omp.c >> config.log 2>&1; then
+    if CPPFLAGS="${CPPFLAGS} -Xclang -fopenmp" PKG_LIBS="-lomp" "${R_HOME}/bin/R" CMD SHLIB test-omp.c >> config.log 2>&1; then
       echo "yes"
       export PKG_CFLAGS="${PKG_CFLAGS} -Xclang -fopenmp"
       export PKG_LIBS="${PKG_LIBS} -lomp"


### PR DESCRIPTION
Amends #6034 by @kevinushey. 

The problem is that `R CMD SHLIB` actually ignores `$LDFLAGS`; you can easily test this with `--dry-run`:


```c
#include <omp.h>
int main() {
  return omp_get_num_threads();
}
```

Above is the `test-omp.c` from the configure script, and then run it with:

```sh
LDFLAGS="-lomp" R CMD SHLIB --dry-run test-omp.c
```

You can see there is no `-lomp` in the output at all. The reason why the feature test succeeds anyway on most systems is that R defaults to `-undefined dynamic_lookup` so it ignores missing libraries.

However, on r-universe we cross compile without `-undefined dynamic_lookup` and therefore the feature test fails.  If we set `-lomp` in `$PKG_LIBS` instead the feature test works.


```sh
PKG_LIBS="-lomp" R CMD SHLIB --dry-run test-omp.c
```

I confirmed this fixes the cross compile as well.

