### PR TITLE
Setdroplevels for in-place removal of unused levels

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -202,5 +202,5 @@ S3method(format_col, expression)
 export(format_list_item)
 S3method(format_list_item, default)
 
-export(fdroplevels)
+export(fdroplevels, setdroplevels)
 S3method(droplevels, data.table)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 # data.table [v1.15.99](https://github.com/Rdatatable/data.table/milestone/30)  (in development)
 
+## BREAKING CHANGES
+
+1. `droplevels(in.place=TRUE)` is deprecated in favor of calling `setdroplevels()`, [#6014](https://github.com/Rdatatable/data.table/issues/6014). Given the associated risks/pain points, we strongly prefer all in-place/by-reference behavior within data.table come from functions `set*` (and `:=`) to make it as clear as possible that inputs are mutable. See below and `?setdroplevels` for more.
+
 ## NEW FEATURES
 
 1. `print.data.table()` shows empty (`NULL`) list column entries as `[NULL]` for emphasis. Previously they would just print nothing (same as for empty string). Part of [#4198](https://github.com/Rdatatable/data.table/issues/4198). Thanks @sritchie73 for the proposal and fix.
@@ -43,6 +47,8 @@
 15. `rbindlist(l, use.names=TRUE)` and `rbind` now works correctly on columns with different class attributes for certain classes such as `Date`, `IDate`, `ITime`, `POSIXct` and `AsIs` with other columns of similar classes, e.g., `IDate` and `Date`. The conversion is done automatically and the class attribute of the final column is determined by the first encountered class attribute in the binding list, [#5309](https://github.com/Rdatatable/data.table/issues/5309), [#4934](https://github.com/Rdatatable/data.table/issues/4934), [#5391](https://github.com/Rdatatable/data.table/issues/5391).
 
 `rbindlist(l, ignore.attr=TRUE)` and `rbind` also gains argument `ignore.attr` to manually deactivate the safety-net of binding columns with different column classes, [#3911](https://github.com/Rdatatable/data.table/issues/3911), [#5542](https://github.com/Rdatatable/data.table/issues/5542). Thanks to @dcaseykc, @fox34, @adrian-quintario, @berg-michael, @arunsrinivasan, @statquant, @pkress, @jrausch12, @therosko, @OfekShilon, @iMissile, @tdhock for the request and @ben-schwen for the PR.
+
+16. New `setdroplevels()` as a by-reference version of the `droplevels()` method, which returns a copy of its input, [#6014](https://github.com/Rdatatable/data.table/issues/6014). Thanks @MichaelChirico for the suggestion and implementation.
 
 ## BUG FIXES
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -1682,7 +1682,7 @@ test(529.4, set(DT1, i=NULL, j=7L, value=5L), error="Item 1 of column numbers in
 
 # Test that data.frame incompability is fixed, came to light in Feb 2012
 DT = data.table(name=c('a','b','c'), value=1:3)
-test(530, base::droplevels(DT[ name != 'a' ]), data.table(name=c('b','c'),value=2:3))   # base:: because we'll implement a fast droplevels, too.
+test(530, droplevels(DT[ name != 'a' ]), data.table(name=c('b','c'),value=2:3))
 
 # Test that .set_row_names() is maintained on .SD for each group
 DT = data.table(a=INT(1,1,2,2,2,3,3,3,3),b=1:9)
@@ -17740,6 +17740,13 @@ test(2214.09, fdroplevels(o[1:5]), droplevels(o[1:5]))
 test(2214.10, droplevels(DT[0]), DT[0])
 test(2214.11, droplevels(data.table()), data.table())
 
+# setdroplevels() for in-place operations #6014
+x = factor(letters[1:10])
+DT = data.table(a = x)[1:5]
+test(2214.12, setdroplevels(DT, except=1L), DT) # don't do anything
+test(2214.13, setdroplevels(DT, except=0L), error="except >= 1")
+test(2214.14, setdroplevels(DT, except=2L), error="except <= length(x)")
+test(2214.15, setdroplevels(DT), DT)
 
 # factor i should be just like character i and work, #1632
 DT = data.table(A=letters[1:3], B=4:6, key="A")

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -17732,7 +17732,7 @@ if (base::getRversion() >= "3.4.0") {
 }
 test(2214.06, droplevels(DT)[["a"]], droplevels(DT[1:5,a]))
 test(2214.07, droplevels(DT, 1)[["a"]], x[1:5])
-test(2214.08, droplevels(DT, in.place=TRUE), DT)
+test(2214.08, droplevels(DT, in.place=TRUE), DT, warning="droplevels() with in.place=TRUE is deprecated.")
 # support ordered factors in fdroplevels
 o = factor(letters[1:10], ordered=TRUE)
 test(2214.09, fdroplevels(o[1:5]), droplevels(o[1:5]))

--- a/man/fdroplevels.Rd
+++ b/man/fdroplevels.Rd
@@ -2,6 +2,7 @@
 \alias{fdroplevels}
 \alias{droplevels}
 \alias{droplevels.data.table}
+\alias{setdroplevels}
 \title{Fast droplevels}
 \description{
   Similar to \code{base::droplevels} but \emph{much faster}.
@@ -9,6 +10,7 @@
 
 \usage{
 fdroplevels(x, exclude = if (anyNA(levels(x))) NULL else NA, \dots)
+setdroplevels(x, except = NULL, exclude = NULL)
 
 \method{droplevels}{data.table}(x, except = NULL, exclude, in.place = FALSE, \dots)
 }


### PR DESCRIPTION
Closes #6014

Tests feel a bit sparse, but I think we're basically covered by existing `droplevels.data.table()` tests, didn't know how much time to spend on redundant testing.

Given that `setdroplevels()` is a pretty easy drop-in replacement for `droplevels(in.place=TRUE)`, and we didn't find any downstream usage, I didn't add an opt-out mechanism for this, LMYK if you think we should be more cautious.