### PR TITLE
Allow setDT(get(...)) to work as previously

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2989,9 +2989,9 @@ setDT = function(x, keep.rownames=FALSE, key=NULL, check.names=FALSE) {
     }
   } else if (name %iscall% "get") { # #6725
     name = match.call(get, name)
-    name[[1L]] = quote(assign)
-    name$value = quote(x)
-    eval(name, parent.frame())
+    e = eval(name$envir, parent.frame(), parent.frame())
+    k = eval(name$x, parent.frame(), parent.frame())
+    assign(k, x, envir=e)
   }
   .Call(CexpandAltRep, x)  # issue#2866 and PR#2882
   invisible(x)

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2987,6 +2987,11 @@ setDT = function(x, keep.rownames=FALSE, key=NULL, check.names=FALSE) {
     } else if (isS4(k)) {
       .Call(CsetS4elt, k, as.character(name[[3L]]), x)
     }
+  } else if (name %iscall% "get") { # #6725
+    name = match.call(get, name)
+    name[[1L]] = quote(assign)
+    name$value = quote(x)
+    eval(name)
   }
   .Call(CexpandAltRep, x)  # issue#2866 and PR#2882
   invisible(x)

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2989,9 +2989,9 @@ setDT = function(x, keep.rownames=FALSE, key=NULL, check.names=FALSE) {
     }
   } else if (name %iscall% "get") { # #6725
     name = match.call(get, name)
-    e = eval(name$envir, parent.frame(), parent.frame())
-    k = eval(name$x, parent.frame(), parent.frame())
-    assign(k, x, envir=e)
+    name[[1L]] = quote(assign)
+    name$value = x
+    eval(name, parent.frame(), parent.frame())
   }
   .Call(CexpandAltRep, x)  # issue#2866 and PR#2882
   invisible(x)

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2991,7 +2991,7 @@ setDT = function(x, keep.rownames=FALSE, key=NULL, check.names=FALSE) {
     name = match.call(get, name)
     name[[1L]] = quote(assign)
     name$value = quote(x)
-    eval(name)
+    eval(name, parent.frame())
   }
   .Call(CexpandAltRep, x)  # issue#2866 and PR#2882
   invisible(x)

--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2988,6 +2988,7 @@ setDT = function(x, keep.rownames=FALSE, key=NULL, check.names=FALSE) {
       .Call(CsetS4elt, k, as.character(name[[3L]]), x)
     }
   } else if (name %iscall% "get") { # #6725
+    # edit 'get(nm, env)' call to be 'assign(nm, x, envir=env)'
     name = match.call(get, name)
     name[[1L]] = quote(assign)
     name$value = x

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -20661,6 +20661,9 @@ foo = function(nm, env) {
 }
 foo('x', e)
 test(2295.4, is.data.table(x))
+e = new.env(parent=topenv())
+e$x = data.frame(a=1)
+foo('x', e)
 
 # #6588: .checkTypos used to give arbitrary strings to stopf as the first argument
 test(2296, d2[x %no such operator% 1], error = '%no such operator%')

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -20653,6 +20653,14 @@ setDT(d2)
 test(2295.1, !is.data.table(d1))
 test(2295.2, rownames(d1), 'b')
 test(2295.3, is.data.table(d2))
+# Ensure against regression noted in #6725
+x = data.frame(a=1)
+e = environment()
+foo = function() {
+  setDT(get('x', envir=e))
+}
+foo()
+test(2295.4, is.data.table(x))
 
 # #6588: .checkTypos used to give arbitrary strings to stopf as the first argument
 test(2296, d2[x %no such operator% 1], error = '%no such operator%')

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -20664,6 +20664,7 @@ test(2295.4, is.data.table(x))
 e = new.env(parent=topenv())
 e$x = data.frame(a=1)
 foo('x', e)
+test(2295.5, is.data.table(e$x))
 
 # #6588: .checkTypos used to give arbitrary strings to stopf as the first argument
 test(2296, d2[x %no such operator% 1], error = '%no such operator%')

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -20656,10 +20656,10 @@ test(2295.3, is.data.table(d2))
 # Ensure against regression noted in #6725
 x = data.frame(a=1)
 e = environment()
-foo = function() {
-  setDT(get('x', envir=e))
+foo = function(nm, env) {
+  setDT(get(nm, envir=env))
 }
-foo()
+foo('x', e)
 test(2295.4, is.data.table(x))
 
 # #6588: .checkTypos used to give arbitrary strings to stopf as the first argument


### PR DESCRIPTION
Closes #6725

Eh, pretty hacky, I'm still not sure we've made a good solution of the breaking changes induced by #6551.

Anyway I think the change is good: running `setDT(env$x)` should definitely behave the same as `setDT(get('x', env))`.