### PR TITLE
adding an atime test case; groupby with dogroups (R expression) #PR4558

### DIFF
--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -135,9 +135,9 @@ test.list <- atime::atime_test_list(
     expr = {
       expr=data.table:::`[.data.table`(d, , (max(v1)-min(v2)), by = id3)
     },
-    Before="793f8545c363d222de18ac892bc7abb80154e724", # This is the link to the Before commit (https://github.com/Rdatatable/data.table/commit/793f8545c363d222de18ac892bc7abb80154e724) as stated here (https://github.com/Rdatatable/data.table/issues/4200#issuecomment-646111420) 
+    Before="793f8545c363d222de18ac892bc7abb80154e724", # Commit (https://github.com/Rdatatable/data.table/commit/793f8545c363d222de18ac892bc7abb80154e724) which was Before the regression was introduced as stated in the issue (https://github.com/Rdatatable/data.table/issues/4200#issuecomment-646111420) 
     Regression="c152ced0e5799acee1589910c69c1a2c6586b95d", # Parent of the first commit (https://github.com/Rdatatable/data.table/commit/15f0598b9828d3af2eb8ddc9b38e0356f42afe4f) in the PR (https://github.com/Rdatatable/data.table/pull/4558/commits) that fixes the regression
-    Fixed="f750448a2efcd258b3aba57136ee6a95ce56b302") # Second commit (https://github.com/Rdatatable/data.table/tree/f750448a2efcd258b3aba57136ee6a95ce56b302) in the PR  that fixes the regression(https://github.com/Rdatatable/data.table/pull/4558/commits)
+    Fixed="f750448a2efcd258b3aba57136ee6a95ce56b302") # Second commit (https://github.com/Rdatatable/data.table/commit/f750448a2efcd258b3aba57136ee6a95ce56b302) in the PR  that fixes the regression(https://github.com/Rdatatable/data.table/pull/4558/commits)
 )
 
 # nolint end: undesirable_operator_linter.

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -135,8 +135,8 @@ test.list <- atime::atime_test_list(
     expr = {
       expr=data.table:::`[.data.table`(d, , (max(v1)-min(v2)), by = id3)
     },
-    Before="793f8545c363d222de18ac892bc7abb80154e724", # Parent of the PR that introduced the regression(https://github.com/Rdatatable/data.table/commit/4aadde8f5a51cd7c8f3889964e7280432ec65bbc) as stated here (https://github.com/Rdatatable/data.table/issues/4200#issuecomment-646111420) https://github.com/Rdatatable/data.table/commit/793f8545c363d222de18ac892bc7abb80154e724
-    Regression="c152ced0e5799acee1589910c69c1a2c6586b95d", # Parent of the first commit(https://github.com/Rdatatable/data.table/pull/4558/commits/15f0598b9828d3af2eb8ddc9b38e0356f42afe4f) in the PR (https://github.com/Rdatatable/data.table/pull/4558/commits)
+    Before="793f8545c363d222de18ac892bc7abb80154e724", # This is the link to the Before commit (https://github.com/Rdatatable/data.table/commit/793f8545c363d222de18ac892bc7abb80154e724) as stated here (https://github.com/Rdatatable/data.table/issues/4200#issuecomment-646111420) 
+    Regression="c152ced0e5799acee1589910c69c1a2c6586b95d", # Parent of the first commit (https://github.com/Rdatatable/data.table/commit/15f0598b9828d3af2eb8ddc9b38e0356f42afe4f) in the PR (https://github.com/Rdatatable/data.table/pull/4558/commits) that fixes the regression
     Fixed="f750448a2efcd258b3aba57136ee6a95ce56b302") # Second commit (https://github.com/Rdatatable/data.table/tree/f750448a2efcd258b3aba57136ee6a95ce56b302) in the PR  that fixes the regression(https://github.com/Rdatatable/data.table/pull/4558/commits)
 )
 

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -108,7 +108,7 @@ test.list <- atime::atime_test_list(
 
   # Issue reported in: https://github.com/Rdatatable/data.table/issues/5426
   # To be fixed in: https://github.com/Rdatatable/data.table/pull/5427
-  "setDT improved in #5427" = atime::atime_test(
+  "setDT improved fixed in #5427" = atime::atime_test(
     N = 10^seq(1, 7),
     setup = {
       L <- replicate(N, 1, simplify = FALSE)
@@ -123,21 +123,21 @@ test.list <- atime::atime_test_list(
 
   # Issue reported in: https://github.com/Rdatatable/data.table/issues/4200
   # To be fixed in: https://github.com/Rdatatable/data.table/pull/4558
-  "groupby with dogroups #4558" = atime::atime_test(
-    N = 10^seq(1, 7),
+  "DT[by] fixed in #4558" = atime::atime_test(
+    N = 10^seq(1, 20),
     setup = {
       d <- data.table(
-      id3 = sample(c(seq.int(N*0.9), sample(N*0.9, N*0.1, TRUE))),
-      v1 = sample(5L, N, TRUE),
-      v2 = sample(5L, N, TRUE)
+        id3 = sample( c(seq.int(N*0.9), sample( N*0.9, N*0.1, TRUE))),
+        v1 = sample(5L, N, TRUE),
+        v2 = sample(5L, N, TRUE)
       )
     },
     expr = {
       expr=data.table:::`[.data.table`(d, , (max(v1)-min(v2)), by = id3)
     },
-    Before="793f8545c363d222de18ac892bc7abb80154e724",#parent of the PR that introduced the regression(https://github.com/Rdatatable/data.table/commit/4aadde8f5a51cd7c8f3889964e7280432ec65bbc) as stated here (https://github.com/Rdatatable/data.table/issues/4200#issuecomment-646111420) https://github.com/Rdatatable/data.table/commit/793f8545c363d222de18ac892bc7abb80154e724
-    Regression="c152ced0e5799acee1589910c69c1a2c6586b95d", #praent of the first commit in the PR (https://github.com/Rdatatable/data.table/commit/15f0598b9828d3af2eb8ddc9b38e0356f42afe4f)
-    Fixed="f750448a2efcd258b3aba57136ee6a95ce56b302")#second commit in the PR that fixes the regression(https://github.com/Rdatatable/data.table/pull/4558/commits)
+    Before="793f8545c363d222de18ac892bc7abb80154e724", # Parent of the PR that introduced the regression(https://github.com/Rdatatable/data.table/commit/4aadde8f5a51cd7c8f3889964e7280432ec65bbc) as stated here (https://github.com/Rdatatable/data.table/issues/4200#issuecomment-646111420) https://github.com/Rdatatable/data.table/commit/793f8545c363d222de18ac892bc7abb80154e724
+    Regression="c152ced0e5799acee1589910c69c1a2c6586b95d", # Parent of the first commit(https://github.com/Rdatatable/data.table/pull/4558/commits/15f0598b9828d3af2eb8ddc9b38e0356f42afe4f) in the PR (https://github.com/Rdatatable/data.table/pull/4558/commits)
+    Fixed="f750448a2efcd258b3aba57136ee6a95ce56b302") # Second commit (https://github.com/Rdatatable/data.table/tree/f750448a2efcd258b3aba57136ee6a95ce56b302) in the PR  that fixes the regression(https://github.com/Rdatatable/data.table/pull/4558/commits)
 )
 
 # nolint end: undesirable_operator_linter.

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -119,6 +119,25 @@ test.list <- atime::atime_test_list(
       data.table:::setDT(L)
     },
     Slow = "c4a2085e35689a108d67dacb2f8261e4964d7e12", # Parent of the first commit in the PR that fixes the issue (https://github.com/Rdatatable/data.table/commit/7cc4da4c1c8e568f655ab5167922dcdb75953801)
-    Fast = "1872f473b20fdcddc5c1b35d79fe9229cd9a1d15") # Last commit in the PR that fixes the issue (https://github.com/Rdatatable/data.table/pull/5427/commits)
+    Fast = "1872f473b20fdcddc5c1b35d79fe9229cd9a1d15"), # Last commit in the PR that fixes the issue (https://github.com/Rdatatable/data.table/pull/5427/commits)
+
+  # Issue reported in: https://github.com/Rdatatable/data.table/issues/4200
+  # To be fixed in: https://github.com/Rdatatable/data.table/pull/4558
+  "groupby with dogroups #4558" = atime::atime_test(
+    N = 10^seq(1, 7),
+    setup = {
+      d <- data.table(
+      id3 = sample(c(seq.int(N*0.9), sample(N*0.9, N*0.1, TRUE))),
+      v1 = sample(5L, N, TRUE),
+      v2 = sample(5L, N, TRUE)
+      )
+    },
+    expr = {
+      expr=data.table:::`[.data.table`(d, , (max(v1)-min(v2)), by = id3)
+    },
+    Before="793f8545c363d222de18ac892bc7abb80154e724",#parent of the PR that introduced the regression(https://github.com/Rdatatable/data.table/commit/4aadde8f5a51cd7c8f3889964e7280432ec65bbc) as stated here (https://github.com/Rdatatable/data.table/issues/4200#issuecomment-646111420) https://github.com/Rdatatable/data.table/commit/793f8545c363d222de18ac892bc7abb80154e724
+    Regression="c152ced0e5799acee1589910c69c1a2c6586b95d", #praent of the first commit in the PR (https://github.com/Rdatatable/data.table/commit/15f0598b9828d3af2eb8ddc9b38e0356f42afe4f)
+    Fixed="f750448a2efcd258b3aba57136ee6a95ce56b302")#second commit in the PR that fixes the regression(https://github.com/Rdatatable/data.table/pull/4558/commits)
 )
+
 # nolint end: undesirable_operator_linter.

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -135,7 +135,7 @@ test.list <- atime::atime_test_list(
     expr = {
       expr=data.table:::`[.data.table`(d, , (max(v1)-min(v2)), by = id3)
     },
-    Before="793f8545c363d222de18ac892bc7abb80154e724", # Commit (https://github.com/Rdatatable/data.table/commit/793f8545c363d222de18ac892bc7abb80154e724) which was Before the regression was introduced as stated in the issue (https://github.com/Rdatatable/data.table/issues/4200#issuecomment-646111420) 
+    Before="905e4d302be0dc326684d7228ece88064321cc00", # Parent of the regression commit (https://github.com/Rdatatable/data.table/commit/c152ced0e5799acee1589910c69c1a2c6586b95d)
     Regression="c152ced0e5799acee1589910c69c1a2c6586b95d", # Parent of the first commit (https://github.com/Rdatatable/data.table/commit/15f0598b9828d3af2eb8ddc9b38e0356f42afe4f) in the PR (https://github.com/Rdatatable/data.table/pull/4558/commits) that fixes the regression
     Fixed="f750448a2efcd258b3aba57136ee6a95ce56b302") # Second commit (https://github.com/Rdatatable/data.table/commit/f750448a2efcd258b3aba57136ee6a95ce56b302) in the PR  that fixes the regression(https://github.com/Rdatatable/data.table/pull/4558/commits)
 )

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -135,9 +135,8 @@ test.list <- atime::atime_test_list(
     expr = {
       expr=data.table:::`[.data.table`(d, , (max(v1)-min(v2)), by = id3)
     },
-    Before="905e4d302be0dc326684d7228ece88064321cc00", # Parent of the regression commit (https://github.com/Rdatatable/data.table/commit/c152ced0e5799acee1589910c69c1a2c6586b95d)
-    Regression="c152ced0e5799acee1589910c69c1a2c6586b95d", # Parent of the first commit (https://github.com/Rdatatable/data.table/commit/15f0598b9828d3af2eb8ddc9b38e0356f42afe4f) in the PR (https://github.com/Rdatatable/data.table/pull/4558/commits) that fixes the regression
+    Before="7a9eaf62ede487625200981018d8692be8c6f134", # Parent of the first commit (https://github.com/Rdatatable/data.table/commit/515de90a6068911a148e54343a3503043b8bb87c) in the PR (https://github.com/Rdatatable/data.table/pull/4164/commits) that introduced the regression
+    Regression="c152ced0e5799acee1589910c69c1a2c6586b95d", # Parent of the first (https://github.com/Rdatatable/data.table/commit/15f0598b9828d3af2eb8ddc9b38e0356f42afe4f) in the PR (https://github.com/Rdatatable/data.table/pull/4558/commits) that fixes the regression
     Fixed="f750448a2efcd258b3aba57136ee6a95ce56b302") # Second commit (https://github.com/Rdatatable/data.table/commit/f750448a2efcd258b3aba57136ee6a95ce56b302) in the PR  that fixes the regression(https://github.com/Rdatatable/data.table/pull/4558/commits)
 )
