### PR TITLE
print.data.table: check for knitr at sys.calls()-6

### DIFF
--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -34,6 +34,8 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
         ( length(SYS) >= 3L && is.symbol(thisSYS <- SYS[[length(SYS)-2L]][[1L]]) &&
           as.character(thisSYS) == 'source') || # suppress printing from source(echo = TRUE) calls, #2369
         ( length(SYS) > 3L && is.symbol(thisSYS <- SYS[[length(SYS)-3L]][[1L]]) &&
+          as.character(thisSYS) %chin% mimicsAutoPrint ) ||
+        ( length(SYS) > 6L && is.symbol(thisSYS <- SYS[[length(SYS)-6L]][[1L]]) &&
           as.character(thisSYS) %chin% mimicsAutoPrint ) )  {
       return(invisible(x))
       # is.symbol() temp fix for #1758.

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -34,7 +34,15 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
         ( length(SYS) >= 3L && is.symbol(thisSYS <- SYS[[length(SYS)-2L]][[1L]]) &&
           as.character(thisSYS) == 'source') || # suppress printing from source(echo = TRUE) calls, #2369
         ( length(SYS) > 3L && is.symbol(thisSYS <- SYS[[length(SYS)-3L]][[1L]]) &&
-          as.character(thisSYS) %chin% mimicsAutoPrint ) ||
+          as.character(thisSYS) %chin% mimicsAutoPrint ) || # suppress printing from knitr, #6509
+          # In previous versions of knitr, call stack when auto-printing looked like:
+          #  knit_print -> knit_print.default -> normal_print -> print -> print.data.table
+          # and we detected and avoided that by checking fourth last call in the stack.
+          # As of September 2024, the call stack can also look like:
+          #  knit_print.default -> normal_print -> render -> evalq -> evalq -> print -> print.data.table
+          # so we have to check the 7th last call in the stack too.
+          # Ideally, we would like to return invisibly from DT[, foo := bar] and have knitr respect that, but a flag in
+          # .Primitive("[") sets all values returned from [.data.table to visible, hence the need for printing hacks later.
         ( length(SYS) > 6L && is.symbol(thisSYS <- SYS[[length(SYS)-6L]][[1L]]) &&
           as.character(thisSYS) %chin% mimicsAutoPrint ) )  {
       return(invisible(x))


### PR DESCRIPTION
This is a band-aid for #6509. Previous check for `mimicsAutoPrint` (i.e. `knit_print.default`) at `sys.calls()[[length(sys.calls())-3L]]` [no longer works after a knitr upgrade](https://github.com/Rdatatable/data.table/issues/6509#issuecomment-2400148516). Currently, the call to the autoprint-like function resides at position -6.

**Edit**: unfortunately there doesn't seem to be a right way to solve this problem. Returning `invisible(anything)` from `[.data.table` sets it back to visible because `PRIMPRINT(.Primitive("["))` says so, and `knitr` respects visibility of the evaluation results.