### PR TITLE
Update Error Message to Explain Namespace Restrictions for `:=` and `let` in `data.table`

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2770,7 +2770,7 @@ address = function(x) .Call(Caddress, eval(substitute(x), parent.frame()))
 
 ":=" = function(...) {
   # this error is detected when eval'ing isub and replaced with a more helpful one when using := in i due to forgetting a comma, #4227
-  stopf('Check that is.data.table(DT) == TRUE. Otherwise, :=, `:=`(...) and let(...) are defined for use in j, once only and in particular ways. See help(":=").', class="dt_invalid_let_error")
+  stopf('Check that is.data.table(DT) == TRUE. Otherwise, :=, `:=`(...) and let(...) are defined for use in j, once only and in particular ways. Namespace appending such as data.table::`:=(...)` is not allowed. See help(":=").', class="dt_invalid_let_error")
 }
 
 # TODO(#6197): Export these.

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2770,7 +2770,7 @@ address = function(x) .Call(Caddress, eval(substitute(x), parent.frame()))
 
 ":=" = function(...) {
   # this error is detected when eval'ing isub and replaced with a more helpful one when using := in i due to forgetting a comma, #4227
-  stopf('Check that is.data.table(DT) == TRUE. Otherwise, :=, `:=`(...) and let(...) are defined for use in j, once only and in particular ways. Namespace appending such as data.table::`:=(...)` is not allowed. See help(":=").', class="dt_invalid_let_error")
+  stopf('Check that is.data.table(DT) == TRUE. Otherwise, :=, `:=`(...) and let(...) are defined for use in j, once only and in particular ways. Note that namespace-qualification like data.table::`:=`(...) is not supported. See help(":=").', class="dt_invalid_let_error")
 }
 
 # TODO(#6197): Export these.


### PR DESCRIPTION
closes #5357.

**Summary of Changes**:
The error message related to the use of `:=` and `let` within the `data.table` package has been updated to provide clearer guidance on namespace appending. The new error message now includes specific information that namespace appending such as `data.table:::=` is not allowed.

- The updated error message now reads:
  ```
  "Check that is.data.table(DT) == TRUE. Otherwise, :=, `:=`(...) and let(...) are defined for use in j, once only and in particular ways. Namespace appending such as data.table::`:=(...)` is not allowed. See help(\":=\")."
  ```

**Details**:
The functions `:=` and `let` in `data.table` are designed to work with non-standard evaluation (NSE). When these functions are used with a namespace prefix (e.g., `data.table:::=`), the NSE mechanisms fail to operate as intended, leading to confusing error messages. The new error message is intended to directly address this misuse and guide users towards the correct usage patterns.

