### PR TITLE
Retain with=FALSE in j=lit:var cases

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -95,7 +95,7 @@ rowwiseDT(
     # [1] "V1" "b" "c"
     ```
 
-4. Queries like `DT[, min(x):max(x)]` now work as expected, i.e. the same as `DT[, seq(min(x), max(x))]` or `with(DT, min(x):max(x))`, [#2069](https://github.com/Rdatatable/data.table/issues/2069). Shorthand like `DT[, a:b]` meaning "select from columns `a` through `b`" still works. Thanks to @franknarf1 for reporting, @jangorecki for the fix, and @MichaelChirico for a follow-up ensuring back-compatibility.
+4. Queries like `DT[, min(x):max(x)]` now work as expected, i.e. the same as `DT[, seq(min(x), max(x))]` or `with(DT, min(x):max(x))`, [#2069](https://github.com/Rdatatable/data.table/issues/2069). Shorthand like `DT[, a:b]` meaning "select from columns `a` through `b`" still works. Thanks to @franknarf1 for reporting, @jangorecki for the fix, and @MichaelChirico for follow-ups ensuring back-compatibility.
 
 5. `fread()` performance improves when specifying `Date` among `colClasses`, [#6105](https://github.com/Rdatatable/data.table/issues/6105). One implication of the change is that the column will be an `IDate` (which also inherits from `Date`), which may affect code strongly relying on the column class to be `Date` exactly; computations with `IDate` and `Date` columns should otherwise be the same. If you strongly prefer the `Date` class, run `as.Date()` explicitly following `fread()`. Thanks @scipima for the report and @MichaelChirico for the fix.
 

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -3045,7 +3045,7 @@ rleidv = function(x, cols=seq_along(x), prefix=NULL) {
   if (root != ":") return(FALSE)
   if (!length(vars)) return(TRUE)              # e.g. 1:10
   if (!all(vars %chin% names(x))) return(TRUE) # e.g. 1:ncol(x)
-  is.name(e[[1L]]) && is.name(e[[2L]])         # e.g. V1:V2, but not min(V1):max(V2) or 1:max(V2)
+  !is.call(e[[2L]]) && !is.call(e[[3L]])       # e.g. V1:V2, but not min(V1):max(V2) or 1:max(V2)
 }
 
 # GForce functions

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -19219,16 +19219,29 @@ for (opt in c(0, 1, 2)) {
 
 # Confusing behavior with DT[, min(var):max(var)] #2069
 DT = data.table(t = c(2L, 1L, 3L), a=0, b=1)
-test(2284.1, DT[, min(t):max(t)], with(DT, min(t):max(t)))
-test(2284.2, DT[, 1:max(t)], with(DT, 1:max(t)))
-test(2284.3, DT[, max(t):1], with(DT, max(t):1))
-test(2284.4, DT[, 1:t[1L]], with(DT, 1:t[1L]))
-test(2284.5, DT[, t[2L]:1], with(DT, t[2L]:1))
-test(2284.6, DT[, min(a):max(t)], with(DT, min(a):max(t)))
+test(2284.01, DT[, min(t):max(t)], with(DT, min(t):max(t)))
+test(2284.02, DT[, 1:max(t)], with(DT, 1:max(t)))
+test(2284.03, DT[, max(t):1], with(DT, max(t):1))
+test(2284.04, DT[, 1:t[1L]], with(DT, 1:t[1L]))
+test(2284.05, DT[, t[2L]:1], with(DT, t[2L]:1))
+test(2284.06, DT[, min(a):max(t)], with(DT, min(a):max(t)))
 # but not every `:` with a call in from or to is with=TRUE, #6486
-test(2284.7, DT[, 1:ncol(DT)], DT)
-test(2284.8, DT[, 2:(ncol(DT) - 1L)], DT[, "a"])
-test(2284.9, DT[, (ncol(DT) - 1L):ncol(DT)], DT[, c("a", "b")])
+test(2284.07, DT[, 1:ncol(DT)], DT)
+test(2284.08, DT[, 2:(ncol(DT) - 1L)], DT[, "a"])
+test(2284.09, DT[, (ncol(DT) - 1L):ncol(DT)], DT[, c("a", "b")])
+# literal:var is the same as literal:literal and var:var
+test(2284.10, DT[, 1:a], DT[, t:a])
+test(2284.11, DT[, 1:a], DT[, 1:2])
+test(2284.12, DT[, t:2], DT[, t:a])
+test(2284.13, DT[, t:2], DT[, 1:2])
+test(2284.14, DT[, 1:b], DT[, t:b])
+test(2284.15, DT[, 1:b], DT[, 1:3])
+test(2284.16, DT[, t:3], DT[, t:b])
+test(2284.17, DT[, t:3], DT[, 1:3])
+test(2284.18, DT[, 2:b], DT[, a:b])
+test(2284.19, DT[, 2:b], DT[, 2:3])
+test(2284.20, DT[, a:3], DT[, a:b])
+test(2284.21, DT[, a:3], DT[, 2:3])
 
 # Extra regression tests for #4772, which was already incidentally fixed by #5183.
 x = data.table(a=1:3)


### PR DESCRIPTION
For #6671 (not closing because we should wait for the revdep checker to confirm the fix).

This also fixes a mistake where `is.name(e[[1]])` was used. `e[[1]]` is always `:` in this case, and therefore is always a `name`. `e[[2]]` and `e[[3]]` are the arguments to `:`, which is what we really want to inspect.

The added tests help cover the mistaken logic there too.