### PR TITLE
missing newline after verbose message

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -459,9 +459,9 @@ replace_dot_alias = function(e) {
         if (!len_common_names) stopf("Attempting to do natural join but no common columns in provided tables")
         if (verbose) {
           which_cols_msg = if (len_common_names == length(x)) {
-            catf("Joining but 'x' has no key, natural join using all 'x' columns")
+            catf("Joining but 'x' has no key, natural join using all 'x' columns\n")
           } else {
-            catf("Joining but 'x' has no key, natural join using: %s", brackify(common_names))
+            catf("Joining but 'x' has no key, natural join using: %s\n", brackify(common_names))
           }
         }
         on = common_names


### PR DESCRIPTION
Observed under `verbose=TRUE`:

```
Joining but 'x' has no key, natural join using: [V1, size]i.V1 has same type (character) as x.V1. No coercion needed.
i.size has same type (integer) as x.size. No coercion needed.
```