### PR TITLE
"Enhanced setDT Documentation: Added Example for RDS/RData Usage and FAQ Link"

### DIFF
--- a/man/setDT.Rd
+++ b/man/setDT.Rd
@@ -60,10 +60,10 @@ X = list(a=1:5, a=6:10)
 setDT(X, check.names=TRUE)[]
 
 # Example demonstrating setDT after loading from RDS
-rds_file <- tempfile(fileext = ".rds")
-X <- data.table(a = 1:5, b = letters[1:5])
+rds_file = tempfile(fileext = ".rds")
+X = data.table(a = 1:5, b = letters[1:5])
 saveRDS(X, rds_file)
-X_loaded <- readRDS(rds_file)
+X_loaded = readRDS(rds_file)
 setDT(X_loaded)  # restore internal data.table attributes
 print(X_loaded)
 unlink(rds_file)  # cleanup

--- a/man/setDT.Rd
+++ b/man/setDT.Rd
@@ -74,6 +74,8 @@ X_loaded <- readRDS(rds_file)
 # Step 4: Restore data.table attributes
 setDT(X_loaded)
 print(X_loaded)
+# Step 5: Clean up the temporary file
+unlink(rds_file); rm(rds_file)
 }
 \keyword{ data }
 

--- a/man/setDT.Rd
+++ b/man/setDT.Rd
@@ -28,7 +28,8 @@ setDT(x, keep.rownames=FALSE, key=NULL, check.names=FALSE)
 }
 
 \seealso{
-  \code{\link{data.table}}, \code{\link{as.data.table}}, \code{\link{setDF}}, \code{\link{copy}}, \code{\link{setkey}}, \code{\link{setcolorder}}, \code{\link{setattr}}, \code{\link{setnames}}, \code{\link{set}}, \code{\link{:=}}, \code{\link{setorder}}
+  \code{\link{data.table}}, \code{\link{as.data.table}}, \code{\link{setDF}}, \code{\link{copy}}, \code{\link{setkey}}, \code{\link{setcolorder}}, \code{\link{setattr}}, \code{\link{setnames}}, \code{\link{set}}, \code{\link{:=}}, \code{\link{setorder}},
+  See the FAQ vignette: \code{vignette("datatable-faq", package = "data.table")}.
 }
 \examples{
 
@@ -58,6 +59,14 @@ setDT(X, key="a")[]
 X = list(a=1:5, a=6:10)
 setDT(X, check.names=TRUE)[]
 
+# FAQ: Dealing with data.table loaded from RDS or RData files
+# Example to demonstrate the usage of setDT after loading from RDS
+if (file.exists("my_data.rds")) {
+  X = readRDS("my_data.rds")  # Load data.table from RDS if file exists
+  setDT(X)  # Make sure to use setDT() after loading
+} else {
+  message("my_data.rds file does not exist. Skipping RDS loading example.")
+}
 }
 \keyword{ data }
 

--- a/man/setDT.Rd
+++ b/man/setDT.Rd
@@ -59,23 +59,14 @@ setDT(X, key="a")[]
 X = list(a=1:5, a=6:10)
 setDT(X, check.names=TRUE)[]
 
-# FAQ: Dealing with data.table loaded from RDS or RData files
-# Example to demonstrate the usage of setDT after loading from RDS
-# Step 1: Define file path
-rds_file = tempfile("my_data.rds_")
-# Step 2: Create and save data.table if the file does not exist
-if (!file.exists(rds_file)) {
-  X <- data.table(a=1:5, b=letters[1:5])  # Create a data.table
-  saveRDS(X, rds_file)  # Save it to an RDS file
-  message("Saved data.table to ", rds_file)
-}
-# Step 3: Load the data.table from the RDS file
+# Example demonstrating setDT after loading from RDS
+rds_file <- tempfile(fileext = ".rds")
+X <- data.table(a = 1:5, b = letters[1:5])
+saveRDS(X, rds_file)
 X_loaded <- readRDS(rds_file)
-# Step 4: Restore data.table attributes
-setDT(X_loaded)
+setDT(X_loaded)  # restore internal data.table attributes
 print(X_loaded)
-# Step 5: Clean up the temporary file
-unlink(rds_file); rm(rds_file)
+unlink(rds_file)  # cleanup
 }
 \keyword{ data }
 

