### PR TITLE
Add an extra condition for checking showProgress value

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -224,7 +224,7 @@ replace_dot_alias = function(e) {
   if ((isTRUE(which)||is.na(which)) && !missing(j)) stopf("which==%s (meaning return row numbers) but j is also supplied. Either you need row numbers or the result of j, but only one type of result can be returned.", which)
   if (is.null(nomatch) && is.na(which)) stopf("which=NA with nomatch=0|NULL would always return an empty vector. Please change or remove either which or nomatch.")
   if (!with && missing(j)) stopf("j must be provided when with=FALSE")
-  if (!isTRUEorFALSE(showProgress)) stopf("%s must be TRUE or FALSE", "showProgress")
+  if (!missing(by) && !isTRUEorFALSE(showProgress)) stopf("%s must be TRUE or FALSE", "showProgress")
   irows = NULL  # Meaning all rows. We avoid creating 1:nrow(x) for efficiency.
   notjoin = FALSE
   rightcols = leftcols = integer()


### PR DESCRIPTION
As noted here:

https://github.com/Rdatatable/data.table/issues/6166#issuecomment-2310735251

This isn't _strictly_ necessary, but I did find it slightly off that the code that triggers the (phantom) error is a query like `DT[,nm,with=FALSE]` -- `showProgress` is never needed for such a case. We only need to check `showProgress` if it might be used, i.e., if `by` is present.

Of course, we could delay checking `showProgress` even further -- it's not used in GForce queries -- but I think that's not very beneficial vs. having the check fail early on in `[`.