### PR TITLE
Simplified and Extended "Updating by Reference" Section in Joins Vignette

### DIFF
--- a/vignettes/datatable-joins.Rmd
+++ b/vignettes/datatable-joins.Rmd
@@ -698,23 +698,38 @@ Products[!"popcorn",
 
 The `:=` operator in `data.table` is used for updating or adding columns by reference. This means it modifies the original `data.table` without creating a copy, which is very memory-efficient, especially for large datasets. When used inside a `data.table`, `:=` allows you to **add new columns** or **modify existing ones** as part of your query.
 
-Let's update our `Products` table with the latest price from `ProductPriceHistory`:
-
-```{r}
-copy(Products)[ProductPriceHistory,
-               on = .(id = product_id),
-               j = `:=`(price = tail(i.price, 1),
-                        last_updated = tail(i.date, 1)),
-               by = .EACHI][]
+1) Let's update our `Products` table with the latest price from `ProductPriceHistory`:
+```{r Simple One-to-One Update}
+Products[ProductPriceHistory, on = .(id = product_id), price := i.price]
 ```
+- The price column in Products is updated using the price column from ProductPriceHistory.
+- The on = .(id = product_id) ensures that updates happen based on matching IDs.
+- This method modifies Products in place, avoiding unnecessary copies.
 
-In this operation:
+2) If we need to get the latest price and date (instead of all matches), we can still use := efficiently:
+```{r Updating with the Latest Record}
+Products[ProductPriceHistory, 
+         on = .(id = product_id),
+         `:=`(price = last(i.price), last_updated = last(i.date)), 
+         by = .EACHI]
+```
+- last(i.price) ensures that only the latest price is selected.
+- last_updated column is added to track the last update date.
+- by = .EACHI ensures that the last price is picked for each product.
 
-- The function copy creates a ***deep*** copy of the `Products` table, preventing modifications made by `:=` from changing the original table by reference.
-- We join `Products` with `ProductPriceHistory` based on `id` and `product_id`.
-- We update the `price` column with the latest price from `ProductPriceHistory`.
-- We add a new `last_updated` column to track when the price was last changed.
-- The `by = .EACHI` ensures that the `tail` function is applied for each product in `ProductPriceHistory`.
+3) When we need to update Products with multiple columns from ProductPriceHistory
+```{r Efficient Right Join Update }
+cols <- setdiff(names(ProductPriceHistory), 'product_id')
+Products[ProductPriceHistory, 
+         on = .(id = product_id), 
+         (cols) := mget(cols)]
+
+```
+- Efficiently updates multiple columns in Products from ProductPriceHistory.
+- mget(cols) retrieves multiple matching columns dynamically.
+- This method is faster and more memory-efficient than Products <- ProductPriceHistory[Products, on=...].
+- Note: := updates Products in place, but does not modify ProductPriceHistory.
+   - Unlike traditional RIGHT JOIN, data.table does not allow i (right table) to be updated directly.
 
 ***
 


### PR DESCRIPTION
Simplified and extended the Updating by Reference section in the Joins in data.table vignette.
closes #6846
in this i 
- Added a simpler one-to-one update example for clarity.
- Provided an efficient solution for updating multiple columns using mget(cols), reducing unnecessary copies.
- Clarified RIGHT JOIN limitations and how := modifies x in place but does not update i.
- Mentioned performance improvements observed in large datasets.
