### PR TITLE
Add a GHA to prevent backsliding on translation compilation

### DIFF
--- a/.ci/linters/po/incomplete_translation_linter.R
+++ b/.ci/linters/po/incomplete_translation_linter.R
@@ -1,7 +1,0 @@
-incomplete_translation_linter <- function(po_file) {
-  res = system2("msgfmt", c("--statistics", po_file, "-o", tempfile()), stdout=TRUE, stderr=TRUE)
-  if (any(grepl("untranslated message|fuzzy translation", res))) {
-    cat(sprintf("In %s, found incomplete translations:\n%s\n", po_file, paste(res, collapse="\n")))
-    stop("Please fix.")
-  }
-}

--- a/.ci/linters/po/msgfmt_linter.R
+++ b/.ci/linters/po/msgfmt_linter.R
@@ -1,0 +1,42 @@
+# Use msgfmt to check for untranslated/fuzzy messages, and for whether
+#   the implied .mo compiled form matches that which is already checked in
+msgfmt_linter <- function(po_file) {
+  mo_tmp <- tempfile()
+  on.exit(unlink(mo_tmp))
+
+  res = system2("msgfmt", c("--statistics", po_file, "-o", mo_tmp)), stdout=TRUE, stderr=TRUE)
+  if (any(grepl("untranslated message|fuzzy translation", res))) {
+    cat(sprintf("In %s, found incomplete translations:\n%s\n", po_file, paste(res, collapse="\n")))
+    stop("Please fix.")
+  }
+
+  mo_ref = sprintf(
+    "inst/%s/LC_MESSAGES/%sdata.table.mo",
+    gsub("^R-|[.]po$", "", po_file),
+    if (startsWith(basename(po_file), "R-")) "R-" else ""
+  )
+
+  if (!file.exists(mo_ref)) {
+    stop(po_file, " has not been compiled as ", mo_ref, ". Please fix.")
+  }
+  if (tools::md5sum(mo_ref) == tools::md5sum(mo_tmp)) return(invisible())
+
+  # NB: file.mtime() will probably be wrong, it will reflect the check-out time of the git repo.
+  last_edit_time = system2("git",
+    c("log", "-1", '--format="%ad"', "--date=format:'%Y-%m-%d %H:%M:%S'", "--", mo_ref),
+    stdout=TRUE
+  )
+  cat(sprintf(
+    ".mo compilation %s of .po translation %s appears out of date! It was last updated %s\n",
+    mo_ref, po_file, last_edit_time
+  ))
+
+  unmo_tmp = tempfile()
+  unmo_ref = tempfile()
+  on.exit(unlink(c(unmo_tmp, unmo_ref), add=TRUE))
+  system2("msgunfmt", c(mo_tmp, "-o", unmo_tmp))
+  system2("msgunfmt", c(mo_ref, "-o", unmo_ref))
+  cat("Here are the observed differences after converting back to .po:\n\n")
+  system2("diff", c(unmo_tmp, unmo_ref))
+  stop("Please fix.")
+}


### PR DESCRIPTION
Follow-up to #6414.

I'm not 100% sure how stable the MD5 sum of the .mo binary is. But let's try & see. If that causes issues, we can probably use the `msgunfmt` output instead. If that's unstable too, we'll probably switch to {potools}, which can read the .po output of `msgunfmt` as a data.table where we can use `all.equal()` after appropriate normalization.