### PR TITLE
Fix: Ensure column widths are data-driven when col.names = "none" in print.data.table 

### DIFF
--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -261,8 +261,8 @@ char.trunc = function(x, trunc.char = getOption("datatable.prettyprint.char")) {
 dt_width = function(x, nrow, class, row.names, col.names) {
   widths = apply(nchar(x, type='width'), 2L, max)
   if (class) widths = pmax(widths, 6L)
-  names_widths = if (col.names == "none") rep(0L, ncol(x)) else sapply(colnames(x), nchar, type = "width")
-  dt_widths = pmax(widths, names_widths)
+  if (col.names != "none") names = sapply(colnames(x), nchar, type="width") else names = 0L
+  dt_widths = pmax(widths, names)
   rownum_width = if (row.names) as.integer(ceiling(log10(nrow))+2.0) else 0L
   cumsum(dt_widths + 1L) + rownum_width
 }

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -139,6 +139,8 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
     print_default(toprint)
     return(invisible(x))
   }
+  if (col.names == "none") 
+  colnames(toprint) <- rep.int("", ncol(toprint))
   if (nrow(toprint)>20L && col.names == "auto")
     # repeat colnames at the bottom if over 20 rows so you don't have to scroll up to see them
     #   option to shut this off per request of Oleg Bondar on SO, #1482
@@ -259,8 +261,8 @@ char.trunc = function(x, trunc.char = getOption("datatable.prettyprint.char")) {
 dt_width = function(x, nrow, class, row.names, col.names) {
   widths = apply(nchar(x, type='width'), 2L, max)
   if (class) widths = pmax(widths, 6L)
-  if (col.names != "none") names = sapply(colnames(x), nchar, type="width") else names = 0L
-  dt_widths = pmax(widths, names)
+  names_widths = if (col.names == "none") rep(0L, ncol(x)) else sapply(colnames(x), nchar, type = "width")
+  dt_widths = pmax(widths, names_widths)
   rownum_width = if (row.names) as.integer(ceiling(log10(nrow))+2.0) else 0L
   cumsum(dt_widths + 1L) + rownum_width
 }

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -21130,7 +21130,7 @@ test(2311.2, nlevels(DT$V1), 2L) # used to be 3
 DF = list(rep(iconv("\uf8", from = "UTF-8", to = "latin1"), 2e6))
 test(2312, fwrite(DF, nullfile(), encoding = "UTF-8", nThread = 2L), NULL)
 
-# New tests for GitHub #6882 (col.names='none' column widths)
+# tests for #6882 (col.names='none' column widths)
 test(2313.1, {
   dt <- data.table(short=1:3, verylongcolumnname=4:6)
   print(dt, col.names="none")

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -21129,3 +21129,17 @@ test(2311.2, nlevels(DT$V1), 2L) # used to be 3
 # avoid translateChar*() in OpenMP threads, #6883
 DF = list(rep(iconv("\uf8", from = "UTF-8", to = "latin1"), 2e6))
 test(2312, fwrite(DF, nullfile(), encoding = "UTF-8", nThread = 2L), NULL)
+
+# New tests for GitHub #6882 (col.names='none' column widths)
+test(2313.1, {
+  dt <- data.table(short=1:3, verylongcolumnname=4:6)
+  print(dt, col.names="none")
+}, output="1: 1 4\n2: 2 5\n3: 3 6")
+test(2313.2, {
+  dt <- data.table(x=123456, y="wide_string")
+  print(dt, col.names="none")
+}, output="1: 123456 wide_string")
+test(2313.3, {
+  dt <- data.table(a=NA_integer_, b=NaN)
+  print(dt, col.names="none")
+}, output="1: NA NaN")


### PR DESCRIPTION
This PR resolves #6882 by ensuring that when col.names = "none" is specified in print.data.table, the column widths are determined solely by the data content, not by the (hidden) column names.

What was changed
Added the following logic to print.data.table:

```
if (col.names == "none") 
  colnames(toprint) <- rep.int("", ncol(toprint))
```
This is placed right after toprint is constructed, but before any formatting or width calculations.

This ensures that all downstream formatting and width calculations use empty column names, so column widths are always based on the data, fully resolving the issue where hidden long column names could cause excessive column width.

@MichaelChirico have a review of this when you have time
this is the change i was suggesting should i change it 
or it works fine let me know 

thank you.