### PR TITLE
Missed/partial translations in setops/fread

### DIFF
--- a/R/devel.R
+++ b/R/devel.R
@@ -36,12 +36,12 @@ update_dev_pkg = function(pkg="data.table", repo="https://Rdatatable.gitlab.io/d
     if (upg) {
       unloadNamespace(pkg) ## hopefully will release dll lock on Windows
       utils::install.packages(pkg, repos=repo, type=type, lib=lib, ...)
+      msg_fmt = gettext("R %s package has been updated to %s (%s)\n")
+    } else {
+      msg_fmt = gettext("R %s package is up-to-date at %s (%s)\n")
     }
-    cat(sprintf("R %s package %s %s (%s)\n",
-                pkg,
-                c("is up-to-date at","has been updated to")[upg+1L],
-                unname(read.dcf(system.file("DESCRIPTION", package=pkg, lib.loc=lib, mustWork=TRUE), fields=field)[, field]),
-                utils::packageVersion(pkg, lib.loc=lib)))
+    field_val = unname(read.dcf(system.file("DESCRIPTION", package=pkg, lib.loc=lib, mustWork=TRUE), fields=field)[, field])
+    cat(sprintf(msg_fmt, pkg, field_val, utils::packageVersion(pkg, lib.loc=lib)))
   })
   invisible(upg)
 }

--- a/R/fread.R
+++ b/R/fread.R
@@ -311,7 +311,7 @@ yaml=FALSE, autostart=NA, tmpdir=tempdir(), tz="UTC")
              methods::as(v, new_class))
       },
       warning = fun <- function(e) {
-        warningf("Column '%s' was requested to be '%s' but fread encountered the following %s:\n\t%s\nso the column has been left as type '%s'", names(ans)[j], new_class, if (inherits(e, "error")) "error" else "warning", e$message, typeof(v))
+        warningf("Column '%s' was requested to be '%s' but fread encountered the following %s:\n\t%s\nso the column has been left as type '%s'", names(ans)[j], new_class, if (inherits(e, "error")) gettext("error") else gettext("warning"), e$message, typeof(v))
         v
       },
       error = fun)

--- a/R/fread.R
+++ b/R/fread.R
@@ -310,8 +310,14 @@ yaml=FALSE, autostart=NA, tmpdir=tempdir(), tz="UTC")
              # finally:
              methods::as(v, new_class))
       },
-      warning = fun <- function(e) {
-        warningf("Column '%s' was requested to be '%s' but fread encountered the following %s:\n\t%s\nso the column has been left as type '%s'", names(ans)[j], new_class, if (inherits(e, "error")) gettext("error") else gettext("warning"), e$message, typeof(v))
+      warning = fun <- function(c) {
+        # NB: branch here for translation purposes (e.g. if error/warning have different grammatical gender)
+        if (inherits(c, "warning")) {
+          msg_fmt <- gettext("Column '%s' was requested to be '%s' but fread encountered the following warning:\n\t%s\nso the column has been left as type '%s'")
+        } else {
+          msg_fmt <- gettext("Column '%s' was requested to be '%s' but fread encountered the following error:\n\t%s\nso the column has been left as type '%s'")
+        }
+        warningf(msg_fmt, names(ans)[j], new_class, conditionMessage(c), typeof(v), domain=NA)
         v
       },
       error = fun)

--- a/R/setops.R
+++ b/R/setops.R
@@ -157,9 +157,9 @@ all.equal.data.table = function(target, current, trim.levels=TRUE, check.attribu
     k1 = key(target)
     k2 = key(current)
     if (!identical(k1, k2)) {
-      return(gettextf(
-        "Datasets have different %s. 'target': %s. 'current': %s.",
-        "keys",
+      return(sprintf(
+        "%s. 'target': %s. 'current': %s.",
+        gettext("Datasets have different keys"),
         if(length(k1)) brackify(k1) else gettextf("has no key"),
         if(length(k2)) brackify(k2) else gettextf("has no key")
       ))
@@ -168,9 +168,9 @@ all.equal.data.table = function(target, current, trim.levels=TRUE, check.attribu
     i1 = indices(target)
     i2 = indices(current)
     if (!identical(i1, i2)) {
-      return(gettextf(
-        "Datasets have different %s. 'target': %s. 'current': %s.",
-        "indices",
+      return(sprintf(
+        "%s. 'target': %s. 'current': %s.",
+        gettext("Datasets have different indices"),
         if(length(i1)) brackify(i1) else gettextf("has no index"),
         if(length(i2)) brackify(i2) else gettextf("has no index")
       ))


### PR DESCRIPTION
Towards #6532; partner: #6534

 - While we _could_ use "condition of class %s" in `fread()`, I think that's less user-friendly. I suspect many (most) users will not be comfortable with that terminology, it's a relatively advanced topic in R and `fread()` might be the first function someone ever uses when learning R.
 - I was a bit indifferent between the approach taken here for `all.equal.data.table()` (change to `sprintf()` and `gettext()` a full sentence) vs. just `gettext("indices")`; I chose the former since sentences are typically easier to translate as a whole. (FFR: a @aitap pointed out, this is also better for translators of gendered languages, where individual words with different genders might affect translation of nearby words)