### PR TITLE
Initialize more variables

### DIFF
--- a/src/fifelse.c
+++ b/src/fifelse.c
@@ -368,7 +368,7 @@ SEXP fcaseR(SEXP rho, SEXP args) {
       }
     } break;
     case STRSXP: {
-      const SEXP *restrict pthens;
+      const SEXP *restrict pthens=NULL;
       if (!naout) pthens = STRING_PTR_RO(thens); // the content is not useful if out is NA_LOGICAL scalar
       const SEXP pna = NA_STRING;
       for (int64_t j=0; j<len2; ++j) {
@@ -386,7 +386,7 @@ SEXP fcaseR(SEXP rho, SEXP args) {
     case VECSXP: {
       // the default value of VECSXP is `NULL` so we don't need to explicitly
       // assign the NA values as it does for other atomic types
-      const SEXP *restrict pthens;
+      const SEXP *restrict pthens=NULL;
       if (!naout) pthens = SEXPPTR_RO(thens); // the content is not useful if out is NA_LOGICAL scalar
       for (int64_t j=0; j<len2; ++j) {
         const int64_t idx = imask ? j : p[j];

--- a/src/frollR.c
+++ b/src/frollR.c
@@ -99,7 +99,7 @@ SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEX
   if (LOGICAL(hasna)[0]==FALSE && LOGICAL(narm)[0])
     error(_("using hasNA FALSE and na.rm TRUE does not make sense, if you know there are NA values use hasNA TRUE, otherwise leave it as default NA"));
 
-  int ialign;                                                   // decode align to integer
+  int ialign=-2;                                                   // decode align to integer
   if (!strcmp(CHAR(STRING_ELT(align, 0)), "right"))
     ialign = 1;
   else if (!strcmp(CHAR(STRING_ELT(align, 0)), "center"))
@@ -133,7 +133,7 @@ SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEX
     dx[i] = REAL(VECTOR_ELT(x, i));                             // assign source columns to C pointers
   }
 
-  enum {MEAN, SUM} sfun;
+  enum {MEAN, SUM} sfun=0;
   if (!strcmp(CHAR(STRING_ELT(fun, 0)), "mean")) {
     sfun = MEAN;
   } else if (!strcmp(CHAR(STRING_ELT(fun, 0)), "sum")) {
@@ -156,7 +156,7 @@ SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEX
     LOGICAL(hasna)[0]==TRUE ? 1 :                               // hasna TRUE, might be some NAs
     -1;                                                         // hasna FALSE, there should be no NAs
 
-  unsigned int ialgo;                                           // decode algo to integer
+  unsigned int ialgo=-1;                                           // decode algo to integer
   if (!strcmp(CHAR(STRING_ELT(algo, 0)), "fast"))
     ialgo = 0;                                                  // fast = 0
   else if (!strcmp(CHAR(STRING_ELT(algo, 0)), "exact"))
@@ -244,7 +244,7 @@ SEXP frollapplyR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP align, SEXP rho) {
     error(_("n must be non 0 length"));
   int *ik = INTEGER(k);
 
-  int ialign;
+  int ialign=-2;
   if (!strcmp(CHAR(STRING_ELT(align, 0)), "right")) {
     ialign = 1;
   } else if (!strcmp(CHAR(STRING_ELT(align, 0)), "center")) {

--- a/src/idatetime.c
+++ b/src/idatetime.c
@@ -128,7 +128,7 @@ SEXP convertDate(SEXP x, SEXP type)
     const int n = length(x);
     if (!isString(type) || length(type) != 1)
         internal_error(__func__, "invalid type for, should have been caught before"); // # nocov
-    datetype ctype;
+    datetype ctype=0;
     bool ansint = true;
     if (!strcmp(CHAR(STRING_ELT(type, 0)), "yday")) ctype = YDAY;
     else if (!strcmp(CHAR(STRING_ELT(type, 0)), "wday")) ctype = WDAY;

--- a/src/nafill.c
+++ b/src/nafill.c
@@ -164,7 +164,7 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP nan_is_na_arg, SEXP inplace, S
     }
   }
 
-  unsigned int itype;
+  unsigned int itype=-1;
   if (!strcmp(CHAR(STRING_ELT(type, 0)), "const"))
     itype = 0;
   else if (!strcmp(CHAR(STRING_ELT(type, 0)), "locf"))


### PR DESCRIPTION
Closes #6466.

This is busy work & a follow-up to #6449. None of these cases have any real risk of being used uninitialized -- we're only initializing to satisfy the compiler.

Besides the fifelse.c cases, these are all owing to `internal_error()` not being recognized as a non-return function.