### PR TITLE
Avoid `memcpy()`-ing 0-length vectors

### DIFF
--- a/src/dogroups.c
+++ b/src/dogroups.c
@@ -535,7 +535,7 @@ SEXP growVector(SEXP x, const R_len_t newlen)
   if (isNull(x)) error(_("growVector passed NULL"));
   PROTECT(newx = allocVector(TYPEOF(x), newlen));   // TO DO: R_realloc(?) here?
   if (newlen < len) len=newlen;   // i.e. shrink
-  switch (TYPEOF(x)) {
+  if (len) switch (TYPEOF(x)) {
   case RAWSXP:  memcpy(RAW(newx),     RAW(x),     len*SIZEOF(x)); break;
   case LGLSXP:  memcpy(LOGICAL(newx), LOGICAL(x), len*SIZEOF(x)); break;
   case INTSXP:  memcpy(INTEGER(newx), INTEGER(x), len*SIZEOF(x)); break;

--- a/src/dogroups.c
+++ b/src/dogroups.c
@@ -536,7 +536,7 @@ SEXP growVector(SEXP x, const R_len_t newlen)
   PROTECT(newx = allocVector(TYPEOF(x), newlen));   // TO DO: R_realloc(?) here?
   if (newlen < len) len=newlen;   // i.e. shrink
   if (!len) { // cannot memcpy invalid pointer, #6819
-    keepattr(newx, x)
+    keepattr(newx, x);
     UNPROTECT(1);
     return newx;
   }

--- a/src/dogroups.c
+++ b/src/dogroups.c
@@ -535,7 +535,12 @@ SEXP growVector(SEXP x, const R_len_t newlen)
   if (isNull(x)) error(_("growVector passed NULL"));
   PROTECT(newx = allocVector(TYPEOF(x), newlen));   // TO DO: R_realloc(?) here?
   if (newlen < len) len=newlen;   // i.e. shrink
-  if (len) switch (TYPEOF(x)) {
+  if (!len) { // cannot memcpy invalid pointer, #6819
+    keepattr(newx, x)
+    UNPROTECT(1);
+    return newx;
+  }
+  switch (TYPEOF(x)) {
   case RAWSXP:  memcpy(RAW(newx),     RAW(x),     len*SIZEOF(x)); break;
   case LGLSXP:  memcpy(LOGICAL(newx), LOGICAL(x), len*SIZEOF(x)); break;
   case INTSXP:  memcpy(INTEGER(newx), INTEGER(x), len*SIZEOF(x)); break;

--- a/src/utils.c
+++ b/src/utils.c
@@ -222,7 +222,7 @@ SEXP copyAsPlain(SEXP x) {
   }
   const int64_t n = XLENGTH(x);
   SEXP ans = PROTECT(allocVector(TYPEOF(x), n));
-  switch (TYPEOF(x)) {
+  if (n) switch (TYPEOF(x)) {
   case RAWSXP:
     memcpy(RAW(ans),     RAW(x),     n*sizeof(Rbyte));
     break;

--- a/src/utils.c
+++ b/src/utils.c
@@ -222,7 +222,15 @@ SEXP copyAsPlain(SEXP x) {
   }
   const int64_t n = XLENGTH(x);
   SEXP ans = PROTECT(allocVector(TYPEOF(x), n));
-  if (n) switch (TYPEOF(x)) {
+  // aside: unlike R's duplicate we do not copy truelength here; important for dogroups.c which uses negative truelenth to mark its specials
+  if (ALTREP(ans))
+    internal_error(__func__, "copyAsPlain returning ALTREP for type '%s'", type2char(TYPEOF(x))); // # nocov
+  if (!n) { // cannot memcpy invalid pointer, #6819
+    DUPLICATE_ATTRIB(ans, x);
+    UNPROTECT(1);
+    return ans;
+  }
+  switch (TYPEOF(x)) {
   case RAWSXP:
     memcpy(RAW(ans),     RAW(x),     n*sizeof(Rbyte));
     break;
@@ -250,9 +258,6 @@ SEXP copyAsPlain(SEXP x) {
     internal_error(__func__, "type '%s' not supported in %s", type2char(TYPEOF(x)), "copyAsPlain()"); // # nocov
   }
   DUPLICATE_ATTRIB(ans, x);
-  // aside: unlike R's duplicate we do not copy truelength here; important for dogroups.c which uses negative truelenth to mark its specials
-  if (ALTREP(ans))
-    internal_error(__func__, "copyAsPlain returning ALTREP for type '%s'", type2char(TYPEOF(x))); // # nocov
   UNPROTECT(1);
   return ans;
 }


### PR DESCRIPTION
The C standard (before C23) says that giving invalid pointers, even with length=0, to `memcpy()` is undefined behaviour. R returns an invalid pointer for vectors of length 0, so avoid calls to `memcpy()` altogether in such cases.

Fixes: #6819