### PR TITLE
fread(): avoid casting int* to Rboolean*

### DIFF
--- a/src/assign.c
+++ b/src/assign.c
@@ -1061,7 +1061,7 @@ const char *memrecycle(const SEXP target, const SEXP where, const int start, con
     case RAWSXP:    BODY(Rbyte, RAW,    int, val!=0,                                    td[i]=cval)
     case LGLSXP:
       if (mc) {
-                    memcpy(td, LOGICAL(source), slen*sizeof(Rboolean)); break;
+                    memcpy(td, LOGICAL(source), slen*sizeof(int)); break;
       } else        BODY(int, LOGICAL,  int, val,                                       td[i]=cval)
     case INTSXP:    BODY(int, INTEGER,  int, val==NA_INTEGER ? NA_LOGICAL : val!=0,     td[i]=cval)
     case REALSXP:
@@ -1207,7 +1207,7 @@ void writeNA(SEXP v, const int from, const int n, const bool listNA)
     memset(RAW(v)+from, 0, n*sizeof(Rbyte));
     break;
   case LGLSXP: {
-    Rboolean *vd = (Rboolean *)LOGICAL(v);
+    int *vd = (int *)LOGICAL(v);
     for (int i=from; i<=to; ++i) vd[i] = NA_LOGICAL;
   } break;
   case INTSXP: {

--- a/src/freadR.c
+++ b/src/freadR.c
@@ -644,7 +644,7 @@ void pushBuffer(ThreadLocalFreadParsingContext *ctx)
       } else
       if (thisSize == 1) {
         if (type[j] > CT_BOOL8_Y) STOP(_("Field size is 1 but the field is of type %d\n"), type[j]);
-        Rboolean *dest = (Rboolean *)LOGICAL(VECTOR_ELT(DT, resj)) + DTi;
+        int *dest = LOGICAL(VECTOR_ELT(DT, resj)) + DTi;
         const char *src1 = (char*)buff1 + off1;
         for (int i=0; i<nRows; ++i) {
           int8_t v = *(int8_t *)src1;

--- a/src/fsort.c
+++ b/src/fsort.c
@@ -117,7 +117,7 @@ SEXP fsort(SEXP x, SEXP verboseArg) {
   t[0] = wallclock();
   if (!IS_TRUE_OR_FALSE(verboseArg))
     error(_("%s must be TRUE or FALSE"), "verbose");
-  Rboolean verbose = LOGICAL(verboseArg)[0];
+  int verbose = LOGICAL(verboseArg)[0];
   if (!isNumeric(x)) error(_("x must be a vector of type double currently"));
   // TODO: not only detect if already sorted, but if it is, just return x to save the duplicate
 

--- a/src/negate.c
+++ b/src/negate.c
@@ -5,7 +5,7 @@ void negateByRef(SEXP x) {
     error("not logical or integer vector");  // # nocov
   }
   const int n = length(x);
-  Rboolean *ansd = (Rboolean *)LOGICAL(x);
+  int *ansd = (int *)LOGICAL(x);
   for(int i=0; i<n; ++i) {
     ansd[i] ^= (ansd[i] != NA_LOGICAL);  // invert true/false but leave NA alone
   }

--- a/src/rbindlist.c
+++ b/src/rbindlist.c
@@ -12,7 +12,7 @@ SEXP rbindlist(SEXP l, SEXP usenamesArg, SEXP fillArg, SEXP idcolArg, SEXP ignor
     error(_("%s should be TRUE or FALSE"), "ignore.attr");
   if (!length(l)) return(l);
   if (TYPEOF(l) != VECSXP) error(_("Input to rbindlist must be a list. This list can contain data.tables, data.frames or plain lists."));
-  Rboolean usenames = LOGICAL(usenamesArg)[0];
+  int usenames = LOGICAL(usenamesArg)[0];
   const bool fill = LOGICAL(fillArg)[0];
   const bool ignoreattr = LOGICAL(ignoreattrArg)[0];
   if (fill && usenames==NA_LOGICAL) {

--- a/src/uniqlist.c
+++ b/src/uniqlist.c
@@ -356,13 +356,13 @@ SEXP uniqueNlogical(SEXP x, SEXP narmArg) {
   const R_xlen_t n = xlength(x);
   if (n==0)
     return ScalarInteger(0);  // empty vector
-  Rboolean first = LOGICAL(x)[0];
+  int first = LOGICAL(x)[0];
   R_xlen_t i=0;
   const int *ix = LOGICAL(x);
   while (++i<n && ix[i]==first);
   if (i==n)
     return ScalarInteger(first==NA_INTEGER && narm ? 0 : 1); // all one value
-  Rboolean second = ix[i];
+  int second = ix[i];
   // we've found 2 different values (first and second). Which one didn't we find? Then just look for that.
   // NA_LOGICAL == INT_MIN checked in init.c
   const int third = (first+second == 1) ? NA_LOGICAL : ( first+second == INT_MIN ? TRUE : FALSE );

--- a/src/utils.c
+++ b/src/utils.c
@@ -227,7 +227,7 @@ SEXP copyAsPlain(SEXP x) {
     memcpy(RAW(ans),     RAW(x),     n*sizeof(Rbyte));
     break;
   case LGLSXP:
-    memcpy(LOGICAL(ans), LOGICAL(x), n*sizeof(Rboolean));
+    memcpy(LOGICAL(ans), LOGICAL(x), n*sizeof(int));
     break;
   case INTSXP:
     memcpy(INTEGER(ans), INTEGER(x), n*sizeof(int));             // covered by 10:1 after test 178


### PR DESCRIPTION
This used to work because the compilers were very likely to use `int` as the underlying type of the `enum Rboolean`. R-devel r87656 changes the definition of `Rboolean` from an `enum` to `bool`, so the sizes and the semantics of the types are very different now. Since `LOGICAL()` returns `int*`, and `NA_INTEGER` is an `int`, keep using that to access the vector contents.

Fixes: #6779. It may be worth looking further, but this one makes the tests pass on my PC.

It's unfortunate that we don't get a compiler warning for this; the sanitizer is also silent. Perhaps the compiler lets it go because accessing objects using a pointer to a byte-sized variable must be fine?