### PR TITLE
Add a linter for calls to omp_set_num_threads

### DIFF
--- a/.ci/linters/c/omp_set_num_threads_linter.R
+++ b/.ci/linters/c/omp_set_num_threads_linter.R
@@ -1,11 +1,13 @@
+
 # Ensure no calls to omp_set_num_threads() [to avoid affecting other packages and base R]
 # Only comments referring to it should be in openmp-utils.c
 omp_set_num_threads_linter = function(c_file) {
-  processed_lines = system2("gcc", c("-fpreprocessed", "-E", "-xc", "-"), stdin=c_file, stdout=TRUE, stderr=FALSE)
+  # strip comments, we only care if the function appears in actual code.
+  processed_lines = system2("gcc", c("-fpreprocessed", "-E", "-xc", "-", c_file), stdout=TRUE, stderr=FALSE)
   idx = grep("omp_set_num_threads", processed_lines, fixed = TRUE)
   if (!length(idx)) return()
   stop(sprintf(
-    "In %s, found 'omp_set_num_threads() usage, which could affect other packages and base R:\n%s",
+    "In %s, found omp_set_num_threads() usage, which could affect other packages and base R:\n%s",
     c_file, paste0("  ", format(idx), ":", processed_lines[idx], collapse = "\n")
   ))
 }

--- a/.ci/linters/c/omp_set_num_threads_linter.R
+++ b/.ci/linters/c/omp_set_num_threads_linter.R
@@ -1,0 +1,11 @@
+# Ensure no calls to omp_set_num_threads() [to avoid affecting other packages and base R]
+# Only comments referring to it should be in openmp-utils.c
+omp_set_num_threads_linter = function(c_file) {
+  processed_lines = system2("gcc", c("-fpreprocessed", "-E", "-xc", "-"), stdin=c_file, stdout=TRUE, stderr=FALSE)
+  idx = grep("omp_set_num_threads", processed_lines, fixed = TRUE)
+  if (!length(idx)) return()
+  stop(sprintf(
+    "In %s, found 'omp_set_num_threads() usage, which could affect other packages and base R:\n%s",
+    c_file, paste0("  ", format(idx), ":", processed_lines[idx], collapse = "\n")
+  ))
+}

--- a/.ci/linters/c/omp_set_num_threads_linter.R
+++ b/.ci/linters/c/omp_set_num_threads_linter.R
@@ -3,7 +3,7 @@
 # Only comments referring to it should be in openmp-utils.c
 omp_set_num_threads_linter = function(c_file) {
   # strip comments, we only care if the function appears in actual code.
-  processed_lines = system2("gcc", c("-fpreprocessed", "-E", "-xc", "-", c_file), stdout=TRUE, stderr=FALSE)
+  processed_lines = system2("gcc", c("-fpreprocessed", "-E", c_file), stdout=TRUE, stderr=FALSE)
   idx = grep("omp_set_num_threads", processed_lines, fixed = TRUE)
   if (!length(idx)) return()
   stop(sprintf(

--- a/.dev/CRAN_Release.cmd
+++ b/.dev/CRAN_Release.cmd
@@ -53,9 +53,6 @@ grep -RI --exclude-dir=".git" --exclude="*.md" --exclude="*~" --color='auto' -P 
 # Unicode is now ok. This unicode in tests.Rraw is passing on CRAN.
 grep -RI --exclude-dir=".git" --exclude="*.md" --exclude="*~" --color='auto' -n "[\]u[0-9]" ./
 
-# Ensure no calls to omp_set_num_threads() [to avoid affecting other packages and base R]
-# Only comments referring to it should be in openmp-utils.c
-grep omp_set_num_threads ./src/*
 
 # Ensure no calls to omp_set_nested() as i) it's hard to fully honor OMP_THREAD_LIMIT as required by CRAN, and
 #                                        ii) a simpler non-nested approach is always preferable if possible, as has been the case so far

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -40,9 +40,10 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
       - name: Lint
         run: |
-          for (f in list.files('.ci/linters/c', full.names=TRUE)) source(f)
-          for (f in list.files('src', pattern='[.]c$', full.names=TRUE)) {
-            alloc_linter(f)
+          linter_env = new.env()
+          for (f in list.files('.ci/linters/c', full.names=TRUE)) sys.source(f, linter_env)
+          for (f in list.files('src', pattern='[.][ch]$', full.names=TRUE)) {
+            for (linter in ls(linter_env)) linter_env[[linter]](f)
             # TODO(#6272): Incorporate more checks from CRAN_Release
           }
         shell: Rscript {0}


### PR DESCRIPTION
Part of #6272

Probably, the step to pre-process the file to strip comments will be repeated by other linters, perhaps we should _just_ work from the preprocessed file for the C linters?

Leaving the simple version for now that's more parallel to the existing code.