--- a/man/setDT.Rd
+++ b/man/setDT.Rd
@@ -65,7 +65,7 @@ setDT(X, check.names=TRUE)[]
 rds_file = tempfile("my_data.rds_")
 # Step 2: Create and save data.table if the file does not exist
 if (!file.exists(rds_file)) {
-  X <- data.table(a = 1:5, b = letters[1:5])  # Create a data.table
+  X <- data.table(a=1:5, b=letters[1:5])  # Create a data.table
   saveRDS(X, rds_file)  # Save it to an RDS file
   message("Saved data.table to ", rds_file)
 }

--- a/man/setDT.Rd
+++ b/man/setDT.Rd
@@ -61,12 +61,20 @@ setDT(X, check.names=TRUE)[]
 
 # FAQ: Dealing with data.table loaded from RDS or RData files
 # Example to demonstrate the usage of setDT after loading from RDS
-if (file.exists("my_data.rds")) {
-  X = readRDS("my_data.rds")  # Load data.table from RDS if file exists
-  setDT(X)  # Make sure to use setDT() after loading
-} else {
-  message("my_data.rds file does not exist. Skipping RDS loading example.")
+# Step 1: Define file path
+rds_file <- "my_data.rds"
+# Step 2: Create and save data.table if the file does not exist
+if (!file.exists(rds_file)) {
+  X <- data.table(a = 1:5, b = letters[1:5])  # Create a data.table
+  saveRDS(X, rds_file)  # Save it to an RDS file
+  message("Saved data.table to ", rds_file)
 }
+# Step 3: Load the data.table from the RDS file
+X_loaded <- readRDS(rds_file)
+# Step 4: Restore data.table attributes
+setDT(X_loaded)
+# Verify structure
+print(X_loaded)
 }
 \keyword{ data }
 

--- a/man/setDT.Rd
+++ b/man/setDT.Rd
@@ -62,7 +62,7 @@ setDT(X, check.names=TRUE)[]
 # FAQ: Dealing with data.table loaded from RDS or RData files
 # Example to demonstrate the usage of setDT after loading from RDS
 # Step 1: Define file path
-rds_file <- "my_data.rds"
+rds_file = tempfile("my_data.rds_")
 # Step 2: Create and save data.table if the file does not exist
 if (!file.exists(rds_file)) {
   X <- data.table(a = 1:5, b = letters[1:5])  # Create a data.table

--- a/man/setDT.Rd
+++ b/man/setDT.Rd
@@ -66,7 +66,7 @@ saveRDS(X, rds_file)
 X_loaded = readRDS(rds_file)
 setDT(X_loaded)  # restore internal data.table attributes
 print(X_loaded)
-unlink(rds_file)  # cleanup
+unlink(rds_file)
 }
 \keyword{ data }
 

--- a/man/setDT.Rd
+++ b/man/setDT.Rd
@@ -73,7 +73,6 @@ if (!file.exists(rds_file)) {
 X_loaded <- readRDS(rds_file)
 # Step 4: Restore data.table attributes
 setDT(X_loaded)
-# Verify structure
 print(X_loaded)
 }
 \keyword{ data }

--- a/man/truelength.Rd
+++ b/man/truelength.Rd
@@ -57,11 +57,19 @@ truelength(DT)-length(DT)  # 2047 slots spare
 
 # FAQ: Dealing with data.table loaded from RDS or RData files
 # Example to demonstrate the usage of setDT after loading from RDS
-if (file.exists("my_data.rds")) {
-  X = readRDS("my_data.rds")  # Load data.table from RDS if file exists
-  setDT(X)  # Make sure to use setDT() after loading
-} else {
-  message("my_data.rds file does not exist. Skipping RDS loading example.")
+# Step 1: Define file path
+rds_file <- "my_data.rds"
+# Step 2: Create and save data.table if the file does not exist
+if (!file.exists(rds_file)) {
+  X <- data.table(a = 1:5, b = letters[1:5])  # Create a data.table
+  saveRDS(X, rds_file)  # Save it to an RDS file
+  message("Saved data.table to ", rds_file)
 }
+# Step 3: Load the data.table from the RDS file
+X_loaded <- readRDS(rds_file)
+# Step 4: Restore data.table attributes
+setDT(X_loaded)
+# Verify structure
+print(X_loaded)
 }
 \keyword{ data }

