### PR TITLE
Replace `isFrame` with the new API `isDataFrame`

### DIFF
--- a/src/data.table.h
+++ b/src/data.table.h
@@ -17,6 +17,7 @@
 #if R_VERSION < R_Version(3, 4, 0)
 #  define SET_GROWABLE_BIT(x)  // #3292
 #endif
+// TODO: remove the `R_SVN_VERSION` check when R 4.5.0 is released (circa Apr. 2025)
 #if R_VERSION < R_Version(4, 5, 0) || R_SVN_REVISION < 86702
 #  define isDataFrame(x) isFrame(x) // #6180
 #endif

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -17,6 +17,9 @@
 #if R_VERSION < R_Version(3, 4, 0)
 #  define SET_GROWABLE_BIT(x)  // #3292
 #endif
+#if R_VERSION < R_Version(4, 5, 0) || R_SVN_REVISION < 86702
+#  define isDataFrame(x) isFrame(x) // #6180
+#endif
 #include <Rinternals.h>
 #define SEXPPTR_RO(x) ((const SEXP *)DATAPTR_RO(x))  // to avoid overhead of looped STRING_ELT and VECTOR_ELT
 #include <stdint.h>    // for uint64_t rather than unsigned long long

--- a/src/dogroups.c
+++ b/src/dogroups.c
@@ -283,7 +283,7 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
       for (int j=0; j<LENGTH(jval); ++j) {
         thiscol = VECTOR_ELT(jval,j);
         if (isNull(thiscol)) continue;
-        if (!isVector(thiscol) || isFrame(thiscol))
+        if (!isVector(thiscol) || isDataFrame(thiscol))
           error(_("Entry %d for group %d in j=list(...) should be atomic vector or list. If you are trying something like j=list(.SD,newcol=mean(colA)) then use := by group instead (much quicker), or cbind or merge afterwards."), j+1, i+1);
         if (isArray(thiscol)) {
           SEXP dims = PROTECT(getAttrib(thiscol, R_DimSymbol));


### PR DESCRIPTION
As of [r87874](https://github.com/r-devel/r-svn/commit/433089747acc1376ee54692922de60b5ccc08ef4) we get:

```
  Found non-API calls to R: ‘LEVELS’, ‘OBJECT’, ‘Rf_GetOption’,
    ‘Rf_isFrame’, ‘SETLENGTH’, ‘SET_GROWABLE_BIT’, ‘SET_TRUELENGTH’,
    ‘TRUELENGTH’
```

Since both the NOTE and the new entry point are in current R-devel, test for both R version and SVN revision to account for revisions that lack the new entry point. Tested manually on r86699 (the last trunk revision before `isDataFrame` was added), r86702 (the revision adding `isDataFrame`), current trunk. Once R-4.5.0 is released, the test for SVN revision can be removed.

See also: #6180, #6244.