### PR TITLE
Make sure data.table is linked (not just compiled) with `-fopenmp` in this particular branch of `configure` for Darwin

### DIFF
--- a/configure
+++ b/configure
@@ -122,6 +122,7 @@ detect_openmp () {
     if CPPFLAGS="${CPPFLAGS} -fopenmp" "${R_HOME}/bin/R" CMD SHLIB test-omp.c >> config.log 2>&1; then
       echo "yes"
       export PKG_CFLAGS="${PKG_CFLAGS} -fopenmp"
+      export PKG_LIBS="${PKG_LIBS} -fopenmp"
       export R_OPENMP_ENABLED=1
       return
     else


### PR DESCRIPTION
At least, that's what I think this does? See #6622, which this partially fixes. Empirically this change allows me to install data.table from source with multithreading working properly into my R4.2 library on my MacBook. (Doesn't work for R4.4 but there's a precompiled binary for that version so I don't care enough to keep futzing with it.)

Holding off on writing a NEWS entry since as mentioned I'm not entirely sure what this change actually does.