### PR TITLE
More R-CMD-check-occasional fixes

### DIFF
--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -128,9 +128,9 @@ jobs:
             system2(Rbin, c("CMD", "build", ".", build_args))
             dt_tar = list.files(pattern = "^data[.]table_.*[.]tar[.]gz$")
             if (!length(dt_tar)) stop("Built tar.gz not found among: ", toString(list.files()))
-            res = system2(Rbin, c("CMD", "check", dt_tar[1L], check_args), stdout=TRUE, env=sprintf("%s=%s", names(env), env))
-            if (!is.null(attr(res, "status")) || grep("^Status:.*(ERROR|WARNING)", res)) {
-              writeLines(res)
+            res = system2(Rbin, c("CMD", "check", dt_tar[1L], check_args), stdout=TRUE, stderr=TRUE, env=sprintf("%s=%s", names(env), env))
+            if (!is.null(attr(res, "status")) || is.na(res) || grep("^Status:.*(ERROR|WARNING)", res)) {
+              writeLines(as.character(res))
               stop("R CMD check failed")
             }
           }

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -42,7 +42,6 @@ jobs:
             r: '4.1'
 
     env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
@@ -90,16 +89,18 @@ jobs:
           _R_CHECK_TESTS_NLINES_: 0
         run: |
           options(crayon.enabled = TRUE)
-          install.packages("remotes")
-          message("*** DONE remotes, now installing requirements ***")
-          remotes::install_deps(dependencies=TRUE, force=TRUE)
+          message("*** Using the following repos for installation ***")
+          print(getOption("repos"))
+          message("*** Installing Suggested packages ***")
+          sugg <- names(tools:::.split_dependencies(read.dcf("DESCRIPTION", "Suggests")))
+          install.packages(sugg)
 
           other_deps_expr = parse('inst/tests/other.Rraw', n=1L)
           eval(other_deps_expr)
           other_pkgs = get(as.character(other_deps_expr[[1L]][[2L]]))
           # Many will not install on oldest R versions
-          message("*** DONE requirements, now installing optional ***")
-          try(remotes::install_cran(c(other_pkgs, "rcmdcheck"), force=TRUE))
+          message("*** Installing fully optional packages ***")
+          try(install.packages(c(other_pkgs, "rcmdcheck")))
 
           has_other_pkg = sapply(other_pkgs, requireNamespace, quietly=TRUE)
           run_other = all(has_other_pkg)

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -1,6 +1,6 @@
 on:
   schedule:
-   - cron: '17 13 22 * *' # 22nd of month at 13:17 UTC
+   - cron: '17 13 23 * *' # 23rd of month at 13:17 UTC
 
 # A more complete suite of checks to run monthly; each PR/merge need not pass all these, but they should pass before CRAN release
 name: R-CMD-check-occasional

--- a/inst/tests/other.Rraw
+++ b/inst/tests/other.Rraw
@@ -30,6 +30,7 @@ if (!all(loaded)) {
   options(warning.length=8000)
   stop(
     "test.data.table('other.Rraw') failed to attach required package(s): ", toString(sort(names(loaded)[!loaded])), ".",
+    "\nHere's .libPaths():\n  ", paste(.libPaths(), collapse="|"),
     "\nHere's all installed packages:\n  ", paste(sort(rownames(installed.packages())), collapse=","),
     "\nHere's the search() path:\n  ", paste(search(), collapse="->"),
     "\nIf you can't install them and this is R CMD check, please set environment variable TEST_DATA_TABLE_WITH_OTHER_PACKAGES back to the default, false; it's currently ", Sys.getenv("TEST_DATA_TABLE_WITH_OTHER_PACKAGES", "<unset>"), ".")


### PR DESCRIPTION
As seen here:

https://github.com/Rdatatable/data.table/actions/runs/10508975968/job/29114081310

I'm not sure how the result of `system2()` can be missing, but here we are.

Side note, we finally have some _passing_ tests 🎉 (for `ubuntu-latest` on R 3.6, only, though, which is weird).