### PR TITLE
macro redefined in fwrite and fread

### DIFF
--- a/src/freadR.h
+++ b/src/freadR.h
@@ -1,6 +1,8 @@
 #ifndef dt_FREAD_R_H
 #define dt_FREAD_R_H
-#define STRICT_R_HEADERS   // https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Error-handling
+#ifndef STRICT_R_HEADERS
+  #define STRICT_R_HEADERS   // https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Error-handling
+#endif
 #include <R.h>
 #include <Rinternals.h>
 #include "po.h"

--- a/src/fwrite.h
+++ b/src/fwrite.h
@@ -2,7 +2,7 @@
   #include "py_fread.h"
 #else
   #ifndef STRICT_R_HEADERS
-  #define STRICT_R_HEADERS
+    #define STRICT_R_HEADERS
   #endif
   #include <R.h>
   #include <Rinternals.h>  // for SEXP in writeList() prototype

--- a/src/fwrite.h
+++ b/src/fwrite.h
@@ -1,7 +1,9 @@
 #ifdef DTPY
   #include "py_fread.h"
 #else
+  #ifndef STRICT_R_HEADERS
   #define STRICT_R_HEADERS
+  #endif
   #include <R.h>
   #include <Rinternals.h>  // for SEXP in writeList() prototype
   #include "po.h"


### PR DESCRIPTION
Currently both `freadR.h` and `fwrite.h` have the line `#define STRICT_R_HEADERS` (see also at [CI](https://gitlab.com/Rdatatable/data.table/-/jobs/7617683486#L145) but happens at test-lin-dev-clang-cran and test-lin-dev-gcc-strict-cran)

This PR adds a directive to only define once, avoiding redefinition.