### PR TITLE
Bumped performance-tests GHA to v1.4.1

### DIFF
--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -20,4 +20,4 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       repo_token: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: Anirban166/Autocomment-atime-results@v1.3.1
+      - uses: Anirban166/Autocomment-atime-results@v1.4.1


### PR DESCRIPTION
This [release](https://github.com/Anirban166/Autocomment-atime-results/releases/tag/v1.4.1) resolves the current (newfound) issue with `git2r` being unable to find the required `libgit2` installation/version (for more information: [#39](https://github.com/Anirban166/Autocomment-atime-results/issues/39))