### PR TITLE
add support for a list of selection expressions in .SDcols

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -98,5 +98,6 @@ Authors@R: c(
   person("Christian", "Wia",       role="ctb"),
   person("Elise", "Maigné",        role="ctb"),
   person("Vincent", "Rocher",      role="ctb"),
-  person("Vijay", "Lulla",         role="ctb")
+  person("Vijay", "Lulla",         role="ctb"),
+  person("Bill", "Evans",          role="ctb")
   )

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -20596,3 +20596,12 @@ test(2295.3, is.data.table(d2))
 
 # #6588: .checkTypos used to give arbitrary strings to stopf as the first argument
 test(2296, d2[x %no such operator% 1], error = '%no such operator%')
+
+# #6619: .SDcols supports list of expressions
+DT = data.table(int1=1L, int2=2L, chr1="A", chr2="B", num1=1, num2=2, lgl=TRUE)
+test(2297.1, DT[, .SD, .SDcols = .(is.logical, !is.numeric)], DT[, .(lgl, chr1, chr2)])
+test(2297.2, DT[, .SD, .SDcols = .(patterns("r2"), c(1L, 1L, 2L, 3L))], DT[, .(chr2, int1, int1, int2, chr1)])
+test(2297.3, DT[, .SD, .SDcols = .("lgl", is.numeric)], DT[, .(lgl, int1, int2, num1, num2)])
+# difference between `--` and `!`
+test(2297.4, DT[, .SD, .SDcols = .(patterns("1$"), --is.integer)], DT[, .(chr1, num1)])
+test(2297.5, DT[, .SD, .SDcols = .(patterns("1$"), !is.integer)], DT[, .(int1, chr1, num1, chr2 ,num2, lgl)])

--- a/man/data.table.Rd
+++ b/man/data.table.Rd
@@ -152,7 +152,17 @@ data.table(\dots, keep.rownames=FALSE, check.names=FALSE, key=NULL, stringsAsFac
 
     Inversion (column dropping instead of keeping) can be accomplished be prepending the argument with \code{!} or \code{-} (there's no difference between these), e.g. \code{.SDcols = !c('x', 'y')}.
 
-    Finally, you can filter columns to include in \code{.SD} based on their \emph{names} according to regular expressions via \code{.SDcols=patterns(regex1, regex2, ...)}. The included columns will be the \emph{intersection} of the columns identified by each pattern; pattern unions can easily be specified with \code{|} in a regex. You can filter columns on \code{values} by passing a function, e.g. \code{.SDcols=\link{is.numeric}}. You can also invert a pattern as usual with \code{.SDcols=!patterns(...)} or \code{.SDcols=!is.numeric}.
+    You can filter columns to include in \code{.SD} based on their \emph{names} according to regular expressions via \code{.SDcols=patterns(regex1, regex2, ...)}. The included columns will be the \emph{intersection} of the columns identified by each pattern; pattern unions can easily be specified with \code{|} in a regex. You can filter columns on \code{values} by passing a function, e.g. \code{.SDcols=\link{is.numeric}}. You can also invert a pattern as usual with \code{.SDcols=!patterns(...)} or \code{.SDcols=!is.numeric}.
+
+    Finally, you can combine any of the other column-selection methods in a list of different column-selection methods. Considerations:
+
+      \itemize{
+          \item The selection of columns is \emph{additive}, meaning that \code{.SDcols=.(is.numeric, 'x')} will include all columns that are numeric and the column named 'x' (whether or not it contains numeric data).
+          \item Selection-inversion (selecting columns that do not meet a condition) works the same using the traditional \code{!} or \code{-}.
+          \item Deduplication. Columns in one element that were selected in previous elements will not be added again. For example, if column \code{x} is a numeric column, then \code{.SDcols=.(is.numeric, 'x')} will return only one instance of the \code{x} column. One can still explicitly choose duplicate columns within each selection, such as \code{.SDcols=.(is.numeric, c(1,1,2,3))}.
+          \item Removing columns that were selected in previous elements in the list is done with a double-minus, as in \code{--cols}. This supports any of the accepted column-selection methods (integers, strings, function calls, etc). For example, \code{.SDcols=.(is.numeric, --'x'} will select all numeric columns except one whose column name is 'x'. Because this only removes columns that were previously selected, a \code{--cols} removal as the first element of \code{.SDcols} has no effect.
+     }
+
 }
   \item{verbose}{ \code{TRUE} turns on status and information messages to the console. Turn this on by default using \code{options(datatable.verbose=TRUE)}. The quantity and types of verbosity may be expanded in future.
 


### PR DESCRIPTION
Closes https://github.com/Rdatatable/data.table/issues/6619.

This adds the ability to select columns with more than one type of expression.

BLUF:

```r
DT = data.table(int1=1L, int2=2L, chr1="A", chr2="B", num1=1, num2=2, lgl=TRUE)
DT[, .SD, .SDcols=.(is.numeric, patterns("2$"), "lgl")]
#     int1  int2  num1  num2   chr2    lgl
#    <int> <int> <num> <num> <char> <lgcl>
# 1:     1     2     1     2      B   TRUE
```

### Justification

Traditional column-selection allows selection by:

- column names
- integers (column index)
- `patterns(..)`
- function call, e.g., `is.numeric`

In order to combine two or more of these in traditional methods, we would need to first run the functions or patterns individually and then either `cbind` them all or do similar efforts to collect column names and pass those into a single `.SDcols=cols` argument. 

If we want to select all numeric columns, those ending in "2", and the "lgl" column, then we would need to do one of these methods:

```r
cbind(DT[, .SD, .SDcols=is.numeric], DT[, .SD, .SDcols=patterns("2$")], DT[, .SD, .SDcols="lgl"])
#     int1  int2  num1  num2  int2   chr2  num2    lgl
#    <int> <int> <num> <num> <int> <char> <num> <lgcl>
# 1:     1     2     1     2     2      B     2   TRUE
```

This naive approach results in duplicate selections in `int2` and `num2`.

Another approach might be:

```r
cols <- unique(c(names(which(sapply(DT, is.numeric))), grep("2$", names(DT), value=TRUE), "lgl"))
DT[, .SD, .SDcols=cols]
#     int1  int2  num1  num2   chr2    lgl
#    <int> <int> <num> <num> <char> <lgcl>
# 1:     1     2     1     2      B   TRUE
```

While the latter is not egregious, my patch enables an inline all-at-once selection that seems intuitive
