### PR TITLE
Remove partial argument usage #6855

### DIFF
--- a/vignettes/datatable-reshape.Rmd
+++ b/vignettes/datatable-reshape.Rmd
@@ -130,7 +130,7 @@ dcast(DT.m1, family_id + age_mother ~ child, value.var = "dob")
 You can also pass a function to aggregate by in `dcast` with the argument `fun.aggregate`. This is particularly essential when the formula provided does not identify single observation for each cell.
 
 ```{r}
-dcast(DT.m1, family_id ~ ., fun.agg = function(x) sum(!is.na(x)), value.var = "dob")
+dcast(DT.m1, family_id ~ ., fun.aggregate = function(x) sum(!is.na(x)), value.var = "dob")
 ```
 
 Check `?dcast` for other useful arguments and additional examples.
@@ -156,7 +156,7 @@ DT
 And you'd like to combine (`melt`) all the `dob` columns together, and `gender` columns together. Using the current functionality, we can do something like this:
 
 ```{r}
-DT.m1 = melt(DT, id = c("family_id", "age_mother"))
+DT.m1 = melt(DT, id.vars = c("family_id", "age_mother"))
 DT.m1[, c("variable", "child") := tstrsplit(variable, "_", fixed = TRUE)]
 DT.c1 = dcast(DT.m1, family_id + age_mother + child ~ variable, value.var = "value")
 DT.c1
@@ -191,7 +191,7 @@ The idea is quite simple. We pass a list of columns to `measure.vars`, where eac
 ```{r}
 colA = paste0("dob_child", 1:3)
 colB = paste0("gender_child", 1:3)
-DT.m2 = melt(DT, measure = list(colA, colB), value.name = c("dob", "gender"))
+DT.m2 = melt(DT, measure.vars = list(colA, colB), value.name = c("dob", "gender"))
 DT.m2
 
 str(DT.m2) ## col type is preserved
@@ -206,7 +206,7 @@ str(DT.m2) ## col type is preserved
 Usually in these problems, the columns we'd like to melt can be distinguished by a common pattern. We can use the function `patterns()`, implemented for convenience, to provide regular expressions for the columns to be combined together. The above operation can be rewritten as:
 
 ```{r}
-DT.m2 = melt(DT, measure = patterns("^dob", "^gender"), value.name = c("dob", "gender"))
+DT.m2 = melt(DT, measure.vars = patterns("^dob", "^gender"), value.name = c("dob", "gender"))
 DT.m2
 ```
 
@@ -256,7 +256,7 @@ can see a more complex usage of `measure`, involving a function which
 is used to convert the `child` string values to integers:
 
 ```{r}
-DT.m3 = melt(DT, measure = measure(value.name, child=as.integer, sep="_child"))
+DT.m3 = melt(DT, measure.vars = measure(value.name, child=as.integer, sep="_child"))
 DT.m3
 ```
 

--- a/vignettes/fr/datatable-reshape.Rmd
+++ b/vignettes/fr/datatable-reshape.Rmd
@@ -129,7 +129,7 @@ dcast(DT.m1, family_id + age_mother ~ child, value.var = "dob")
 Vous pouvez également passer une fonction d'agrégation dans `dcast` avec l'argument `fun.aggregate`. Ceci est particulièrement essentiel lorsque la formule fournie ne permet pas d'identifier une seule observation pour chaque cellule.
 
 ```{r}
-dcast(DT.m1, family_id ~ ., fun.agg = function(x) sum(!is.na(x)), value.var = "dob")
+dcast(DT.m1, family_id ~ ., fun.aggregate = function(x) sum(!is.na(x)), value.var = "dob")
 ```
 
 Voir `?dcast` pour d'autres arguments utiles et des exemples supplémentaires.
@@ -156,7 +156,7 @@ DT
 Et vous aimeriez combiner (avec `melt`) toutes les colonnes `dob` ensemble, ainsi que toutes les colonnes `gender` ensemble. Avec la fonctionnalité actuelle, nous pouvons faire quelque chose comme ceci :
 
 ```{r}
-DT.m1 = melt(DT, id = c("family_id", "age_mother"))
+DT.m1 = melt(DT, id.vars = c("family_id", "age_mother"))
 DT.m1[, c("variable", "child") := tstrsplit(variable, "_", fixed = TRUE)]
 DT.c1 = dcast(DT.m1, family_id + age_mother + child ~ variable, value.var = "value")
 DT.c1
@@ -191,7 +191,7 @@ L'idée est assez simple. Nous passons une liste de colonnes à `measure.vars`, 
 ```{r}
 colA = paste0("dob_child", 1:3)
 colB = paste0("gender_child", 1:3)
