### PR TITLE
Run more GHA on pull requests targeting any branch

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -1,10 +1,7 @@
 on:
   push:
-    branches:
-     - master
+    branches: [master]
   pull_request:
-    branches:
-     - master
 
 name: code-quality
 

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -2,8 +2,6 @@ name: atime performance tests
 
 on:
   pull_request:
-    branches:
-      - '*'
     types:
       - opened
       - reopened

--- a/.github/workflows/rchk.yaml
+++ b/.github/workflows/rchk.yaml
@@ -17,8 +17,7 @@
 # under the License.
 on:
   push:
-    branches:
-      - master
+    branches: [master]
   pull_request:
 
 name: 'rchk'

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master]
 
 name: test-coverage.yaml
 


### PR DESCRIPTION
Seen in #6432; stacked PRs will still benefit from seeing coverage reports up-stack.

Get consistent with the rest of the GHA for `pull_request:` trigger while we're here. cc @Anirban166, I didn't check to be 100% sure `branches: '*'` is the same as just not filtering by branch, but I think it is. Note that #6432 _is_ running the atime tests.