### PR TITLE
`groupingsets()`: introduce and make use of the `enclos` argument

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -21129,3 +21129,27 @@ test(2311.2, nlevels(DT$V1), 2L) # used to be 3
 # avoid translateChar*() in OpenMP threads, #6883
 DF = list(rep(iconv("\uf8", from = "UTF-8", to = "latin1"), 2e6))
 test(2312, fwrite(DF, nullfile(), encoding = "UTF-8", nThread = 2L), NULL)
+
+# 'sets' is a local variable in groupingsets(), cube(), rollup() and shouldn't leak into the 'j' expression
+n = 24L
+set.seed(25)
+DT = data.table(
+    color = sample(c("green","yellow","red"), n, TRUE),
+    year = as.Date(sample(paste0(2011:2015,"-01-01"), n, TRUE)),
+    status = as.factor(sample(c("removed","active","inactive","archived"), n, TRUE)),
+    amount = sample(1:5, n, TRUE),
+    value = sample(c(3, 3.5, 2.5, 2), n, TRUE)
+)
+sets = 0
+test(2313.0,
+  groupingsets(DT, j = c(list(count=.N + ..sets)), by = c("color","year","status"), sets = list("color", c("year","status"), character()), id=TRUE),
+  groupingsets(DT, j = c(list(count=.N + 0)), by = c("color","year","status"), sets = list("color", c("year","status"), character()), id=TRUE)
+)
+test(2313.1,
+  cube(DT, j = sum(value) + ..sets, by = c("color","year","status"), id=TRUE),
+  cube(DT, j = sum(value), by = c("color","year","status"), id=TRUE)
+)
+test(2313.2,
+  rollup(DT, j = sum(value) + ..sets, by=c("color","year","status"), label="total"),
+  rollup(DT, j = sum(value), by=c("color","year","status"), label="total")
+)

--- a/man/groupingsets.Rd
+++ b/man/groupingsets.Rd
@@ -15,7 +15,7 @@ rollup(x, \dots)
 cube(x, \dots)
 \method{cube}{data.table}(x, j, by, .SDcols, id = FALSE, label = NULL, \dots)
 groupingsets(x, \dots)
-\method{groupingsets}{data.table}(x, j, by, sets, .SDcols, id = FALSE, jj, label = NULL, \dots)
+\method{groupingsets}{data.table}(x, j, by, sets, .SDcols, id = FALSE, jj, label = NULL, enclos = parent.frame(), \dots)
 }
 \arguments{
 	\item{x}{\code{data.table}.}
@@ -27,6 +27,7 @@ groupingsets(x, \dots)
 	\item{id}{logical default \code{FALSE}. If \code{TRUE} it will add leading column with bit mask of grouping sets.}
 	\item{jj}{quoted version of \code{j} argument, for convenience. When provided function will ignore \code{j} argument.}
 	\item{label}{label(s) to be used in the 'total' rows in the grouping variable columns of the output, that is, in rows where the grouping variable has been aggregated. Can be a named list of scalars, or a scalar, or \code{NULL}. Defaults to \code{NULL}, which results in the grouping variables having \code{NA} in their 'total' rows. See Details.}
+	\item{enclos}{the environment containing the symbols referenced by \code{jj}. When writing functions that accept a \code{j} environment for non-standard evaluation by \pkg{data.table}, \code{\link[base]{substitute}()} it and forward it to \code{groupingsets} using the \code{jj} argument, set this to the \code{\link[base]{parent.frame}()} of the function that captures \code{j}.}
 }
 \details{
     All three functions \code{rollup, cube, groupingsets} are generic methods, \code{data.table} methods are provided.


### PR DESCRIPTION
When forwarding the `j` argument for non-standard evaluation via `jj=`, also forward the environment containing the symbols that it may be referencing. Now `groupingsets()` `substitute`s all the local arguments into the `x[, jj, ...]` call and then evaluates it in the specified environment, making it possible for `jj` to refer to local symbols without confusing them to variables belonging to `groupingsets()` or its caller.

To avoid `cedta()` problems, set `.datatable.aware = TRUE` in the environment where the call is evaluated. (A column named `.datatable.aware` would be shadowed. So it goes.)

An alternative solution would give the `enclos=` argument to `[.data.table` instead of evaluating the `[` call inside `enclos`, but that would require carefully replacing a lot of `parent.frame()` calls. Also, `[.data.table` already has an `env=` argument, which operates on the expression directly, not provides an enclosing environment.

Another alternative solution could construct [Brodie Gaslam's DIY quosure](https://www.brodieg.com/2020/08/11/quosures/#quosures-au-naturel), but `[.data.table` doesn't seem to "see" inside such calls (for example, to replace the `.(...)` special form with `list(...)`) when given one as the `j` argument and I didn't investigate it further.

Fixes: #5560