### PR TITLE
Replace the use of `OBJECT`

### DIFF
--- a/src/assign.c
+++ b/src/assign.c
@@ -1157,7 +1157,7 @@ const char *memrecycle(const SEXP target, const SEXP where, const int start, con
           }
           break;
         }
-        if (OBJECT(source) && getAttrib(source, R_ClassSymbol)!=R_NilValue) {
+        if (isObject(source)) {
           // otherwise coerceVector doesn't call the as.character method for Date, IDate, integer64, nanotime, etc; PR#5189
           // this if() is to save the overhead of the R call eval() when we know there can be no method
           source = PROTECT(eval(PROTECT(lang2(sym_as_character, source)), R_GlobalEnv)); protecti+=2;

--- a/src/dogroups.c
+++ b/src/dogroups.c
@@ -516,10 +516,10 @@ SEXP keepattr(SEXP to, SEXP from)
   SET_ATTRIB(to, ATTRIB(from));
   if (isS4(from)) {
     to = PROTECT(asS4(to, TRUE, 1));
-    SET_OBJECT(to, OBJECT(from));
+    SET_OBJECT(to, isObject(from));
     UNPROTECT(1);
   } else {
-    SET_OBJECT(to, OBJECT(from));
+    SET_OBJECT(to, isObject(from));
   }
   return to;
 }


### PR DESCRIPTION
`Rf_isObject` has existed for a long time and does essentially the same thing as `OBJECT`, so no compatibility problems envisioned. With this, we should account for the entry points being newly checked since R-devel [r87851](https://github.com/r-devel/r-svn/commit/ff7bd62d5bbfa028e8c2635963f5e86a13f14b17).

See also: #6180