### PR TITLE
configure: test linking with -fopenmp, test the resulting shared object

### DIFF
--- a/configure
+++ b/configure
@@ -94,7 +94,7 @@ detect_openmp () {
   check_openmp_flags "R installation is configured to use OpenMP" '$(SHLIB_OPENMP_CFLAGS)' '$(SHLIB_OPENMP_CFLAGS)' && return
 
   # https://github.com/Rdatatable/data.table/issues/6409
-  check_openmp_flags "R installation supports openmp with \"-fopenmp\" flag" -fopenmp -fopenmp && return
+  check_openmp_flags "R installation supports OpenMP with \"-fopenmp\" flag" -fopenmp -fopenmp && return
 
   if [ "$(uname)" = "Darwin" ]; then
 

--- a/configure
+++ b/configure
@@ -75,57 +75,42 @@ fi
 # necessarily here in configure). Hence use -fopenmp directly for this detection step.
 # printf not echo to pass checkbashisms w.r.t. to the \n
 
-cat <<EOF > test-omp.c
-#include <omp.h>
-int main() {
-  return omp_get_num_threads();
+check_openmp_flags () {
+  "${R_HOME}/bin/Rscript" tools/check-openmp-flags.R "$1" "$2"
 }
-EOF
 
 detect_openmp () {
+  printf "%s" "* checking if R installation is configured to use OpenMP... "
+  if check_openmp_flags '$(SHLIB_OPENMP_CFLAGS)' '$(SHLIB_OPENMP_CFLAGS)' >> config.log 2>&1; then
+    echo "yes"
+    export R_OPENMP_CFLAGS='$(SHLIB_OPENMP_CFLAGS)'
+    export R_OPENMP_LIBS='$(SHLIB_OPENMP_CFLAGS)'
+    export R_OPENMP_ENABLED=1
+    return
+  else
+    echo "no"
+  fi
 
-  if [ "$(uname)" = "Linux" ]; then
-
-    printf "%s" "* checking if R installation supports OpenMP without any extra hints... "
-    if "${R_HOME}/bin/R" CMD SHLIB test-omp.c >> config.log 2>&1; then
-      echo "yes"
-      export R_OPENMP_ENABLED=1
-      return
-    else
-      echo "no"
-    fi
-
-
-    printf "%s" "* checking if R installation supports openmp with \"-fopenmp\" flag... "
-    if ${CC} ${CFLAGS} -fopenmp test-omp.c >> config.log 2>&1; then
-      echo "yes"
-      export PKG_CFLAGS="${PKG_CFLAGS} -fopenmp"
-      export R_OPENMP_ENABLED=1
-      return
-    else
-      echo "no"
-    fi
-  fi # uname=Linux
+  # https://github.com/Rdatatable/data.table/issues/6409
+  printf "%s" "* checking if R installation supports openmp with \"-fopenmp\" flag... "
+  if check_openmp_flags -fopenmp -fopenmp >> config.log 2>&1; then
+    echo "yes"
+    export R_OPENMP_CFLAGS="-fopenmp"
+    export R_OPENMP_LIBS="-fopenmp"
+    export R_OPENMP_ENABLED=1
+    return
+  else
+    echo "no"
+  fi
 
   if [ "$(uname)" = "Darwin" ]; then
 
     # https://mac.r-project.org/openmp
     printf "%s" "* checking if R installation supports OpenMP with \"-Xclang -fopenmp\" ... "
-    if CPPFLAGS="${CPPFLAGS} -Xclang -fopenmp" PKG_LIBS="-lomp" "${R_HOME}/bin/R" CMD SHLIB test-omp.c >> config.log 2>&1; then
+    if check_openmp_flags "-Xclang -fopenmp" -lomp >> config.log 2>&1; then
       echo "yes"
-      export PKG_CFLAGS="${PKG_CFLAGS} -Xclang -fopenmp"
-      export PKG_LIBS="${PKG_LIBS} -lomp"
-      export R_OPENMP_ENABLED=1
-      return
-    else
-      echo "no"
-    fi
-
-    # https://github.com/Rdatatable/data.table/issues/6409
-    printf "%s" "* checking if R installation supports OpenMP with \"-fopenmp\" ... "
-    if CPPFLAGS="${CPPFLAGS} -fopenmp" "${R_HOME}/bin/R" CMD SHLIB test-omp.c >> config.log 2>&1; then
-      echo "yes"
-      export PKG_CFLAGS="${PKG_CFLAGS} -fopenmp"
+      export R_OPENMP_CFLAGS="-Xclang -fopenmp"
+      export R_OPENMP_LIBS="-lomp"
       export R_OPENMP_ENABLED=1
       return
     else
@@ -142,10 +127,10 @@ detect_openmp () {
       printf "%s" "* checking if libomp installation at ${HOMEBREW_PREFIX}/opt/libomp can be used... "
       LIBOMP_INCLUDE="-I${HOMEBREW_PREFIX}/opt/libomp/include -Xclang -fopenmp"
       LIBOMP_LINK="-L${HOMEBREW_PREFIX}/opt/libomp/lib -lomp"
-      if ${CC} ${CFLAGS} ${LIBOMP_INCLUDE} ${LIBOMP_LINK} test-omp.c >> config.log 2>&1; then
+      if check_openmp_flags "${LIBOMP_INCLUDE}" "${LIBOMP_LINK}" >> config.log 2>&1; then
         echo "yes"
-        export PKG_CFLAGS="${PKG_CFLAGS} ${LIBOMP_INCLUDE}"
-        export PKG_LIBS="${PKG_LIBS} ${LIBOMP_LINK}"
+        export R_OPENMP_CFLAGS="${LIBOMP_INCLUDE}"
+        export R_OPENMP_LIBS="${LIBOMP_LINK}"
         export R_OPENMP_ENABLED=1
         return
       else
@@ -160,8 +145,6 @@ detect_openmp () {
 }
 
 detect_openmp
-# Clean up.
-rm -f test-omp.* a.out
 
 if [ "${R_OPENMP_ENABLED}" = "0" ]; then
   echo "***"
@@ -171,9 +154,9 @@ if [ "${R_OPENMP_ENABLED}" = "0" ]; then
   echo "***   https://github.com/Rdatatable/data.table/wiki/Installation"
   echo "*** Continuing installation without OpenMP support..."
   echo "***"
-  sed -e "s|@openmp_cflags@||" src/Makevars.in > src/Makevars
+  sed -e "s|@openmp_cflags@||" -e "s|@openmp_ldflags@||" src/Makevars.in > src/Makevars
 else
-  sed -e "s|@openmp_cflags@|\$(SHLIB_OPENMP_CFLAGS)|" src/Makevars.in > src/Makevars
+  sed -e "s|@openmp_cflags@|${R_OPENMP_CFLAGS}|" -e "s|@openmp_ldflags@|${R_OPENMP_LIBS}|" src/Makevars.in > src/Makevars
 fi
 
 # retain user supplied PKG_ env variables, #4664. See comments in Makevars.in too.

--- a/configure
+++ b/configure
@@ -75,47 +75,31 @@ fi
 # necessarily here in configure). Hence use -fopenmp directly for this detection step.
 # printf not echo to pass checkbashisms w.r.t. to the \n
 
+# Usage: "user-facing string" "CFLAGS" "LDFLAGS"
 check_openmp_flags () {
-  "${R_HOME}/bin/Rscript" tools/check-openmp-flags.R "$1" "$2"
+  printf "* checking if %s... " "$1"
+  if "${R_HOME}/bin/Rscript" tools/check-openmp-flags.R "${PKG_CFLAGS} $2" "${PKG_LIBS} $3" >> config.log 2>&1; then
+    echo "yes"
+    export R_OPENMP_CFLAGS="$2"
+    export R_OPENMP_LIBS="$3"
+    export R_OPENMP_ENABLED=1
+    return 0
+  else
+    echo "no"
+    return 1
+  fi
 }
 
 detect_openmp () {
-  printf "%s" "* checking if R installation is configured to use OpenMP... "
-  if check_openmp_flags '$(SHLIB_OPENMP_CFLAGS)' '$(SHLIB_OPENMP_CFLAGS)' >> config.log 2>&1; then
-    echo "yes"
-    export R_OPENMP_CFLAGS='$(SHLIB_OPENMP_CFLAGS)'
-    export R_OPENMP_LIBS='$(SHLIB_OPENMP_CFLAGS)'
-    export R_OPENMP_ENABLED=1
-    return
-  else
-    echo "no"
-  fi
+  check_openmp_flags "R installation is configured to use OpenMP" '$(SHLIB_OPENMP_CFLAGS)' '$(SHLIB_OPENMP_CFLAGS)' && return
 
   # https://github.com/Rdatatable/data.table/issues/6409
-  printf "%s" "* checking if R installation supports openmp with \"-fopenmp\" flag... "
-  if check_openmp_flags -fopenmp -fopenmp >> config.log 2>&1; then
-    echo "yes"
-    export R_OPENMP_CFLAGS="-fopenmp"
-    export R_OPENMP_LIBS="-fopenmp"
-    export R_OPENMP_ENABLED=1
-    return
-  else
-    echo "no"
-  fi
+  check_openmp_flags "R installation supports openmp with \"-fopenmp\" flag" -fopenmp -fopenmp && return
 
   if [ "$(uname)" = "Darwin" ]; then
 
     # https://mac.r-project.org/openmp
-    printf "%s" "* checking if R installation supports OpenMP with \"-Xclang -fopenmp\" ... "
-    if check_openmp_flags "-Xclang -fopenmp" -lomp >> config.log 2>&1; then
-      echo "yes"
-      export R_OPENMP_CFLAGS="-Xclang -fopenmp"
-      export R_OPENMP_LIBS="-lomp"
-      export R_OPENMP_ENABLED=1
-      return
-    else
-      echo "no"
-    fi
+    check_openmp_flags "R installation supports OpenMP with \"-Xclang -fopenmp\" " "-Xclang -fopenmp" "-lomp" && return
 
     if [ "$(uname -m)" = "arm64" ]; then
       HOMEBREW_PREFIX=/opt/homebrew
@@ -124,18 +108,9 @@ detect_openmp () {
     fi
 
     if [ -e "${HOMEBREW_PREFIX}/opt/libomp" ]; then
-      printf "%s" "* checking if libomp installation at ${HOMEBREW_PREFIX}/opt/libomp can be used... "
       LIBOMP_INCLUDE="-I${HOMEBREW_PREFIX}/opt/libomp/include -Xclang -fopenmp"
       LIBOMP_LINK="-L${HOMEBREW_PREFIX}/opt/libomp/lib -lomp"
-      if check_openmp_flags "${LIBOMP_INCLUDE}" "${LIBOMP_LINK}" >> config.log 2>&1; then
-        echo "yes"
-        export R_OPENMP_CFLAGS="${LIBOMP_INCLUDE}"
-        export R_OPENMP_LIBS="${LIBOMP_LINK}"
-        export R_OPENMP_ENABLED=1
-        return
-      else
-        echo "no"
-      fi
+      check_openmp_flags "libomp installation at ${HOMEBREW_PREFIX}/opt/libomp can be used" "${LIBOMP_INCLUDE}" "${LIBOMP_LINK}" && return
     fi
 
   fi # uname=Darwin
@@ -154,9 +129,9 @@ if [ "${R_OPENMP_ENABLED}" = "0" ]; then
   echo "***   https://github.com/Rdatatable/data.table/wiki/Installation"
   echo "*** Continuing installation without OpenMP support..."
   echo "***"
-  sed -e "s|@openmp_cflags@||" -e "s|@openmp_ldflags@||" src/Makevars.in > src/Makevars
+  sed -e "s|@openmp_cflags@||" -e "s|@openmp_libs@||" src/Makevars.in > src/Makevars
 else
-  sed -e "s|@openmp_cflags@|${R_OPENMP_CFLAGS}|" -e "s|@openmp_ldflags@|${R_OPENMP_LIBS}|" src/Makevars.in > src/Makevars
+  sed -e "s|@openmp_cflags@|${R_OPENMP_CFLAGS}|" -e "s|@openmp_libs@|${R_OPENMP_LIBS}|" src/Makevars.in > src/Makevars
 fi
 
 # retain user supplied PKG_ env variables, #4664. See comments in Makevars.in too.

--- a/configure
+++ b/configure
@@ -91,6 +91,9 @@ check_openmp_flags () {
 }
 
 detect_openmp () {
+  R_OPENMP_CFLAGS=
+  R_OPENMP_LIBS=
+
   check_openmp_flags "R installation is configured to use OpenMP" '$(SHLIB_OPENMP_CFLAGS)' '$(SHLIB_OPENMP_CFLAGS)' && return
 
   # https://github.com/Rdatatable/data.table/issues/6409
@@ -129,10 +132,8 @@ if [ "${R_OPENMP_ENABLED}" = "0" ]; then
   echo "***   https://github.com/Rdatatable/data.table/wiki/Installation"
   echo "*** Continuing installation without OpenMP support..."
   echo "***"
-  sed -e "s|@openmp_cflags@||" -e "s|@openmp_libs@||" src/Makevars.in > src/Makevars
-else
-  sed -e "s|@openmp_cflags@|${R_OPENMP_CFLAGS}|" -e "s|@openmp_libs@|${R_OPENMP_LIBS}|" src/Makevars.in > src/Makevars
 fi
+sed -e "s|@openmp_cflags@|${R_OPENMP_CFLAGS}|" -e "s|@openmp_libs@|${R_OPENMP_LIBS}|" src/Makevars.in > src/Makevars
 
 # retain user supplied PKG_ env variables, #4664. See comments in Makevars.in too.
 sed -e "s|@PKG_CFLAGS@|$PKG_CFLAGS|" src/Makevars > src/Makevars.tmp && mv src/Makevars.tmp src/Makevars

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -1,5 +1,5 @@
 PKG_CFLAGS = @PKG_CFLAGS@ @openmp_cflags@ @zlib_cflags@
-PKG_LIBS = @PKG_LIBS@ @openmp_ldflags@ @zlib_libs@
+PKG_LIBS = @PKG_LIBS@ @openmp_libs@ @zlib_libs@
 # See WRE $1.2.1.1. But retain user supplied PKG_* too, #4664.
 # WRE states ($1.6) that += isn't portable and that we aren't allowed to use it.
 # Otherwise we could use the much simpler PKG_LIBS += @openmp_cflags@ -lz.

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -1,5 +1,5 @@
 PKG_CFLAGS = @PKG_CFLAGS@ @openmp_cflags@ @zlib_cflags@
-PKG_LIBS = @PKG_LIBS@ @openmp_cflags@ @zlib_libs@
+PKG_LIBS = @PKG_LIBS@ @openmp_ldflags@ @zlib_libs@
 # See WRE $1.2.1.1. But retain user supplied PKG_* too, #4664.
 # WRE states ($1.6) that += isn't portable and that we aren't allowed to use it.
 # Otherwise we could use the much simpler PKG_LIBS += @openmp_cflags@ -lz.

--- a/tools/check-openmp-flags.R
+++ b/tools/check-openmp-flags.R
@@ -1,0 +1,39 @@
+args <- commandArgs(TRUE)
+stopifnot(`Usage: Rscript check-openmp-flags.R CFLAGS LDFLAGS` = length(args) == 2)
+# We'll need to create Makevars (and object and DLL files too)
+setwd(tempdir())
+cat(sprintf(
+  "Testing if OpenMP works with CFLAGS='%s' and LDFLAGS='%s':\n",
+  args[[1]], args[[2]]
+))
+
+# It must be a 'Makevars' for constructs like $(SHLIB_OPENMP_CFLAGS) to work:
+writeLines(c(
+  paste("PKG_CFLAGS =", args[[1]]),
+  paste("PKG_LIBS =", args[[2]])
+), "Makevars")
+
+# Will succeed to compile even without OpenMP but return 0
+writeLines("
+#ifdef _OPENMP
+ #include <omp.h>
+#endif
+void test_openmp(int * numprocs) {
+ *numprocs =
+#ifdef _OPENMP
+  omp_get_max_threads()
+#else
+  0
+#endif
+ ;
+}
+", "test.c")
+
+# May fail to compile anyway
+stopifnot(tools::Rcmd("SHLIB --preclean test.c") == 0)
+
+dyn.load(paste0("test", .Platform$dynlib.ext))
+success <- .C("test_openmp", ans = integer(1))$ans > 0
+
+cat(sprintf("Result: %s\n", if (success) "yes" else "no"))
+q("no", status = !success)

--- a/tools/check-openmp-flags.R
+++ b/tools/check-openmp-flags.R
@@ -1,9 +1,9 @@
 args <- commandArgs(TRUE)
-stopifnot(`Usage: Rscript check-openmp-flags.R CFLAGS LDFLAGS` = length(args) == 2)
+stopifnot(`Usage: Rscript check-openmp-flags.R CFLAGS LIBS` = length(args) == 2)
 # We'll need to create Makevars (and object and DLL files too)
 setwd(tempdir())
 cat(sprintf(
-  "Testing if OpenMP works with CFLAGS='%s' and LDFLAGS='%s':\n",
+  "Testing if OpenMP works with CFLAGS='%s' and LIBS='%s':\n",
   args[[1]], args[[2]]
 ))
 


### PR DESCRIPTION
 * When testing various OpenMP-related flags, `dyn.load()` the resulting shared object and run code from it before deciding to use these flags for `data.table`
 * When testing `-fopenmp`, add it to both compiler and linker flags

Hopefully, this will fix #6622 and prevent similar problems in the future. A more conservative fix is #6633.

Upsides:
* A configuration that successfully compiles but later doesn't work is much less likely to be chosen
  * Instead of compiling a shared object that fails to load, `data.table` will install without OpenMP support
* At least on GNU/Linux and (seemingly) @dvg-p4's Homebrew toolchain, `-fopenmp` is required in both compiler and linker flags

Downsides:
* If something makes `omp_get_max_threads()` return a number ≤ 0 during `data.table` installation, the build process will consider OpenMP not working and disable it.
  * On my GNU/Linux setup, setting environment variables `OMP_NUM_THREADS=0` or `OMP_THREAD_LIMIT=0` results in warnings, but `omp_get_max_threads()` remains positive.
* `-fopenmp` is now tested unconditionally, not limited to `uname %in% c('Linux', 'Darwin')`. Something that previously built single-threaded `data.table` may now enable OpenMP and surprise someone.
* `configure` now runs an R script. This can be rewritten back into a shell script if we can guarantee `mktemp -d` available on everything that runs `data.table`.
* Only tested on GNU/Linux. Given enough free time, can test on FreeBSD, OpenBSD VMs, but not a Mac.