### PR TITLE
Use new grepv internally (with backport)

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -904,7 +904,7 @@ replace_dot_alias = function(e) {
             if (length(byvars) == 1L) tt = byvars
             else {
               # take the first variable that is (1) not eval (#3758) and (2) starts with a character that can't start a variable name
-              tt = grep("^eval$|^[^[:alpha:]. ]", byvars, invert=TRUE, value=TRUE)
+              tt = grepv("^eval$|^[^[:alpha:]. ]", byvars, invert=TRUE)
               # byvars but exclude functions or `0`+`1` becomes `+`
               tt = if (length(tt)) tt[1L] else all.vars(bysubl[[jj+1L]])[1L]
             }

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -169,7 +169,7 @@ shouldPrint = function(x) {
 # for removing the head (column names) of matrix output entirely,
 #   as opposed to printing a blank line, for excluding col.names per PR #1483
 # be sure to remove colnames from any row where they exist, #4270
-cut_colnames = function(x) writeLines(grep("^\\s*(?:[0-9]+:|---)", capture.output(x), value=TRUE))
+cut_colnames = function(x) writeLines(grepv("^\\s*(?:[0-9]+:|---)", capture.output(x)))
 
 # for printing the dims for list columns #3671; used by format.data.table()
 paste_dims = function(x) {

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -458,7 +458,7 @@ test = function(num,x,y=TRUE,error=NULL,warning=NULL,message=NULL,output=NULL,no
       # if a warning containing this string occurs, ignore it. First need for #4182 where warning about 'timedatectl' only
       # occurs in R 3.4, and maybe only on docker too not for users running test.data.table().
       stopifnot(is.character(ignore.warning), !anyNA(ignore.warning), nchar(ignore.warning)>=1L)
-      for (msg in ignore.warning) observed = grep(msg, observed, value=TRUE, invert=TRUE) # allow multiple for translated messages rather than relying on '|' to always work
+      for (msg in ignore.warning) observed = grepv(msg, observed, invert=TRUE) # allow multiple for translated messages rather than relying on '|' to always work
     }
     if (length(expected) != length(observed) && (!foreign || is.null(ignore.warning))) {
       # nocov start

--- a/R/utils.R
+++ b/R/utils.R
@@ -24,6 +24,9 @@ nan_is_na = function(x) {
 # R 4.4.0
 if (!exists("%||%", "package:base")) `%||%` <- function(x, y) if (is.null(x)) y else x # nolint: coalesce_linter.
 
+# R 4.5.0
+if (!exists("grepv", "package:base")) grepv <- function(...) grep(..., value=TRUE)
+
 internal_error = function(...) {
   e1 = gettext("Internal error in")
   e2 = deparse(head(tail(sys.calls(), 2L), 1L)[[1L]][[1L]])


### PR DESCRIPTION
`grepv()` is a nice new wrapper of `grep()` for subsetting a vector. I think it's a very nice addition -- it saves some characters and makes `grep()` less of a Swiss army knife (`grep()` --> integer output, `grepv()` --> string output).