--- a/man/truelength.Rd
+++ b/man/truelength.Rd
@@ -69,7 +69,6 @@ if (!file.exists(rds_file)) {
 X_loaded <- readRDS(rds_file)
 # Step 4: Restore data.table attributes
 setDT(X_loaded)
-# Verify structure
 print(X_loaded)
 }
 \keyword{ data }

--- a/man/truelength.Rd
+++ b/man/truelength.Rd
@@ -44,7 +44,7 @@ alloc.col(DT,
     \code{setalloccol} \emph{reallocates} \code{DT} by reference. This may be useful for efficiency if you know you are about to going to add a lot of columns in a loop.
     It also returns the new \code{DT}, for convenience in compound queries.
 }
-\seealso{ \code{\link{copy}}}
+\seealso{ \code{\link{copy}} }
 \examples{
 DT = data.table(a=1:3,b=4:6)
 length(DT)                 # 2 column pointer slots used

--- a/man/truelength.Rd
+++ b/man/truelength.Rd
@@ -57,18 +57,19 @@ truelength(DT)-length(DT)  # 2047 slots spare
 
 # FAQ: Dealing with data.table loaded from RDS or RData files
 # Example to demonstrate the usage of setDT after loading from RDS
-# Step 1: Define file path
-rds_file <- "my_data.rds"
+# Step 1: Define a temporary file path
+rds_file <- tempfile("my_data.rds_")
 # Step 2: Create and save data.table if the file does not exist
-if (!file.exists(rds_file)) {
-  X <- data.table(a = 1:5, b = letters[1:5])  # Create a data.table
-  saveRDS(X, rds_file)  # Save it to an RDS file
-  message("Saved data.table to ", rds_file)
-}
+X <- data.table(a = 1:5, b = letters[1:5])  # Create a data.table
+saveRDS(X, rds_file)  # Save it to an RDS file
+message("Saved data.table to ", rds_file)
 # Step 3: Load the data.table from the RDS file
 X_loaded <- readRDS(rds_file)
 # Step 4: Restore data.table attributes
 setDT(X_loaded)
 print(X_loaded)
+# Step 6: Clean up the temporary file
+unlink(rds_file)  # Delete the file
+rm(rds_file)  # Remove the variable reference
 }
 \keyword{ data }

--- a/man/truelength.Rd
+++ b/man/truelength.Rd
@@ -44,7 +44,7 @@ alloc.col(DT,
     \code{setalloccol} \emph{reallocates} \code{DT} by reference. This may be useful for efficiency if you know you are about to going to add a lot of columns in a loop.
     It also returns the new \code{DT}, for convenience in compound queries.
 }
-\seealso{ \code{\link{copy}}, See the FAQ vignette: \code{vignette("datatable-faq", package = "data.table")}.}
+\seealso{ \code{\link{copy}}}
 \examples{
 DT = data.table(a=1:3,b=4:6)
 length(DT)                 # 2 column pointer slots used
@@ -54,22 +54,5 @@ length(DT)                 # 2 used
 truelength(DT)             # 2050 allocated, 2048 free
 DT[,c:=7L]                 # add new column by assigning to spare slot
 truelength(DT)-length(DT)  # 2047 slots spare
-
-# FAQ: Dealing with data.table loaded from RDS or RData files
-# Example to demonstrate the usage of setDT after loading from RDS
-# Step 1: Define a temporary file path
-rds_file <- tempfile("my_data.rds_")
-# Step 2: Create and save data.table if the file does not exist
-X <- data.table(a = 1:5, b = letters[1:5])  # Create a data.table
-saveRDS(X, rds_file)  # Save it to an RDS file
-message("Saved data.table to ", rds_file)
-# Step 3: Load the data.table from the RDS file
-X_loaded <- readRDS(rds_file)
-# Step 4: Restore data.table attributes
-setDT(X_loaded)
-print(X_loaded)
-# Step 6: Clean up the temporary file
-unlink(rds_file)  # Delete the file
-rm(rds_file)  # Remove the variable reference
 }
 \keyword{ data }

