### PR TITLE
Don't attempt reuseSorting on non-data.table in bmerge

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -69,6 +69,8 @@ rowwiseDT(
 
 11. `fread()` automatically detects timestamps with sub-second accuracy again, [#6440](https://github.com/Rdatatable/data.table/issues/6440). This was a regression due to interference with new `dec='auto'` support. Thanks @kav2k for the concise report and @MichaelChirico for the fix.
 
+12. Restore some join operations on `x` and `i` (e.g. an anti-join `x[!i]`)  where `i` is an extended data.frame, but not a data.table (e.g. a `tbl`), [#6501](https://github.com/Rdatatable/data.table/issues/6501). Thanks @MichaelChirico for the report and PR.
+
 ## NOTES
 
 1. Tests run again when some Suggests packages are missing, [#6411](https://github.com/Rdatatable/data.table/issues/6411). Thanks @aadler for the note and @MichaelChirico for the fix.

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -19263,3 +19263,10 @@ df = data.frame(a=1:3)
 setDT(df)
 attr(df, "att") = 1
 test(2291.1, set(df, NULL, "new", "new"), error="attributes .* have been reassigned")
+
+# don't try to re-use sorting on a non-data.table, #6501
+x = data.table(id = "aaa")
+y = data.frame(id = "bbb")
+test(2292.1, x[!y, on='id'], x)
+class(y) = c("tbl_df", "tbl", "data.frame")
+test(2292.2, x[!y, on = "id"], x)

--- a/src/bmerge.c
+++ b/src/bmerge.c
@@ -160,7 +160,8 @@ SEXP bmerge(SEXP idt, SEXP xdt, SEXP icolsArg, SEXP xcolsArg, SEXP xoArg, SEXP r
   protecti += 2;
 
   SEXP ascArg = PROTECT(ScalarInteger(1));
-  SEXP oSxp = PROTECT(forderReuseSorting(idt, icolsArg, /* retGrpArg= */ScalarLogical(FALSE), /* retStatsArg= */ScalarLogical(FALSE), /* sortGroupsArg= */ScalarLogical(TRUE), ascArg, /* naArg= */ScalarLogical(FALSE), /* reuseSortingArg= */ScalarLogical(TRUE))); protecti++;
+  SEXP reuseSortingArg = INHERITS(idt, char_datatable) ? ScalarLogical(TRUE) : ScalarLogical(FALSE);
+  SEXP oSxp = PROTECT(forderReuseSorting(idt, icolsArg, /* retGrpArg= */ScalarLogical(FALSE), /* retStatsArg= */ScalarLogical(FALSE), /* sortGroupsArg= */ScalarLogical(TRUE), ascArg, /* naArg= */ScalarLogical(FALSE), reuseSortingArg)); protecti++;
   UNPROTECT(2); // down stack to 'ascArg'
   PROTECT(oSxp);
 


### PR DESCRIPTION
Closes #6501.

I still don't see why having an extended class like `tbl_df` is necessary, i.e. why plain `data.frame` doesn't wind up here. Maybe Jan sees a more robust diagnosis.