### PR TITLE
Newline in verbose output

### DIFF
--- a/R/bmerge.R
+++ b/R/bmerge.R
@@ -102,7 +102,7 @@ bmerge = function(i, x, icols, xcols, roll, rollends, nomatch, mult, ops, verbos
         if (!isReallyReal(i[[ic]])) {
           # common case of ad hoc user-typed integers missing L postfix joining to correct integer keys
           # we've always coerced to int and returned int, for convenience.
-          if (verbose) catf("Coercing double column %s (which contains no fractions) to type integer to match type of %s", iname, xname)
+          if (verbose) catf("Coercing double column %s (which contains no fractions) to type integer to match type of %s.\n", iname, xname)
           val = as.integer(i[[ic]])
           if (!is.null(attributes(i[[ic]]))) attributes(val) = attributes(i[[ic]])  # to retain Date for example; 3679
           set(i, j=ic, value=val)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18747,4 +18747,4 @@ test(2270, options=c(datatable.optimize=1L), DT[, mean(b, 1), by=a], data.table(
 # Missing newline in verbose output -> harder to read
 DT1 = data.table(a=1:2)
 DT2 = data.table(a=c(1, 1, 2, 2), b=1:4)
-test(2271, options=c(datatable.verbose=TRUE), copy(DT1)[DT2, on='a', v := 4], copy(DT1)[, v := 4], output="x.a\nAssigning")
+test(2271, options=c(datatable.verbose=TRUE), copy(DT1)[DT2, on='a', v := 4], copy(DT1)[, v := 4], output="x.a.\nAssigning")

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18743,3 +18743,8 @@ test(2269.2, fread("x\n?\n \n", colClasses="POSIXct", na.strings="?"), dt)
 # Error found by revdep in #6284: mean(a,b) is valid, expr names() can be NULL
 DT = data.table(a = 1, b = 2)
 test(2270, options=c(datatable.optimize=1L), DT[, mean(b, 1), by=a], data.table(a=1, V1=2), warning="Unable to optimize call to mean()")
+
+# Missing newline in verbose output -> harder to read
+DT1 = data.table(a=1:2)
+DT2 = data.table(a=c(1, 1, 2, 2), b=1:4)
+test(2271, options=c(datatable.verbose=TRUE), copy(DT1)[DT2, on='a', v := 4], copy(DT1)[, v := 4], output="x.a\nAssigning")


### PR DESCRIPTION
Noticed this verbose output:

```r
DT1 = data.table(a = 1:2)
DT2 = data.table(a = c(1, 1, 2, 2), b = 1:4)
DT1[DT2, on='a', v := 4, verbose=TRUE]
# Coercing double column i.a (which contains no fractions) to type integer to match type of x.aAssigning to all 4 rows
```