### PR TITLE
Version-guard STRING_PTR definition

### DIFF
--- a/src/data.table.h
+++ b/src/data.table.h
@@ -6,6 +6,7 @@
 #  define ALTREP(x) 0     // #2866
 #  define USE_RINTERNALS  // #3301
 #  define DATAPTR_RO(x) ((const void *)DATAPTR(x))
+#  define STRING_PTR_RO STRING_PTR
 #  define R_Calloc(x, y) Calloc(x, y)         // #6380
 #  define R_Realloc(x, y, z) Realloc(x, y, z)
 #  define R_Free(x) Free(x)
@@ -15,9 +16,6 @@
 #endif
 #include <Rinternals.h>
 #define SEXPPTR_RO(x) ((const SEXP *)DATAPTR_RO(x))  // to avoid overhead of looped STRING_ELT and VECTOR_ELT
-#ifndef STRING_PTR_RO
-#define STRING_PTR_RO STRING_PTR
-#endif
 #include <stdint.h>    // for uint64_t rather than unsigned long long
 #include <stdarg.h>    // for va_list, va_start
 #include <stdbool.h>


### PR DESCRIPTION
Part of #6180. I'm not quite sure why the `#ifndef` approach failed us, but I confirmed this works, as well as confirming R 3.5.0 is the first version where `STRING_PTR_RO()` is in a release:

https://github.com/wch/r-source/blob/tags/R-3-4-4/src/include/Rinternals.h
https://github.com/wch/r-source/blob/tags/R-3-5-0/src/include/Rinternals.h