### PR TITLE
Solve the `knitr` auto-printing problem by registering a method for `knit_print`

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -104,6 +104,8 @@ if (getRversion() >= "4.0.0") {
   # version of R (and that is checked in .onLoad with error if not).
   export(.rbind.data.table) # only export in R<4.0.0 where it is still used; R-devel now detects it is missing doc, #5600
 }
+if (getRversion() >= "3.6.0") S3method(knitr::knit_print, data.table)
+# else manual delayed registration from the onLoad hook
 S3method(dim, data.table)
 S3method(dimnames, data.table)
 S3method("dimnames<-", data.table)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -104,8 +104,7 @@ if (getRversion() >= "4.0.0") {
   # version of R (and that is checked in .onLoad with error if not).
   export(.rbind.data.table) # only export in R<4.0.0 where it is still used; R-devel now detects it is missing doc, #5600
 }
-if (getRversion() >= "3.6.0") S3method(knitr::knit_print, data.table)
-# else manual delayed registration from the onLoad hook
+if (getRversion() >= "3.6.0") S3method(knitr::knit_print, data.table) # else manual delayed registration from the onLoad hook
 S3method(dim, data.table)
 S3method(dimnames, data.table)
 S3method("dimnames<-", data.table)

--- a/NEWS.md
+++ b/NEWS.md
@@ -113,6 +113,8 @@ rowwiseDT(
 
 13. `rbindlist(l, use.names=TRUE)` can now handle different encodings for the column names in different entries of `l`, [#5452](https://github.com/Rdatatable/data.table/issues/5452). Thanks to @MEO265 for the report, and Benjamin Schwendinger for the fix.
 
+14. The auto-printing suppression in `knitr` documents is now done by implementing a method for `knit_print` instead of looking up the call stack, [#6589](https://github.com/Rdatatable/data.table/pull/6589). Thanks to @jangorecki for the report [#6509](https://github.com/Rdatatable/data.table/issues/6509) and @aitap for the fix.
+
 ## NOTES
 
 1. Tests run again when some Suggests packages are missing, [#6411](https://github.com/Rdatatable/data.table/issues/6411). Thanks @aadler for the note and @MichaelChirico for the fix.

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -66,7 +66,7 @@
       lockBinding("rbind.data.frame",baseenv())
     }
   }
-  if (session_r_version < "3.6.0") {
+  if (session_r_version < "3.6.0") { # corresponds to S3method() directive in NAMESPACE
     # no delayed registration support for NAMESPACE; perform it manually
     if (isNamespaceLoaded("knitr")) {
       registerS3method("knit_print", "data.table", knit_print.data.table, envir = asNamespace("knitr"))

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -69,10 +69,10 @@
   if (session_r_version < "3.6.0") {
     # no delayed registration support for NAMESPACE; perform it manually
     if (isNamespaceLoaded("knitr")) {
-        registerS3method("knit_print", "data.table", knit_print.data.table, envir = asNamespace("knitr"))
+      registerS3method("knit_print", "data.table", knit_print.data.table, envir = asNamespace("knitr"))
     }
     setHook(packageEvent("knitr", "onLoad"), function(...) {
-        registerS3method("knit_print", "data.table", knit_print.data.table, envir = asNamespace("knitr"))
+      registerS3method("knit_print", "data.table", knit_print.data.table, envir = asNamespace("knitr"))
     })
   }
 

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -70,11 +70,10 @@
     # no delayed registration support for NAMESPACE; perform it manually
     if (isNamespaceLoaded("knitr")) {
       registerS3method("knit_print", "data.table", knit_print.data.table, envir = asNamespace("knitr"))
-    } else {
-      setHook(packageEvent("knitr", "onLoad"), function(...) {
-        registerS3method("knit_print", "data.table", knit_print.data.table, envir = asNamespace("knitr"))
-      })
     }
+    setHook(packageEvent("knitr", "onLoad"), function(...) {
+      registerS3method("knit_print", "data.table", knit_print.data.table, envir = asNamespace("knitr"))
+    })
   }
 
   # Set options for the speed boost in v1.8.0 by avoiding 'default' arg of getOption(,default=)

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -66,6 +66,15 @@
       lockBinding("rbind.data.frame",baseenv())
     }
   }
+  if (session_r_version < "3.6.0") {
+    # no delayed registration support for NAMESPACE; perform it manually
+    if (isNamespaceLoaded("knitr")) {
+        registerS3method("knit_print", "data.table", knit_print.data.table, envir = asNamespace("knitr"))
+    }
+    setHook(packageEvent("knitr", "onLoad"), function(...) {
+        registerS3method("knit_print", "data.table", knit_print.data.table, envir = asNamespace("knitr"))
+    })
+  }
 
   # Set options for the speed boost in v1.8.0 by avoiding 'default' arg of getOption(,default=)
   # In fread and fwrite we have moved back to using getOption's default argument since it is unlikely fread and fread will be called in a loop many times, plus they

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -70,10 +70,11 @@
     # no delayed registration support for NAMESPACE; perform it manually
     if (isNamespaceLoaded("knitr")) {
       registerS3method("knit_print", "data.table", knit_print.data.table, envir = asNamespace("knitr"))
+    } else {
+      setHook(packageEvent("knitr", "onLoad"), function(...) {
+        registerS3method("knit_print", "data.table", knit_print.data.table, envir = asNamespace("knitr"))
+      })
     }
-    setHook(packageEvent("knitr", "onLoad"), function(...) {
-      registerS3method("knit_print", "data.table", knit_print.data.table, envir = asNamespace("knitr"))
-    })
   }
 
   # Set options for the speed boost in v1.8.0 by avoiding 'default' arg of getOption(,default=)

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -30,7 +30,9 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
     # Other options investigated (could revisit): Cstack_info(), .Last.value gets set first before autoprint, history(), sys.status(),
     #   topenv(), inspecting next statement in caller, using clock() at C level to timeout suppression after some number of cycles
     SYS = sys.calls()
-    if (length(SYS) <= 2L) { # "> DT" auto-print or "> print(DT)" explicit print (cannot distinguish from R 3.2.0 but that's ok)
+    if (length(SYS) <= 2L ||  # "> DT" auto-print or "> print(DT)" explicit print (cannot distinguish from R 3.2.0 but that's ok)
+        ( length(SYS) >= 3L && is.symbol(thisSYS <- SYS[[length(SYS)-2L]][[1L]]) &&
+          as.character(thisSYS) == 'source') ) { # suppress printing from source(echo = TRUE) calls, #2369
       return(invisible(x))
     }
   }

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -30,13 +30,8 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
     # Other options investigated (could revisit): Cstack_info(), .Last.value gets set first before autoprint, history(), sys.status(),
     #   topenv(), inspecting next statement in caller, using clock() at C level to timeout suppression after some number of cycles
     SYS = sys.calls()
-    if (length(SYS) <= 2L ||  # "> DT" auto-print or "> print(DT)" explicit print (cannot distinguish from R 3.2.0 but that's ok)
-        ( length(SYS) >= 3L && is.symbol(thisSYS <- SYS[[length(SYS)-2L]][[1L]]) &&
-          as.character(thisSYS) == 'source') || # suppress printing from source(echo = TRUE) calls, #2369
-        ( length(SYS) > 3L && is.symbol(thisSYS <- SYS[[length(SYS)-3L]][[1L]]) &&
-          as.character(thisSYS) %chin% mimicsAutoPrint ) )  {
+    if (length(SYS) <= 2L) { # "> DT" auto-print or "> print(DT)" explicit print (cannot distinguish from R 3.2.0 but that's ok)
       return(invisible(x))
-      # is.symbol() temp fix for #1758.
     }
   }
   if (!is.numeric(nrows)) nrows = 100L
@@ -157,9 +152,6 @@ format.data.table = function(x, ..., justify="none") {
   }
   do.call(cbind, lapply(x, format_col, ..., justify=justify))
 }