-
 # nolint end: undesirable_operator_linter.

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -127,7 +127,7 @@ test.list <- atime::atime_test_list(
     N = 10^seq(1, 20),
     setup = {
       d <- data.table(
-        id3 = sample( c(seq.int(N*0.9), sample( N*0.9, N*0.1, TRUE))),
+        id3 = sample(c(seq.int(N*0.9), sample( N*0.9, N*0.1, TRUE))),
         v1 = sample(5L, N, TRUE),
         v2 = sample(5L, N, TRUE)
       )
@@ -137,6 +137,6 @@ test.list <- atime::atime_test_list(
     },
     Before="7a9eaf62ede487625200981018d8692be8c6f134", # Parent of the first commit (https://github.com/Rdatatable/data.table/commit/515de90a6068911a148e54343a3503043b8bb87c) in the PR (https://github.com/Rdatatable/data.table/pull/4164/commits) that introduced the regression
     Regression="c152ced0e5799acee1589910c69c1a2c6586b95d", # Parent of the first (https://github.com/Rdatatable/data.table/commit/15f0598b9828d3af2eb8ddc9b38e0356f42afe4f) in the PR (https://github.com/Rdatatable/data.table/pull/4558/commits) that fixes the regression
-    Fixed="f750448a2efcd258b3aba57136ee6a95ce56b302") # Second commit (https://github.com/Rdatatable/data.table/commit/f750448a2efcd258b3aba57136ee6a95ce56b302) in the PR  that fixes the regression(https://github.com/Rdatatable/data.table/pull/4558/commits)
+    Fixed="f750448a2efcd258b3aba57136ee6a95ce56b302") # Second commit (https://github.com/Rdatatable/data.table/commit/f750448a2efcd258b3aba57136ee6a95ce56b302) in the PR that fixes the regression(https://github.com/Rdatatable/data.table/pull/4558/commits)
 )
 # nolint end: undesirable_operator_linter.

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -136,7 +136,7 @@ test.list <- atime::atime_test_list(
       expr=data.table:::`[.data.table`(d, , max(v1) - min(v2), by = id3)
     },
     Before = "7a9eaf62ede487625200981018d8692be8c6f134", # Parent of the first commit (https://github.com/Rdatatable/data.table/commit/515de90a6068911a148e54343a3503043b8bb87c) in the PR (https://github.com/Rdatatable/data.table/pull/4164/commits) that introduced the regression
