### PR TITLE
tweak env verbose output

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -174,7 +174,7 @@ replace_dot_alias = function(e) {
         stopf("When by and keyby are both provided, keyby must be TRUE or FALSE")
     }
     if (missing(by)) { missingby=TRUE; by=bysub=NULL }  # possible when env is used, PR#4304
-    else if (verbose && !is.null(env)) catf("Argument '%s' after substitute: %s\n", "by", paste(deparse(bysub, width.cutoff=500L), collapse=" "))
+    else if (verbose && !is.null(env)) catf("Argument '%s' after substitute: %s\n", "by", paste(deparse(bysub, width.cutoff=500L), collapse="\n"))
   }
   bynull = !missingby && is.null(by) #3530
   byjoin = !is.null(by) && is.symbol(bysub) && bysub==".EACHI"
@@ -239,7 +239,7 @@ replace_dot_alias = function(e) {
         substitute2(.j, env),
         list(.j = substitute(j))
       ))
-      if (missing(jsub)) {j = substitute(); jsub=NULL} else if (verbose && !is.null(env)) catf("Argument '%s' after substitute: %s\n", "j", paste(deparse(jsub, width.cutoff=500L), collapse=" "))
+      if (missing(jsub)) {j = substitute(); jsub=NULL} else if (verbose && !is.null(env)) catf("Argument '%s' after substitute: %s\n", "j", paste(deparse(jsub, width.cutoff=500L), collapse="\n"))
     }
   }
   if (!missing(j)) {
@@ -328,7 +328,7 @@ replace_dot_alias = function(e) {
         substitute2(.i, env),
         list(.i = substitute(i))
       ))
-      if (missing(isub)) {i = substitute(); isub=NULL} else if (verbose && !is.null(env)) catf("Argument '%s' after substitute: %s\n", "i", paste(deparse(isub, width.cutoff=500L), collapse=" "))
+      if (missing(isub)) {i = substitute(); isub=NULL} else if (verbose && !is.null(env)) catf("Argument '%s' after substitute: %s\n", "i", paste(deparse(isub, width.cutoff=500L), collapse="\n"))
     }
   }
   if (!missing(i)) {


### PR DESCRIPTION
This PR improves verbose output when expressions are long.
Before:
```
#> Argument 'j' after substitute: {     cat("calculating group", format(.BY$Species), "...")     tmp = Sepal.Length^2 + Sepal.Width^2     Sys.sleep(1)     ans = mean(sqrt(tmp))     cat(" done with", .GRP, "/", .NGRP, "group\n")     list(mean.sepal.hypotenuse = ans) }
```
After:
```
#> Argument 'j' after substitute: {
#>     cat("calculating group", format(.BY$Species), "...")
#>     tmp = Sepal.Length^2 + Sepal.Width^2
#>     Sys.sleep(1)
#>     ans = mean(sqrt(tmp))
#>     cat(" done with", .GRP, "/", .NGRP, "group\n")
#>     list(mean.sepal.hypotenuse = ans)
#> }
```