### PR TITLE
tests: Detect session encoding incapable of U+00F1

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18768,7 +18768,7 @@ if (test_bit64) local({
 # non-ASCII plain symbol in by, #4708
 # NB: recall we can't use non-ASCII symbols in the test script. The text is a-<n-tilde>-o (year in Spanish)
 native_ano = iconv("a\U00F1o", "UTF-8", "")
-if (!is.na(native_ano)) { # #6339: symbol must be represented in native encoding
+if (identical(native_ano, "a\U00F1o")) { # #6339: symbol must be represented in native encoding
   DT = data.table(a = rep(1:3, 2))
   setnames(DT, "a", native_ano)
   test(2266, eval(parse(text=sprintf("DT[ , .N, %s]$N[1L]", native_ano))), 2L)


### PR DESCRIPTION
`iconv()` does not necessarily fail to convert `U+00F1` to ASCII and return `NA`. For example, FreeBSD `iconv()` succeeds and returns `?` instead of the character in question. Use `identical()` to compare the result of the conversion back to the original (which internally converts both to UTF-8).

Closes: #6339

Should with the part of #6559 that's about encodings, but not OpenMP