### PR TITLE
Growable ALTREP vectors

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -1353,6 +1353,7 @@ replace_dot_alias = function(e) {
       }
       if (!with || missing(j)) return(ans)
       if (!is.data.table(ans)) setattr(ans, "class", c("data.table","data.frame"))  # DF |> DT(,.SD[...]) .SD should be data.table, test 2212.013
+      setgrowable(ans)
       SDenv$.SDall = ans
       SDenv$.SD = if (length(non_sdvars)) shallow(SDenv$.SDall, sdvars) else SDenv$.SDall
       SDenv$.N = nrow(ans)
@@ -1591,6 +1592,7 @@ replace_dot_alias = function(e) {
     SDenv$.SDall = .Call(CsubsetDT, x, if (length(len__)) seq_len(max(len__)) else 0L, xcols)  # must be deep copy when largest group is a subset
     if (!is.data.table(SDenv$.SDall)) setattr(SDenv$.SDall, "class", c("data.table","data.frame"))  # DF |> DT(,.SD[...],by=grp) needs .SD to be data.table, test 2022.012
     if (xdotcols) setattr(SDenv$.SDall, 'names', ansvars[xcolsAns]) # now that we allow 'x.' prefix in 'j', #2313 bug fix - [xcolsAns]
+    setgrowable(SDenv$.SDall)
     SDenv$.SD = if (length(non_sdvars)) shallow(SDenv$.SDall, sdvars) else SDenv$.SDall
   }
   if (nrow(SDenv$.SDall)==0L) {

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -21,3 +21,5 @@ fitsInInt32 = function(x) .Call(CfitsInInt32R, x)
 fitsInInt64 = function(x) .Call(CfitsInInt64R, x)
 
 coerceAs = function(x, as, copy=TRUE) .Call(CcoerceAs, x, as, copy)
+
+setgrowable = function(x) .Call(Csetgrowable, x)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -19303,12 +19303,6 @@ test(2290.3, DT[, `:=`(a, c := 3)], error="It looks like you re-used `:=` in arg
 # partially-named `:=`(...) --> different branch, same error
 test(2290.4, DT[, `:=`(a = 2, c := 3)], error="It looks like you re-used `:=` in argument 2")
 
-# segfault when selfref is not ok before set #6410
-df = data.frame(a=1:3)
-setDT(df)
-attr(df, "att") = 1
-test(2291.1, set(df, NULL, "new", "new"), error="attributes .* have been reassigned")
-
 # ns-qualified bysub error, #6493
 DT = data.table(a = 1)
 test(2292.1, DT[, .N, by=base::mget("a")], data.table(a = 1, N = 1L))

--- a/src/assign.c
+++ b/src/assign.c
@@ -323,7 +323,7 @@ SEXP shallowwrapper(SEXP dt, SEXP cols) {
 }
 
 SEXP truelength(SEXP x) {
-  return ScalarInteger(isNull(x) ? 0 : growable_max_size(x));
+  return ScalarInteger(is_growable(x) ? growable_max_size(x) : 0);
 }
 
 SEXP selfrefokwrapper(SEXP x, SEXP verbose) {
@@ -520,7 +520,7 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values)
   // modify DT by reference. Other than if new columns are being added and the allocVec() fails with
   // out-of-memory. In that case the user will receive hard halt and know to rerun.
   if (length(newcolnames)) {
-    oldtncol = growable_max_size(dt);   // TO DO: oldtncol can be just called tl now, as we won't realloc here any more.
+    oldtncol = is_growable(dt) ? growable_max_size(dt) : 0;   // TO DO: oldtncol can be just called tl now, as we won't realloc here any more.
 
     if (oldtncol<oldncol) {
       if (oldtncol==0) error(_("This data.table has either been loaded from disk (e.g. using readRDS()/load()) or constructed manually (e.g. using structure()). Please run setDT() or setalloccol() on it first (to pre-allocate space for new columns) before assigning by reference to it."));   // #2996

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -305,6 +305,10 @@ SEXP growable_allocate(SEXPTYPE type, R_xlen_t size, R_xlen_t max_size);
 R_xlen_t growable_max_size(SEXP x);
 // Resize a growable vector to newsize. Will signal an error if newsize exceeds max_size.
 void growable_resize(SEXP x, R_xlen_t newsize);
+// Return TRUE if growable_resize(x) and growable_max_size(x) are valid operations.
+Rboolean is_growable(SEXP x);
+// Transform x into a growable vector. The return value must be reprotected in place of x. What happens to x is deliberately not specified, but no copying occurs.
+SEXP make_growable(SEXP x);
 
 // functions called from R level .Call/.External and registered in init.c
 // these now live here to pass -Wstrict-prototypes, #5477
@@ -379,4 +383,5 @@ SEXP dt_has_zlib(void);
 SEXP startsWithAny(SEXP, SEXP, SEXP);
 SEXP convertDate(SEXP, SEXP);
 SEXP fastmean(SEXP);
+SEXP setgrowable(SEXP x);
 

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -143,7 +143,7 @@ uint64_t dtwiddle(double x);
 SEXP forder(SEXP DT, SEXP by, SEXP retGrpArg, SEXP retStatsArg, SEXP sortGroupsArg, SEXP ascArg, SEXP naArg);
 SEXP forderReuseSorting(SEXP DT, SEXP by, SEXP retGrpArg, SEXP retStatsArg, SEXP sortGroupsArg, SEXP ascArg, SEXP naArg, SEXP reuseSortingArg); // reuseSorting wrapper to forder
 int getNumericRounding_C(void);
-void internal_error_with_cleanup(const char *call_name, const char *format, ...);
+NORET void internal_error_with_cleanup(const char *call_name, const char *format, ...);
 
 // reorder.c
 SEXP reorder(SEXP x, SEXP order);
@@ -259,7 +259,7 @@ SEXP islockedR(SEXP x);
 bool need2utf8(SEXP x);
 SEXP coerceUtf8IfNeeded(SEXP x);
 SEXP coerceAs(SEXP x, SEXP as, SEXP copyArg);
-void internal_error(const char *call_name, const char *format, ...);
+NORET void internal_error(const char *call_name, const char *format, ...);
 
 // types.c
 char *end(char *start);

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -17,6 +17,9 @@
 #if R_VERSION < R_Version(3, 4, 0)
 #  define SET_GROWABLE_BIT(x)  // #3292
 #endif
+#if R_VERSION >= R_Version(4, 3, 0)
+#  define USE_GROWABLE_ALTREP
+#endif
 #include <Rinternals.h>
 #define SEXPPTR_RO(x) ((const SEXP *)DATAPTR_RO(x))  // to avoid overhead of looped STRING_ELT and VECTOR_ELT
 #include <stdint.h>    // for uint64_t rather than unsigned long long
@@ -309,6 +312,9 @@ void growable_resize(SEXP x, R_xlen_t newsize);
 Rboolean is_growable(SEXP x);
 // Transform x into a growable vector. The return value must be reprotected in place of x. What happens to x is deliberately not specified, but no copying occurs.
 SEXP make_growable(SEXP x);
+#if R_VERSION >= R_Version(4, 3, 0)
+void register_altrep_classes(DllInfo*);
+#endif
 
 // functions called from R level .Call/.External and registered in init.c
 // these now live here to pass -Wstrict-prototypes, #5477

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -298,6 +298,14 @@ void hash_set(hashtab *, SEXP key, R_xlen_t value);
 // Returns the value corresponding to the key present in the hash, otherwise returns ifnotfound.
 R_xlen_t hash_lookup(const hashtab *, SEXP key, R_xlen_t ifnotfound);
 
+// growable.c
+// Return a new vector of given type. Initially its xlength() is equal to size. Using growable_resize(), it can be increased to up to max_size.
+SEXP growable_allocate(SEXPTYPE type, R_xlen_t size, R_xlen_t max_size);
+// Return the max_size of a growable vector. Behaviour is undefined if x was not allocated by growable_allocate.
+R_xlen_t growable_max_size(SEXP x);
+// Resize a growable vector to newsize. Will signal an error if newsize exceeds max_size.
+void growable_resize(SEXP x, R_xlen_t newsize);
+
 // functions called from R level .Call/.External and registered in init.c
 // these now live here to pass -Wstrict-prototypes, #5477
 // all arguments must be SEXP since they are called from R level

--- a/src/dogroups.c
+++ b/src/dogroups.c
@@ -45,11 +45,10 @@ static bool anySpecialStatic(SEXP x, hashtab * specials) {
   // (see data.table.h), and isNewList() is true for NULL
   if (n==0)
     return false;
+  if (hash_lookup(specials, x, 0)<0) return true; // test 2158
   if (isVectorAtomic(x))
-    return ALTREP(x) || hash_lookup(specials, x, 0)<0;
+    return ALTREP(x); // see test 2156: ALTREP is a source of sharing we can't trace reliably
   if (isNewList(x)) {
-    if (hash_lookup(specials, x, 0)<0)
-      return true;  // test 2158
     for (int i=0; i<n; ++i) {
       list_el = VECTOR_ELT(x,i);
       if (anySpecialStatic(list_el, specials))

--- a/src/dogroups.c
+++ b/src/dogroups.c
@@ -523,7 +523,7 @@ SEXP growVector(SEXP x, const R_len_t newlen)
   SEXP newx;
   R_len_t len = length(x);
   if (isNull(x)) error(_("growVector passed NULL"));
-  PROTECT(newx = allocVector(TYPEOF(x), newlen));   // TO DO: R_realloc(?) here?
+  PROTECT(newx = growable_allocate(TYPEOF(x), newlen, newlen)); // may be shrunk later by fread
   if (newlen < len) len=newlen;   // i.e. shrink
   switch (TYPEOF(x)) {
   case RAWSXP:  memcpy(RAW(newx),     RAW(x),     len*SIZEOF(x)); break;

--- a/src/dogroups.c
+++ b/src/dogroups.c
@@ -124,7 +124,7 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
   for (R_len_t i=0; i<n; ++i) {
     if (ilens[i] > maxGrpSize) maxGrpSize = ilens[i];
   }
-  defineVar(install(".I"), I = PROTECT(allocVector(INTSXP, maxGrpSize)), env); nprotect++;
+  defineVar(install(".I"), I = PROTECT(growable_allocate(INTSXP, maxGrpSize, maxGrpSize)), env); nprotect++;
   hash_set(specials, I, -maxGrpSize);  // marker for anySpecialStatic(); see its comments
   R_LockBinding(install(".I"), env);
 
@@ -197,7 +197,7 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
     INTEGER(GRP)[0] = i+1;  // group counter exposed as .GRP
     INTEGER(rownames)[1] = -grpn;  // the .set_row_names() of .SD. Not .N when nomatch=NA and this is a nomatch
     for (int j=0; j<length(SDall); ++j) {
-      SETLENGTH(VECTOR_ELT(SDall,j), grpn);  // before copying data in otherwise assigning after the end could error R API checks
+      growable_resize(VECTOR_ELT(SDall,j), grpn);  // before copying data in otherwise assigning after the end could error R API checks
       defineVar(nameSyms[j], VECTOR_ELT(SDall, j), env);
       // Redo this defineVar for each group in case user's j assigned to the column names (env is static) (tests 387 and 388)
       // nameSyms pre-stored to save repeated install() for efficiency, though.
@@ -230,14 +230,14 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
         // and we hope that reference counting on by default from R 4.0 will avoid costly gc()s.
       }
       grpn = 1;  // it may not be 1 e.g. test 722. TODO: revisit.
-      SETLENGTH(I, grpn);
+      growable_resize(I, grpn);
       INTEGER(I)[0] = 0;
       for (int j=0; j<length(xSD); ++j) {
         writeNA(VECTOR_ELT(xSD, j), 0, 1, false);
       }
     } else {
       if (verbose) tstart = wallclock();
-      SETLENGTH(I, grpn);
+      growable_resize(I, grpn);
       int *iI = INTEGER(I);
       if (LENGTH(order)==0) {
         const int rownum = grpn ? istarts[i]-1 : -1;
@@ -318,13 +318,13 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
         RHS = VECTOR_ELT(jval,j%LENGTH(jval));
         if (isNull(target)) {
           // first time adding to new column
-          if (TRUELENGTH(dt) < colj+1) internal_error(__func__, "Trying to add new column by reference but tl is full; setalloccol should have run first at R level before getting to this point"); // # nocov
+          if (growable_max_size(dt) < colj+1) internal_error(__func__, "Trying to add new column by reference but table is full; setalloccol should have run first at R level before getting to this point"); // # nocov
           target = PROTECT(allocNAVectorLike(RHS, n));
           // Even if we could know reliably to switch from allocNAVectorLike to allocVector for slight speedup, user code could still
           // contain a switched halt, and in that case we'd want the groups not yet done to have NA rather than 0 or uninitialized.
           // Increment length only if the allocation passes, #1676. But before SET_VECTOR_ELT otherwise attempt-to-set-index-n/n R error
-          SETLENGTH(dtnames, LENGTH(dtnames)+1);
-          SETLENGTH(dt, LENGTH(dt)+1);
+          growable_resize(dtnames, LENGTH(dtnames)+1);
+          growable_resize(dt, LENGTH(dt)+1);
           SET_VECTOR_ELT(dt, colj, target);
           UNPROTECT(1);
           SET_STRING_ELT(dtnames, colj, STRING_ELT(newnames, colj-origncol));
@@ -482,11 +482,9 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
   // Also reset truelength on specials; see comments in anySpecialStatic().
   for (int j=0; j<length(SDall); ++j) {
     SEXP this = VECTOR_ELT(SDall,j);
-    SETLENGTH(this, maxGrpSize);
-    SET_TRUELENGTH(this, maxGrpSize);
+    growable_resize(this, maxGrpSize);
   }
-  SETLENGTH(I, maxGrpSize);
-  SET_TRUELENGTH(I, maxGrpSize);
+  growable_resize(I, maxGrpSize);
   if (verbose) {
     if (nblock[0] && nblock[1]) internal_error(__func__, "block 0 [%d] and block 1 [%d] have both run", nblock[0], nblock[1]); // # nocov
     int w = nblock[1]>0;

--- a/src/freadR.c
+++ b/src/freadR.c
@@ -257,7 +257,7 @@ bool userOverride(int8_t *type, lenOff *colNames, const char *anchor, const int 
   if (typeSize[CT_BOOL8_N]!=1) internal_error(__func__, "typeSize[CT_BOOL8_N] != 1"); // # nocov
   if (typeSize[CT_STRING]!=8) internal_error(__func__, "typeSize[CT_STRING] != 1"); // # nocov
   colNamesSxp = R_NilValue;
-  SET_VECTOR_ELT(RCHK, 1, colNamesSxp=allocVector(STRSXP, ncol));
+  SET_VECTOR_ELT(RCHK, 1, colNamesSxp=growable_allocate(STRSXP, ncol, ncol));
   for (int i=0; i<ncol; i++) {
     SEXP elem;
     if (colNames==NULL || colNames[i].len<=0) {
@@ -445,7 +445,7 @@ size_t allocateDT(int8_t *typeArg, int8_t *sizeArg, int ncolArg, int ndrop, size
   if (newDT) {
     ncol = ncolArg;
     dtnrows = allocNrow;
-    SET_VECTOR_ELT(RCHK, 0, DT=allocVector(VECSXP, ncol-ndrop));
+    SET_VECTOR_ELT(RCHK, 0, DT=growable_allocate(VECSXP, ncol-ndrop, ncol-ndrop));
     if (ndrop==0) {
       setAttrib(DT, R_NamesSymbol, colNamesSxp);  // colNames mkChar'd in userOverride step
       if (colClassesAs) setAttrib(DT, sym_colClassesAs, colClassesAs);
@@ -497,7 +497,7 @@ size_t allocateDT(int8_t *typeArg, int8_t *sizeArg, int ncolArg, int ndrop, size
     int typeChanged = (type[i] > 0) && (newDT || TYPEOF(col) != typeSxp[type[i]] || oldIsInt64 != newIsInt64);
     int nrowChanged = (allocNrow != dtnrows);
     if (typeChanged || nrowChanged) {
-      SEXP thiscol = typeChanged ? allocVector(typeSxp[type[i]], allocNrow)  // no need to PROTECT, passed immediately to SET_VECTOR_ELT, see R-exts 5.9.1
+      SEXP thiscol = typeChanged ? growable_allocate(typeSxp[type[i]], allocNrow, allocNrow)  // no need to PROTECT, passed immediately to SET_VECTOR_ELT, see R-exts 5.9.1
                                  : growVector(col, allocNrow);
       SET_VECTOR_ELT(DT,resi,thiscol);
       if (type[i]==CT_INT64) {
@@ -519,7 +519,6 @@ size_t allocateDT(int8_t *typeArg, int8_t *sizeArg, int ncolArg, int ndrop, size
 
         setAttrib(thiscol, sym_tzone, ScalarString(char_UTC)); // see news for v1.13.0
       }
-      SET_TRUELENGTH(thiscol, allocNrow);
       DTbytes += SIZEOF(thiscol)*allocNrow;
     }
     resi++;
@@ -536,9 +535,7 @@ void setFinalNrow(size_t nrow) {
       return;
     const int ncol=LENGTH(DT);
     for (int i=0; i<ncol; i++) {
-      SETLENGTH(VECTOR_ELT(DT,i), nrow);
-      SET_TRUELENGTH(VECTOR_ELT(DT,i), dtnrows);
-      SET_GROWABLE_BIT(VECTOR_ELT(DT,i));  // #3292
+      growable_resize(VECTOR_ELT(DT,i), nrow);
     }
   }
   R_FlushConsole(); // # 2481. Just a convenient place; nothing per se to do with setFinalNrow()
@@ -551,8 +548,8 @@ void dropFilledCols(int* dropArg, int ndelete) {
     SET_VECTOR_ELT(DT, dropFill[i], R_NilValue);
     SET_STRING_ELT(colNamesSxp, dropFill[i], NA_STRING);
   }
-  SETLENGTH(DT, ndt-ndelete);
-  SETLENGTH(colNamesSxp, ndt-ndelete);
+  growable_resize(DT, ndt-ndelete);
+  growable_resize(colNamesSxp, ndt-ndelete);
 }
 
 void pushBuffer(ThreadLocalFreadParsingContext *ctx)

--- a/src/growable.c
+++ b/src/growable.c
@@ -1,0 +1,23 @@
+#include "data.table.h"
+
+SEXP growable_allocate(SEXPTYPE type, R_xlen_t size, R_xlen_t max_size) {
+  SEXP ret = PROTECT(allocVector(type, max_size));
+  SET_TRUELENGTH(ret, max_size);
+  SET_GROWABLE_BIT(ret);
+  SETLENGTH(ret, size);
+  UNPROTECT(1);
+  return ret;
+}
+
+R_xlen_t growable_max_size(SEXP x) {
+  return TRUELENGTH(x);
+}
+
+void growable_resize(SEXP x, R_xlen_t newsize) {
+  R_xlen_t max_size;
+  if (newsize > (max_size = growable_max_size(x))) internal_error(
+    __func__, "newsize=%g > max_size=%g",
+    (double)newsize, (double)max_size
+  );
+  SETLENGTH(x, newsize);
+}

--- a/src/growable.c
+++ b/src/growable.c
@@ -3,7 +3,9 @@
 SEXP growable_allocate(SEXPTYPE type, R_xlen_t size, R_xlen_t max_size) {
   SEXP ret = PROTECT(allocVector(type, max_size));
   SET_TRUELENGTH(ret, max_size);
+#if R_VERSION >= R_Version(3, 4, 0)
   SET_GROWABLE_BIT(ret);
+#endif // otherwise perceived memory use will end up higher
   SETLENGTH(ret, size);
   UNPROTECT(1);
   return ret;
@@ -20,4 +22,19 @@ void growable_resize(SEXP x, R_xlen_t newsize) {
     (double)newsize, (double)max_size
   );
   SETLENGTH(x, newsize);
+}
+
+Rboolean is_growable(SEXP x) {
+  return isVector(x) && TRUELENGTH(x) >= XLENGTH(x)
+#if R_VERSION >= R_Version(3, 4, 0)
+    && IS_GROWABLE(x)
+#endif
+  ;
+}
+
+// Assuming no ALTREP for now
+SEXP make_growable(SEXP x) {
+  if (TRUELENGTH(x) < XLENGTH(x)) SET_TRUELENGTH(x, XLENGTH(x));
+  SET_GROWABLE_BIT(x);
+  return x;
 }

--- a/src/growable.c
+++ b/src/growable.c
@@ -1,5 +1,7 @@
 #include "data.table.h"
 
+#ifndef USE_GROWABLE_ALTREP
+
 SEXP growable_allocate(SEXPTYPE type, R_xlen_t size, R_xlen_t max_size) {
   SEXP ret = PROTECT(allocVector(type, max_size));
   SET_TRUELENGTH(ret, max_size);
@@ -32,9 +34,243 @@ Rboolean is_growable(SEXP x) {
   ;
 }
 
-// Assuming no ALTREP for now
+// Assuming no ALTREP columns
 SEXP make_growable(SEXP x) {
   if (TRUELENGTH(x) < XLENGTH(x)) SET_TRUELENGTH(x, XLENGTH(x));
   SET_GROWABLE_BIT(x);
   return x;
 }
+
+#else
+
+#include <R_ext/Altrep.h>
+
+static R_altrep_class_t dta_grow_string, dta_grow_integer, dta_grow_logical, dta_grow_real, dta_grow_complex, dta_grow_raw, dta_grow_list;
+static Rcomplex NA_COMPLEX = { 0, };
+
+/*
+ALTREP class layout:
+data1 = underlying vector
+data2 = its current length stored as a length-1 REALSXP
+Unless we implement an Unserialize method, this can be changed any time.
+Classes have been released on CRAN with a Serialized_state/Unserialize pair will have to stay as they have been defined in order to keep *.rds files readable.
+*/
+
+static R_xlen_t altall_Length(SEXP x) {
+  return (R_xlen_t)REAL(R_altrep_data2(x))[0];
+}
+
+#define make_inspect_method(classname) \
+  static Rboolean alt##classname##_Inspect( \
+    SEXP x, int pre, int deep, int pvec, \
+    void (*inspect_subtree)(SEXP x, int pre, int deep, int pvec) \
+  ) { \
+    (void)pre; (void)deep; (void)pvec; (void)inspect_subtree; \
+    Rprintf("data.table::growable" #classname "_v0(truelength=%g) ", (double)XLENGTH(R_altrep_data1(x))); \
+    return FALSE; \
+  }
+make_inspect_method(string)
+make_inspect_method(integer)
+make_inspect_method(logical)
+make_inspect_method(real)
+make_inspect_method(complex)
+make_inspect_method(raw)
+make_inspect_method(list)
+#undef make_inspect_method
+
+#define make_dataptr_method(class, accessor) \
+  static void * alt##class##_Dataptr(SEXP x, Rboolean writable) { \
+    (void)writable; \
+    return (void*)accessor(R_altrep_data1(x)); \
+  }
+make_dataptr_method(string, STRING_PTR_RO)
+make_dataptr_method(integer, INTEGER)
+make_dataptr_method(logical, LOGICAL)
+make_dataptr_method(real, REAL)
+make_dataptr_method(complex, COMPLEX)
+make_dataptr_method(raw, RAW)
+make_dataptr_method(list, DATAPTR_RO) // VECTOR_PTR_RO to appear in R-4.5
+#undef make_dataptr_method
+
+static const void * altall_Dataptr_or_null(SEXP x) { return DATAPTR_RO(x); }
+
+// lots of boilerplate, but R calling *_ELT one by one would be far too slow
+#define make_extract_subset_method(class, type, accessor, NA) \
+  static SEXP alt##class##_Extract_subset(SEXP x, SEXP indx, SEXP call) { \
+    (void)call; \
+    indx = PROTECT(coerceVector(indx, REALSXP)); \
+    double * ii = REAL(indx); \
+    R_xlen_t rlen = XLENGTH(indx), mylen = XLENGTH(x); \
+    SEXP ret = PROTECT(allocVector(TYPEOF(x), rlen)); \
+    type *rdata = accessor(ret), *mydata = accessor(x); \
+    for (R_xlen_t i = 0; i < rlen; ++i) \
+      rdata[i] = (ii[i] >= 1 && ii[i] <= mylen) ? mydata[(R_xlen_t)ii[i]-1] : NA; \
+    UNPROTECT(2); \
+    return ret; \
+  }
+make_extract_subset_method(integer, int, INTEGER, NA_INTEGER)
+make_extract_subset_method(logical, int, LOGICAL, NA_LOGICAL)
+make_extract_subset_method(real, double, REAL, NA_REAL)
+make_extract_subset_method(complex, Rcomplex, COMPLEX, NA_COMPLEX)
+make_extract_subset_method(raw, Rbyte, RAW, 0)
+// not implementing the string and list methods because those do require the write barrier and are thus no better than calling *_ELT one by one
+#undef make_extract_subset_method
+
+#define make_elt_method(class, accessor) \
+  static SEXP alt##class##_Elt(SEXP x, R_xlen_t i) { \
+    return accessor(R_altrep_data1(x), i); \
+  }
+make_elt_method(string, STRING_ELT)
+make_elt_method(list, VECTOR_ELT)
+#undef make_elt_method
+
+#define make_set_elt_method(class, accessor) \
+  static void alt##class##_Set_elt(SEXP x, R_xlen_t i, SEXP v) { \
+    accessor(R_altrep_data1(x), i, v); \
+  }
+make_set_elt_method(string, SET_STRING_ELT)
+make_set_elt_method(list, SET_VECTOR_ELT)
+#undef make_set_elt_method
+
+// liked the Extract_subset methods? say hello to Get_region
+#define make_get_region_method(class, type, accessor) \
+  static R_xlen_t alt##class##_Get_region( \
+    SEXP x, R_xlen_t i, R_xlen_t n, type * buf \
+  ) { \
+    R_xlen_t j = 0, mylen = XLENGTH(x); \
+    type * data = accessor(x); \
+    for (; j < n && i < mylen; ++i, ++j) buf[j] = data[i]; \
+    return j; \
+  }
+make_get_region_method(integer, int, INTEGER)
+make_get_region_method(logical, int, LOGICAL)
+make_get_region_method(real, double, REAL)
+make_get_region_method(complex, Rcomplex, COMPLEX)
+make_get_region_method(raw, Rbyte, RAW)
+#undef make_get_region_method
+
+void register_altrep_classes(DllInfo * info) {
+  // Used by the altcomplex_Extract_subset method
+  NA_COMPLEX = (Rcomplex){ .r = NA_REAL, .i = NA_REAL };
+
+  dta_grow_string = R_make_altstring_class("growable_string_v0", "data.table", info);
+  R_set_altrep_Length_method(dta_grow_string, altall_Length);
+  R_set_altrep_Inspect_method(dta_grow_string, altstring_Inspect);
+  R_set_altvec_Dataptr_method(dta_grow_string, altstring_Dataptr);
+  R_set_altvec_Dataptr_or_null_method(dta_grow_string, altall_Dataptr_or_null);
+  R_set_altstring_Elt_method(dta_grow_string, altstring_Elt);
+  R_set_altstring_Set_elt_method(dta_grow_string, altstring_Set_elt);
+  dta_grow_integer = R_make_altinteger_class("growable_integer_v0", "data.table", info);
+  R_set_altrep_Length_method(dta_grow_integer, altall_Length);
+  R_set_altrep_Inspect_method(dta_grow_integer, altinteger_Inspect);
+  R_set_altvec_Dataptr_method(dta_grow_integer, altinteger_Dataptr);
+  R_set_altvec_Dataptr_or_null_method(dta_grow_integer, altall_Dataptr_or_null);
+  R_set_altvec_Extract_subset_method(dta_grow_integer, altinteger_Extract_subset);
+  R_set_altinteger_Get_region_method(dta_grow_integer, altinteger_Get_region);
+  dta_grow_logical = R_make_altlogical_class("growable_logical_v0", "data.table", info);
+  R_set_altrep_Length_method(dta_grow_logical, altall_Length);
+  R_set_altrep_Inspect_method(dta_grow_logical, altlogical_Inspect);
+  R_set_altvec_Dataptr_method(dta_grow_logical, altlogical_Dataptr);
+  R_set_altvec_Dataptr_or_null_method(dta_grow_logical, altall_Dataptr_or_null);
+  R_set_altvec_Extract_subset_method(dta_grow_logical, altlogical_Extract_subset);
+  R_set_altlogical_Get_region_method(dta_grow_logical, altlogical_Get_region);
+  dta_grow_real = R_make_altreal_class("growable_real_v0", "data.table", info);
+  R_set_altrep_Length_method(dta_grow_real, altall_Length);
+  R_set_altrep_Inspect_method(dta_grow_real, altreal_Inspect);
+  R_set_altvec_Dataptr_method(dta_grow_real, altreal_Dataptr);
+  R_set_altvec_Dataptr_or_null_method(dta_grow_real, altall_Dataptr_or_null);
+  R_set_altvec_Extract_subset_method(dta_grow_real, altreal_Extract_subset);
+  R_set_altreal_Get_region_method(dta_grow_real, altreal_Get_region);
+  dta_grow_complex = R_make_altcomplex_class("growable_complex_v0", "data.table", info);
+  R_set_altrep_Length_method(dta_grow_complex, altall_Length);
+  R_set_altrep_Inspect_method(dta_grow_complex, altcomplex_Inspect);
+  R_set_altvec_Dataptr_method(dta_grow_complex, altcomplex_Dataptr);
+  R_set_altvec_Dataptr_or_null_method(dta_grow_complex, altall_Dataptr_or_null);
+  R_set_altvec_Extract_subset_method(dta_grow_complex, altcomplex_Extract_subset);
+  R_set_altcomplex_Get_region_method(dta_grow_complex, altcomplex_Get_region);
+  dta_grow_raw = R_make_altraw_class("growable_raw_v0", "data.table", info);
+  R_set_altrep_Length_method(dta_grow_raw, altall_Length);
+  R_set_altrep_Inspect_method(dta_grow_raw, altraw_Inspect);
+  R_set_altvec_Dataptr_method(dta_grow_raw, altraw_Dataptr);
+  R_set_altvec_Dataptr_or_null_method(dta_grow_raw, altall_Dataptr_or_null);
+  R_set_altvec_Extract_subset_method(dta_grow_raw, altraw_Extract_subset);
+  R_set_altraw_Get_region_method(dta_grow_raw, altraw_Get_region);
+  dta_grow_list = R_make_altlist_class("growable_list_v0", "data.table", info);
+  R_set_altrep_Length_method(dta_grow_list, altall_Length);
+  R_set_altrep_Inspect_method(dta_grow_list, altlist_Inspect);
+  R_set_altvec_Dataptr_method(dta_grow_list, altlist_Dataptr);
+  R_set_altvec_Dataptr_or_null_method(dta_grow_list, altall_Dataptr_or_null);
+  R_set_altlist_Elt_method(dta_grow_list, altlist_Elt);
+  R_set_altlist_Set_elt_method(dta_grow_list, altlist_Set_elt);
+}
+
+static R_altrep_class_t dta_grow_string, dta_grow_integer, dta_grow_logical, dta_grow_real, dta_grow_complex, dta_grow_raw, dta_grow_list;
+
+static R_altrep_class_t type2class(SEXPTYPE type) {
+  switch(type) {
+  case STRSXP:
+    return dta_grow_string;
+  case INTSXP:
+    return dta_grow_integer;
+  case LGLSXP:
+    return dta_grow_logical;
+  case REALSXP:
+    return dta_grow_real;
+  case CPLXSXP:
+    return dta_grow_complex;
+  case RAWSXP:
+    return dta_grow_raw;
+  case VECSXP:
+  case EXPRSXP:
+    return dta_grow_list;
+  default:
+    internal_error(__func__, "Can't create a growable vector of type '%s'", type2char(type));
+  }
+}
+
+SEXP growable_allocate(SEXPTYPE type, R_xlen_t size, R_xlen_t max_size) {
+  SEXP ret = PROTECT(R_new_altrep(type2class(type), R_NilValue, R_NilValue));
+  R_set_altrep_data1(ret, allocVector(type, max_size));
+  R_set_altrep_data2(ret, ScalarReal(size));
+  UNPROTECT(1);
+  return ret;
+}
+
+R_xlen_t growable_max_size(SEXP x) {
+  return XLENGTH(R_altrep_data1(x));
+}
+
+void growable_resize(SEXP x, R_xlen_t newsize) {
+  R_xlen_t max_size;
+  if (newsize > (max_size = growable_max_size(x))) internal_error(
+    __func__, "newsize=%g > max_size=%g",
+    (double)newsize, (double)max_size
+  );
+  REAL(R_altrep_data2(x))[0] = newsize;
+}
+
+Rboolean is_growable(SEXP x) {
+  switch(TYPEOF(x)) {
+  case STRSXP:
+  case INTSXP:
+  case LGLSXP:
+  case REALSXP:
+  case CPLXSXP:
+  case RAWSXP:
+  case VECSXP:
+    return R_altrep_inherits(x, type2class(TYPEOF(x)));
+  default:
+    return FALSE;
+  }
+}
+
+SEXP make_growable(SEXP x) {
+  SEXP ret = PROTECT(R_new_altrep(type2class(TYPEOF(x)), R_NilValue, R_NilValue));
+  R_set_altrep_data1(ret, x);
+  R_set_altrep_data2(ret, ScalarReal(XLENGTH(x)));
+  SHALLOW_DUPLICATE_ATTRIB(ret, x);
+  UNPROTECT(1);
+  return ret;
+}
+
+#endif

--- a/src/init.c
+++ b/src/init.c
@@ -150,6 +150,7 @@ R_CallMethodDef callMethods[] = {
 {"CconvertDate", (DL_FUNC)&convertDate, -1},
 {"Cnotchin", (DL_FUNC)&notchin, -1},
 {"Cwarn_matrix_column_r", (DL_FUNC)&warn_matrix_column_r, -1},
+{"Csetgrowable", (DL_FUNC)&setgrowable, -1},
 {NULL, NULL, 0}
 };
 

--- a/src/init.c
+++ b/src/init.c
@@ -203,8 +203,12 @@ void attribute_visible R_init_data_table(DllInfo *info)
 
   SEXP tmp = PROTECT(allocVector(INTSXP,2));
   if (LENGTH(tmp)!=2) error(_("Checking LENGTH(allocVector(INTSXP,2)) [%d] is 2 %s"), LENGTH(tmp), msg);
+#if R_VERSION >= R_Version(4, 3, 0)
+  register_altrep_classes(info);
+#else
   // Use (long long) to cast R_xlen_t to a fixed type to robustly avoid -Wformat compiler warnings, see #5768
   if (TRUELENGTH(tmp)!=0) error(_("Checking TRUELENGTH(allocVector(INTSXP,2)) [%lld] is 0 %s"), (long long)TRUELENGTH(tmp), msg);
+#endif
   UNPROTECT(1);
 
   // According to IEEE (http://en.wikipedia.org/wiki/IEEE_754-1985#Zero) we can rely on 0.0 being all 0 bits.

--- a/src/reorder.c
+++ b/src/reorder.c
@@ -24,13 +24,17 @@ SEXP reorder(SEXP x, SEXP order)
         error(_("Column %d is length %d which differs from length of column 1 (%d). Invalid data.table."), i+1, length(v), nrow);
       if (SIZEOF(v) > maxSize)
         maxSize=SIZEOF(v);
+#ifndef USE_GROWABLE_ALTREP
       if (ALTREP(v)) SET_VECTOR_ELT(x, i, copyAsPlain(v));
+#endif
     }
     copySharedColumns(x); // otherwise two columns which point to the same vector would be reordered and then re-reordered, issues linked in PR#3768
   } else {
     if (SIZEOF(x)!=4 && SIZEOF(x)!=8 && SIZEOF(x)!=16 && SIZEOF(x)!=1)
       error(_("reorder accepts vectors but this non-VECSXP is type '%s' which isn't yet supported (SIZEOF=%zu)"), type2char(TYPEOF(x)), SIZEOF(x));
+#ifndef USE_GROWABLE_ALTREP
     if (ALTREP(x)) internal_error(__func__, "cannot reorder an ALTREP vector. Please see NEWS item 2 in v1.11.4"); // # nocov
+#endif
     maxSize = SIZEOF(x);
     nrow = length(x);
     ncol = 1;
@@ -40,7 +44,9 @@ SEXP reorder(SEXP x, SEXP order)
   if (length(order) != nrow)
     error("nrow(x)[%d]!=length(order)[%d]", nrow, length(order)); // # notranslate
   int nprotect = 0;
+#ifndef USE_GROWABLE_ALTREP
   if (ALTREP(order)) { order=PROTECT(copyAsPlain(order)); nprotect++; }  // TODO: if it's an ALTREP sequence some optimizations are possible rather than expand
+#endif
 
   const int *restrict idx = INTEGER(order);
   int i=0;

--- a/src/subset.c
+++ b/src/subset.c
@@ -297,7 +297,7 @@ SEXP subsetDT(SEXP x, SEXP rows, SEXP cols) { // API change needs update NEWS.md
   }
 
   int overAlloc = checkOverAlloc(GetOption(install("datatable.alloccol"), R_NilValue));
-  SEXP ans = PROTECT(allocVector(VECSXP, LENGTH(cols)+overAlloc)); nprotect++;  // doing alloc.col directly here; eventually alloc.col can be deprecated.
+  SEXP ans = PROTECT(growable_allocate(VECSXP, LENGTH(cols), LENGTH(cols)+overAlloc)); nprotect++;  // doing alloc.col directly here; eventually alloc.col can be deprecated.
 
   // user-defined and superclass attributes get copied as from v1.12.0
   copyMostAttrib(x, ans);
@@ -305,8 +305,6 @@ SEXP subsetDT(SEXP x, SEXP rows, SEXP cols) { // API change needs update NEWS.md
   // includes row.names (oddly, given other dims aren't) and "sorted" dealt with below
   // class is also copied here which retains superclass name in class vector as has been the case for many years; e.g. tests 1228.* for #64
 
-  SET_TRUELENGTH(ans, LENGTH(ans));
-  SETLENGTH(ans, LENGTH(cols));
   int ansn;
   if (isNull(rows)) {
     ansn = nrow;
@@ -329,9 +327,7 @@ SEXP subsetDT(SEXP x, SEXP rows, SEXP cols) { // API change needs update NEWS.md
       subsetVectorRaw(target, source, rows, anyNA);  // parallel within column
     }
   }
-  SEXP tmp = PROTECT(allocVector(STRSXP, LENGTH(cols)+overAlloc)); nprotect++;
-  SET_TRUELENGTH(tmp, LENGTH(tmp));
-  SETLENGTH(tmp, LENGTH(cols));
+  SEXP tmp = PROTECT(growable_allocate(STRSXP, LENGTH(cols), LENGTH(cols)+overAlloc)); nprotect++;
   setAttrib(ans, R_NamesSymbol, tmp);
   subsetVectorRaw(tmp, getAttrib(x, R_NamesSymbol), cols, /*anyNA=*/false);
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -202,6 +202,9 @@ inline bool INHERITS(SEXP x, SEXP char_) {
   return false;
 }
 
+#ifdef USE_GROWABLE_ALTREP
+SEXP copyAsPlain(SEXP x) { return duplicate(x); }
+#else
 SEXP copyAsPlain(SEXP x) {
   // v1.12.2 and before used standard R duplicate() to do this. But duplicate() is not guaranteed to not return an ALTREP.
   // e.g. ALTREP 'wrapper' on factor column (with materialized INTSXP) in package VIM under example(hotdeck)
@@ -256,6 +259,7 @@ SEXP copyAsPlain(SEXP x) {
   UNPROTECT(1);
   return ans;
 }
+#endif
 
 void copySharedColumns(SEXP x) {
   const int ncol = length(x);
@@ -266,7 +270,12 @@ void copySharedColumns(SEXP x) {
   int nShared=0;
   for (int i=0; i<ncol; ++i) {
     SEXP thiscol = xp[i];
-    if (ALTREP(thiscol) || hash_lookup(marks, thiscol, 0)<0) {
+    if (
+      hash_lookup(marks, thiscol, 0)<0
+#ifndef USE_GROWABLE_ALTREP
+      || ALTREP(thiscol)
+#endif
+    ) {
       shared[i] = true;  // we mark ALTREP as 'shared' too, whereas 'tocopy' would be better word to use for ALTREP
       nShared++;
     } else {

--- a/src/wrappers.c
+++ b/src/wrappers.c
@@ -124,3 +124,13 @@ SEXP warn_matrix_column_r(SEXP i) {
   warn_matrix_column(INTEGER(i)[0]);
   return R_NilValue;
 }
+
+SEXP setgrowable(SEXP x) {
+  for (R_xlen_t i = 0; i < xlength(x); ++i) {
+    SEXP this = VECTOR_ELT(x, i);
+    // relying on the rest of data.table machinery to avoid the need for resizing
+    if (!is_growable(this) && !ALTREP(this))
+      SET_VECTOR_ELT(x, i, make_growable(this));
+  }
+  return R_NilValue;
+}


### PR DESCRIPTION
Ongoing work towards #6180. Depends on #6694. Detailed motivation in a [pending blog post](https://github.com/rdatatable-community/The-Raft/blob/56ccfaad8251839d4ed17136274f67abe4c3924a/posts/2024-12-02-non-api-use/index.qmd#L247-L346).

Good news:

```
* checking compiled code ... NOTE
File ‘data.table/libs/data_table.so’:
  Found non-API call to R: ‘LEVELS’ # <-- and that's it!
```

Bad news:

```
Test 2289.2 ran without errors but failed check that x equals y:
> x = dt[, b, a] 
   a b  [Key= Types=int,lis Classes=int,lis]
1: 1 1                                      
2: 2 2                                      
> y = dt 
   a b  [Key= Types=int,exp Classes=int,exp]
1: 1 1                                      
2: 2 2                                      
Datasets have different column modes. First 3: b(list!=expression)
```

Unfortunately, since there is no `altexpression` ALTREP class, best I was able to support `EXPRSXP` columns was by creating `VECSXP` lists for their contents.

How long do we have and does anyone have a plan B?