### PR TITLE
remove check for unavailabe dependencies on ancient R

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -209,6 +209,9 @@ test-lin-ancient-cran:
   <<: *test-lin
   script:
     - *install-deps
+    - Rscript -e 'install.packages("https://cran.r-project.org/src/contrib/Archive/xts/pkgname_version.tar.gz", repos = NULL, type = "source")'
+    - Rscript -e 'install.packages("https://cran.r-project.org/src/contrib/Archive/evaluate/pkgname_version.tar.gz", repos = NULL, type = "source")'
+    - Rscript -e 'install.packages("knitr")'
     - R CMD check --no-manual $(ls -1t data.table_*.tar.gz | head -n 1)
 
 .test-win-template: &test-win

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -211,7 +211,7 @@ test-lin-ancient-cran:
     - *install-deps
     - Rscript -e 'install.packages("https://cran.r-project.org/src/contrib/Archive/xts/xts_0.12.2.tar.gz", repos = NULL, type = "source")'
     - Rscript -e 'install.packages("https://cran.r-project.org/src/contrib/Archive/evaluate/evaluate_0.23.tar.gz", repos = NULL, type = "source")'
-    - Rscript -e 'install.packages("knitr")'
+    - Rscript -e 'install.packages("knitr", repos = "https://cloud.r-project.org")'
     - R CMD check --no-manual $(ls -1t data.table_*.tar.gz | head -n 1)
 
 .test-win-template: &test-win

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -205,14 +205,14 @@ test-lin-dev-clang-cran:
 
 # stated dependency on R
 test-lin-ancient-cran:
-  image: registry.gitlab.com/jangorecki/dockerfiles/r-3.3.0
   <<: *test-lin
+  image: registry.gitlab.com/jangorecki/dockerfiles/r-3.3.0
+  variables:
+    _R_CHECK_FORCE_SUGGESTS_: "FALSE"
   script:
     - *install-deps
     - Rscript -e 'install.packages("https://cran.r-project.org/src/contrib/Archive/xts/xts_0.12.2.tar.gz", repos = NULL, type = "source")'
-    - Rscript -e 'install.packages("https://cran.r-project.org/src/contrib/Archive/evaluate/evaluate_0.23.tar.gz", repos = NULL, type = "source")'
-    - Rscript -e 'install.packages("knitr", repos = "https://cloud.r-project.org")'
-    - R CMD check --no-manual $(ls -1t data.table_*.tar.gz | head -n 1)
+    - R CMD check --no-manual --no-build-vignettes --ignore-vignettes $(ls -1t data.table_*.tar.gz | head -n 1)
 
 .test-win-template: &test-win
   <<: *test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -212,6 +212,8 @@ test-lin-ancient-cran:
   script:
     - *install-deps
     - Rscript -e 'install.packages("https://cran.r-project.org/src/contrib/Archive/xts/xts_0.12.2.tar.gz", repos = NULL, type = "source")'
+    # knitr requires evaluate, which requires R 3.6.0.
+    # Restore checking vignettes if upgrading our R dependency means knitr can be installed.
     - R CMD check --no-manual --no-build-vignettes --ignore-vignettes $(ls -1t data.table_*.tar.gz | head -n 1)
 
 .test-win-template: &test-win

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -211,7 +211,6 @@ test-lin-ancient-cran:
     _R_CHECK_FORCE_SUGGESTS_: "FALSE" # can be removed if all dependencies are available, e.g. knitr, xts
   script:
     - *install-deps
-    - Rscript -e 'install.packages("https://cran.r-project.org/src/contrib/Archive/xts/xts_0.12.2.tar.gz", repos = NULL, type = "source")'
     # knitr requires evaluate, which requires R 3.6.0.
     # Restore checking vignettes if upgrading our R dependency means knitr can be installed.
     - R CMD check --no-manual --no-build-vignettes --ignore-vignettes $(ls -1t data.table_*.tar.gz | head -n 1)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -209,8 +209,8 @@ test-lin-ancient-cran:
   <<: *test-lin
   script:
     - *install-deps
-    - Rscript -e 'install.packages("https://cran.r-project.org/src/contrib/Archive/xts/pkgname_version.tar.gz", repos = NULL, type = "source")'
-    - Rscript -e 'install.packages("https://cran.r-project.org/src/contrib/Archive/evaluate/pkgname_version.tar.gz", repos = NULL, type = "source")'
+    - Rscript -e 'install.packages("https://cran.r-project.org/src/contrib/Archive/xts/xts_0.12.2.tar.gz", repos = NULL, type = "source")'
+    - Rscript -e 'install.packages("https://cran.r-project.org/src/contrib/Archive/evaluate/evaluate_0.23.tar.gz", repos = NULL, type = "source")'
     - Rscript -e 'install.packages("knitr")'
     - R CMD check --no-manual $(ls -1t data.table_*.tar.gz | head -n 1)
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -208,7 +208,7 @@ test-lin-ancient-cran:
   <<: *test-lin
   image: registry.gitlab.com/jangorecki/dockerfiles/r-3.3.0
   variables:
-    _R_CHECK_FORCE_SUGGESTS_: "FALSE"
+    _R_CHECK_FORCE_SUGGESTS_: "FALSE" # can be removed if all dependencies are available, e.g. knitr, xts
   script:
     - *install-deps
     - Rscript -e 'install.packages("https://cran.r-project.org/src/contrib/Archive/xts/xts_0.12.2.tar.gz", repos = NULL, type = "source")'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -208,7 +208,7 @@ test-lin-ancient-cran:
   <<: *test-lin
   image: registry.gitlab.com/jangorecki/dockerfiles/r-3.3.0
   variables:
-    _R_CHECK_FORCE_SUGGESTS_: "FALSE" # can be removed if all dependencies are available, e.g. knitr, xts
+    _R_CHECK_FORCE_SUGGESTS_: "FALSE" # can be removed if all dependencies are available (knitr, xts, etc.)
   script:
     - *install-deps
     # knitr requires evaluate, which requires R 3.6.0.


### PR DESCRIPTION
Current CI ancient job is failing because new version of `xts`, and `evaluate` depend on `R 4.0.0`. This PR patches the CI job by installing fixed versions for certain packages, afterwards. 