### PR TITLE
Provide our own `.formula2varlist` implementation

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -2454,7 +2454,7 @@ split.data.table = function(x, f, drop = FALSE, by, sorted = FALSE, keep.by = TR
     # same as split.data.frame - handling all exceptions, factor orders etc, in a single stream of processing was a nightmare in factor and drop consistency
     # evaluate formula mirroring split.data.frame #5392. Mimics base::.formula2varlist.
     if (inherits(f, "formula"))
-        f = eval(attr(terms(f), "variables"), x, environment(f))
+        f = formula_vars(f, x)
     # be sure to use x[ind, , drop = FALSE], not x[ind], in case downstream methods don't follow the same subsetting semantics (#5365)
     return(lapply(split(x = seq_len(nrow(x)), f = f, drop = drop, ...), function(ind) x[ind, , drop = FALSE]))
   }
@@ -2530,7 +2530,7 @@ sort_by.data.table <- function(x, y, ...)
 {
   if (!cedta()) return(NextMethod()) # nocov
   if (inherits(y, "formula"))
-    y <- .formula2varlist(y, x)
+    y <- formula_vars(y, x)
   if (!is.list(y))
     y <- list(y)
   # use forder instead of base 'order'

--- a/R/utils.R
+++ b/R/utils.R
@@ -212,3 +212,11 @@ rss = function() {  #5515 #5517
   round(ans / 1024.0, 1L)  # return MB
   # nocov end
 }
+
+formula_vars = function(f, x) { # .formula2varlist is not API and seems to have appeared after R-4.2, #6841
+  terms <- terms(f)
+  setNames(
+    eval(attr(terms, "variables"), x, environment(f)),
+    attr(terms, "term.labels")
+  )
+}


### PR DESCRIPTION
Since [`base::.formula2varlist` is not an API](https://search.r-project.org/R/refmans/base/html/base-internal.html) and is now needed in two places, provide our own implementation.

Fixes: #6841. Tested manually that an older R version no longer complains about "no visible binding for `.formula2varlist`" during `R CMD check`.

Alternatively, we could try some tricks to convince the static analysis tools on R < 4.3 that `.formula2varlist` exists (despite `sort_by.data.table` is not used there).