### PR TITLE
Print column classes at the bottom if class is enabled

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 2. `melt()` now supports using `patterns()` with `id.vars`, [#6867](https://github.com/Rdatatable/data.table/issues/6867). Thanks to Toby Dylan Hocking for the suggestion and PR.
 
+3. `print.data.table()` now shows column classes at the bottom of large tables when `class=TRUE` and `col.names="auto"` (default) for tables with more than 20 rows, [#6902](https://github.com/Rdatatable/data.table/issues/6902). This follows the same behavior as column names at the bottom, making it easier to see column types for large tables without scrolling back to the top. Thanks to @TimTaylor for the suggestion and @Mukulyadav2004 for the PR.
+
 ## BUG FIXES
 
 1. Custom binary operators from the `lubridate` package now work with objects of class `IDate` as with a `Date` subclass, [#6839](https://github.com/Rdatatable/data.table/issues/6839). Thanks @emallickhossain for the report and @aitap for the fix.

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -142,7 +142,15 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
   if (nrow(toprint)>20L && col.names == "auto")
     # repeat colnames at the bottom if over 20 rows so you don't have to scroll up to see them
     #   option to shut this off per request of Oleg Bondar on SO, #1482
-    toprint = rbind(toprint, matrix(if (quote) old else colnames(toprint), nrow=1L)) # fixes bug #97
+    if (isTRUE(class)) {
+      # Add both column names and classes when classes are enabled
+      mat_abbs <- matrix(abbs, nrow = 1L)
+      rownames(mat_abbs) <- ""
+      toprint <- rbind(toprint, matrix(if (quote) old else colnames(toprint), nrow=1L), matrix(abbs, nrow=1L))
+    } else {
+      # Original behavior (just column names at bottom)
+      toprint <- rbind(toprint, matrix(if (quote) old else colnames(toprint), nrow=1L))
+    }
   print_default(toprint)
   invisible(x)
 }

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -21129,3 +21129,10 @@ test(2311.2, nlevels(DT$V1), 2L) # used to be 3
 # avoid translateChar*() in OpenMP threads, #6883
 DF = list(rep(iconv("\uf8", from = "UTF-8", to = "latin1"), 2e6))
 test(2312, fwrite(DF, nullfile(), encoding = "UTF-8", nThread = 2L), NULL)
+
+# Testing column footer display with col.names options in print.data.table #6902
+dt = data.table(id = 1:25, value = sample(letters, 25, replace = TRUE), number = rnorm(25))
+# Test with class=TRUE shows classes at bottom with default col.names="auto"
+test(2312.1, any(grepl("<int>", tail(capture.output(print(dt, class = TRUE)), 2))), TRUE)
+# Test that class=TRUE with col.names="top" doesn't show classes at bottom
+test(2312.2, !any(grepl("<int>", tail(capture.output(print(dt, class = TRUE, col.names = "top")), 2))), TRUE)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -21133,6 +21133,6 @@ test(2312, fwrite(DF, nullfile(), encoding = "UTF-8", nThread = 2L), NULL)
 # Testing column footer display with col.names options in print.data.table #6902
 dt = data.table(id = 1:25, value = sample(letters, 25, replace = TRUE), number = rnorm(25))
 # Test with class=TRUE shows classes at bottom with default col.names="auto"
-test(2312.1, any(grepl("<int>", tail(capture.output(print(dt, class = TRUE)), 2))), TRUE)
+test(2313.1, any(grepl("<int>", tail(capture.output(print(dt, class = TRUE)), 2))), TRUE)
 # Test that class=TRUE with col.names="top" doesn't show classes at bottom
-test(2312.2, !any(grepl("<int>", tail(capture.output(print(dt, class = TRUE, col.names = "top")), 2))), TRUE)
+test(2313.2, !any(grepl("<int>", tail(capture.output(print(dt, class = TRUE, col.names = "top")), 2))), TRUE)

--- a/man/print.data.table.Rd
+++ b/man/print.data.table.Rd
@@ -41,9 +41,9 @@
   \item{x}{ A \code{data.table}. }
   \item{topn}{ The number of rows to be printed from the beginning and end of tables with more than \code{nrows} rows. }
   \item{nrows}{ The number of rows which will be printed before truncation is enforced. }
-  \item{class}{ If \code{TRUE}, the resulting output will include above each column its storage class (or a self-evident abbreviation thereof). }
+  \item{class}{ If \code{TRUE}, the resulting output will include above each column its storage class (or a self-evident abbreviation thereof). When combined with \code{col.names="auto"} and tables >20 rows, classes will also appear at the bottom.}
   \item{row.names}{ If \code{TRUE}, row indices will be printed alongside \code{x}. }
-  \item{col.names}{ One of three flavours for controlling the display of column names in output. \code{"auto"} includes column names above the data, as well as below the table if \code{nrow(x) > 20}. \code{"top"} excludes this lower register when applicable, and \code{"none"} suppresses column names altogether (as well as column classes if \code{class = TRUE}. }
+  \item{col.names}{ One of three flavours for controlling the display of column names in output. \code{"auto"} includes column names above the data, as well as below the table if \code{nrow(x) > 20} (when \code{class=TRUE}, column classes will also appear at the bottom). \code{"top"} excludes this lower register when applicable, and \code{"none"} suppresses column names altogether (as well as column classes if \code{class = TRUE}. }
   \item{print.keys}{ If \code{TRUE}, any \code{\link{key}} and/or \code{\link[=indices]{index}} currently assigned to \code{x} will be printed prior to the preview of the data. }
   \item{trunc.cols}{ If \code{TRUE}, only the columns that can be printed in the console without wrapping the columns to new lines will be printed (similar to \code{tibbles}). }
   \item{show.indices}{ If \code{TRUE}, indices will be printed as columns alongside \code{x}. }


### PR DESCRIPTION
Closes #6902 

This PR implements functionality to print column classes at the bottom of a data.table, following the same logic that determines whether to print column names at the bottom. 

Implementation:

- Reused the existing logic that decides when to show column names at the bottom.
- The only change is:
- -   If class = TRUE, it now shows both column names and their classes at the bottom.
- -   Otherwise, it only shows the column names. 
