### PR TITLE
add translation teams to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -40,6 +40,7 @@
 /po/ @michaelchirico
 /R/translation.R @michaelchirico
 /src/po.h @michaelchirico
+/po/*.pot @Rdatatable/translators
 /po/*zh_CN.po @Rdatatable/chinese
 /po/*pt_BR.po @Rdatatable/brazil
 /po/*es.po @Rdatatable/spanish

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -40,6 +40,9 @@
 /po/ @michaelchirico
 /R/translation.R @michaelchirico
 /src/po.h @michaelchirico
+po/*zh_CN.po @Rdatatable/chinese
+po/*pt_BR.po @Rdatatable/brazil
+po/*es.po @Rdatatable/spanish
 
 # printing
 /R/print.data.table.R @michaelchirico

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -40,9 +40,9 @@
 /po/ @michaelchirico
 /R/translation.R @michaelchirico
 /src/po.h @michaelchirico
-po/*zh_CN.po @Rdatatable/chinese
-po/*pt_BR.po @Rdatatable/brazil
-po/*es.po @Rdatatable/spanish
+/po/*zh_CN.po @Rdatatable/chinese
+/po/*pt_BR.po @Rdatatable/brazil
+/po/*es.po @Rdatatable/spanish
 
 # printing
 /R/print.data.table.R @michaelchirico


### PR DESCRIPTION
hi @Rdatatable/translators
I propose that we add lines to CODEOWNERS so that a translation team will be notified when there are PRs that modify the files related to their language.