### PR TITLE
Add a code-quality check for translations

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -47,3 +47,26 @@ jobs:
             # TODO(#6272): Incorporate more checks from CRAN_Release
           }
         shell: Rscript {0}
+  lint-po:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: r-lib/actions/setup-r@v2
+      - name: Check translations
+        run: |
+          setwd("po")
+          for (po_file in list.files(pattern = "[.]po$")) {
+            res = tools::checkPoFile(po_file, strictPlural=TRUE)
+            if (NROW(res)) { print(res); stop("Fix the above .po file issues.") }
+
+            if (!any(grepl("charset=UTF-8", readLines(po_file), fixed=TRUE)))
+              stop("In ", po_file, ", please use charset=UTF-8.")
+
+            res = system2("msgfmt", c("--statistics", po_file, "-o", tempfile()), stdout=TRUE, stderr=TRUE)
+            if (any(grepl("untranslated message|fuzzy translation", res))) {
+              cat(sprintf("In %s, found incomplete translations:\n%s\n", po_file, paste(res, collapse="\n")))
+              stop("Please fix.")
+            }
+          }
+          cat("All translation quality checks completed successfully!\n")
+        shell: Rscript {0}


### PR DESCRIPTION
Following #6355, #6199, and #6281, it will be nice to perform the (minimal) checks I've been doing manually, automatically. The tests are very lightweight, so we start by just doing them on every PR.