-
-mimicsAutoPrint = c("knit_print.default")
-# add maybe repr_text.default.  See https://github.com/Rdatatable/data.table/issues/933#issuecomment-220237965
 
 shouldPrint = function(x) {
   ret = (identical(.global$print, "") ||   # to save address() calls and adding lots of address strings to R's global cache
@@ -287,4 +279,10 @@ trunc_cols_message = function(not_printed, abbs, class, col.names){
     n, brackify(paste0(not_printed, classes)),
     domain=NA
   )
+}
+
+# Maybe add a method for repr::repr_text.  See https://github.com/Rdatatable/data.table/issues/933#issuecomment-220237965
+knit_print.data.table <- function(x, ...) {
+  if (!shouldPrint(x)) return(invisible(x))
+  NextMethod()
 }

--- a/tests/autoprint.R
+++ b/tests/autoprint.R
@@ -43,3 +43,15 @@ DT[1,a:=10L][]                        # yes. ...[] == oops, forgot print(...)
 tryCatch(DT[,foo:=ColumnNameTypo], error=function(e) e$message)         # error: not found.
 DT                                    # yes
 DT                                    # yes
+
+# Regression test for auto-printing suppression in source(), #2369
+local({
+  f = tempfile(fileext = ".R")
+  on.exit(unlink(f))
+  writeLines(c(
+    "library(data.table)",
+    "DT = data.table(a = 1)",
+    "DT[,a:=1] # not auto-printed"
+  ), f)
+  source(f, local = TRUE, echo = TRUE)
+})

--- a/tests/autoprint.Rout.save
+++ b/tests/autoprint.Rout.save
@@ -136,6 +136,24 @@ NULL
 1:    10
 2:    10
 > 
+> # Regression test for auto-printing suppression in source(), #2369
+> local({
++   f = tempfile(fileext = ".R")
++   on.exit(unlink(f))
++   writeLines(c(
++     "library(data.table)",
++     "DT = data.table(a = 1)",
++     "DT[,a:=1] # not auto-printed"
++   ), f)
++   source(f, local = TRUE, echo = TRUE)
++ })
+
+> library(data.table)
+
+> DT = data.table(a = 1)
+
+> DT[, `:=`(a, 1)]
+> 
 > proc.time()
    user  system elapsed 
   0.223   0.016   0.231 


### PR DESCRIPTION
It turns out that there is a better solution for #6566 after all. It's documented in [`vignette('knit_print')`](https://cran.r-project.org/web/packages/knitr/vignettes/knit_print.html#for-package-authors) that packages can override `knitr`'s (auto-)printing behaviour by registering a method for it. R ≥ 3.6 can perform "delayed registration" of S3 methods for a generic in a package without requiring it to be loaded, hence keeping `knitr` in `Suggests:`. In R &in; [3.3, 3.6), the same thing can be done manually: I've reused a piece of code from `base::registerS3methods` to register `knit_print.data.table` if the package is already loaded and set a hook to register it later if needed.

The method itself just checks `shouldPrint(x)` and returns `invisible(x)` if not, otherwise delegates to the default method.

This can close #6566 if we don't want to change the behaviour of `.Primitive("[")` with regards to visibility.