-    Regression = "c152ced0e5799acee1589910c69c1a2c6586b95d", # Parent of the first (https://github.com/Rdatatable/data.table/commit/15f0598b9828d3af2eb8ddc9b38e0356f42afe4f) in the PR (https://github.com/Rdatatable/data.table/pull/4558/commits) that fixes the regression
-    Fixed = "f750448a2efcd258b3aba57136ee6a95ce56b302") # Second commit of the PR that fixes the regression(https://github.com/Rdatatable/data.table/pull/4558/commits)
+    Regression = "c152ced0e5799acee1589910c69c1a2c6586b95d", # Parent of the first commit (https://github.com/Rdatatable/data.table/commit/15f0598b9828d3af2eb8ddc9b38e0356f42afe4f) in the PR (https://github.com/Rdatatable/data.table/pull/4558/commits) that fixes the regression
+    Fixed = "f750448a2efcd258b3aba57136ee6a95ce56b302") # Second commit of the PR (https://github.com/Rdatatable/data.table/pull/4558/commits) that fixes the regression
 )
 # nolint end: undesirable_operator_linter.

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -108,7 +108,7 @@ test.list <- atime::atime_test_list(
 
   # Issue reported in: https://github.com/Rdatatable/data.table/issues/5426
   # To be fixed in: https://github.com/Rdatatable/data.table/pull/5427
-  "setDT improved fixed in #5427" = atime::atime_test(
+  "setDT improved in #5427" = atime::atime_test(
     N = 10^seq(1, 7),
     setup = {
       L <- replicate(N, 1, simplify = FALSE)
@@ -133,10 +133,10 @@ test.list <- atime::atime_test_list(
       )
     },
     expr = {
-      expr=data.table:::`[.data.table`(d, , (max(v1)-min(v2)), by = id3)
+      expr=data.table:::`[.data.table`(d, , max(v1) - min(v2), by = id3)
     },
-    Before="7a9eaf62ede487625200981018d8692be8c6f134", # Parent of the first commit (https://github.com/Rdatatable/data.table/commit/515de90a6068911a148e54343a3503043b8bb87c) in the PR (https://github.com/Rdatatable/data.table/pull/4164/commits) that introduced the regression
-    Regression="c152ced0e5799acee1589910c69c1a2c6586b95d", # Parent of the first (https://github.com/Rdatatable/data.table/commit/15f0598b9828d3af2eb8ddc9b38e0356f42afe4f) in the PR (https://github.com/Rdatatable/data.table/pull/4558/commits) that fixes the regression
-    Fixed="f750448a2efcd258b3aba57136ee6a95ce56b302") # Second commit (https://github.com/Rdatatable/data.table/commit/f750448a2efcd258b3aba57136ee6a95ce56b302) in the PR that fixes the regression(https://github.com/Rdatatable/data.table/pull/4558/commits)
+    Before = "7a9eaf62ede487625200981018d8692be8c6f134", # Parent of the first commit (https://github.com/Rdatatable/data.table/commit/515de90a6068911a148e54343a3503043b8bb87c) in the PR (https://github.com/Rdatatable/data.table/pull/4164/commits) that introduced the regression
+    Regression = "c152ced0e5799acee1589910c69c1a2c6586b95d", # Parent of the first (https://github.com/Rdatatable/data.table/commit/15f0598b9828d3af2eb8ddc9b38e0356f42afe4f) in the PR (https://github.com/Rdatatable/data.table/pull/4558/commits) that fixes the regression
+    Fixed = "f750448a2efcd258b3aba57136ee6a95ce56b302") # Second commit of the PR that fixes the regression(https://github.com/Rdatatable/data.table/pull/4558/commits)
 )
 # nolint end: undesirable_operator_linter.


### PR DESCRIPTION
This test case discusses the issue reported on performing group computations, specifically when running R's C eval on each group (q7 and q8) in the db-benchmark, indicating a slowness in the implementation of the code. https://github.com/Rdatatable/data.table/issues/4200

This is the https://github.com/Rdatatable/data.table/pull/4558 that discusses the Cause of the Regression: https://github.com/Rdatatable/data.table/issues/4200#issue-555186870 which appears that the regression occurred during the evaluation of C code within these particular groups, indicating a performance issue or slowness in the implementation of the code.

[The regression was fixed Regression by the addition of const int nth = getDTthreads](https://github.com/Rdatatable/data.table/pull/4558/files)