### PR TITLE
tests.Rraw: only call setlocale(en_US.UTF-8) if not already UTF-8

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18525,7 +18525,9 @@ rm(.datatable.aware)
 # tests for trunc.char handling wide characters # 5096
 local({
   lc_ctype = Sys.getlocale('LC_CTYPE')
-  Sys.setlocale('LC_CTYPE', "en_US.UTF-8") # Japanese multibyte characters require utf8
+  # Japanese multibyte characters require utf8. As of 2025, we're likely to be already running in a UTF-8 locale, but if not, try this setlocale() call as a last chance.
+  # Unfortunately, there is no guaranteed, portable way of switching to UTF-8 US English.
+  if (!l10n_info()$`UTF-8`) Sys.setlocale('LC_CTYPE', "en_US.UTF-8")
   on.exit(Sys.setlocale('LC_CTYPE', lc_ctype))
   accented_a = "\u0061\u0301"
   ja_ichi = "\u4E00"


### PR DESCRIPTION
This avoids the `Sys.setlocale()` call on systems where the current locale is already UTF-8-compatible (almost all modern systems). If the `en_US.UTF-8` locale is missing, the call will fail, producing a warning. Mostly harmless and rare, but is annoying when it happens.