### PR TITLE
`.onAttach`: translate the `Sys.setLanguage('en')` message

### DIFF
--- a/R/onAttach.R
+++ b/R/onAttach.R
@@ -27,7 +27,7 @@
     if (gettext("TRANSLATION CHECK") != "TRANSLATION CHECK") {
       packageStartupMessagef(
         "**********\nRunning data.table in English; package support is available in English only. When searching for online help, be sure to also check for the English error message. This can be obtained by looking at the po/R-<locale>.po and po/<locale>.po files in the package source, where the native language and English error messages can be found side-by-side.%s\n**********",
-        if (exists('Sys.setLanguage', envir=baseenv())) " You can also try calling Sys.setLanguage('en') prior to reproducing the error message." else ""
+        if (exists('Sys.setLanguage', envir=baseenv())) gettext(" You can also try calling Sys.setLanguage('en') prior to reproducing the error message.") else ""
       )
     }
     if (dev && (Sys.Date() - as.Date(d))>28L)


### PR DESCRIPTION
Without the explicit `gettext()`, it's neither picked up into the `R-data.table.pot` file nor translated, due to being a format argument.