### PR TITLE
`test.data.table()`: fix arguments to catf()

### DIFF
--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -383,11 +383,13 @@ test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,no
        }
        assign("lasttime", proc.time()[3L], parent.frame(), inherits=TRUE)  # after gc() to exclude gc() time from next test when memtest
     }, add=TRUE )
-    if (showProgress) { # nocov start
+    if (showProgress) {
+      # nocov start
       cat("\r") # notranslate: \r can't be in gettextf msg
       catf("Running test id %s", numStr)
       cat("         ")   # notranslate
-    } # nocov end
+      # nocov end
+    }
     # See PR #4090 for comments about change here in Dec 2019.
     # If a segfault error occurs in future and we'd like to know after which test, then arrange for the
     # try(sys.source()) in test.data.table() to be run in a separate R process. That process could write out

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -383,10 +383,11 @@ test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,no
        }
        assign("lasttime", proc.time()[3L], parent.frame(), inherits=TRUE)  # after gc() to exclude gc() time from next test when memtest
     }, add=TRUE )
-    if (showProgress) {
+    if (showProgress) { # nocov start
       cat("\r") # notranslate: \r can't be in gettextf msg
-      catf("Running test id", numStr, "         ")   # nocov.
-    }
+      catf("Running test id %s", numStr)
+      cat("         ")   # notranslate
+    } # nocov end
     # See PR #4090 for comments about change here in Dec 2019.
     # If a segfault error occurs in future and we'd like to know after which test, then arrange for the
     # try(sys.source()) in test.data.table() to be run in a separate R process. That process could write out


### PR DESCRIPTION
Most of #6808 can wait, but this avoids an error in `test.data.table(showProgress=TRUE)`:

```
> test.data.table()
data.table 1.16.99 IN DEVELOPMENT built 2025-02-10 14:18:50 UTC; ivan using 8 threads (see ?getDTthreads).  Latest news: r-datatable.com
getDTthreads(verbose=TRUE):
  OpenMP version (_OPENMP)       201511
  omp_get_num_procs()            16
  R_DATATABLE_NUM_PROCS_PERCENT  unset (default 50)
  R_DATATABLE_NUM_THREADS        unset
  R_DATATABLE_THROTTLE           unset (default 1024)
  omp_get_thread_limit()         2147483647
  omp_get_max_threads()          16
  OMP_THREAD_LIMIT               unset
  OMP_NUM_THREADS                unset
  RestoreAfterFork               true
  data.table is using 8 threads with throttle==1024. See ?setDTthreads.
test.data.table() running: <...>/library/data.table/tests/tests.Rraw
Error in sprintf(gettext(fmt, domain = domain, trim = trim), ...) :
  (converted from warning) 2 arguments not used by format 'Running test id'
In addition: There were 50 or more warnings (use warnings() to see the first 50)

Mon Feb 10 17:19:42 2025  endian==little, sizeof(long double)==16, longdouble.digits==64, sizeof(pointer)==8, TZ==unset, Sys.timezone()=='Europe/Moscow', Sys.getlocale()=='LC_CTYPE=ru_RU.UTF-8;LC_NUMERIC=C;LC_TIME=ru_RU.UTF-8;LC_COLLATE=ru_RU.UTF-8;LC_MONETARY=ru_RU.UTF-8;LC_MESSAGES=ru_RU.UTF-8;LC_PAPER=ru_RU.UTF-8;LC_NAME=C;LC_ADDRESS=C;LC_TELEPHONE=C;LC_MEASUREMENT=ru_RU.UTF-8;LC_IDENTIFICATION=C', l10n_info()=='MBCS=TRUE; UTF-8=TRUE; Latin-1=FALSE; codeset=UTF-8', getDTthreads()=='OpenMP version (_OPENMP)==201511; omp_get_num_procs()==16; R_DATATABLE_NUM_PROCS_PERCENT==unset (default 50); R_DATATABLE_NUM_THREADS==unset; R_DATATABLE_THROTTLE==unset (default 1024); omp_get_thread_limit()==2147483647; omp_get_max_threads()==16; OMP_THREAD_LIMIT==unset; OMP_NUM_THREADS==unset; RestoreAfterFork==true; data.table is using
8 threads with throttle==1024. See ?setDTthreads.', .libPaths()=='<...>/library', zlibVersion()==1.2.13 ZLIB_VERSION==1.2.13
Error in test.data.table() :
  Failed in 19.6s elapsed (21.6s cpu) after test 1743.34 before the next test() call in <...>/library/data.table/tests/tests.Rraw
```