### PR TITLE
made `typeLetter` global string constant

### DIFF
--- a/src/fread.c
+++ b/src/fread.c
@@ -214,7 +214,7 @@ static const char* strlim(const char *ch, size_t limit) {
   return ptr;
 }
 
-static char *typeLetter = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+static const char *typeLetter = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
 static char *typesAsString(int ncol) {
   int nLetters = strlen(typeLetter);


### PR DESCRIPTION
making global objects const, including string literals, is considered good practice and improves both readability and compiler optimizations