### PR TITLE
Avoid memcpy() of empty vector

### DIFF
--- a/src/fmelt.c
+++ b/src/fmelt.c
@@ -552,11 +552,11 @@ SEXP getvaluecols(SEXP DT, SEXP dtnames, Rboolean valfactor, Rboolean verbose, s
           //TODO complex value type: case CPLXSXP: { } break;
         case REALSXP : {
           double *dtarget = REAL(target);
-          const double *dthiscol = REAL(thiscol);
+          const double *dthiscol = REAL_RO(thiscol);
           if (data->narm) {
             for (int k=0; k<thislen; ++k)
               dtarget[counter + k] = dthiscol[ithisidx[k]-1];
-          } else {
+          } else if (data->nrow) {
             memcpy(dtarget + j*data->nrow, dthiscol, data->nrow*size);
           }
         }
@@ -564,11 +564,11 @@ SEXP getvaluecols(SEXP DT, SEXP dtnames, Rboolean valfactor, Rboolean verbose, s
         case INTSXP :
         case LGLSXP : {
           int *itarget = INTEGER(target);
-          const int *ithiscol = INTEGER(thiscol);
+          const int *ithiscol = INTEGER_RO(thiscol);
           if (data->narm) {
             for (int k=0; k<thislen; ++k)
               itarget[counter + k] = ithiscol[ithisidx[k]-1];
-          } else {
+          } else if (data->nrow) {
             memcpy(itarget + j*data->nrow, ithiscol, data->nrow*size);
           }
         } break;


### PR DESCRIPTION
Same source as #6907, and comments in #6819.

This was triggered proximately through the {expss} test suite, I'm working on finding a more minimal example we can add to our test suite.

I still don't understand why our setup is finding these where they're not visible elsewhere :)