### PR TITLE
Remove trailing comma from `rowwiseDT()` example in news

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,7 +20,7 @@ rowwiseDT(
   a=,b=,c=,  d=,
   1, 2, "a", 2:3,
   3, 4, "b", list("e"),
-  5, 6, "c", ~a+b,
+  5, 6, "c", ~a+b
 )
 #>        a     b      c      d
 #>    <num> <num> <char> <list>


### PR DESCRIPTION
This PR removes the redundant trailing comma from the `rowwiseDT()` example in `NEWS.md` to avoid the cryptic error:

```r
rowwiseDT(
  a=,b=,c=,  d=,
  1, 2, "a", 2:3,
  3, 4, "b", list("e"),
  5, 6, "c", ~a+b,
)
#> Error in FUN(X[[i]], ...) : argument is missing, with no default
```