### PR TITLE
change -std=c99 to c11 in cc()

### DIFF
--- a/.dev/cc.R
+++ b/.dev/cc.R
@@ -91,9 +91,9 @@ cc = function(test=FALSE, clean=FALSE, debug=FALSE, omp=!debug, path=Sys.getenv(
   if (clean) system("rm *.o *.so")
   OMP = if (omp) "openmp" else "no-openmp"
   if (debug) {
-    cmd = sprintf(R"(MAKEFLAGS='-j CC=%s PKG_CFLAGS=-f% CFLAGS=-std=c99\ -O0\ -ggdb\ %s\ -pedantic' R CMD SHLIB -d -o data_table.so *.c)", CC, OMP, W32)
+    cmd = sprintf(R"(MAKEFLAGS='-j CC=%s PKG_CFLAGS=-f% CFLAGS=-O0\ -ggdb\ %s\ -pedantic' R CMD SHLIB -d -o data_table.so *.c)", CC, OMP, W32)
   } else {
-    cmd = sprintf(R"(MAKEFLAGS='-j CC=%s CFLAGS=-f%s\ -std=c99\ -O3\ -pipe\ -Wall\ -pedantic\ -Wstrict-prototypes\ -isystem\ /usr/share/R/include\ %s\ -fno-common' R CMD SHLIB -o data_table.so *.c)", CC, OMP, W32)
+    cmd = sprintf(R"(MAKEFLAGS='-j CC=%s CFLAGS=-f%s\ -O3\ -pipe\ -Wall\ -pedantic\ -Wstrict-prototypes\ -isystem\ /usr/share/R/include\ %s\ -fno-common' R CMD SHLIB -o data_table.so *.c)", CC, OMP, W32)
     # the -isystem suppresses strict-prototypes warnings from R's headers, #5477. Look at the output to see what -I is and pass the same path to -isystem.
     # TODO add -Wextra too?
   }

--- a/.dev/cc.R
+++ b/.dev/cc.R
@@ -91,9 +91,9 @@ cc = function(test=FALSE, clean=FALSE, debug=FALSE, omp=!debug, path=Sys.getenv(
   if (clean) system("rm *.o *.so")
   OMP = if (omp) "openmp" else "no-openmp"
   if (debug) {
-    cmd = sprintf(R"(MAKEFLAGS='-j CC=%s PKG_CFLAGS=-f% CFLAGS=-O0\ -ggdb\ %s\ -pedantic' R CMD SHLIB -d -o data_table.so *.c)", CC, OMP, W32)
+    cmd = sprintf(R"(MAKEFLAGS='-j CC=%s PKG_CFLAGS=-f% CFLAGS=-std=c11\ -O0\ -ggdb\ %s\ -pedantic' R CMD SHLIB -d -o data_table.so *.c)", CC, OMP, W32)
   } else {
-    cmd = sprintf(R"(MAKEFLAGS='-j CC=%s CFLAGS=-f%s\ -O3\ -pipe\ -Wall\ -pedantic\ -Wstrict-prototypes\ -isystem\ /usr/share/R/include\ %s\ -fno-common' R CMD SHLIB -o data_table.so *.c)", CC, OMP, W32)
+    cmd = sprintf(R"(MAKEFLAGS='-j CC=%s CFLAGS=-f%s\ -std=c11\ -O3\ -pipe\ -Wall\ -pedantic\ -Wstrict-prototypes\ -isystem\ /usr/share/R/include\ %s\ -fno-common' R CMD SHLIB -o data_table.so *.c)", CC, OMP, W32)
     # the -isystem suppresses strict-prototypes warnings from R's headers, #5477. Look at the output to see what -I is and pass the same path to -isystem.
     # TODO add -Wextra too?
   }


### PR DESCRIPTION
closes #6471 

using this PR, I do not observe any warning from gcc on windows with rtools44, when compiling reorder.o with cc()
```r
> cc()
C:/Users/hoct2726/R/data.table/src 
Running command:
MAKEFLAGS='-j CC=gcc CFLAGS=-fopenmp\ -O3\ -pipe\ -Wall\ -pedantic\ -Wstrict-prototypes\ -isystem\ /usr/share/R/include\ -DWIN32\ -fno-common' R CMD SHLIB -o data_table.so *.c
using C compiler: 'gcc.exe (GCC) 13.2.0'
gcc -I"C:/PROGRA~1/R/R-44~1.1/include" -DNDEBUG     -I"C:/rtools44/x86_64-w64-mingw32.static.posix/include"  -fopenmp   -fopenmp -O3 -pipe -Wall -pedantic -Wstrict-prototypes -isystem /usr/share/R/include -DWIN32 -fno-common -c assign.c -o assign.o
...
gcc -I"C:/PROGRA~1/R/R-44~1.1/include" -DNDEBUG     -I"C:/rtools44/x86_64-w64-mingw32.static.posix/include"  -fopenmp   -fopenmp -O3 -pipe -Wall -pedantic -Wstrict-prototypes -isystem /usr/share/R/include -DWIN32 -fno-common -c reorder.c -o reorder.o
gcc -I"C:/PROGRA~1/R/R-44~1.1/include" -DNDEBUG     -I"C:/rtools44/x86_64-w64-mingw32.static.posix/include"  -fopenmp   -fopenmp -O3 -pipe -Wall -pedantic -Wstrict-prototypes -isystem /usr/share/R/include -DWIN32 -fno-common -c shift.c -o shift.o
```