-DT.m2 = melt(DT, measure = list(colA, colB), value.name = c("dob", "gender"))
+DT.m2 = melt(DT, measure.vars = list(colA, colB), value.name = c("dob", "gender"))
 DT.m2
 
 str(DT.m2) ## le type de col est préservé
@@ -206,7 +206,7 @@ str(DT.m2) ## le type de col est préservé
 En général, dans ce type de problème, les colonnes que l'on souhaite transformer avec `melt` peuvent être distinguées par un motif commun. Nous pouvons utiliser la fonction `patterns()`, implémentée pour faciliter cette tâche, pour fournir des expressions régulières correspondant aux colonnes à combiner ensemble. L'opération ci-dessus peut alors être réécrite comme suit :
 
 ```{r}
-DT.m2 = melt(DT, measure = patterns("^dob", "^gender"), value.name = c("dob", "gender"))
+DT.m2 = melt(DT, measure.vars = patterns("^dob", "^gender"), value.name = c("dob", "gender"))
 DT.m2
 ```
 
@@ -241,7 +241,7 @@ melt(two.iris, measure.vars = measure(part, value.name, sep="."))
 En revenant à l'exemple des données sur les familles et les enfants, nous pouvons voir une utilisation plus complexe de `measure`, impliquant une fonction utilisée pour convertir les valeurs de la chaîne `child` en entiers :
 
 ```{r}
-DT.m3 = melt(DT, measure = measure(value.name, child=as.integer, sep="_child"))
+DT.m3 = melt(DT, measure.vars = measure(value.name, child=as.integer, sep="_child"))
 DT.m3
 ```
 

--- a/vignettes/ru/datatable-reshape.Rmd
+++ b/vignettes/ru/datatable-reshape.Rmd
@@ -159,7 +159,7 @@ dcast(DT.m1, family_id + age_mother ~ child, value.var = "dob")
 одного наблюдения для каждой описываемой ею ячейки.
 
 ```{r}
-dcast(DT.m1, family_id ~ ., fun.agg = function(x) sum(!is.na(x)), value.var = "dob")
+dcast(DT.m1, family_id ~ ., fun.aggregate = function(x) sum(!is.na(x)), value.var = "dob")
 ```
 
 Ознакомьтесь с `?dcast`, чтобы узнать о других полезных аргументах и
@@ -191,7 +191,7 @@ DT
 примерно следующее:
 
 ```{r}
-DT.m1 = melt(DT, id = c("family_id", "age_mother"))
+DT.m1 = melt(DT, id.vars = c("family_id", "age_mother"))
 DT.m1[, c("variable", "child") := tstrsplit(variable, "_", fixed = TRUE)]
 DT.c1 = dcast(DT.m1, family_id + age_mother + child ~ variable, value.var = "value")
 DT.c1
@@ -241,7 +241,7 @@ str(DT.c1) ## столбец gender теперь класса IDate!
 ```{r}
 colA = paste0("dob_child", 1:3)
 colB = paste0("gender_child", 1:3)
-DT.m2 = melt(DT, measure = list(colA, colB), value.name = c("dob", "gender"))
+DT.m2 = melt(DT, measure.vars = list(colA, colB), value.name = c("dob", "gender"))
 DT.m2
 
 str(DT.m2) ## тип столбца сохранён
@@ -259,7 +259,7 @@ str(DT.m2) ## тип столбца сохранён
 `patterns()`. Приведенную выше операцию можно переписать так:
 
 ```{r}
-DT.m2 = melt(DT, measure = patterns("^dob", "^gender"), value.name = c("dob", "gender"))
+DT.m2 = melt(DT, measure.vars = patterns("^dob", "^gender"), value.name = c("dob", "gender"))
 DT.m2
 ```
 
@@ -312,7 +312,7 @@ melt(two.iris, measure.vars = measure(part, value.name, sep="."))
 для преобразования строковых значений `child` в целые числа:
 
 ```{r}
-DT.m3 = melt(DT, measure = measure(value.name, child=as.integer, sep="_child"))
+DT.m3 = melt(DT, measure.vars = measure(value.name, child=as.integer, sep="_child"))
 DT.m3
 ```
 


### PR DESCRIPTION
Closes #6855 

This PR replaces partial argument names (id, fun.agg, measure) with their full names (id.vars, fun.aggregate, measure.vars) in the following vignettes for improved clarity and consistency:

->vignettes/data.table-reshape.Rmd
->vignettes/fr/data.table-reshape.Rmd
->vignettes/ru/data.table-reshape.Rmd
Additionally, these changes ensure better alignment with the surrounding text for improved coherence.

@MichaelChirico, please review when you have time. Thank you!