### PR TITLE
Adapt to changed RHOME in runner for pkgup GHA job

### DIFF
--- a/.github/workflows/pkgup.yaml
+++ b/.github/workflows/pkgup.yaml
@@ -9,8 +9,8 @@ concurrency:
 
 on:
   push:
-    branches:
-      - 'master'
+    #branches:
+    #  - 'master'
 
 name: pkgdown-deploy
 
@@ -50,25 +50,28 @@ jobs:
           cp -R ${{ env.R_LIBS_USER }} library
           R CMD INSTALL --library="library" $(ls -1t data.table_*.tar.gz | head -n 1) --html
           mkdir -p doc/html
-          cp /usr/share/R/doc/html/{left.jpg,up.jpg,Rlogo.svg,R.css,index.html} doc/html
-          Rscript -e 'utils::make.packages.html("library", docdir="doc")'
-          sed -i "s|file://|../..|g" doc/html/packages.html
-          mkdir -p public
-          mv doc public/doc
-          cp -r --parents library/*/{html,help,doc,demo,DESCRIPTION,README,NEWS,README.md,NEWS.md} public 2>/dev/null || :
-          sed -i 's|"/doc/html/|"/data.table/doc/html/|g' public/library/data.table/doc/index.html 2>/dev/null || :
-      - name: repo
-        if: github.ref == 'refs/heads/master'
-        run: |
-          mkdir -p public/src/contrib
-          mv $(ls -1t data.table_*.tar.gz | head -n 1) public/src/contrib
-          Rscript -e 'tools::write_PACKAGES("public/src/contrib", fields="Revision")'
-      - name: upload
-        if: github.ref == 'refs/heads/master'
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: "public"
-      - name: deploy
-        if: github.ref == 'refs/heads/master'
-        id: deployment
-        uses: actions/deploy-pages@v4
+          RHOME=$(Rscript -e "R.home()")
+          echo "R.home()=${RHOME}"
+          ls /usr/share/R/doc/html
+      #     cp /usr/share/R/doc/html/{left.jpg,up.jpg,Rlogo.svg,R.css,index.html} doc/html
+      #     Rscript -e 'utils::make.packages.html("library", docdir="doc")'
+      #     sed -i "s|file://|../..|g" doc/html/packages.html
+      #     mkdir -p public
+      #     mv doc public/doc
+      #     cp -r --parents library/*/{html,help,doc,demo,DESCRIPTION,README,NEWS,README.md,NEWS.md} public 2>/dev/null || :
+      #     sed -i 's|"/doc/html/|"/data.table/doc/html/|g' public/library/data.table/doc/index.html 2>/dev/null || :
+      # - name: repo
+      #   if: github.ref == 'refs/heads/master'
+      #   run: |
+      #     mkdir -p public/src/contrib
+      #     mv $(ls -1t data.table_*.tar.gz | head -n 1) public/src/contrib
+      #     Rscript -e 'tools::write_PACKAGES("public/src/contrib", fields="Revision")'
+      # - name: upload
+      #   if: github.ref == 'refs/heads/master'
+      #   uses: actions/upload-pages-artifact@v3
+      #   with:
+      #     path: "public"
+      # - name: deploy
+      #   if: github.ref == 'refs/heads/master'
+      #   id: deployment
+      #   uses: actions/deploy-pages@v4

--- a/.github/workflows/pkgup.yaml
+++ b/.github/workflows/pkgup.yaml
@@ -17,9 +17,9 @@ name: pkgdown-deploy
 jobs:
   build:
     name: data.table
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+    # environment:
+    #   name: github-pages
+    #   url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
         run: |
           R CMD check --as-cran --no-manual $(ls -1t data.table_*.tar.gz | head -n 1)
       - name: manual
-        if: github.ref == 'refs/heads/master'
+        # if: github.ref == 'refs/heads/master'
         run: |
           cp -R ${{ env.R_LIBS_USER }} library
           R CMD INSTALL --library="library" $(ls -1t data.table_*.tar.gz | head -n 1) --html

--- a/.github/workflows/pkgup.yaml
+++ b/.github/workflows/pkgup.yaml
@@ -9,17 +9,17 @@ concurrency:
 
 on:
   push:
-    #branches:
-    #  - 'master'
+    branches:
+      - 'master'
 
 name: pkgdown-deploy
 
 jobs:
   build:
     name: data.table
-    # environment:
-    #   name: github-pages
-    #   url: ${{ steps.deployment.outputs.page_url }}
+      environment:
+        name: github-pages
+        url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -45,34 +45,30 @@ jobs:
         run: |
           R CMD check --as-cran --no-manual $(ls -1t data.table_*.tar.gz | head -n 1)
       - name: manual
-        # if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         run: |
           cp -R ${{ env.R_LIBS_USER }} library
           R CMD INSTALL --library="library" $(ls -1t data.table_*.tar.gz | head -n 1) --html
           mkdir -p doc/html
