### PR TITLE
add committer emails

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Authors@R: c(
   person("Arun","Srinivasan",      role="aut",          email="asrini@pm.me"),
   person("Jan","Gorecki",          role="aut"),
   person("Michael","Chirico",      role="aut", comment = c(ORCID="0000-0003-0787-087X")),
-  person("Toby","Hocking",         role="aut", comment = c(ORCID="0000-0002-3146-0865")),
+  person("Toby","Hocking",         role="aut",          email="toby.hocking@r-project.org", comment = c(ORCID="0000-0002-3146-0865")),
   person("Benjamin","Schwendinger",role="aut", comment = c(ORCID="0000-0003-3315-8114")),
   person("Pasha","Stetsenko",      role="ctb"),
   person("Tom","Short",            role="ctb"),


### PR DESCRIPTION
to support #6803 I would suggest that committer add their emails to DESCRIPTION.