### PR TITLE
Supply '%s' to translation

### DIFF
--- a/po/R-zh_CN.po
+++ b/po/R-zh_CN.po
@@ -3075,7 +3075,7 @@ msgstr "内部错误：此时不匹配的因子类型应已被发现"
 #: shift.R:3
 #, c-format
 msgid "Provided argument fill=%s will be ignored since type='cyclic'."
-msgstr "提供的 fill= 参数将被忽略，因为 type='cyclic'。"
+msgstr "提供的 fill=%s 参数将被忽略，因为 type='cyclic'。"
 
 #: tables.R:46
 #, c-format


### PR DESCRIPTION
Seen in #6355 where this .po file is now failing `checkPoFile()`.