### PR TITLE
PROTECT() more in forder+bmerge

### DIFF
--- a/src/bmerge.c
+++ b/src/bmerge.c
@@ -162,7 +162,11 @@ SEXP bmerge(SEXP idt, SEXP xdt, SEXP icolsArg, SEXP xcolsArg, SEXP xoArg, SEXP r
   allGrp1[0] = TRUE;
   protecti += 2;
 
-  SEXP oSxp = PROTECT(forderReuseSorting(idt, icolsArg, /* retGrpArg= */ScalarLogical(FALSE), /* retStatsArg= */ScalarLogical(FALSE), /* sortGroupsArg= */ScalarLogical(TRUE), /* ascArg= */ScalarInteger(1), /* naArg= */ScalarLogical(FALSE), /* lazyArg= */ScalarLogical(TRUE))); protecti++;
+  SEXP ascArg = PROTECT(ScalarInteger(1));
+  SEXP oSxp = PROTECT(forderReuseSorting(idt, icolsArg, /* retGrpArg= */ScalarLogical(FALSE), /* retStatsArg= */ScalarLogical(FALSE), /* sortGroupsArg= */ScalarLogical(TRUE), ascArg, /* naArg= */ScalarLogical(FALSE), /* lazyArg= */ScalarLogical(TRUE))); protecti++;
+  UNPROTECT(2); // down stack to 'ascArg'
+  PROTECT(oSxp);
+
   if (!LENGTH(oSxp))
     o = NULL;
   else

--- a/src/forder.c
+++ b/src/forder.c
@@ -1540,10 +1540,12 @@ bool colsKeyHead(SEXP x, SEXP cols) {
 SEXP idxName(SEXP x, SEXP cols) {
   if (!isInteger(cols))
     error("internal error: 'cols' must be an integer"); // # nocov
-  SEXP dt_names = getAttrib(x, R_NamesSymbol);
+  SEXP dt_names = PROTECT(getAttrib(x, R_NamesSymbol));
   if (!isString(dt_names))
     error("internal error: 'DT' has no names"); // # nocov
   SEXP idx_names = PROTECT(subsetVector(dt_names, cols));
+  UNPROTECT(2); // down-stack to 'dt_names'
+  PROTECT(idx_names);
   SEXP char_underscore2 = PROTECT(ScalarString(mkChar("__")));
   SEXP char_empty = PROTECT(ScalarString(mkChar("")));
   SEXP sym_paste0 = install("paste0");


### PR DESCRIPTION
Follow-up to #4386 given the `rchk` results:

https://github.com/Rdatatable/data.table/actions/runs/10148033664/job/28059822291?pr=6263

```
Function bmerge
  [UP] calling allocating function forderReuseSorting(?,?,?,?,?,V,?,?) with argument allocated using Rf_ScalarInteger /rchk/packages/build/a4VtYr2D/data.table/src/bmerge.c:165

Function idxName
  [UP] calling allocating function subsetVector with a fresh pointer (dt_names <arg 1>) /rchk/packages/build/a4VtYr2D/data.table/src/forder.c:1546
```

for `idxName`, we might just keep `dt_names` protected and do `UNPROTECT(6)` for simplicity.