--- a/man/truelength.Rd
+++ b/man/truelength.Rd
@@ -44,7 +44,7 @@ alloc.col(DT,
     \code{setalloccol} \emph{reallocates} \code{DT} by reference. This may be useful for efficiency if you know you are about to going to add a lot of columns in a loop.
     It also returns the new \code{DT}, for convenience in compound queries.
 }
-\seealso{ \code{\link{copy}} }
+\seealso{ \code{\link{copy}}, See the FAQ vignette: \code{vignette("datatable-faq", package = "data.table")}.}
 \examples{
 DT = data.table(a=1:3,b=4:6)
 length(DT)                 # 2 column pointer slots used
@@ -54,5 +54,14 @@ length(DT)                 # 2 used
 truelength(DT)             # 2050 allocated, 2048 free
 DT[,c:=7L]                 # add new column by assigning to spare slot
 truelength(DT)-length(DT)  # 2047 slots spare
+
+# FAQ: Dealing with data.table loaded from RDS or RData files
+# Example to demonstrate the usage of setDT after loading from RDS
+if (file.exists("my_data.rds")) {
+  X = readRDS("my_data.rds")  # Load data.table from RDS if file exists
+  setDT(X)  # Make sure to use setDT() after loading
+} else {
+  message("my_data.rds file does not exist. Skipping RDS loading example.")
+}
 }
 \keyword{ data }

--- a/vignettes/datatable-faq.Rmd
+++ b/vignettes/datatable-faq.Rmd
@@ -620,7 +620,7 @@ DT[ , b := rnorm(5)]  # 'replace' integer column with a numeric column
 
 ## Reading data.table from RDS or RData file
 
-`*.RDS` and `*.RData` are file types which can store in-memory R objects on disk efficiently. However, storing `data.table` into a binary file loses its column over-allocation and `truelength()`. This isn't a big deal -- your `data.table` will be copied in memory on the next _by reference_ operation and throw a warning.  
+`*.RDS` and `*.RData` are file types which can store in-memory R objects on disk efficiently. However, storing `data.table` into a binary file loses its column over-allocation (see also `?truelength`). This isn't a big deal -- your `data.table` will be copied in memory on the next _by reference_ operation and throw a warning.  
 Therefore, it is recommended to call `setDT()` on each `data.table` loaded with `readRDS()` or `load()` calls to restore its internal attributes. If you only need to pre-allocate space for new columns, `setalloccol()` can also be used.  
 
 For more details, see `?setDT` and `?truelength`.

--- a/vignettes/datatable-faq.Rmd
+++ b/vignettes/datatable-faq.Rmd
@@ -620,7 +620,10 @@ DT[ , b := rnorm(5)]  # 'replace' integer column with a numeric column
 
 ## Reading data.table from RDS or RData file
 
-`*.RDS` and `*.RData` are file types which can store in-memory R objects on disk efficiently. However, storing data.table into the binary file loses its column over-allocation. This isn't a big deal -- your data.table will be copied in memory on the next _by reference_ operation and throw a warning. Therefore it is recommended to call `setalloccol()` on each data.table loaded with `readRDS()` or `load()` calls.
+`*.RDS` and `*.RData` are file types which can store in-memory R objects on disk efficiently. However, storing `data.table` into a binary file loses its column over-allocation and `truelength()`. This isn't a big deal -- your `data.table` will be copied in memory on the next _by reference_ operation and throw a warning.  
+Therefore, it is recommended to call `setDT()` on each `data.table` loaded with `readRDS()` or `load()` calls to restore its internal attributes. If you only need to pre-allocate space for new columns, `setalloccol()` can also be used.  
+
+For more details, see `?setDT` and `?truelength`.
 
 # General questions about the package
 


### PR DESCRIPTION
closes #6888 
This PR enhances the documentation for the setDT function by addressing a common issue related to data.tables loaded from disk. The following changes have been made:

- Added Example for RDS/RData Usage:
A new example demonstrates the proper usage of setDT() to restore internal attributes (e.g., truelength) for data.tables loaded via readRDS() or load(). This ensures users can avoid unexpected behavior during by-reference operations.
- Linked FAQ Vignette:
Included a link to the FAQ vignette (vignette("datatable-faq", package = "data.table")) in the \seealso section of the ?setdt and ?truelength, providing users with additional context and troubleshooting guidance.

kindly have a review when you have time .
thank you.