### PR TITLE
Remove trailing NULL in Authors@R in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -91,6 +91,5 @@ Authors@R: c(
   person("Doris", "Amoakohene",    role="ctb"),
   person("Ivan", "Krylov",         role="ctb"),
   person("Michael","Young",        role="ctb"),
-  person("Mark", "Seeto",          role="ctb"),
-  NULL
+  person("Mark", "Seeto",          role="ctb")
   )


### PR DESCRIPTION
This `NULL` is causing a `NOTE` in `R CMD check`. It's obfuscated by our CI because this check has a _known_ `NOTE`, namely that the check runner is not authored by the package maintainer, but this is a second report under the same 
`NOTE`:

```
* checking CRAN incoming feasibility ... [2s/17s] NOTE
Maintainer: ‘Tyson Barrett <t.barrett88@gmail.com>’
Authors@R field should be a call to person(), or combine such calls.
```

I wish R would just allow `NULL` entries but I'm not invested enough to kick up that dust for now:

https://github.com/r-devel/r-svn/blob/f844acd21e5fccbf4cf11dc74c74d4b98a7de6b5/src/library/tools/R/QC.R#L7818-L7837

(The trailing `NULL` is to shrink the git diff when adding new authors to eliminate the distracting "diff" consisting of a `,` on one line)