### PR TITLE
Rename the `test-lin-san` GitLab CI job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -213,7 +213,7 @@ test-lin-ancient-cran:
     - R CMD check --no-manual --no-build-vignettes --ignore-vignettes $(ls -1t data.table_*.tar.gz | head -n 1)
 
 # run the main checks with Address(+Leak),UBSanitizer enabled
-test-lin-san:
+test-lin-dev-san:
   <<: *test-lin
   image: registry.gitlab.com/rdatatable/dockerfiles/r-devel-clang-san
   variables:
@@ -329,7 +329,7 @@ integration:
     - saas-linux-medium-amd64
   only:
     - master
-  needs: ["mirror-packages","build","test-lin-rel","test-lin-rel-cran","test-lin-dev-gcc-strict-cran","test-lin-dev-clang-cran","test-lin-rel-vanilla","test-lin-ancient-cran","test-lin-san","test-win-rel","test-win-dev" ,"test-win-old","test-mac-rel","test-mac-old"]
+  needs: ["mirror-packages","build","test-lin-rel","test-lin-rel-cran","test-lin-dev-gcc-strict-cran","test-lin-dev-clang-cran","test-lin-rel-vanilla","test-lin-ancient-cran","test-lin-dev-san","test-win-rel","test-win-dev" ,"test-win-old","test-mac-rel","test-mac-old"]
   script:
     - R --version
     - *install-deps ## markdown pkg not present in r-pkgdown image


### PR DESCRIPTION
As it turns out, #6476 [broke GitLab CI](https://gitlab.com/Rdatatable/data.table/-/pipelines/1716214169) because test stage names are expected to follow a pattern of `test-<platform>-<R version>[-<suffixes...>]`:
https://github.com/Rdatatable/data.table/blob/3afc750115abad122a27089605837c5b5aa881c9/.ci/publish.R#L162-L168
(And if `<R version>` is not `rel`, `dev`, or `old`, it must be a series of digits to be joined by dots.)

Perhaps this needs a comment in `.gitlab-ci.yml`, but I'm not sure where to place it.