### PR TITLE
Correct commented argument name

### DIFF
--- a/src/bmerge.c
+++ b/src/bmerge.c
@@ -163,7 +163,7 @@ SEXP bmerge(SEXP idt, SEXP xdt, SEXP icolsArg, SEXP xcolsArg, SEXP xoArg, SEXP r
   protecti += 2;
 
   SEXP ascArg = PROTECT(ScalarInteger(1));
-  SEXP oSxp = PROTECT(forderReuseSorting(idt, icolsArg, /* retGrpArg= */ScalarLogical(FALSE), /* retStatsArg= */ScalarLogical(FALSE), /* sortGroupsArg= */ScalarLogical(TRUE), ascArg, /* naArg= */ScalarLogical(FALSE), /* lazyArg= */ScalarLogical(TRUE))); protecti++;
+  SEXP oSxp = PROTECT(forderReuseSorting(idt, icolsArg, /* retGrpArg= */ScalarLogical(FALSE), /* retStatsArg= */ScalarLogical(FALSE), /* sortGroupsArg= */ScalarLogical(TRUE), ascArg, /* naArg= */ScalarLogical(FALSE), /* reuseSortingArg= */ScalarLogical(TRUE))); protecti++;
   UNPROTECT(2); // down stack to 'ascArg'
   PROTECT(oSxp);
 

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -195,9 +195,9 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols,
                 SEXP on, SEXP verbose, SEXP showProgressArg);
 
 // bmerge.c
-SEXP bmerge(SEXP iArg, SEXP xArg, SEXP icolsArg, SEXP xcolsArg,
-                SEXP xoArg, SEXP rollarg, SEXP rollendsArg, SEXP nomatchArg,
-                SEXP multArg, SEXP opArg, SEXP nqgrpArg, SEXP nqmaxgrpArg);
+SEXP bmerge(SEXP idt, SEXP xdt, SEXP icolsArg, SEXP xcolsArg,
+            SEXP xoArg, SEXP rollarg, SEXP rollendsArg, SEXP nomatchArg,
+            SEXP multArg, SEXP opArg, SEXP nqgrpArg, SEXP nqmaxgrpArg);
 
 // quickselect
 double dquickselect(double *x, int n);


### PR DESCRIPTION
 - `lazyArg` caught by `clang-tidy`'s `bugprone-argument-comment` checker:

    https://clang.llvm.org/extra/clang-tidy/checks/bugprone/argument-comment.html

- `idt`,`xdt` caught by `clang-tidy`'s `readability-inconsistent-declaration-parameter-name` checker:

    https://clang.llvm.org/extra/clang-tidy/checks/readability/inconsistent-declaration-parameter-name.html

https://github.com/Rdatatable/data.table/blob/534fc18009f0bbbe46cb0e7e1e856850618ba80c/src/bmerge.c#L42