### PR TITLE
Replace links that fail URL checks

### DIFF
--- a/man/fread.Rd
+++ b/man/fread.Rd
@@ -139,7 +139,7 @@ Background :\cr
 \url{https://stackoverflow.com/a/9818473/403310}\cr
 \url{https://stackoverflow.com/questions/9608950/reading-huge-files-using-memory-mapped-files}
 
-finagler = "to get or achieve by guile or manipulation" \url{https://dictionary.reference.com/browse/finagler}
+finagle = "to obtain (something) by indirect or involved means", \url{https://www.merriam-webster.com/dictionary/finagler}
 
 On YAML, see \url{https://yaml.org/}.
 }

--- a/man/fwrite.Rd
+++ b/man/fwrite.Rd
@@ -57,7 +57,7 @@ fwrite(x, file = "", append = FALSE, quote = "auto",
   \item{nThread}{The number of threads to use. Experiment to see what works best for your data on your hardware.}
   \item{showProgress}{ Display a progress meter on the console? Ignored when \code{file==""}. }
   \item{compress}{If \code{compress = "auto"} and if \code{file} ends in \code{.gz} then output format is gzipped csv else csv. If \code{compress = "none"}, output format is always csv. If \code{compress = "gzip"} then format is gzipped csv. Output to the console is never gzipped even if \code{compress = "gzip"}. By default, \code{compress = "auto"}.}
-  \item{compressLevel}{Level of compression between 1 and 9, 6 by default. See \url{https://linux.die.net/man/1/gzip} for details.}
+  \item{compressLevel}{Level of compression between 1 and 9, 6 by default. See \url{https://www.gnu.org/software/gzip/manual/html_node/Invoking-gzip.html} for details.}
   \item{yaml}{If \code{TRUE}, \code{fwrite} will output a CSVY file, that is, a CSV file with metadata stored as a YAML header, using \code{\link[yaml]{as.yaml}}. See \code{Details}. }
   \item{bom}{If \code{TRUE} a BOM (Byte Order Mark) sequence (EF BB BF) is added at the beginning of the file; format 'UTF-8 with BOM'.}
   \item{verbose}{Be chatty and report timings?}


### PR DESCRIPTION
Current candidate for 1.17.2 (#6860) has two URLs that get flagged by `R CMD check --as-cran`. One redirects to a 404 error page, another is a Cloudflare false positive but still could be replaced by the official documentation.

Replace these links with ones that don't fail `curl -I`. If this is a good idea, consider cherry-picking into `patch-1.17.2`.