### PR TITLE
Skip test 1623 if '~' not defined

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -8912,7 +8912,7 @@ ans2[ , (date_cols) := lapply(.SD, as.IDate), .SDcols = date_cols]
 test(1622.1, ans1, ans2)
 test(1622.2, ans1, fread(testDir("issue_1573_fill.txt"), fill=TRUE, sep=" ", na.strings=""))
 
-# fix for #989
+# fix for #989; possibly skip for #6576
 if (dir.exists("~")) test(1623, fread("~"), error="File '~' is a directory")
 
 # testing print.rownames option, #1097 (part of #1523)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -8913,7 +8913,7 @@ test(1622.1, ans1, ans2)
 test(1622.2, ans1, fread(testDir("issue_1573_fill.txt"), fill=TRUE, sep=" ", na.strings=""))
 
 # fix for #989
-test(1623, fread("~"), error="File '~' is a directory")
+if (dir.exists("~")) test(1623, fread("~"), error="File '~' is a directory")
 
 # testing print.rownames option, #1097 (part of #1523)
 options(datatable.print.rownames = FALSE)


### PR DESCRIPTION
Fixes #6576

This skips the test if "~" is undefined on the system. However, a better solution might be to test a directory that is guaranteed to exist, e.g., `tempdir()`.