### PR TITLE
Minimal set of changes to permit master to be 1.17.99

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: data.table
-Version: 1.16.99
+Version: 1.17.99
 Title: Extension of `data.frame`
 Depends: R (>= 3.3.0)
 Imports: methods

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ some:
 
 .PHONY: clean
 clean:
-	$(RM) data.table_1.16.99.tar.gz
+	$(RM) data.table_1.17.99.tar.gz
 	$(RM) src/*.o
 	$(RM) src/*.so
 
@@ -28,7 +28,7 @@ build:
 
 .PHONY: install
 install:
-	$(R) CMD INSTALL data.table_1.16.99.tar.gz
+	$(R) CMD INSTALL data.table_1.17.99.tar.gz
 
 .PHONY: uninstall
 uninstall:
@@ -40,7 +40,7 @@ test:
 
 .PHONY: check
 check:
-	_R_CHECK_CRAN_INCOMING_REMOTE_=false $(R) CMD check data.table_1.16.99.tar.gz --as-cran --ignore-vignettes --no-stop-on-test-error
+	_R_CHECK_CRAN_INCOMING_REMOTE_=false $(R) CMD check data.table_1.17.99.tar.gz --as-cran --ignore-vignettes --no-stop-on-test-error
 
 .PHONY: revision
 revision:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 **If you are viewing this file on CRAN, please check [latest news on GitHub](https://github.com/Rdatatable/data.table/blob/master/NEWS.md) where the formatting is also better.**
 
-# data.table [v1.16.99](https://github.com/Rdatatable/data.table/milestone/31)  (in development)
+# data.table [v1.17.99](https://github.com/Rdatatable/data.table/milestone/35)  (in development)
+
+
+
+# data.table [v1.17.0](https://github.com/Rdatatable/data.table/milestone/34)  (20 Feb 2025)
 
 ## POTENTIALLY BREAKING CHANGES
 

--- a/src/init.c
+++ b/src/init.c
@@ -372,6 +372,6 @@ SEXP initLastUpdated(SEXP var) {
 
 SEXP dllVersion(void) {
   // .onLoad calls this and checks the same as packageVersion() to ensure no R/C version mismatch, #3056
-  return(ScalarString(mkChar("1.16.99")));
+  return(ScalarString(mkChar("1.17.99")));
 }
 


### PR DESCRIPTION
Congratulations on getting 1.17.0 onto CRAN.

As with previous releases, `master` lags as is still at 1.16.99 in DESCRIPTION and src/init.c (plus some .po files I left alone).  Feel free to add to the PR as needed.