-          RHOME=$(R RHOME)
-          echo "RHOME=${RHOME}"
-          ls ${RHOME}
-          cp "${RHOME}/doc/html/{left.jpg,up.jpg,Rlogo.svg,R.css,index.html}" doc/html
-      #     cp /usr/share/R/doc/html/{left.jpg,up.jpg,Rlogo.svg,R.css,index.html} doc/html
-      #     Rscript -e 'utils::make.packages.html("library", docdir="doc")'
-      #     sed -i "s|file://|../..|g" doc/html/packages.html
-      #     mkdir -p public
-      #     mv doc public/doc
-      #     cp -r --parents library/*/{html,help,doc,demo,DESCRIPTION,README,NEWS,README.md,NEWS.md} public 2>/dev/null || :
-      #     sed -i 's|"/doc/html/|"/data.table/doc/html/|g' public/library/data.table/doc/index.html 2>/dev/null || :
-      # - name: repo
-      #   if: github.ref == 'refs/heads/master'
-      #   run: |
-      #     mkdir -p public/src/contrib
-      #     mv $(ls -1t data.table_*.tar.gz | head -n 1) public/src/contrib
-      #     Rscript -e 'tools::write_PACKAGES("public/src/contrib", fields="Revision")'
-      # - name: upload
-      #   if: github.ref == 'refs/heads/master'
-      #   uses: actions/upload-pages-artifact@v3
-      #   with:
-      #     path: "public"
-      # - name: deploy
-      #   if: github.ref == 'refs/heads/master'
-      #   id: deployment
-      #   uses: actions/deploy-pages@v4
+          cp $(R RHOME)/doc/html/{left.jpg,up.jpg,Rlogo.svg,R.css,index.html} doc/html
+          Rscript -e 'utils::make.packages.html("library", docdir="doc")'
+          sed -i "s|file://|../..|g" doc/html/packages.html
+          mkdir -p public
+          mv doc public/doc
+          cp -r --parents library/*/{html,help,doc,demo,DESCRIPTION,README,NEWS,README.md,NEWS.md} public 2>/dev/null || :
+          sed -i 's|"/doc/html/|"/data.table/doc/html/|g' public/library/data.table/doc/index.html 2>/dev/null || :
+      - name: repo
+        if: github.ref == 'refs/heads/master'
+        run: |
+          mkdir -p public/src/contrib
+          mv $(ls -1t data.table_*.tar.gz | head -n 1) public/src/contrib
+          Rscript -e 'tools::write_PACKAGES("public/src/contrib", fields="Revision")'
+      - name: upload
+        if: github.ref == 'refs/heads/master'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "public"
+      - name: deploy
+        if: github.ref == 'refs/heads/master'
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pkgup.yaml
+++ b/.github/workflows/pkgup.yaml
@@ -53,7 +53,7 @@ jobs:
           RHOME=$(R RHOME)
           echo "RHOME=${RHOME}"
           ls ${RHOME}
-          cp "${RHOME}/{left.jpg,up.jpg,Rlogo.svg,R.css,index.html}" doc/html
+          cp "${RHOME}/doc/html/{left.jpg,up.jpg,Rlogo.svg,R.css,index.html}" doc/html
       #     cp /usr/share/R/doc/html/{left.jpg,up.jpg,Rlogo.svg,R.css,index.html} doc/html
       #     Rscript -e 'utils::make.packages.html("library", docdir="doc")'
       #     sed -i "s|file://|../..|g" doc/html/packages.html

--- a/.github/workflows/pkgup.yaml
+++ b/.github/workflows/pkgup.yaml
@@ -17,9 +17,9 @@ name: pkgdown-deploy
 jobs:
   build:
     name: data.table
-      environment:
-        name: github-pages
-        url: ${{ steps.deployment.outputs.page_url }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pkgup.yaml
+++ b/.github/workflows/pkgup.yaml
@@ -50,9 +50,10 @@ jobs:
           cp -R ${{ env.R_LIBS_USER }} library
           R CMD INSTALL --library="library" $(ls -1t data.table_*.tar.gz | head -n 1) --html
           mkdir -p doc/html
-          RHOME=$(Rscript -e "R.home()")
+          RHOME=$(Rscript -e "writeLines(R.home())")
           echo "R.home()=${RHOME}"
-          ls /usr/share/R/doc/html
+          ls ${RHOME}
+          cp "${RHOME}/{left.jpg,up.jpg,Rlogo.svg,R.css,index.html}" doc/html
       #     cp /usr/share/R/doc/html/{left.jpg,up.jpg,Rlogo.svg,R.css,index.html} doc/html
       #     Rscript -e 'utils::make.packages.html("library", docdir="doc")'
       #     sed -i "s|file://|../..|g" doc/html/packages.html

--- a/.github/workflows/pkgup.yaml
+++ b/.github/workflows/pkgup.yaml
@@ -50,8 +50,8 @@ jobs:
           cp -R ${{ env.R_LIBS_USER }} library
           R CMD INSTALL --library="library" $(ls -1t data.table_*.tar.gz | head -n 1) --html
           mkdir -p doc/html
-          RHOME=$(Rscript -e "writeLines(R.home())")
-          echo "R.home()=${RHOME}"
+          RHOME=$(R RHOME)
+          echo "RHOME=${RHOME}"
           ls ${RHOME}
           cp "${RHOME}/{left.jpg,up.jpg,Rlogo.svg,R.css,index.html}" doc/html
       #     cp /usr/share/R/doc/html/{left.jpg,up.jpg,Rlogo.svg,R.css,index.html} doc/html


### PR DESCRIPTION
This GHA is failing on `master`:

https://github.com/Rdatatable/data.table/actions/runs/12817202760

Based on the error it looks like `R.home()` has changed on these machines. Instead we should prefer the much more robust approach taken in this PR. Based on documentation:

https://stat.ethz.ch/R-manual/R-devel/library/base/html/Rhome.html