### PR TITLE
fwrite: avoid deflateEnd() for uninitialized strm

### DIFF
--- a/src/fwrite.c
+++ b/src/fwrite.c
@@ -927,8 +927,8 @@ void fwriteMain(fwriteMainArgs args)
     }
   }
 #ifndef NOZLIB
-  else {
-    // was unconditionally initialized for zbuffSize, not used for header
+  else if (args.is_gzip) {
+    // zstrm initialized for zbuffSize calculation, but not used for header
     deflateEnd(&strm);
   }
 #endif


### PR DESCRIPTION
As diagnosed by @ben-schwen, when `!args.is_gzip`, `strm` is not initialized, so calling `deflateEnd()` on it is a mistake. Sorry about it.

Fixes: #6857

Tested using `R CMD check PeakSegDisk*.tar.gz` after observing the crash without the fix and by running `fwrite(list(1:100), "/dev/null")` under Valgrind (which knows about undefined values and diagnoses the problem immediately). Unfortunately, Valgrind is too slow to run everything in it.