### PR TITLE
Edit 'Calloc' et al on old versions for atime

### DIFF
--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -117,6 +117,11 @@ test.list <- atime::atime_test_list(
       file.path("src", "init.c"),
       paste0("R_init_", Package_regex),
       paste0("R_init_", gsub("[.]", "_", new.Package_)))
+    # allow compilation on new R versions where 'Calloc' is not defined
+    pkg_find_replace(
+      file.path("src", "*.c"),
+      "\\b(Calloc|Free|Realloc)",
+      "R_\\1")
     pkg_find_replace(
       "NAMESPACE",
       sprintf('useDynLib\\("?%s"?', Package_regex),

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -120,7 +120,7 @@ test.list <- atime::atime_test_list(
     # allow compilation on new R versions where 'Calloc' is not defined
     pkg_find_replace(
       file.path("src", "*.c"),
-      "\\b(Calloc|Free|Realloc)",
+      "\\b(Calloc|Free|Realloc)\\b",
       "R_\\1")
     pkg_find_replace(
       "NAMESPACE",


### PR DESCRIPTION
@tdhock it looks like atime is failing to compile older {data.table} commits with current versions of R, e.g.

```
bmerge.c: In function ‘bmerge’:
bmerge.c:107:16: warning: implicit declaration of function ‘Calloc’; did you mean ‘valloc’? [-Wimplicit-function-declaration]
  107 |     retFirst = Calloc(anslen, int); // anslen is set above
      |                ^~~~~~
      |                valloc
```

What's the right way to deal with that?

I took a stab at it here.