### PR TITLE
Don't mention 14-year-old version info in ?alloc.col

### DIFF
--- a/man/truelength.Rd
+++ b/man/truelength.Rd
@@ -36,9 +36,13 @@ alloc.col(DT,
     Please note: over-allocation of the column pointer vector is not for efficiency \emph{per se}; it is so that \code{:=} can add columns by reference without a shallow copy.
 }
 \value{
-    \code{truelength(x)} returns the length of the vector allocated in memory. \code{length(x)} of those items are in use. Currently, it is just the list vector of column pointers that is over-allocated (i.e. \code{truelength(DT)}), not the column vectors themselves, which would in future allow fast row \code{insert()}. For tables loaded from disk however, \code{truelength} is 0 in \R 2.14.0+ (and random in \R <= 2.13.2), which is perhaps unexpected. \code{data.table} detects this state and over-allocates the loaded \code{data.table} when the next column addition occurs. All other operations on \code{data.table} (such as fast grouping and joins) do not need \code{truelength}.
+    \code{truelength(x)} returns the length of the vector allocated in memory. \code{length(x)} of those items are in use. Currently, it is just the list vector of column
+    pointers that is over-allocated (i.e. \code{truelength(DT)}), not the column vectors themselves, which would in future allow fast row \code{insert()}. For tables loaded
+    from disk however, \code{truelength} is 0, which is perhaps unexpected. \code{data.table} detects this state and over-allocates the loaded \code{data.table} when the
+    next column addition occurs. All other operations on \code{data.table} (such as fast grouping and joins) do not need \code{truelength}.
 
-    \code{setalloccol} \emph{reallocates} \code{DT} by reference. This may be useful for efficiency if you know you are about to going to add a lot of columns in a loop. It also returns the new \code{DT}, for convenience in compound queries.
+    \code{setalloccol} \emph{reallocates} \code{DT} by reference. This may be useful for efficiency if you know you are about to going to add a lot of columns in a loop.
+    It also returns the new \code{DT}, for convenience in compound queries.
 }
 \seealso{ \code{\link{copy}} }
 \examples{


### PR DESCRIPTION
v1.7.2 is from 2011, I don't think it's relevant to detail a before/after 2011 distinction any more.

R 2.14.0 is also from 2011.

https://cran.r-project.org/src/contrib/Archive/data.table/
https://github.com/wch/r-source/tree/tags/R-2-14-0

Also wrapped some of the text, not all IDEs do text wrapping so these very-very wide lines are a bit hard to work with.