### PR TITLE
Replace `GetOption` with `GetOption1`

### DIFF
--- a/src/forder.c
+++ b/src/forder.c
@@ -1616,7 +1616,7 @@ void putIndex(SEXP x, SEXP cols, SEXP o) {
 
 // isTRUE(getOption("datatable.use.index"))
 bool GetUseIndex(void) {
-  SEXP opt = GetOption(install("datatable.use.index"), R_NilValue);
+  SEXP opt = GetOption1(install("datatable.use.index"));
   if (!IS_TRUE_OR_FALSE(opt))
     error(_("'datatable.use.index' option must be TRUE or FALSE")); // # nocov
   return LOGICAL(opt)[0];
@@ -1627,7 +1627,7 @@ bool GetAutoIndex(void) {
   // for now temporarily 'forder.auto.index' not 'auto.index' to disabled it by default
   // because it writes attr on .SD which is re-used by all groups leading to incorrect results
   // DT[, .(uN=uniqueN(.SD)), by=A]
-  SEXP opt = GetOption(install("datatable.forder.auto.index"), R_NilValue);
+  SEXP opt = GetOption1(install("datatable.forder.auto.index"));
   if (isNull(opt))
     return false;
   if (!IS_TRUE_OR_FALSE(opt))

--- a/src/freadR.c
+++ b/src/freadR.c
@@ -132,7 +132,7 @@ SEXP freadR(
   args.logical01 = LOGICAL(logical01Arg)[0];
   args.logicalYN = LOGICAL(logicalYNArg)[0];
   {
-    SEXP tt = PROTECT(GetOption(sym_old_fread_datetime_character, R_NilValue));
+    SEXP tt = PROTECT(GetOption1(sym_old_fread_datetime_character));
     args.oldNoDateTime = oldNoDateTime = isLogical(tt) && LENGTH(tt)==1 && LOGICAL(tt)[0]==TRUE;
     UNPROTECT(1);
   }

--- a/src/init.c
+++ b/src/init.c
@@ -329,7 +329,7 @@ inline double LLtoD(long long x) {
 
 int GetVerbose(void) {
   // don't call repetitively; save first in that case
-  SEXP opt = GetOption(sym_verbose, R_NilValue);
+  SEXP opt = GetOption1(sym_verbose);
   if ((!isLogical(opt) && !isInteger(opt)) || LENGTH(opt)!=1 || INTEGER(opt)[0]==NA_INTEGER)
     error(_("verbose option must be length 1 non-NA logical or integer"));
   return INTEGER(opt)[0];

--- a/src/rbindlist.c
+++ b/src/rbindlist.c
@@ -228,7 +228,7 @@ SEXP rbindlist(SEXP l, SEXP usenamesArg, SEXP fillArg, SEXP idcolArg, SEXP ignor
         }
       }
       if (buff[0]) {
-        SEXP opt = GetOption(install("datatable.rbindlist.check"), R_NilValue);
+        SEXP opt = GetOption1(install("datatable.rbindlist.check"));
         if (!isNull(opt) && !(isString(opt) && length(opt)==1)) {
           warning(_("options()$datatable.rbindlist.check is set but is not a single string. See news item 5 in v1.12.2."));
           opt = R_NilValue;

--- a/src/subset.c
+++ b/src/subset.c
@@ -296,7 +296,7 @@ SEXP subsetDT(SEXP x, SEXP rows, SEXP cols) { // API change needs update NEWS.md
     if (this<1 || this>LENGTH(x)) error(_("Item %d of cols is %d which is outside the range [1,ncol(x)=%d]"), i+1, this, LENGTH(x));
   }
 
-  int overAlloc = checkOverAlloc(GetOption(install("datatable.alloccol"), R_NilValue));
+  int overAlloc = checkOverAlloc(GetOption1(install("datatable.alloccol")));
   SEXP ans = PROTECT(allocVector(VECSXP, LENGTH(cols)+overAlloc)); nprotect++;  // doing alloc.col directly here; eventually alloc.col can be deprecated.
 
   // user-defined and superclass attributes get copied as from v1.12.0


### PR DESCRIPTION
As of [`r87874`](https://github.com/r-devel/r-svn/commit/433089747acc1376ee54692922de60b5ccc08ef4) we get:

```
  Found non-API calls to R: ‘LEVELS’, ‘OBJECT’, ‘Rf_GetOption’,
    ‘Rf_isFrame’, ‘SETLENGTH’, ‘SET_GROWABLE_BIT’, ‘SET_TRUELENGTH’,
    ‘TRUELENGTH’
```

`GetOption1()` has been available since R-2.13, and `GetOption()` has been ignoring its second argument for a long time, so there's no portability cost.

See also: #6180