### PR TITLE
Just gc() on ancient R where gc(full=TRUE) is not available

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -19226,7 +19226,8 @@ test(2286,
        x<2, structure(list(1), class = "foo"),
        x<3, structure(list(2), class = "foo"),
        # Force gc() and some allocations which have a good chance at landing in the region that was earlier left unprotected
-       { gc(full = TRUE); replicate(10, FALSE); x<4 },
+       # TODO(R>=3.5.0): no need to branch here for gc(full=TRUE)
+       { if ("full" %in% names(formals(gc))) gc(full = TRUE) else gc(); replicate(10, FALSE); x<4 },
        `attr<-`(list(3), "class", "foo")),
      structure(list(1, 2, 3), class = "foo"))
 


### PR DESCRIPTION
As seen on GLCI:

https://gitlab.com/Rdatatable/data.table/-/jobs/7943818855

Introduced in #6452 cc @aitap for viz