### PR TITLE
`.checkTypos`: Avoid giving arbitrary strings to `gettextf`

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -123,7 +123,7 @@ replace_dot_alias = function(e) {
       stopf("Object '%s' not found amongst %s", used, brackify(ref))
     }
   } else {
-    stopf(err$message)
+    stopf("%s", err$message)
   }
 }
 

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -123,7 +123,7 @@ replace_dot_alias = function(e) {
       stopf("Object '%s' not found amongst %s", used, brackify(ref))
     }
   } else {
-    stopf("%s", err$message)
+    stopf("%s", err$message, domain=NA)
   }
 }
 

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -123,6 +123,7 @@ replace_dot_alias = function(e) {
       stopf("Object '%s' not found amongst %s", used, brackify(ref))
     }
   } else {
+    # Don't use stopf() directly, since err$message might have '%', #6588
     stopf("%s", err$message, domain=NA)
   }
 }

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -20591,3 +20591,6 @@ setDT(d2)
 test(2295.1, !is.data.table(d1))
 test(2295.2, rownames(d1), 'b')
 test(2295.3, is.data.table(d2))
+
+# #6588: .checkTypos used to give arbitrary strings to stopf as the first argument
+test(2296, d2[x %no such operator% 1], error = '%no such operator%')


### PR DESCRIPTION
As reported in #6588, `err$message` is already translated at this point and may contain `%`. Avoid trying to printf-expand it once again.

Fixes: #6588