### PR TITLE
Consistently set R_LIBS_USER across steps

### DIFF
--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -1,6 +1,6 @@
 on:
   schedule:
-   - cron: '17 13 17 * *' # 17th of month at 13:17 UTC
+   - cron: '17 13 18 * *' # 18th of month at 13:17 UTC
 
 # A more complete suite of checks to run monthly; each PR/merge need not pass all these, but they should pass before CRAN release
 name: R-CMD-check-occasional
@@ -103,6 +103,7 @@ jobs:
           R_LIBS_USER: /home/runner/work/r-lib
         run: |
           options(crayon.enabled = TRUE)
+          install.packages("remotes") # different R_LIBS_USER now...
           remotes::install_deps(dependencies=TRUE, force=TRUE)
 
           # we define this in data.table namespace, but it appears to be exec

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -83,11 +83,15 @@ jobs:
         run: brew install gdal proj
 
       - name: Install remotes
+        env:
+          R_LIBS_USER: /home/runner/work/r-lib
         run: install.packages("remotes")
         shell: Rscript {0}
 
       - name: Install system dependencies
         if: runner.os == 'Linux'
+        env:
+          R_LIBS_USER: /home/runner/work/r-lib
         run: |
           while read -r cmd
           do


### PR DESCRIPTION
Latest run: "remotes not found", implies the library where `install.remotes()` succeeds in the earlier steps winds up unfound later. Should be solved by setting `R_LIBS_USER` consistently. How does this differ from #6251? Beats me...