### PR TITLE
`fwrite`: pre-encode strings and factor levels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@
 
 5. `as.data.table()` on `x` avoids an infinite loop if the output of the corresponding `as.data.frame()` method has the same class as the input, [#6874](https://github.com/Rdatatable/data.table/issues/6874). Concretely, we had `class(x) = c('foo', 'data.frame')` and `class(as.data.frame(x)) = c('foo', 'data.frame')`, so `as.data.frame.foo` wound up getting called repeatedly. Thanks @matschmitz for the report and @ben-schwen for the fix.
 
+6. `fwrite()` now avoids a crash when translating strings into a different encoding, [#6883](https://github.com/Rdatatable/data.table/issues/6883). Thanks @filipemsc for the report and @aitap for the fix.
+
 ## NOTES
 
 1. Continued work to remove non-API C functions, [#6180](https://github.com/Rdatatable/data.table/issues/6180). Thanks Ivan Krylov for the PRs and for writing a clear and concise guide about the R API: https://aitap.codeberg.page/R-api/.

--- a/R/fwrite.R
+++ b/R/fwrite.R
@@ -111,6 +111,15 @@ fwrite = function(x, file="", append=FALSE, quote="auto",
   }
   # nocov end
   file = enc2native(file) # CfwriteR cannot handle UTF-8 if that is not the native encoding, see #3078.
+  # pre-encode any strings or factor levels to avoid translateChar trying to allocate from OpenMP threads
+  if (encoding %chin% c("UTF-8", "native")) {
+    enc = switch(encoding, "UTF-8" = enc2utf8, "native" = enc2native)
+    x = lapply(x, function(x) {
+      if (is.character(x)) x = enc(x)
+      if (is.factor(x)) levels(x) = enc(levels(x))
+      x
+    })
+  }
   .Call(CfwriteR, x, file, sep, sep2, eol, na, dec, quote, qmethod=="escape", append,
         row.names, col.names, logical01, scipen, dateTimeAs, buffMB, nThread,
         showProgress, is_gzip, compressLevel, bom, yaml, verbose, encoding)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -21115,5 +21115,5 @@ DF = structure(list(a = 1:2), class = c("data.frame", "no.reset"), row.names = c
 test(2310.01, as.data.table(DF), data.table(a=1:2))
 
 # avoid translateChar*() in OpenMP threads, #6883
-DF = list(rep(iconv(strrep("\uf8", 100), to = "latin1"), 100000))
+DF = list(rep(iconv(strrep("\uf8", 100), from = "UTF-8", to = "latin1"), 100000))
 test(2311, fwrite(DF, nullfile(), encoding = "UTF-8"), NULL)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -21113,3 +21113,7 @@ test(2309.09, as.data.table(df, keep.rownames=TRUE), data.table(rn = c("a","b"),
 as.data.frame.no.reset = function(x) x
 DF = structure(list(a = 1:2), class = c("data.frame", "no.reset"), row.names = c(NA, -2L))
 test(2310.01, as.data.table(DF), data.table(a=1:2))
+
+# avoid translateChar*() in OpenMP threads, #6883
+DF = list(rep(iconv(strrep("\uf8", 100), to = "latin1"), 100000))
+test(2311, fwrite(DF, nullfile(), encoding = "UTF-8"), NULL)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -21115,5 +21115,5 @@ DF = structure(list(a = 1:2), class = c("data.frame", "no.reset"), row.names = c
 test(2310.01, as.data.table(DF), data.table(a=1:2))
 
 # avoid translateChar*() in OpenMP threads, #6883
-DF = list(rep(iconv(strrep("\uf8", 100), from = "UTF-8", to = "latin1"), 100000))
-test(2311, fwrite(DF, nullfile(), encoding = "UTF-8"), NULL)
+DF = list(rep(iconv("\uf8", from = "UTF-8", to = "latin1"), 2e6))
+test(2311, fwrite(DF, nullfile(), encoding = "UTF-8", nThread = 2L), NULL)


### PR DESCRIPTION
Previously, `fwrite()` deferred encoding of the strings to `fwriteR.c`:[`getString`](https://github.com/Rdatatable/data.table/blob/2cb03162a21328cc5f68a8c3b0e554f5edfcb5b9/src/fwriteR.c#L22-L25),[`getCategString`](https://github.com/Rdatatable/data.table/blob/2cb03162a21328cc5f68a8c3b0e554f5edfcb5b9/src/fwriteR.c#L50-L54) called from OpenMP threads. Calling translateChar(UTF8) to encode a string results in memory allocation unless it is already in the desired encoding, which is unsafe to perform on a non-main thread.

Fixes: #6883