### PR TITLE
Bumped performance-tests GHA to v1.3.1

### DIFF
--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -22,4 +22,4 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       repo_token: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: Anirban166/Autocomment-atime-results@v1.2.1
+      - uses: Anirban166/Autocomment-atime-results@v1.3.1


### PR DESCRIPTION
Changelog:
- Previously, the time taken to run `atime::atime_pkg` was reported, which consisted of two tasks - Installing the different (git) versions of `data.table`, and running/plotting the test cases. Both of these are now considered separately for a clear breakdown.
- The plot shown in the PR threads will be one generated for preview, meaning it is condensed to only show the top 4 tests (the number can be configured using the `N.tests.preview` variable in our [tests.R](https://github.com/Rdatatable/data.table/blob/master/.ci/atime/tests.R)) based on having the most significant differences between HEAD and min. The full version (all tests) will be shown when we click/tap on the plot. 
(Note: Currently, the width of the preview plot is based on the total number of test cases as opposed to the number considered for generating the image, but it has been fixed and we just need to wait for that updated version of `atime` to be on CRAN, as that issue should automatically be resolved - Needs no updating on the GHA end)
- The timings information have been organized in a table. (I like this in particular as it avoids the repeated 'Time taken to ... ' lines)
- Only the second count is shown if a task we are measuring falls under 60 seconds.

This stemmed from [#36](https://github.com/Anirban166/Autocomment-atime-results/issues/36) and [#37](https://github.com/Anirban166/Autocomment-atime-results/issues/37) - Thanks @tdhock!