### PR TITLE
Fix typo in join vignette: Replace "banana" with "soda" (#6798)

### DIFF
--- a/vignettes/datatable-joins.Rmd
+++ b/vignettes/datatable-joins.Rmd
@@ -529,14 +529,6 @@ A non-equi join is a type of join where the condition for matching rows is based
 - Finding the nearest match.
 - Comparing ranges of values between tables.
 
-### Key Constraints
-- **Column Requirements**:
-  - Only column *names* (not expressions) can be used with binary operators
-  - Left operand must be from `x` (left table)
-  - Right operand must be from `i` (right table)
-- **Naming Behavior**:
-  - Joined columns inherit names from `x` but contain values from `i`
-
 It is a great alternative when, after applying a right or inner join, you:
 
 - Want to reduce the number of returned rows based on comparisons of numeric columns between tables.

--- a/vignettes/datatable-joins.Rmd
+++ b/vignettes/datatable-joins.Rmd
@@ -320,7 +320,7 @@ Products[!ProductReceived,
          on = c("id" = "product_id")]
 ```
 
-As you can see, the result only has 'banana', as it was the only product that is not present in the `ProductReceived` table.
+As you can see, the result only has 'soda', as it was the only product that is not present in the `ProductReceived` table.
 
 ```{r}
 ProductReceived[!Products,
@@ -390,7 +390,7 @@ Here some important considerations:
   - It didn't add the prefix `i.` to any column.
   
 - **Row level**
-  - All rows from in the `i` table were kept as we never received any banana but row is still part of the results.
+  - All rows from in the `i` table were kept as we never received any soda but row is still part of the results.
   - The row related to `product_id = 6` is not part of the results any more as it is not present in the `Products` table.
 
 
@@ -528,6 +528,14 @@ A non-equi join is a type of join where the condition for matching rows is based
 
 - Finding the nearest match.
 - Comparing ranges of values between tables.
+
+### Key Constraints
+- **Column Requirements**:
+  - Only column *names* (not expressions) can be used with binary operators
+  - Left operand must be from `x` (left table)
+  - Right operand must be from `i` (right table)
+- **Naming Behavior**:
+  - Joined columns inherit names from `x` but contain values from `i`
 
 It is a great alternative when, after applying a right or inner join, you:
 

--- a/vignettes/datatable-joins.Rmd
+++ b/vignettes/datatable-joins.Rmd
@@ -390,7 +390,7 @@ Here some important considerations:
   - It didn't add the prefix `i.` to any column.
   
 - **Row level**
-  - All rows from in the `i` table were kept as we never received any soda but row is still part of the results.
+  - All rows from the `i` table were kept: the soda entry from `Products` that was not matched by any row in `ProductReceived` is still part of the results.
   - The row related to `product_id = 6` is not part of the results any more as it is not present in the `Products` table.
 
 


### PR DESCRIPTION
closes #6798 
This PR corrects two instances of "banana" to "soda" in the datatable-joins.Rmd vignette:

Line 323: Changed "banana" to "soda" in the explanation of anti-join results.
Line 393: Updated "banana" to "soda" in the description of retained rows.

These changes align the text with the example data and code output, where soda (id=4) is the product not present in the ProductReceived table.

Files changed: vignettes/datatable-joins.Rmd
