### PR TITLE
False negatives in alloc check linter

### DIFF
--- a/.ci/linters/c/alloc_linter.R
+++ b/.ci/linters/c/alloc_linter.R
@@ -6,7 +6,7 @@ alloc_linter = function(c_obj) {
   lines = c_obj$lines
   # Be a bit more precise to avoid mentions in comments, and allow
   #   malloc(0) to be used for convenience (e.g. #6757)
-  alloc_lines = grep(R"{=\s*([(]\w+\s*[*][)])?\s*[mc]alloc[(][^0]}", lines)
+  alloc_lines = grep(R"{=\s*([(]\s*\w+\s*[*]\s*[)])?\s*[mc]alloc[(][^0]}", lines)
   if (!length(alloc_lines)) return()
   # int *tmp=(int*)malloc(...); or just int tmp=malloc(...);
   alloc_keys = lines[alloc_lines] |>

--- a/.ci/linters/c/alloc_linter.R
+++ b/.ci/linters/c/alloc_linter.R
@@ -6,7 +6,7 @@ alloc_linter = function(c_obj) {
   lines = c_obj$lines
   # Be a bit more precise to avoid mentions in comments, and allow
   #   malloc(0) to be used for convenience (e.g. #6757)
-  alloc_lines = grep(R"{=\s*([(]\w+\s*[*][)])?[mc]alloc[(][^0]}", lines)
+  alloc_lines = grep(R"{=\s*([(]\w+\s*[*][)])?\s*[mc]alloc[(][^0]}", lines)
   if (!length(alloc_lines)) return()
   # int *tmp=(int*)malloc(...); or just int tmp=malloc(...);
   alloc_keys = lines[alloc_lines] |>
@@ -31,7 +31,7 @@ alloc_linter = function(c_obj) {
       cat("FILE: ", c_obj$path, "; LINES: ", head(bad_lines_idx, 1L), "-", tail(bad_lines_idx, 1L), "\n", sep="")
       writeLines(lines[bad_lines_idx])
       cat(strrep("-", max(nchar(lines[bad_lines_idx]))), "\n", sep="")
-      stop("Expected the malloc()/calloc() usage above to be followed immediately by error checking.", call.=FALSE)
+      stop("Expected the malloc()/calloc() usage above to be followed immediately by error checking (using '!', not '==NULL').", call.=FALSE)
     }
   })
 }

--- a/src/assign.c
+++ b/src/assign.c
@@ -647,7 +647,7 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values)
       // check the position of the first appearance of an assigned column in the index.
       // the new index will be truncated to this position.
       char *s4 = (char*) malloc(strlen(c1) + 3);
-      if(s4 == NULL){
+      if (!s4) {
         internal_error(__func__, "Couldn't allocate memory for s4"); // # nocov
       }
       memcpy(s4, c1, strlen(c1));
@@ -657,7 +657,7 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values)
       for(int i = 0; i < xlength(assignedNames); i++){
         tc2 = CHAR(STRING_ELT(assignedNames, i));
         char *s5 = (char*) malloc(strlen(tc2) + 5); //4 * '_' + \0
-        if(s5 == NULL){
+        if (!s5) {
           free(s4);                                                  // # nocov
           internal_error(__func__, "Couldn't allocate memory for s5"); // # nocov
         }


### PR DESCRIPTION
As discovered in #6951 -- by omitting the valid whitespace checks, we missed a few cases in the earlier sweep.

Also make clear in the failure message that our convention is `!ptr`, not `ptr==NULL`.

Split off for clarity.