### PR TITLE
Only run atime tests on non-fork branches

### DIFF
--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   comment:
+    if: github.repository == 'Rdatatable/data.table'
     runs-on: ubuntu-latest
     container: ghcr.io/iterative/cml:0-dvc2-base1
     env:


### PR DESCRIPTION
Observed in #4883 -- PRs originating from a fork will fail:

https://github.com/Rdatatable/data.table/actions/runs/10734222605/job/29768987281?pr=4883

```shell
Run git switch "${GITHUB_BASE_REF}"
# Previous HEAD position was 34257529 Merge 578abecb6b580da7fed2c80b4343c4d1a6b8717e into b56682218696ea6970e189e5f55cf0102a516121
# Switched to a new branch 'master'
# branch 'master' set up to track 'origin/master'.
# fatal: invalid reference: named_lapply
# Error: Process completed with exit code 128.
```

The alternative is to try and get this running on fork-originated PRs, I'm not sure it's needed.