### PR TITLE
Fix issues mixing 'const'-ness of STRING_PTR_RO

### DIFF
--- a/src/chmatch.c
+++ b/src/chmatch.c
@@ -35,12 +35,13 @@ static SEXP chmatchMain(SEXP x, SEXP table, int nomatch, bool chin, bool chmatch
     return ans;
   }
   // Since non-ASCII strings may be marked with different encodings, it only make sense to compare
-  // the bytes under a same encoding (UTF-8) #3844 #3850
+  // the bytes under a same encoding (UTF-8) #3844 #3850.
+  // Not 'const' because we might SET_TRUELENGTH() below.
   SEXP *xd;
   if (isSymbol(x)) {
     xd = &sym;
   } else {
-    xd = STRING_PTR_RO(PROTECT(coerceUtf8IfNeeded(x))); nprotect++;
+    xd = (SEXP *)STRING_PTR_RO(PROTECT(coerceUtf8IfNeeded(x))); nprotect++;
   }
   const SEXP *td = STRING_PTR_RO(PROTECT(coerceUtf8IfNeeded(table))); nprotect++;
   if (xlen==1) {

--- a/src/coalesce.c
+++ b/src/coalesce.c
@@ -53,7 +53,7 @@ SEXP coalesce(SEXP x, SEXP inplaceArg) {
     first = PROTECT(copyAsPlain(first)); nprotect++;
     if (verbose) Rprintf(_("coalesce copied first item (inplace=FALSE)\n"));
   }
-  void **valP = (void **)R_alloc(nval, sizeof(void *));
+  const void **valP = (const void **)R_alloc(nval, sizeof(void *));
   switch(TYPEOF(first)) {
   case LGLSXP:
   case INTSXP: {
@@ -66,7 +66,7 @@ SEXP coalesce(SEXP x, SEXP inplaceArg) {
         finalVal = tt;
         break;  // stop early on the first singleton that is not NA; minimizes deepest loop body below
       }
-      valP[k++] = INTEGER(item);
+      valP[k++] = INTEGER_RO(item);
     }
     const bool final=(finalVal!=NA_INTEGER);
     #pragma omp parallel for num_threads(getDTthreads(nrow, true))
@@ -89,7 +89,7 @@ SEXP coalesce(SEXP x, SEXP inplaceArg) {
           finalVal = tt;
           break;
         }
-        valP[k++] = REAL(item);
+        valP[k++] = REAL_RO(item);
       }
       const bool final = (finalVal!=NA_INTEGER64);
       #pragma omp parallel for num_threads(getDTthreads(nrow, true))
@@ -110,7 +110,7 @@ SEXP coalesce(SEXP x, SEXP inplaceArg) {
           finalVal = tt;
           break;
         }
-        valP[k++] = REAL(item);
+        valP[k++] = REAL_RO(item);
       }
       const bool final = !ISNAN(finalVal);
       #pragma omp parallel for num_threads(getDTthreads(nrow, true))
@@ -133,7 +133,7 @@ SEXP coalesce(SEXP x, SEXP inplaceArg) {
         finalVal = tt;
         break;
       }
-      valP[k++] = COMPLEX(item);
+      valP[k++] = COMPLEX_RO(item);
     }
     const bool final = !ISNAN(finalVal.r) && !ISNAN(finalVal.i);
     #pragma omp parallel for num_threads(getDTthreads(nrow, true))

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -7,6 +7,9 @@
 #  define USE_RINTERNALS  // #3301
 #  define DATAPTR_RO(x) ((const void *)DATAPTR(x))
 #  define STRING_PTR_RO STRING_PTR
+#  define INTEGER_RO INTEGER
+#  define REAL_RO REAL
+#  define COMPLEX_RO COMPLEX
 #  define R_Calloc(x, y) Calloc(x, y)         // #6380
 #  define R_Realloc(x, y, z) Realloc(x, y, z)
 #  define R_Free(x) Free(x)


### PR DESCRIPTION
Closes #6656

Thanks for looking into this @aitap! I _think_ the PR here is the best option.

 - for chmatch.c, `xd` is not `const` because of this:
https://github.com/Rdatatable/data.table/blob/a5995579d8512bfa51e35c056a992406f074d4e6/src/chmatch.c#L117
 - for coalesce.c, I think just switching to the `_RO` accessors for the other `SEXPTYPE`s is correct -- `valP` is only ever read from (and its value coerced before writing to `val`).