### PR TITLE
`memrecycle()`: match factor levels in UTF-8

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@
 
 5. `as.data.table()` on `x` avoids an infinite loop if the output of the corresponding `as.data.frame()` method has the same class as the input, [#6874](https://github.com/Rdatatable/data.table/issues/6874). Concretely, we had `class(x) = c('foo', 'data.frame')` and `class(as.data.frame(x)) = c('foo', 'data.frame')`, so `as.data.frame.foo` wound up getting called repeatedly. Thanks @matschmitz for the report and @ben-schwen for the fix.
 
+6. By-reference sub-assignments to factor columns now match the levels in UTF-8, preventing their duplication when the same level exists in different encodings, [#6886](https://github.com/Rdatatable/data.table/issues/6886). Thanks @iagogv3 for the report and @aitap for the fix.
+
 ## NOTES
 
 1. Continued work to remove non-API C functions, [#6180](https://github.com/Rdatatable/data.table/issues/6180). Thanks Ivan Krylov for the PRs and for writing a clear and concise guide about the R API: https://aitap.codeberg.page/R-api/.

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -21114,6 +21114,10 @@ DF = structure(list(a = 1:2), class = c("data.frame", "no.reset"), row.names = c
 test(2310.01, as.data.table(DF), data.table(a=1:2))
 
 # memrecycle() did not consider string encodings for factor levels #6886
-DT = data.table(factor(rep(enc2utf8("\uf8"), 3)))
-DT[1, V1 := iconv(levels(V1), from = "UTF-8", to = "latin1")]
-test(2311, nlevels(DT$V1), 1L)
+DT = data.table(factor(rep("\uf8", 3)))
+# identical() to V1's only level but stored in a different CHARSXP
+samelevel = iconv(levels(DT$V1), from = "UTF-8", to = "latin1")
+DT[1, V1 := samelevel]
+test(2311.1, nlevels(DT$V1), 1L) # used to be 2
+DT[1, V1 := factor("a", levels = c("a", samelevel))]
+test(2311.2, nlevels(DT$V1), 2L) # used to be 3

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -21115,6 +21115,6 @@ DF = structure(list(a = 1:2), class = c("data.frame", "no.reset"), row.names = c
 test(2310.01, as.data.table(DF), data.table(a=1:2))
 
 # memrecycle() did not consider string encodings for factor levels #6886
-DT = data.table(factor(rep(enc2utf8('ø'), 3)))
-DT[1,V1 := iconv('ø', to='latin1')]
-test(2311, length(levels(DT$V1)), 1L)
+DT = data.table(factor(rep(enc2utf8("\uf8"), 3)))
+DT[1, V1 := iconv(levels(V1), from = "UTF-8", to = "latin1")]
+test(2311, nlevels(DT$V1), 1L)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -21113,3 +21113,8 @@ test(2309.09, as.data.table(df, keep.rownames=TRUE), data.table(rn = c("a","b"),
 as.data.frame.no.reset = function(x) x
 DF = structure(list(a = 1:2), class = c("data.frame", "no.reset"), row.names = c(NA, -2L))
 test(2310.01, as.data.table(DF), data.table(a=1:2))
+
+# memrecycle() did not consider string encodings for factor levels #6886
+DT = data.table(factor(rep(enc2utf8('ø'), 3)))
+DT[1,V1 := iconv('ø', to='latin1')]
+test(2311, length(levels(DT$V1)), 1L)

--- a/src/assign.c
+++ b/src/assign.c
@@ -823,8 +823,10 @@ const char *memrecycle(const SEXP target, const SEXP where, const int start, con
       SEXP targetLevels = PROTECT(getAttrib(target, R_LevelsSymbol)); protecti++;
       SEXP sourceLevels = source;  // character source
       if (sourceIsFactor) { sourceLevels=PROTECT(getAttrib(source, R_LevelsSymbol)); protecti++; }
+      sourceLevels = PROTECT(coerceUtf8IfNeeded(sourceLevels)); protecti++;
       if (!sourceIsFactor || !R_compute_identical(sourceLevels, targetLevels, 0)) {  // !sourceIsFactor for test 2115.6
         const int nTargetLevels=length(targetLevels), nSourceLevels=length(sourceLevels);
+        targetLevels = PROTECT(coerceUtf8IfNeeded(targetLevels)); protecti++;
         const SEXP *targetLevelsD=STRING_PTR_RO(targetLevels), *sourceLevelsD=STRING_PTR_RO(sourceLevels);
         SEXP newSource = PROTECT(allocVector(INTSXP, length(source))); protecti++;
         savetl_init();


### PR DESCRIPTION
Previously, by-reference sub-assignment to a factor column could fail to match strings with identical content if they had different encoding bits (even `CE_NATIVE` in a UTF-8 locale vs. `CE_UTF8`), causing duplicate levels.

Fixes: #6886