### PR TITLE
Switch to h2/h3 hierarchy of NEWS (not h1/h2)

### DIFF
--- a/NEWS.0.md
+++ b/NEWS.0.md
@@ -1,9 +1,11 @@
 
+# data.table news and updates (historical)
+
 **This is OLD NEWS. Latest news is on GitHub [here](https://github.com/Rdatatable/data.table/blob/master/NEWS.md).**
 
-# data.table v1.9.8  (on CRAN 25 Nov 2016)
+## data.table v1.9.8  (on CRAN 25 Nov 2016)
 
-## POTENTIALLY BREAKING CHANGES
+### POTENTIALLY BREAKING CHANGES
 
   1. By default all columns are now used by `unique()`, `duplicated()` and `uniqueN()` data.table methods, [#1284](https://github.com/Rdatatable/data.table/issues/1284) and [#1841](https://github.com/Rdatatable/data.table/issues/1841). To restore old behaviour: `options(datatable.old.unique.by.key=TRUE)`. In 1 year this option to restore the old default will be deprecated with warning. In 2 years the option will be removed. Please explicitly pass `by=key(DT)` for clarity. Only code that relies on the default is affected. 266 CRAN and Bioconductor packages using data.table were checked before release. 9 needed to change and were notified. Any lines of code without test coverage will have been missed by these checks. Any packages not on CRAN or Bioconductor were not checked.
 
@@ -11,7 +13,7 @@
 
   3. When `j` contains no unquoted variable names (whether column names or not), `with=` is now automatically set to `FALSE`. Thus, `DT[,1]`, `DT[,"someCol"]`, `DT[,c("colA","colB")]` and `DT[,100:109]` now work as we all expect them to; i.e., returning columns, [#1188](https://github.com/Rdatatable/data.table/issues/1188), [#1149](https://github.com/Rdatatable/data.table/issues/1149). Since there are no variable names there is no ambiguity as to what was intended. `DT[,colName1:colName2]` no longer needs `with=FALSE` either since that is also unambiguous. That is a single call to the `:` function so `with=TRUE` could make no sense, despite the presence of unquoted variable names. These changes can be made since nobody can be using the existing behaviour of returning back the literal `j` value since that can never be useful. This provides a new ability and should not break any existing code. Selecting a single column still returns a 1-column data.table (not a vector, unlike `data.frame` by default) for type consistency for code (e.g. within `DT[...][...]` chains) that can sometimes select several columns and sometime one, as has always been the case in data.table. In future, `DT[,myCols]` (i.e. a single variable name) will look for `myCols` in calling scope without needing to set `with=FALSE` too, just as a single symbol appearing in `i` does already. The new behaviour can be turned on now by setting the tersely named option: `options(datatable.WhenJisSymbolThenCallingScope=TRUE)`. The default is currently `FALSE` to give you time to change your code. In this future state, one way (i.e. `DT[,theColName]`) to select the column as a vector rather than a 1-column data.table will no longer work leaving the two other ways that have always worked remaining (since data.table is still just a `list` after all): `DT[["someCol"]]` and `DT$someCol`. Those base R methods are faster too (when iterated many times) by avoiding the small argument checking overhead inside the more flexible `DT[...]` syntax as has been highlighted in `example(data.table)` for many years. In the next release, `DT[,someCol]` will continue with old current behaviour but start to warn if the new option is not set. Then the default will change to TRUE to nudge you to move forward whilst still retaining a way for you to restore old behaviour for this feature only, whilst still allowing you to benefit from other new features of the latest release without changing your code. Then finally after an estimated 2 years from now, the option will be removed.
 
-## NEW FEATURES
+### NEW FEATURES
 
   1. `fwrite()` - parallel .csv writer:
     * Thanks to Otto Seiskari for the initial pull request [#580](https://github.com/Rdatatable/data.table/issues/580) that provided C code, R wrapper, manual page and extensive tests.
@@ -101,7 +103,7 @@
   30. `keyby=` is now much faster by not doing not needed work; e.g. 25s down to 13s for a 1.5GB DT with 200m rows and 86m groups. With more groups or bigger data, larger speedup factors are possible. Please always use `keyby=` unless you really need `by=`. `by=` returns the groups in first appearance order and takes longer to do that. See [#1880](https://github.com/Rdatatable/data.table/issues/1880) for more info and please register your views there on changing the default.
 
 
-## BUG FIXES
+### BUG FIXES
 
   1. Now compiles and runs on IBM AIX gcc. Thanks to Vinh Nguyen for investigation and testing, [#1351](https://github.com/Rdatatable/data.table/issues/1351).
 
@@ -259,7 +261,7 @@
 
   77. `fread` is now consistent to `read.table` on `colClasses` vector containing NA, also fixes mixed character and factor in `colClasses` vector. Closes [#1910](https://github.com/Rdatatable/data.table/issues/1910).
 
-## NOTES
+### NOTES
 
   1. Updated error message on invalid joins to reflect the new `on=` syntax, [#1368](https://github.com/Rdatatable/data.table/issues/1368). Thanks @MichaelChirico.
 
@@ -350,9 +352,9 @@
   42. Thanks to @rrichmond for finding and reporting a regression in dev before release with `roll` not respecting fractions in type double, [#1904](https://github.com/Rdatatable/data.table/issues/1904). For example dates like `zoo::as.yearmon("2016-11")` which is stored as `double` value 2016.833. Fixed and test added.
 
 
-# data.table v1.9.6  (on CRAN 19 Sep 2015)
+## data.table v1.9.6  (on CRAN 19 Sep 2015)
 
-## NEW FEATURES
+### NEW FEATURES
 
   1. `fread`
       * passes `showProgress=FALSE` through to `download.file()` (as `quiet=TRUE`). Thanks to a pull request from Karl Broman and Richard Scriven for filing the issue, [#741](https://github.com/Rdatatable/data.table/issues/741).
@@ -422,7 +424,7 @@
 
   25. `setDT()` gains `check.names` argument paralleling that of `fread`, `data.table`, and `base` functionality, allowing poorly declared objects to be converted to tidy `data.table`s by reference. Closes [#1338](https://github.com/Rdatatable/data.table/issues/1338); thanks to @MichaelChirico for the FR/PR.
 
-## BUG FIXES
+### BUG FIXES
 
   1. `if (TRUE) DT[,LHS:=RHS]` no longer prints, [#869](https://github.com/Rdatatable/data.table/issues/869) and [#1122](https://github.com/Rdatatable/data.table/issues/1122). Tests added. To get this to work we've had to live with one downside: if a `:=` is used inside a function with no `DT[]` before the end of the function, then the next time `DT` or `print(DT)` is typed at the prompt, nothing will be printed. A repeated `DT` or `print(DT)` will print. To avoid this: include a `DT[]` after the last `:=` in your function. If that is not possible (e.g., it's not a function you can change) then `DT[]` at the prompt is guaranteed to print. As before, adding an extra `[]` on the end of a `:=` query is a recommended idiom to update and then print; e.g. `> DT[,foo:=3L][]`. Thanks to Jureiss and Jan Gorecki for reporting.
 
@@ -594,7 +596,7 @@
 
   67. `as.list` method for `IDate` object works properly. Closes [#1315](https://github.com/Rdatatable/data.table/issues/1315). Thanks to @gwerbin.
 
-## NOTES
+### NOTES
 
   1. Clearer explanation of what `duplicated()` does (borrowed from base). Thanks to @matthieugomez for pointing out. Closes [#872](https://github.com/Rdatatable/data.table/issues/872).
 
@@ -634,9 +636,9 @@
 
   14. Fixed `allow.cartesian` documentation to `nrow(x)+nrow(i)` instead of `max(nrow(x), nrow(i))`. Closes [#1123](https://github.com/Rdatatable/data.table/issues/1123).
 
-# data.table v1.9.4  (on CRAN 2 Oct 2014)
+## data.table v1.9.4  (on CRAN 2 Oct 2014)
 
-## NEW FEATURES
+### NEW FEATURES
 
   1. `by=.EACHI` runs `j` for each group in `DT` that each row of `i` joins to.
     ```
@@ -782,7 +784,7 @@
     ```
 
 
-## BUG FIXES
+### BUG FIXES
 
 
   1.  When joining to fewer columns than the key has, using one of the later key columns explicitly in j repeated the first value. A problem introduced by v1.9.2 and not caught bythe 1,220 tests, or tests in 37 dependent packages. Test added. Many thanks to Michele Carriero for reporting.
@@ -881,7 +883,7 @@
 
   45. Grouping using external variables on keyed data.tables did not return correct results at times. Thanks to @colinfang for reporting. Closes [#762](https://github.com/Rdatatable/data.table/issues/762).
 
-## NOTES
+### NOTES
 
   1.  Reminder: using `rolltolast` still works but since v1.9.2 now issues the following warning:
      > 'rolltolast' has been marked 'deprecated' in ?data.table since v1.8.8 on CRAN 3 Mar 2013, see NEWS. Please change to the more flexible 'rollends' instead. 'rolltolast' will be removed in the next version."
@@ -928,9 +930,9 @@
 
 ---
 
-# data.table v1.9.2 (on CRAN 27 Feb 2014)
+## data.table v1.9.2 (on CRAN 27 Feb 2014)
 
-## NEW FEATURES
+### NEW FEATURES
 
   1.  Fast methods of `reshape2`'s `melt` and `dcast` have been implemented for `data.table`, **FR #2627**. Most settings are identical to `reshape2`, see `?melt.data.table.`
     > `melt`: 10 million rows and 5 columns, 61.3 seconds reduced to 1.2 seconds.
@@ -1066,7 +1068,7 @@
     DT[, list(b,1:2), by=a]        # now recycles the 1:2 with warning to length 3
     ```
 
-## BUG FIXES
+### BUG FIXES
 
   1.  Long outstanding (usually small) memory leak in grouping fixed, #2648. When the last group is smaller than the largest group, the difference in those sizes was not being released. Also evident in non-trivial aggregations where each group returns a different number of rows. Most users run a grouping
      query once and will never have noticed these, but anyone looping calls to grouping (such as when running in parallel, or benchmarking) may have suffered. Tests added. Thanks to many including vc273 and Y T for reporting [here](https://stackoverflow.com/questions/20349159/memory-leak-in-data-table-grouped-assignment-by-reference) and [here](https://stackoverflow.com/questions/15651515/slow-memory-leak-in-data-table-when-returning-named-lists-in-j-trying-to-reshap) on SO.
@@ -1179,7 +1181,7 @@
 
   50.  `CJ()` now orders character vectors in a locale consistent with `setkey`, #5375. Typically this affected whether upper case letters were ordered before lower case letters; they were by `setkey()` but not by `CJ()`. This difference started in v1.8.10 with the change "CJ() is 90% faster...", see NEWS below. Test added and avenues for differences closed off and nailed down, with no loss in performance. Many thanks to Malcolm Hawkes for reporting.
 
-## THANKS FOR BETA TESTING TO :
+### THANKS FOR BETA TESTING TO :
 
   1.  Zach Mayer for a reproducible segfault related to radix sorting character strings longer than 20. Test added.
 
@@ -1211,7 +1213,7 @@
 
   11.  Ricardo Saporta for finding a crash when i is empty and a join column is character, #5387. Test added.
 
-## NOTES
+### NOTES
 
   1.  If `fread` detects data which would be lost if the column was read according to type supplied in `colClasses`, e.g. a numeric column specified as integer in `colClasses`, the message that it has ignored colClasses is upgraded to warning instead of just a line in `verbose=TRUE` mode.
 
@@ -1234,9 +1236,9 @@
 
 ---
 
-# data.table v1.8.10 (on CRAN 03 Sep 2013)
+## data.table v1.8.10 (on CRAN 03 Sep 2013)
 
-## NEW FEATURES
+### NEW FEATURES
 
   *  fread :
      * If some column names are blank they are now given default names rather than causing
@@ -1300,7 +1302,7 @@
      has been copied or not by R, programmatically.
        https://stackoverflow.com/a/10913296/403310
 
-## BUG FIXES
+### BUG FIXES
 
   *  merge no longer returns spurious NA row(s) when y is empty and all.y=TRUE (or all=TRUE), #2633. Thanks
      to Vinicius Almendra for reporting. Test added.
@@ -1358,7 +1360,7 @@ USER VISIBLE CHANGES
 	 to Josh O'Brien's investigation :
 	   https://stackoverflow.com/questions/15931801/why-does-trace-edit-true-not-work-when-data-table
 
-## NOTES
+### NOTES
 
   *  Tests 617,646 and 647 could sometimes fail (e.g. r-prerel-solaris-sparc on 7 Mar 2013)
      due to machine tolerance. Fixed.
@@ -1381,9 +1383,9 @@ USER VISIBLE CHANGES
      Odd numbers are development, evens on CRAN.
 
 
-# data.table v1.8.8 (on CRAN 06 Mar 2013)
+## data.table v1.8.8 (on CRAN 06 Mar 2013)
 
-## NEW FEATURES
+### NEW FEATURES
 
     *   New function fread(), a fast and friendly file reader.
         *  header, skip, nrows, sep and colClasses are all auto detected.
@@ -1425,7 +1427,7 @@ USER VISIBLE CHANGES
         {roll=TRUE;rollends=c(FALSE,FALSE)}.
         This implements [FR#615](https://github.com/Rdatatable/data.table/issues/615) & [FR#459](https://github.com/Rdatatable/data.table/issues/459) and helps several recent S.O. questions.
 
-## BUG FIXES
+### BUG FIXES
 
     *   setnames(DT,c(NA,NA)) is now a type error rather than a segfault, #2393.
         Thanks to Damian Betebenner for reporting.
@@ -1479,7 +1481,7 @@ USER VISIBLE CHANGES
         Many thanks to Charles, Joris Meys, and, Spacedman whose solution is now used
         by data.table internally (https://stackoverflow.com/a/13606880/403310).
 
-## NOTES
+### NOTES
 
     *   print(DT,topn=2), where topn is provided explicitly, now prints the top and bottom 2 rows
         even when nrow(x)<100 [options()$datatable.print.nrows]. And the 'topn' argument is now first
@@ -1500,15 +1502,15 @@ USER VISIBLE CHANGES
         Odd numbers are development, evens on CRAN.
 
 
-# data.table v1.8.6 (on CRAN 13 Nov 2012)
+## data.table v1.8.6 (on CRAN 13 Nov 2012)
 
-## BUG FIXES
+### BUG FIXES
 
     *   A variable in calling scope was not found when combining i, j and by in
         one query, i used that local variable, and that query occurred inside a
         function, #2368. This worked in 1.8.2, a regression. Test added.
 
-## COMPATIBILITY FOR R 2.12.0-2.15.0
+### COMPATIBILITY FOR R 2.12.0-2.15.0
 
     *   setnames used paste0() to construct its error messages, a function
         added to R 2.15.0. Reverted to use paste(). Tests added.
@@ -1516,7 +1518,7 @@ USER VISIBLE CHANGES
     *   X[Y] where Y is empty (test 764) failed due to reliance on a pmin()
         enhancement in R 2.15.1. Removed reliance.
 
-## NOTES
+### NOTES
 
     *   test.data.table() now passes in 2.12.0, the stated dependency, as well as
         2.14.0, 2.15.0, 2.15.1, 2.15.2 and R-devel.
@@ -1531,9 +1533,9 @@ USER VISIBLE CHANGES
         Odd numbers are development, evens on CRAN.
 
 
-# data.table v1.8.4 (on CRAN 9 Nov 2012)
+## data.table v1.8.4 (on CRAN 9 Nov 2012)
 
-## NEW FEATURES
+### NEW FEATURES
 
     *   New printing options have been added :
             options(datatable.print.nrows=100)
@@ -1632,7 +1634,7 @@ USER VISIBLE CHANGES
 
     *   setnames() now works on data.frame, #2273. Thanks to Christian Hudon for the suggestion.
 
-## BUG FIXES
+### BUG FIXES
 
     *   A large slowdown (many minutes instead of a few secs) in X[Y] joins has been fixed, #2216.
         This occurred where the number of rows in i was large, and at least one row joined to
@@ -1757,7 +1759,7 @@ USER VISIBLE CHANGES
             DT[, {list(name1=sum(v),name2=sum(w))}, by="a,b"]  # now ok, no blank column names in result
             DT[, list(name1=sum(v),name2=sum(w)), by="a,b"]    # ok before
 
-## USER VISIBLE CHANGES
+### USER VISIBLE CHANGES
 
     *   J() now issues a warning (when used *outside* DT[...]) that using it
         outside DT[...] is deprecated. See item below in v1.8.2.
@@ -1796,7 +1798,7 @@ USER VISIBLE CHANGES
     *   Efficiency warnings when joining between a factor column and a character column are now downgraded
         to messages when verbosity is on, #2265i. Thanks to Christian Hudon for the suggestion.
 
-## THANKS TO BETA TESTING (bugs caught in 1.8.3 before release to CRAN)
+### THANKS TO BETA TESTING (bugs caught in 1.8.3 before release to CRAN)
 
     *   Combining a join with mult="first"|"last" followed by by inside the same [...] gave incorrect
         results or a crash, #2303. Many thanks to Garrett See for the reproducible example and
@@ -1804,7 +1806,7 @@ USER VISIBLE CHANGES
 
     *   Examples in ?data.table have been updated now that := no longer prints. Thanks to Garrett See.
 
-## NOTES
+### NOTES
 
     *   There are now 869 raw tests. test.data.table() should return precisely this number of
         tests passed. If not, then somehow, a slightly stale version from R-Forge is likely
@@ -1813,9 +1815,9 @@ USER VISIBLE CHANGES
     *   v1.8.3 was an R-Forge only beta release. v1.8.4 was released to CRAN.
 
 
-# data.table v1.8.2
+## data.table v1.8.2
 
-## NEW FEATURES
+### NEW FEATURES
 
     *   Numeric columns (type 'double') are now allowed in keys and ad hoc
         by. J() and SJ() no longer coerce 'double' to 'integer'. i join columns
@@ -1900,7 +1902,7 @@ USER VISIBLE CHANGES
     *   New function rbindlist(l). This does the same as do.call("rbind",l), but much
         faster.
 
-## BUG FIXES
+### BUG FIXES
 
     *   DT[,f(.SD),by=colA] where f(x)=x[,colB:=1L] was a segfault, bug#1727.
         This is now a graceful error to say that using := in .SD's j is
@@ -2002,7 +2004,7 @@ USER VISIBLE CHANGES
             DT[, mean(foo), by=colA]     # worked before
             DT[, mean(foo), by="colA"]   # worked before
 
-## USER VISIBLE CHANGES
+### USER VISIBLE CHANGES
 
     *   Incorrect syntax error message for := now includes advice to check that
         DT is a data.table rather than a data.frame. Thanks to a comment by
@@ -2036,7 +2038,7 @@ USER VISIBLE CHANGES
         The tail as well as the head of large tables is now printed.
 
 
-## THANKS TO BETA TESTING (i.e. bugs caught in 1.8.1 before release to CRAN) :
+### THANKS TO BETA TESTING (i.e. bugs caught in 1.8.1 before release to CRAN) :
 
     *   Florian Oswald for #2094: DT[,newcol:=NA] now adds a new logical column ok.
         Test added.
@@ -2062,16 +2064,16 @@ USER VISIBLE CHANGES
         column subset such as DT[,list(x)], or after changing all column names
         with setnames(), was an error. Fixed and tests added.
 
-## NOTES
+### NOTES
 
     *   There are now 717 raw tests, plus S4 tests.
 
     *   v1.8.1 was an R-Forge only beta release. v1.8.2 was released to CRAN.
 
 
-# data.table v1.8.0
+## data.table v1.8.0
 
-## NEW FEATURES
+### NEW FEATURES
 
     *   character columns are now allowed in keys and are preferred to
         factor. data.table() and setkey() no longer coerce character to
@@ -2150,7 +2152,7 @@ USER VISIBLE CHANGES
         was the culprit and has been removed internally from all 11 calls.
 
 
-## BUG FIXES
+### BUG FIXES
 
     *   Fixed a `suffixes` handling bug in merge.data.table that was
         only recently introduced during the recent "fast-merge"-ing reboot.
@@ -2202,14 +2204,14 @@ USER VISIBLE CHANGES
         added.
 
 
-## THANKS TO
+### THANKS TO
 
     *   Joshua Ulrich for spotting a missing PACKAGE="data.table"
         in .Call in setkey.R, and suggesting as.list.default() and
         unique.default() to avoid dispatch for speed, all implemented.
 
 
-## USER-VISIBLE CHANGES
+### USER-VISIBLE CHANGES
 
     *   Providing .SDcols when j doesn't use .SD is downgraded from error to warning,
         and verbosity now reports which columns have been detected as used by j.
@@ -2219,9 +2221,9 @@ USER VISIBLE CHANGES
         This difference to data.frame has been added to FAQ 2.17.
 
 
-# data.table v1.7.10
+## data.table v1.7.10
 
-## NEW FEATURES
+### NEW FEATURES
 
     *   New function setcolorder() reorders the columns by name
         or by number, by reference with no copy. This is (almost)
@@ -2232,7 +2234,7 @@ USER VISIBLE CHANGES
         the same name.
 
 
-## BUG FIXES
+### BUG FIXES
 
     *   tracemem() in example(setkey) was causing CRAN check errors
         on machines where R is compiled without memory profiling available,
@@ -2248,7 +2250,7 @@ USER VISIBLE CHANGES
         scope. Fixed and tests added.
 
 
-## USER-VISIBLE CHANGES
+### USER-VISIBLE CHANGES
 
     *   Updating an existing column using := after a key<- now works without warning
         or error. This can be useful in interactive use when you forget to use setkey()
@@ -2260,9 +2262,9 @@ USER VISIBLE CHANGES
         obtain deprecated merge() suffixes pre v1.5.4.
 
 
-# data.table v1.7.9
+## data.table v1.7.9
 
-## NEW FEATURES
+### NEW FEATURES
 
    *    New function setnames(), referred to in 1.7.8 warning messages.
         It makes no copy of the whole data object, unlike names<- and
@@ -2280,7 +2282,7 @@ USER VISIBLE CHANGES
         vector. As before with names<-, if a key column's name is changed,
         the "sorted" attribute is updated with the new column name.
 
-## BUG FIXES
+### BUG FIXES
 
    *    Incompatibility with reshape() of 3 column tables fixed
         (introduced by 1.7.8) :
@@ -2294,9 +2296,9 @@ USER VISIBLE CHANGES
         Again, thanks to Damian Betebenner for reporting.
 
 
-# data.table v1.7.8
+## data.table v1.7.8
 
-## BUG FIXES
+### BUG FIXES
 
    *    unique(DT) now works when DT is keyed and a key
         column is called 'x' (an internal scoping conflict
@@ -2342,7 +2344,7 @@ USER VISIBLE CHANGES
         improved in ?data.table. Thanks to Joseph Voelkel for
         reporting.
 
-## NEW FEATURES
+### NEW FEATURES
 
    *    Multiple new columns can be added by reference using
         := and with=FALSE; e.g.,
@@ -2362,7 +2364,7 @@ USER VISIBLE CHANGES
    *    merge() now uses (manual) secondary keys, for speed.
 
 
-## USER VISIBLE CHANGES
+### USER VISIBLE CHANGES
 
    *    The loc argument of setkey has been removed. This wasn't very
         useful and didn't warrant a period of deprecation.
@@ -2375,9 +2377,9 @@ USER VISIBLE CHANGES
         of i's key are used to join.
 
 
-# data.table v1.7.7
+## data.table v1.7.7
 
-## BUG FIXES
+### BUG FIXES
 
    *    Previous bug fix for random crash in R <= 2.13.2
         related to truelength and over-allocation didn't
@@ -2387,9 +2389,9 @@ USER VISIBLE CHANGES
         mac). So if they pass, this issue is fixed.
 
 
-# data.table v1.7.6
+## data.table v1.7.6
 
-## NEW FEATURES
+### NEW FEATURES
 
    *    An empty list column can now be added with :=, and
         data.table() accepts empty list().
@@ -2397,7 +2399,7 @@ USER VISIBLE CHANGES
             data.table(a=1:3,b=list())
         Empty list columns contain NULL for all rows.
 
-## BUG FIXES
+### BUG FIXES
 
    *    Adding a column to a data.table loaded from disk could
         result in a memory corruption in R <= 2.13.2, revealed
@@ -2408,9 +2410,9 @@ USER VISIBLE CHANGES
         Betebenner for reporting.
 
 
-# data.table v1.7.5
+## data.table v1.7.5
 
-## BUG FIXES
+### BUG FIXES
 
    *    merge()-ing a data.table where its key is not the first
         few columns in order now works correctly and without
@@ -2439,7 +2441,7 @@ USER VISIBLE CHANGES
         Christoph_J on Stack Overflow.
 
 
-## USER VISIBLE CHANGES
+### USER VISIBLE CHANGES
 
    *    rbind now cross-refs colnames as data.frame does, rather
         than always binding by column order, FR#1634. A warning is
@@ -2452,14 +2454,14 @@ USER VISIBLE CHANGES
 
    *    New option datatable.allocwarn. See ?truelength.
 
-## NOTES
+### NOTES
 
    *    There are now 472 raw tests, plus S4 tests.
 
 
-# data.table v1.7.4
+## data.table v1.7.4
 
-## BUG FIXES
+### BUG FIXES
 
    *    v1.7.3 failed CRAN checks (and could crash) in R pre-2.14.0.
         Over-allocation in v1.7.3 uses truelength which is initialized
@@ -2467,16 +2469,16 @@ USER VISIBLE CHANGES
         known and coded for but only tested in 2.14.0 before previous
         release to CRAN.
 
-## NOTES
+### NOTES
 
    *    Two unused C variables removed to pass warning from one CRAN
         check machine (r-devel-fedora). -Wno-unused removed from
         Makevars to catch this in future before submitting to CRAN.
 
 
-# data.table v1.7.3
+## data.table v1.7.3
 
-## NEW FEATURES
+### NEW FEATURES
 
     *   data.table now over-allocates its vector of column pointer slots
         (100 by default). This allows := to add columns fully by
@@ -2502,7 +2504,7 @@ USER VISIBLE CHANGES
     *   cbind(DT,...) now retains DT's key, as wished for by Chris Neff
         and partly implementing FR#295.
 
-## BUG FIXES
+### BUG FIXES
 
     *   Assignment to factor columns (using :=, [<- or $<-) could cause
         'variable not found' errors and a segfault in some circumstances
@@ -2516,7 +2518,7 @@ USER VISIBLE CHANGES
     *   An unnecessarily strict machine tolerance test failed CRAN checks
         on Mac preventing v1.7.2 availability for Mac (only).
 
-## USER VISIBLE CHANGES
+### USER VISIBLE CHANGES
 
     *   := now has its own help page in addition to the examples in ?data.table,
         see help(":=").
@@ -2529,9 +2531,9 @@ USER VISIBLE CHANGES
         to Chris Neff for suggesting, #1642.
 
 
-# data.table v1.7.2
+## data.table v1.7.2
 
-## NEW FEATURES
+### NEW FEATURES
 
     *   unique and duplicated methods now work on unkeyed tables (comparing
         all columns in that case) and both now respect machine tolerance for
@@ -2544,7 +2546,7 @@ USER VISIBLE CHANGES
         list to data.table() now creates a single list column.
 
 
-## BUG FIXES
+### BUG FIXES
 
     *   Assigning to a column variable using <- or = in j now
         works (creating a local copy within j), rather than
@@ -2562,9 +2564,9 @@ USER VISIBLE CHANGES
         #1640. Thanks to Stavros Macrakis for reporting.
 
 
-# data.table v1.7.1
+## data.table v1.7.1
 
-## BUG FIXES
+### BUG FIXES
 
     *   .SD is now locked, partially fixing #1624. It was never
         the intention to allow assignment to .SD. Take a 'copy(.SD)'
@@ -2575,7 +2577,7 @@ USER VISIBLE CHANGES
             DT[x==1,y:=x]
         Thanks to Muhammad Waliji for reporting.
 
-## USER VISIBLE CHANGES
+### USER VISIBLE CHANGES
 
     *   Error message "column <name> of i is not internally type integer"
         is now more helpful adding "i doesn't need to be keyed, just
@@ -2583,9 +2585,9 @@ USER VISIBLE CHANGES
         Christoph_J for his SO question.
 
 
-# data.table v1.7.0
+## data.table v1.7.0
 
-## NEW FEATURES
+### NEW FEATURES
 
     *   data.table() now accepts list columns directly rather than
         needing to add list columns to an existing data.table; e.g.,
@@ -2634,7 +2636,7 @@ USER VISIBLE CHANGES
         To change the type of a column, provide a full length RHS (i.e.
         'replace' the column).
 
-## BUG FIXES
+### BUG FIXES
 
     *   := with i all FALSE no longer sets the whole column, fixing
         bug #1570. Thanks to Chris Neff for reporting.
@@ -2675,23 +2677,23 @@ USER VISIBLE CHANGES
         on an empty "...") is fixed and test added. data.table was switching
         on list(...)[[1]] rather than ..1. Thanks to RYogi for reporting #1623.
 
-## USER VISIBLE CHANGES
+### USER VISIBLE CHANGES
 
     *   cbind and rbind are no longer masked. But, please do read FAQ 2.23,
         4.4 and 5.1.
 
 
-# data.table v1.6.6
+## data.table v1.6.6
 
-## BUG FIXES
+### BUG FIXES
 
     *   Tests using .Call("Rf_setAttrib",...) passed CRAN acceptance
         checks but failed on many (but not all) platforms. Fixed.
         Thanks to Prof Brian Ripley for investigating the issue.
 
-# data.table v1.6.5
+## data.table v1.6.5
 
-## NEW FEATURES
+### NEW FEATURES
 
     *   The LHS of := may now be column names or positions
         when with=FALSE; e.g.,
@@ -2728,7 +2730,7 @@ USER VISIBLE CHANGES
         copied on write by setkey, key<- or :=.
 
 
-## BUG FIXES
+### BUG FIXES
 
     *   DT[,z:=a/b] and DT[a>3,z:=a/b] work again, where a and
         b are columns of DT. Thanks to Chris Neff for reporting,
@@ -2757,19 +2759,19 @@ USER VISIBLE CHANGES
         Lianoglou for reporting.
 
 
-## USER VISIBLE CHANGES
+### USER VISIBLE CHANGES
 
     *   setkey's verbose messages expanded.
 
 
-# data.table v1.6.4
+## data.table v1.6.4
 
-## NEW FEATURES
+### NEW FEATURES
 
     *   DT[colA>3,which=TRUE] now returns row numbers rather
         than a logical vector, for consistency.
 
-## BUG FIXES
+### BUG FIXES
 
     *   Changing a keyed column name now updates the key, too,
         so an invalid key no longer arises, fixing #1495.
@@ -2807,7 +2809,7 @@ USER VISIBLE CHANGES
         Thanks to Timothee Carayol for reporting.
 
 
-## NOTES
+### NOTES
 
     *   The package uses two features (packageVersion() and \href in Rd)
         added to R 2.12.0 and is therefore dependent on that release.
@@ -2816,9 +2818,9 @@ USER VISIBLE CHANGES
         be ignored in versions >= 2.12.0 and < 2.12.2 patched.
 
 
-# data.table v1.6.3
+## data.table v1.6.3
 
-## NEW FEATURES
+### NEW FEATURES
 
     *   Ad hoc grouping now returns results in the same order each
         group first appears in the table, rather than sorting the
@@ -2885,7 +2887,7 @@ USER VISIBLE CHANGES
         *Please note*, := is new and experimental.
 
 
-## BUG FIXES
+### BUG FIXES
 
     *   merge()ing two data.table's with user-defined `suffixes`
         was getting tripped up when column names in x ended in
@@ -2920,7 +2922,7 @@ USER VISIBLE CHANGES
         to Chris Neff for reporting.
 
 
-## USER-VISIBLE CHANGES
+### USER-VISIBLE CHANGES
 
     *   The startup banner has been shortened to one line.
 
@@ -2932,16 +2934,16 @@ USER VISIBLE CHANGES
         resolves bug #1481 by documenting non support in ?data.table.
 
 
-## DEPRECATED & DEFUNCT
+### DEPRECATED & DEFUNCT
 
    *    Use of the DT() alias in j is no longer caught for backwards
         compatibility and is now fully removed. As warned in NEWS
         for v1.5.3, v1.4, and FAQs 2.6 and 2.7.
 
 
-# data.table v1.6.2
+## data.table v1.6.2
 
-## NEW FEATURES
+### NEW FEATURES
 
    *    setkey no longer copies the whole table and should be
         faster for large tables. Each column is reordered by reference
@@ -2955,9 +2957,9 @@ USER VISIBLE CHANGES
         convenience generally, and for efficiency.
 
 
-# data.table v1.6.1
+## data.table v1.6.1
 
-## NEW FEATURES
+### NEW FEATURES
 
    *    j's environment is now consistently reused so
         that local variables may be set which persist
@@ -2984,7 +2986,7 @@ USER VISIBLE CHANGES
             DT[,list(GROUPDATA[.BY]$name,sum(v)),by=grp]
 
 
-## BUG FIXES
+### BUG FIXES
 
    *    A 'by' character vector of column names now
         works when there are less rows than columns; e.g.,
@@ -3009,7 +3011,7 @@ USER VISIBLE CHANGES
         to Alexander Peterhansl for reporting.
 
 
-## USER-VISIBLE CHANGES
+### USER-VISIBLE CHANGES
 
     *   ?data.table now documents that logical i is not quite
         the same as i in [.data.frame. NA are treated as FALSE,
@@ -3023,9 +3025,9 @@ USER VISIBLE CHANGES
 
 
 
-# data.table v1.6
+## data.table v1.6
 
-## NEW FEATURES
+### NEW FEATURES
 
    *    data.table now plays nicely with S4 classes. Slots can be
         defined to be S4 objects, S4 classes can inherit from data.table,
@@ -3041,7 +3043,7 @@ USER VISIBLE CHANGES
         However, X[Y] syntax is preferred; some users never use merge.
 
 
-## BUG FIXES
+### BUG FIXES
 
    *    by=key(DT) now works when the number of rows is not
         divisible by the number of groups (#1298, an odd bug).
@@ -3061,7 +3063,7 @@ USER VISIBLE CHANGES
         reporting.
 
 
-## USER-VISIBLE CHANGES
+### USER-VISIBLE CHANGES
 
    *    Additions and updates to FAQ vignette. Thanks to Dennis
         Murphy for his thorough proof reading.
@@ -3074,9 +3076,9 @@ USER VISIBLE CHANGES
         IDateTime in v1.5 (see below).
 
 
-# data.table v1.5.3
+## data.table v1.5.3
 
-## NEW FEATURES
+### NEW FEATURES
 
    *    .SD no longer includes 'by' columns, FR#978. This resolves
         the long standing annoyance of duplicated 'by' columns
@@ -3106,7 +3108,7 @@ USER VISIBLE CHANGES
         all.equal) and character to factor, FR#1051, as setkey
         already does.
 
-## USER-VISIBLE CHANGES
+### USER-VISIBLE CHANGES
 
    *    The default for mult is now "all", as planned and
         prior notice given in FAQ 2.2.
@@ -3114,15 +3116,15 @@ USER VISIBLE CHANGES
    *    ?[.data.table has been merged into ?data.table and updated,
         simplified, corrected and formatted.
 
-## DEPRECATED & DEFUNCT
+### DEPRECATED & DEFUNCT
 
    *    The DT() alias is now fully deprecated, as warned
         in NEWS for v1.4, and FAQs 2.6 and 2.7.
 
 
-# data.table v1.5.2
+## data.table v1.5.2
 
-## NEW FEATURES
+### NEW FEATURES
 
    *    'by' now works when DT contains list() columns i.e.
         where each value in a column may itself be vector
@@ -3131,7 +3133,7 @@ USER VISIBLE CHANGES
    *    The result from merge() is now keyed. FR#1244.
 
 
-## BUG FIXES
+### BUG FIXES
 
     *   eval of parse()-ed expressions now works without
         needing quote() in the expression, bug #1243. Thanks
@@ -3150,9 +3152,9 @@ USER VISIBLE CHANGES
         Lianoglou for reporting.
 
 
-# data.table v1.5.1
+## data.table v1.5.1
 
-## BUG FIXES
+### BUG FIXES
 
     *   Fixed inheritance for other packages importing or depending
         on data.table, bugs #1093 and #1132. Thanks to Koert Kuipers
@@ -3162,9 +3164,9 @@ USER VISIBLE CHANGES
         fixing bug #1131 related to inheritance from data.frame.
 
 
-# data.table v1.5
+## data.table v1.5
 
-## NEW FEATURES
+### NEW FEATURES
 
     *   data.table now *inherits* from data.frame, for functions and
         packages which _only_ accept data.frame, saving time and
@@ -3186,7 +3188,7 @@ USER VISIBLE CHANGES
         that evaluate to logical. Thanks to David Winsemius for highlighting.
 
 
-## BUG FIXES
+### BUG FIXES
 
     *   DT[,5] now returns 5 as FAQ 1.1 says, for consistency
         with DT[,c(5)] and DT[,5+0]. DT[,"region"] now returns
@@ -3241,22 +3243,22 @@ USER VISIBLE CHANGES
         #1060. Thanks to Johann Hibschman for reporting.
 
 
-## NOTES
+### NOTES
 
     *   The package uses the 'default' option of base::getOption,
         and is therefore dependent on R 2.10.0. Updated DESCRIPTION
         file accordingly. Thanks to Christian Hudon for reporting.
 
 
-# data.table v1.4.1
+## data.table v1.4.1
 
 
-## NEW FEATURES
+### NEW FEATURES
 
     *   Vignettes tidied up.
 
 
-## BUG FIXES
+### BUG FIXES
 
     *   Out of order levels in key columns are now sorted by
         setkey. Thanks to Steve Lianoglou for reporting.
@@ -3264,10 +3266,10 @@ USER VISIBLE CHANGES
 
 
 
-# data.table v1.4
+## data.table v1.4
 
 
-## NEW FEATURES
+### NEW FEATURES
 
     *   'by' faster. Memory is allocated first for the result, then
     populated directly by the result of j for each group. Can be 10
@@ -3300,7 +3302,7 @@ USER VISIBLE CHANGES
     *   Three vignettes added : FAQ, Intro & Timings
 
 
-## DEPRECATED & DEFUNCT
+### DEPRECATED & DEFUNCT
 
     *   The DT alias is removed. Use 'data.table' instead to create
     objects. See 2nd new feature above.
@@ -3316,20 +3318,20 @@ USER VISIBLE CHANGES
     Grouping is simpler now, these are superfluous.
 
 
-## BUG FIXES
+### BUG FIXES
 
     *   Column classes are now retained by subset and grouping.
 
     *   tail no longer fails when a column 'x' exists.
 
 
-## KNOWN PROBLEMS
+### KNOWN PROBLEMS
 
     *   Minor : Join Inherited Scope not working, contrary
         to the documentation.
 
 
-## NOTES
+### NOTES
 
     *   v1.4 was essentially the branch at rev 44, reintegrated
     at rev 78.
@@ -3337,10 +3339,10 @@ USER VISIBLE CHANGES
 
 
 
-# data.table v1.3
+## data.table v1.3
 
 
-## NEW FEATURES
+### NEW FEATURES
 
     *   Radix sorting added. Speeds up setkey and add-hoc 'by'
     by factor of 10 or more.
@@ -3364,18 +3366,18 @@ USER VISIBLE CHANGES
     *   29 tests added to test.data.table(), now 127.
 
 
-## USER-VISIBLE CHANGES
+### USER-VISIBLE CHANGES
 
     *   Default of mb changed, now tables(mb=TRUE)
 
 
-## DEPRECATED & DEFUNCT
+### DEPRECATED & DEFUNCT
 
     *   ... removed in [.data.table.
     j may not be a function, so this is now superfluous.
 
 
-## BUG FIXES
+### BUG FIXES
 
     *   Incorrect version warning with R 2.10+ fixed.
 
@@ -3384,12 +3386,12 @@ USER VISIBLE CHANGES
     names. It also speeds up grouping a little.
 
 
-## NOTES
+### NOTES
 
     *   v1.3 was not released to CRAN. R-Forge repository only.
 
 
 
-# data.table v1.2 released to CRAN in Aug 2008
+## data.table v1.2 released to CRAN in Aug 2008
 
 

--- a/NEWS.1.md
+++ b/NEWS.1.md
@@ -1,9 +1,11 @@
 
+# data.table news and updates (historical)
+
 **This is OLD NEWS. Latest news is on GitHub [here](https://github.com/Rdatatable/data.table/blob/master/NEWS.md).**
 
-# data.table [v1.14.10](https://github.com/Rdatatable/data.table/milestone/20?closed=1)  (8 Dec 2023)
+## data.table [v1.14.10](https://github.com/Rdatatable/data.table/milestone/20?closed=1)  (8 Dec 2023)
 
-## NOTES
+### NOTES
 
 1. Maintainer of the package for CRAN releases is from now on Tyson Barrett (@tysonstanley), [#5710](https://github.com/Rdatatable/data.table/issues/5710).
 
@@ -14,9 +16,9 @@
 4. Fix multiple format warnings (e.g., -Wformat) [#5712](https://github.com/Rdatatable/data.table/pull/5712), [#5781](https://github.com/Rdatatable/data.table/pull/5781), [#5800](https://github.com/Rdatatable/data.table/pull/5800), [#5786](https://github.com/Rdatatable/data.table/pull/5786). Thanks to @MichaelChirico and @jangorecki for the patches.
 
 
-# data.table [v1.14.8](https://github.com/Rdatatable/data.table/milestone/28?closed=1)  (17 Feb 2023)
+## data.table [v1.14.8](https://github.com/Rdatatable/data.table/milestone/28?closed=1)  (17 Feb 2023)
 
-## NOTES
+### NOTES
 
 1. Test 1613.605 now passes changes to `as.data.frame()` in R-devel, [#5597](https://github.com/Rdatatable/data.table/pull/5597). Thanks to Avraham Adler for reporting.
 
@@ -25,13 +27,13 @@
 3. `.rbind.data.table` (note the leading `.`) is no longer exported when `data.table` is installed in R>=4.0.0 (Apr 2020), [#5600](https://github.com/Rdatatable/data.table/pull/5600). It was never documented which R-devel now detects and warns about. It is only needed by `data.table` internals to support R<4.0.0; see note 1 in v1.12.6 (Oct 2019) below in this file for more details.
 
 
-# data.table [v1.14.6](https://github.com/Rdatatable/data.table/milestone/27?closed=1)  (16 Nov 2022)
+## data.table [v1.14.6](https://github.com/Rdatatable/data.table/milestone/27?closed=1)  (16 Nov 2022)
 
-## BUG FIXES
+### BUG FIXES
 
 1. `fread()` could leak memory, [#3292](https://github.com/Rdatatable/data.table/issues/3292). Thanks to @patrickhowerter for reporting, and Jim Hester for the fix. The fix requires R 3.4.0 or later. Loading `data.table` in earlier versions now highlights this issue on startup, asks users to upgrade R, and warns that we intend to upgrade `data.table`'s dependency from 8 year old R 3.1.0 (April 2014) to 5 year old R 3.4.0 (April 2017).
 
-## NOTES
+### NOTES
 
 1. Test 1962.098 has been modified to pass latest changes to `POSIXt` in R-devel.
 
@@ -40,9 +42,9 @@
 3. The memory usage of the test suite has been halved, [#5507](https://github.com/Rdatatable/data.table/issues/5507).
 
 
-# data.table [v1.14.4](https://github.com/Rdatatable/data.table/milestone/26?closed=1)  (17 Oct 2022)
+## data.table [v1.14.4](https://github.com/Rdatatable/data.table/milestone/26?closed=1)  (17 Oct 2022)
 
-## NOTES
+### NOTES
 
 1. gcc 12.1 (May 2022) now detects and warns about an always-false condition (`-Waddress`) in `fread` which caused a small efficiency saving never to be invoked, [#5476](https://github.com/Rdatatable/data.table/pull/5476). Thanks to CRAN for testing latest versions of compilers.
 
@@ -81,16 +83,16 @@
     > ... the basename of the DLL needs to be both a valid file name and valid as part of a C entry point (e.g. it cannot contain ‘.’): for portable code it is best to confine DLL names to be ASCII alphanumeric plus underscore. If entry point R_init_lib is not found it is also looked for with ‘.’ replaced by ‘_’.
 
 
-# data.table [v1.14.2](https://github.com/Rdatatable/data.table/milestone/24?closed=1)  (27 Sep 2021)
+## data.table [v1.14.2](https://github.com/Rdatatable/data.table/milestone/24?closed=1)  (27 Sep 2021)
 
-## NOTES
+### NOTES
 
 1. clang 13.0.0 (Sep 2021) requires the system header `omp.h` to be included before R's headers, [#5122](https://github.com/Rdatatable/data.table/issues/5122). Many thanks to Prof Ripley for testing and providing a patch file.
 
 
-# data.table [v1.14.0](https://github.com/Rdatatable/data.table/milestone/23?closed=1)  (21 Feb 2021)
+## data.table [v1.14.0](https://github.com/Rdatatable/data.table/milestone/23?closed=1)  (21 Feb 2021)
 
-## POTENTIALLY BREAKING CHANGES
+### POTENTIALLY BREAKING CHANGES
 
 1. In v1.13.0 (July 2020) native parsing of datetime was added to `fread` by Michael Chirico which dramatically improved performance. Before then datetime was read as type character by default which was slow. Since v1.13.0, UTC-marked datetime (e.g. `2020-07-24T10:11:12.134Z` where the final `Z` is present) has been read automatically as POSIXct and quickly. We provided the migration option `datatable.old.fread.datetime.character` to revert to the previous slow character behavior. We also added the `tz=` argument to control unmarked datetime; i.e. where the `Z` (or equivalent UTC postfix) is missing in the data. The default `tz=""` reads unmarked datetime as character as before, slowly. We gave you the ability to set `tz="UTC"` to turn on the new behavior and read unmarked datetime as UTC, quickly. R sessions that are running in UTC by setting the TZ environment variable, as is good practice and common in production, have also been reading unmarked datetime as UTC since v1.13.0, much faster. Note 1 of v1.13.0 (below in this file) ended `In addition to convenience, fread is now significantly faster in the presence of dates, UTC-marked datetimes, and unmarked datetime when tz="UTC" is provided.`.
 
@@ -100,22 +102,22 @@
 
     The community was consulted in [this tweet](https://twitter.com/MattDowle/status/1358011599336931328) before release.
 
-## BUG FIXES
+### BUG FIXES
 
 1. If `fread()` discards a single line footer, the warning message which includes the discarded text now displays any non-ASCII characters correctly on Windows, [#4747](https://github.com/Rdatatable/data.table/issues/4747). Thanks to @shrektan for reporting and the PR.
 
 2. `fintersect()` now retains the order of the first argument as reasonably expected, rather than retaining the order of the second argument, [#4716](https://github.com/Rdatatable/data.table/issues/4716). Thanks to Michel Lang for reporting, and Ben Schwen for the PR.
 
-## NOTES
+### NOTES
 
 1. Compiling from source no longer requires `zlib` header files to be available, [#4844](https://github.com/Rdatatable/data.table/pull/4844). The output suggests installing `zlib` headers, and how (e.g. `zlib1g-dev` on Ubuntu) as before, but now proceeds with `gzip` compression disabled in `fwrite`. Upon calling `fwrite(DT, "file.csv.gz")` at runtime, an error message suggests to reinstall `data.table` with `zlib` headers available. This does not apply to users on Windows or Mac who install the pre-compiled binary package from CRAN.
 
 2. `r-datatable.com` continues to be the short, canonical and long-standing URL which forwards to the current homepage. The homepage domain has changed a few times over the years but those using `r-datatable.com` did not need to change their links. For example, we use `r-datatable.com` in messages (and translated messages) in preference to the word 'homepage' to save users time in searching for the current homepage. The web forwarding was provided by Domain Monster but they do not support `https://r-datatable.com`, only `http://r-datatable.com`, despite the homepage being forwarded to being `https:` for many years. Meanwhile, CRAN submission checks now require all URLs to be `https:`, rejecting `http:`. Therefore we have moved to [gandi.net](https://www.gandi.net) who do support `https:` web forwarding and so [https://r-datatable.com](https://r-datatable.com) now forwards correctly. Thanks to Dirk Eddelbuettel for suggesting Gandi. Further, Gandi allows the web-forward to be marked 301 (permanent) or 302 (temporary). Since the very point of `https://r-datatable.com` is to be a forward, 302 is appropriate in this case. This enables us to link to it in DESCRIPTION, README, and this NEWS item. Otherwise, CRAN submission checks would require the 301 forward to be followed; i.e. the forward replaced with where it points to and the package resubmitted. Thanks to Uwe Ligges for explaining this distinction.
 
 
-# data.table [v1.13.6](https://github.com/Rdatatable/data.table/milestone/22?closed=1)  (30 Dec 2020)
+## data.table [v1.13.6](https://github.com/Rdatatable/data.table/milestone/22?closed=1)  (30 Dec 2020)
 
-## BUG FIXES
+### BUG FIXES
 
 1. Grouping could throw an error `Failed to allocate counts or TMP` with more than 1e9 rows even with sufficient RAM due to an integer overflow, [#4295](https://github.com/Rdatatable/data.table/issues/4295) [#4818](https://github.com/Rdatatable/data.table/issues/4818). Thanks to @renkun-ken and @jangorecki for reporting, and @shrektan for fixing.
 
@@ -123,14 +125,14 @@
 
     It should be carefully noted that we cannot be sure it really is a problem unique to CRAN's Solaris. Even if it seems that way after one year of observations. For example, it could be compiler flags, or particular memory circumstances, either of which could occur on other operating systems too. However, we are unaware of why it would make sense for the OpenMP implementation to move the structure at that point. Any optimizations such as aligning the set of structures to cache line boundaries could be performed at the start of the parallel region, not after the parallel for. If anyone reading this knows more, please let us know.
 
-## NOTES
+### NOTES
 
 1. The last release took place at the same time as several breaking changes were made to R-devel. The CRAN submissions process runs against latest daily R-devel so we had to keep up with those latest changes by making several resubmissions. Then each resubmission reruns against the new latest R-devel again. Overall it took 7 days. For example, we added the new `environments=FALSE` to our `all.equal` call. Then about 4 hours after 1.13.4 was accepted, the `s` was dropped and we now need to resubmit with `environment=FALSE`. In any case, we have suggested that the default should be FALSE first to give packages some notice, as opposed to generating errors in the CRAN submissions process within hours. Then the default for `environment=` could be TRUE in 6 months time after packages have had some time to update in advance of the default change. Readers of this NEWS file will be familiar with `data.table`'s approach to change control and know that we do this ourselves.
 
 
-# data.table [v1.13.4](https://github.com/Rdatatable/data.table/milestone/21?closed=1)  (08 Dec 2020)
+## data.table [v1.13.4](https://github.com/Rdatatable/data.table/milestone/21?closed=1)  (08 Dec 2020)
 
-## BUG FIXES
+### BUG FIXES
 
 1. `as.matrix(<empty DT>)` now retains the column type for the empty matrix result, [#4762](https://github.com/Rdatatable/data.table/issues/4762). Thus, for example, `min(DT[0])` where DT's columns are numeric, is now consistent with non-empty all-NA input and returns `Inf` with R's warning `no non-missing arguments to min; returning Inf` rather than R's error `only defined on a data frame with all numeric[-alike] variables`. Thanks to @mb706 for reporting.
 
@@ -138,7 +140,7 @@
 
 3. Columns containing functions that don't inherit the class `'function'` would fail to group, [#4814](https://github.com/Rdatatable/data.table/issues/4814). Thanks @mb706 for reporting, @ecoRoland2 for helping investigate, and @Coorsaa for a follow-up example involving environments.
 
-## NOTES
+### NOTES
 
 1. Continuous daily testing by CRAN using latest daily R-devel revealed, within one day of the change to R-devel, that a future version of R would break one of our tests, [#4769](https://github.com/Rdatatable/data.table/issues/4769). The characters "-alike" were added into one of R's error messages, so our too-strict test which expected the error `only defined on a data frame with all numeric variables` will fail when it sees the new error message `only defined on a data frame with all numeric-alike variables`. We have relaxed the pattern the test looks for to `data.*frame.*numeric` well in advance of the future version of R being released. Readers are reminded that CRAN is not just a host for packages. It is also a giant test suite for R-devel. For more information, [behind the scenes of cran, 2016](https://h2o.ai/blog/2016/behind-the-scenes-of-cran/).
 
@@ -147,9 +149,9 @@
 3. Thanks to @fredguinog for testing `fcase` in development before 1.13.0 was released and finding a segfault, [#4378](https://github.com/Rdatatable/data.table/issues/4378). It was found separately by the `rchk` tool (which uses static code analysis) in release procedures and fixed before `fcase` was released, but the reproducible example has now been added to the test suite for completeness. Thanks also to @shrektan for investigating, proposing a very similar fix at C level, and a different reproducible example which has also been added to the test suite.
 
 
-# data.table [v1.13.2](https://github.com/Rdatatable/data.table/milestone/19?closed=1)  (19 Oct 2020)
+## data.table [v1.13.2](https://github.com/Rdatatable/data.table/milestone/19?closed=1)  (19 Oct 2020)
 
-## BUG FIXES
+### BUG FIXES
 
 1. `test.data.table()` could fail the 2nd time it is run by a user in the same R session on Windows due to not resetting locale properly after testing Chinese translation, [#4630](https://github.com/Rdatatable/data.table/pull/4630). Thanks to Cole Miller for investigating and fixing.
 
@@ -161,7 +163,7 @@
 
 5. `dplyr::mutate(setDT(as.list(1:64)), V1=11)` threw error `can't set ALTREP truelength`, [#4734](https://github.com/Rdatatable/data.table/issues/4734). Thanks to @etryn for the reproducible example, and to Cole Miller for refinements.
 
-## NOTES
+### NOTES
 
 1. `bit64` v4.0.2 and `bit` v4.0.3, both released on 30th July, correctly broke `data.table`'s tests. Like other packages on our `Suggest` list, we check `data.table` works with `bit64` in our tests. The first break was because `all.equal` always returned `TRUE` in previous versions of `bit64`. Now that `all.equal` works for `integer64`, the incorrect test comparison was revealed. If you use `bit64`, or `nanotime` which uses `bit64`, it is highly recommended to upgrade to the latest `bit64` version. Thanks to Cole Miller for the PR to accommodate `bit64`'s update.
 
@@ -178,9 +180,9 @@
 has a better chance of working on Mac.
 
 
-# data.table [v1.13.0](https://github.com/Rdatatable/data.table/milestone/17?closed=1)  (24 Jul 2020)
+## data.table [v1.13.0](https://github.com/Rdatatable/data.table/milestone/17?closed=1)  (24 Jul 2020)
 
-## POTENTIALLY BREAKING CHANGES
+### POTENTIALLY BREAKING CHANGES
 
 1. `fread` now supports native parsing of `%Y-%m-%d`, and [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) `%Y-%m-%dT%H:%M:%OS%z`, [#4464](https://github.com/Rdatatable/data.table/pull/4464). Dates are returned as `data.table`'s `integer`-backed `IDate` class (see `?IDate`), and datetimes are returned as `POSIXct` provided either `Z` or the offset from `UTC` is present; e.g. `fwrite()` outputs UTC by default including the final `Z`. Reminder that `IDate` inherits from R's `Date` and is identical other than it uses the `integer` type where (oddly) R uses the `double` type for dates (8 bytes instead of 4). `fread()` gains a `tz` argument to control datetime values that are missing a Z or UTC-offset (now referred to as *unmarked* datetimes); e.g. as written by `write.csv`. By default `tz=""` means, as in R, read the unmarked datetime in local time. Unless the timezone of the R session is UTC (e.g. the TZ environment variable is set to `"UTC"`, or `""` on non-Windows), unmarked datetime will then by read by `fread` as character, as before. If you have been using `colClasses="POSIXct"` that will still work using R's `as.POSIXct()` which will interpret the unmarked datetime in local time, as before, and still slowly. You can tell `fread` to read unmarked datetime as UTC, and quickly, by passing `tz="UTC"` which may be appropriate in many circumstances. Note that the default behaviour of R to read and write csv using unmarked datetime can lead to different research results when the csv file has been saved in one timezone and read in another due to observations being shifted to a different date. If you have been using `colClasses="POSIXct"` for UTC-marked datetime (e.g. as written by `fwrite` including the final `Z`) then it will automatically speed up with no changes needed.
 
@@ -188,7 +190,7 @@ has a better chance of working on Mac.
 
     The minor version number is bumped from 12 to 13, i.e. `v1.13.0`, where the `.0` conveys 'be-aware' as is common practice. As with any new feature, there may be bugs to fix and changes to defaults required in future. In addition to convenience, `fread` is now significantly faster in the presence of dates, UTC-marked datetimes, and unmarked datetime when tz="UTC" is provided.
 
-## NEW FEATURES
+### NEW FEATURES
 
 1. `%chin%` and `chmatch(x, table)` are faster when `x` is length 1, `table` is long, and `x` occurs near the start of `table`. Thanks to Michael Chirico for the suggestion, [#4117](https://github.com/Rdatatable/data.table/pull/4117#discussion_r358378409).
 
@@ -267,7 +269,7 @@ has a better chance of working on Mac.
 
 15. A new throttle feature has been introduced to speed up small data tasks that are repeated in a loop, [#3175](https://github.com/Rdatatable/data.table/issues/3175) [#3438](https://github.com/Rdatatable/data.table/issues/3438) [#3205](https://github.com/Rdatatable/data.table/issues/3205) [#3735](https://github.com/Rdatatable/data.table/issues/3735) [#3739](https://github.com/Rdatatable/data.table/issues/3739) [#4284](https://github.com/Rdatatable/data.table/issues/4284) [#4527](https://github.com/Rdatatable/data.table/issues/4527) [#4294](https://github.com/Rdatatable/data.table/issues/4294) [#1120](https://github.com/Rdatatable/data.table/issues/1120). The default throttle of 1024 means that a single thread will be used when nrow<=1024, two threads when nrow<=2048, etc. To change the default, use `setDTthreads(throttle=)`. Or use the new environment variable `R_DATATABLE_THROTTLE`. If you use `Sys.setenv()` in a running R session to change this environment variable, be sure to run an empty `setDTthreads()` call afterwards for the change to take effect; see `?setDTthreads`. The word *throttle* is used to convey that the number of threads is restricted (throttled) for small data tasks. Reducing throttle to 1 will turn off throttling and should revert behaviour to past versions (i.e. using many threads even for small data). Increasing throttle to, say, 65536 will utilize multi-threading only for larger datasets. The value 1024 is a guess. We welcome feedback and test results indicating what the best default should be.
 
-## BUG FIXES
+### BUG FIXES
 
 1. A NULL timezone on POSIXct was interpreted by `as.IDate` and `as.ITime` as UTC rather than the session's default timezone (`tz=""`) , [#4085](https://github.com/Rdatatable/data.table/issues/4085).
 
@@ -309,7 +311,7 @@ has a better chance of working on Mac.
 
 20. The environment variable `R_DATATABLE_NUM_THREADS` was being limited by `R_DATATABLE_NUM_PROCS_PERCENT` (by default 50%), [#4514](https://github.com/Rdatatable/data.table/issues/4514). It is now consistent with `setDTthreads()` and only limited by the full number of logical CPUs. For example, on a machine with 8 logical CPUs, `R_DATATABLE_NUM_THREADS=6` now results in 6 threads rather than 4 (50% of 8).
 
-## NOTES
+### NOTES
 
 1. Retrospective license change permission was sought from and granted by 4 contributors who were missed in [PR#2456](https://github.com/Rdatatable/data.table/pull/2456), [#4140](https://github.com/Rdatatable/data.table/pull/4140). We had used [GitHub's contributor page](https://github.com/Rdatatable/data.table/graphs/contributors) which omits 3 of these due to invalid email addresses, unlike GitLab's contributor page which includes the ids. The 4th omission was a PR to a script which should not have been excluded; a script is code too. We are sorry these contributors were not properly credited before. They have now been added to the contributors list as displayed on CRAN. All the contributors of code to data.table hold its copyright jointly; your contributions belong to you. You contributed to data.table when it had a particular license at that time, and you contributed on that basis. This is why in the last license change, all contributors of code were consulted and each had a veto.
 
@@ -361,19 +363,19 @@ has a better chance of working on Mac.
 13. The `datatable.old.unique.by.key` option has been removed as per the 4 year schedule detailed in note 10 of v1.12.4 (Oct 2019), note 10 of v1.11.0 (May 2018), and note 1 of v1.9.8 (Nov 2016). It has been generating a helpful warning for 2 years, and helpful error for 1 year.
 
 
-# data.table [v1.12.8](https://github.com/Rdatatable/data.table/milestone/15?closed=1)  (09 Dec 2019)
+## data.table [v1.12.8](https://github.com/Rdatatable/data.table/milestone/15?closed=1)  (09 Dec 2019)
 
-## NEW FEATURES
+### NEW FEATURES
 
 1. `DT[, {...; .(A,B)}]` (i.e. when `.()` is the final item of a multi-statement `{...}`) now auto-names the columns `A` and `B` (just like `DT[, .(A,B)]`) rather than `V1` and `V2`, [#2478](https://github.com/Rdatatable/data.table/issues/2478) [#609](https://github.com/Rdatatable/data.table/issues/609). Similarly, `DT[, if (.N>1) .(B), by=A]` now auto-names the column `B` rather than `V1`. Explicit names are unaffected; e.g. `DT[, {... y= ...; .(A=C+y)}, by=...]` named the column `A` before, and still does. Thanks also to @renkun-ken for his go-first strong testing which caught an issue not caught by the test suite or by revdep testing, related to NULL being the last item, [#4061](https://github.com/Rdatatable/data.table/issues/4061).
 
-## BUG FIXES
+### BUG FIXES
 
 1. `frollapply` could segfault and exceed R's C protect limits, [#3993](https://github.com/Rdatatable/data.table/issues/3993). Thanks to @DavisVaughan for reporting and fixing.
 
 2. `DT[, sum(grp), by=grp]` (i.e. aggregating the same column being grouped) could error with `object 'grp' not found`, [#3103](https://github.com/Rdatatable/data.table/issues/3103). Thanks to @cbailiss for reporting.
 
-## NOTES
+### NOTES
 
 1. Links in the manual were creating warnings when installing HTML, [#4000](https://github.com/Rdatatable/data.table/issues/4000). Thanks to Morgan Jacob.
 
@@ -384,9 +386,9 @@ has a better chance of working on Mac.
 4. `test.data.table()` gains `showProgress=interactive()` to suppress the thousands of `Running test id <num> ...` lines displayed by CRAN checks when there are warnings or errors.
 
 
-# data.table [v1.12.6](https://github.com/Rdatatable/data.table/milestone/18?closed=1)  (18 Oct 2019)
+## data.table [v1.12.6](https://github.com/Rdatatable/data.table/milestone/18?closed=1)  (18 Oct 2019)
 
-## BUG FIXES
+### BUG FIXES
 
 1. `shift()` on a `nanotime` with the default `fill=NA` now fills a `nanotime` missing value correctly, [#3945](https://github.com/Rdatatable/data.table/issues/3945). Thanks to @mschubmehl for reporting and fixing in PR [#3942](https://github.com/Rdatatable/data.table/pull/3942).
 
@@ -396,14 +398,14 @@ has a better chance of working on Mac.
 
 4. A leak could occur in the event of an unsupported column type error, or if working memory could only partially be allocated; [#3940](https://github.com/Rdatatable/data.table/issues/3940). Found thanks to `clang`'s Leak Sanitizer (prompted by CRAN's diligent use of latest tools), and two tests in the test suite which tested the unsupported-type error.
 
-## NOTES
+### NOTES
 
 1. Many thanks to Kurt Hornik for fixing R's S3 dispatch of `rbind` and `cbind` methods, [#3948](https://github.com/Rdatatable/data.table/issues/3948). With `R>=4.0.0` (current R-devel), `data.table` now registers the S3 methods `cbind.data.table` and `rbind.data.table`, and no longer applies the workaround documented in FAQ 2.24.
 
 
-# data.table [v1.12.4](https://github.com/Rdatatable/data.table/milestone/16?closed=1)  (03 Oct 2019)
+## data.table [v1.12.4](https://github.com/Rdatatable/data.table/milestone/16?closed=1)  (03 Oct 2019)
 
-## NEW FEATURES
+### NEW FEATURES
 
 1. `rleid()` functions now support long vectors (length > 2 billion).
 
@@ -634,7 +636,7 @@ has a better chance of working on Mac.
 
 29. `:=` and `set()` now use zero-copy type coercion. Accordingly, `DT[..., integerColumn:=0]` and `set(DT,i,j,0)` no longer warn about the `0` ('numeric') needing to be `0L` ('integer') because there is no longer any time or space used for this coercion. The old long warning was off-putting to new users ("what and why L?"), whereas advanced users appreciated the old warning so they could avoid the coercion. Although the time and space for one coercion in a single call is unmeasurably small, when placed in a loop the small overhead of any allocation on R's heap could start to become noticeable (more so for `set()` whose purpose is low-overhead looping). Further, when assigning a value across columns of varying types, it could be inconvenient to supply the correct type for every column. Hence, zero-copy coercion was introduced to satisfy all these requirements. A warning is still issued, as before, when fractional data is discarded; e.g. when 3.14 is assigned to an integer column. Zero-copy coercion applies to length>1 vectors as well as length-1 vectors.
 
-## BUG FIXES
+### BUG FIXES
 
 1. `first`, `last`, `head` and `tail` by group no longer error in some cases, [#2030](https://github.com/Rdatatable/data.table/issues/2030) [#3462](https://github.com/Rdatatable/data.table/issues/3462). Thanks to @franknarf1 for reporting.
 
@@ -741,7 +743,7 @@ has a better chance of working on Mac.
 
 46. Adding a `list` column containing an item of type `list` to a one row `data.table` could fail, [#3626](https://github.com/Rdatatable/data.table/issues/3626). Thanks to Jakob Richter for reporting.
 
-## NOTES
+### NOTES
 
 1. `rbindlist`'s `use.names="check"` now emits its message for automatic column names (`"V[0-9]+"`) too, [#3484](https://github.com/Rdatatable/data.table/pull/3484). See news item 5 of v1.12.2 below.
 
@@ -809,9 +811,9 @@ has a better chance of working on Mac.
     ```
 
 
-# data.table [v1.12.2](https://github.com/Rdatatable/data.table/milestone/14?closed=1)  (07 Apr 2019)
+## data.table [v1.12.2](https://github.com/Rdatatable/data.table/milestone/14?closed=1)  (07 Apr 2019)
 
-## NEW FEATURES
+### NEW FEATURES
 
 1. `:=` no longer recycles length>1 RHS vectors. There was a warning when recycling left a remainder but no warning when the LHS length was an exact multiple of the RHS length (the same behaviour as base R). Consistent feedback for several years has been that recycling is more often a bug. In rare cases where you need to recycle a length>1 vector, please use `rep()` explicitly. Single values are still recycled silently as before. Early warning was given in [this tweet](https://twitter.com/MattDowle/status/1088544083499311104). The 774 CRAN and Bioconductor packages using `data.table` were tested and the maintainers of the 16 packages affected (2%) were consulted before going ahead, [#3310](https://github.com/Rdatatable/data.table/pull/3310). Upon agreement we went ahead. Many thanks to all those maintainers for already updating on CRAN, [#3347](https://github.com/Rdatatable/data.table/pull/3347).
 
@@ -835,7 +837,7 @@ has a better chance of working on Mac.
 
 6. `fread` gains `keepLeadingZeros`, [#2999](https://github.com/Rdatatable/data.table/issues/2999). By default `FALSE` so that, as before, a field containing `001` is interpreted as the integer 1, otherwise the character string `"001"`. The default may be changed using `options(datatable.keepLeadingZeros=TRUE)`. Many thanks to @marc-outins for the PR.
 
-## BUG FIXES
+### BUG FIXES
 
 1. `rbindlist()` of a malformed factor which is missing a levels attribute is now a helpful error rather than a cryptic error about `STRING_ELT`, [#3315](https://github.com/Rdatatable/data.table/issues/3315). Thanks to Michael Chirico for reporting.
 
@@ -875,7 +877,7 @@ has a better chance of working on Mac.
 
 19. Subsetting does a better job of catching a malformed `data.table` with error rather than segfault. A column may not be NULL, nor may a column be an object which has columns (such as a `data.frame` or `matrix`). Thanks to a comment and reproducible example in [#3369](https://github.com/Rdatatable/data.table/issues/3369) from Drew Abbot which demonstrated the issue which arose from parsing JSON. The next release will enable `as.data.table` to unpack columns which are `data.frame` to support this use case.
 
-## NOTES
+### NOTES
 
 1. When upgrading to 1.12.0 some Windows users might have seen `CdllVersion not found` in some circumstances. We found a way to catch that so the [helpful message](https://twitter.com/MattDowle/status/1084528873549705217) now occurs for those upgrading from versions prior to 1.12.0 too, as well as those upgrading from 1.12.0 to a later version. See item 1 in notes section of 1.12.0 below for more background.
 
@@ -903,9 +905,9 @@ has a better chance of working on Mac.
 10. The `key(DT)<-` form of `setkey()` has been warning since at least 2012 to use `setkey()`. The warning is now stronger: `key(x)<-value is deprecated and not supported. Please change to use setkey().`. This warning will be upgraded to error in one year.
 
 
-# data.table v1.12.0  (13 Jan 2019)
+## data.table v1.12.0  (13 Jan 2019)
 
-## NEW FEATURES
+### NEW FEATURES
 
 1. `setDTthreads()` gains `restore_after_fork=`, [#2885](https://github.com/Rdatatable/data.table/issues/2885). The default `NULL` leaves the internal option unchanged which by default is `TRUE`. `data.table` has always switched to single-threaded mode on fork. It used to restore multithreading after a fork too but problems were reported on Mac and Intel OpenMP library (see 1.10.4 notes below). We are now trying again thanks to suggestions and success reported by Kun Ren and Mark Klik in package `fst`. If you experience problems with multithreading after a fork, please restart R and call `setDTthreads(restore_after_fork=FALSE)`.
 
@@ -960,7 +962,7 @@ has a better chance of working on Mac.
 
     If a superclass defines attributes that may not be valid after a `[` subset then the superclass should implement its own `[` method to manage those after calling `NextMethod()`.
 
-## BUG FIXES
+### BUG FIXES
 
 1. Providing an `i` subset expression when attempting to delete a column correctly failed with helpful error, but when the column was missing too created a new column full of `NULL` values, [#3089](https://github.com/Rdatatable/data.table/issues/3089). Thanks to Michael Chirico for reporting.
 
@@ -990,7 +992,7 @@ has a better chance of working on Mac.
 
 14. Fixed an edge-case bug of platform-dependent output of `strtoi("", base = 2L)` on which `groupingsets` had relied, [#3267](https://github.com/Rdatatable/data.table/issues/3267).
 
-## NOTES
+### NOTES
 
 1. When data.table loads it now checks its DLL version against the version of its R level code. This is to detect installation issues on Windows when i) the DLL is in use by another R session and ii) the CRAN source version > CRAN binary binary which happens just after a new release (R prompts users to install from source until the CRAN binary is available). This situation can lead to a state where the package's new R code calls old C code in the old DLL; [R#17478](https://bugs.r-project.org/show_bug.cgi?id=17478), [#3056](https://github.com/Rdatatable/data.table/issues/3056). This broken state can persist until, hopefully, you experience a strange error caused by the mismatch. Otherwise, wrong results may occur silently. This situation applies to any R package with compiled code not just data.table, is Windows-only, and is long-standing. It has only recently been understood as it typically only occurs during the few days after each new release until binaries are available on CRAN.
 
@@ -1005,13 +1007,13 @@ has a better chance of working on Mac.
 6. The one and only usage of `UNPROTECT_PTR()` has been removed, [#3232](https://github.com/Rdatatable/data.table/issues/3232). Thanks to Tomas Kalibera's investigation and advice here: https://developer.r-project.org/Blog/public/2018/12/10/unprotecting-by-value/index.html
 
 
-# data.table v1.11.8  (30 Sep 2018)
+## data.table v1.11.8  (30 Sep 2018)
 
-## NEW FEATURES
+### NEW FEATURES
 
 1. `fread()` can now read `.gz` and `.bz2` files directly: `fread("file.csv.gz")`, [#717](https://github.com/Rdatatable/data.table/issues/717) [#3058](https://github.com/Rdatatable/data.table/issues/3058). It uses `R.utils::decompressFile` to decompress to a `tempfile()` which is then read by `fread()` in the usual way. For greater speed on large-RAM servers, it is recommended to use ramdisk for temporary files by setting `TMPDIR` to `/dev/shm` before starting R; see `?tempdir`. The decompressed temporary file is removed as soon as `fread` completes even if there is an error reading the file. Reading a remote compressed file in one step will be supported in the next version; e.g. `fread("https://domain.org/file.csv.bz2")`.
 
-## BUG FIXES
+### BUG FIXES
 
 1. Joining two keyed tables using `on=` to columns not forming a leading subset of `key(i)` could result in an invalidly keyed result, [#3061](https://github.com/Rdatatable/data.table/issues/3061). Subsequent queries on the result could then return incorrect results. A warning `longer object length is not a multiple of shorter object length` could also occur. Thanks to @renkun-ken for reporting and the PR.
 
@@ -1023,7 +1025,7 @@ has a better chance of working on Mac.
 
 5. `as.data.table` `matrix` method now properly handles rownames for 0 column data.table output. Thanks @mllg for reporting. Closes [#3149](https://github.com/Rdatatable/data.table/issues/3149).
 
-## NOTES
+### NOTES
 
 1. The test suite now turns on R's new _R_CHECK_LENGTH_1_LOGIC2_ to catch when internal use of `&&` or `||` encounter arguments of length more than one. Thanks to Hugh Parsonage for implementing and fixing the problems caught by this.
 
@@ -1037,9 +1039,9 @@ has a better chance of working on Mac.
     ```
 
 
-# data.table v1.11.6  (19 Sep 2018)
+## data.table v1.11.6  (19 Sep 2018)
 
-## NEW FEATURES
+### NEW FEATURES
 
 1. For convenience when some of the files in `fnams` are empty in `rbindlist(lapply(fnams,fread))`, `fread` now reads empty input as a null-data.table with warning rather than error, [#2898](https://github.com/Rdatatable/data.table/issues/2898). For consistency, `fwrite(data.table(NULL))` now creates an empty file and warns instead of error, too.
 
@@ -1055,7 +1057,7 @@ has a better chance of working on Mac.
 
 7. If an appropriate index exists, `keyby=` will now use it. For example, given `setindex(DT,colA,colB)`, both `DT[,j,keyby=colA]` (a leading subset of the index columns) and `DT[,j,keyby=.(colA,colB)]` will use the index, but not `DT[,j,keyby=.(colB,colA)]`. The option `options(datatable.use.index=FALSE)` will turn this feature off. Please always use `keyby=` unless you wish to retain the order of groups by first-appearance order (in which case use `by=`). Also, both `keyby=` and `by=` already used the key where possible but are now faster when using just the first column of the key. As usual, setting `verbose=TRUE` either per-query or globally using `options(datatable.verbose=TRUE)` will report what's being done internally.
 
-## BUG FIXES
+### BUG FIXES
 
 1. `fread` now respects the order of columns passed to `select=` when column numbers are used, [#2986](https://github.com/Rdatatable/data.table/issues/2986). It already respected the order when column names are used. Thanks @privefl for raising the issue.
 
@@ -1083,7 +1085,7 @@ has a better chance of working on Mac.
 
 13. Fixed 7 memory faults thanks to CRAN's [`rchk`](https://github.com/kalibera/rchk) tool by Tomas Kalibera, [#3033](https://github.com/Rdatatable/data.table/pull/3033).
 
-## NOTES
+### NOTES
 
 1. The type coercion warning message has been improved, [#2989](https://github.com/Rdatatable/data.table/pull/2989). Thanks to @sarahbeeysian on Twitter for highlighting. For example, given the follow statements:
 
@@ -1137,7 +1139,7 @@ has a better chance of working on Mac.
 5. Error added for incorrect usage of `%between%`, with some helpful diagnostic hints, [#3014](https://github.com/Rdatatable/data.table/issues/3014). Thanks @peterlittlejohn for offering his user experience and providing the impetus.
 
 
-# data.table v1.11.4  (27 May 2018)
+## data.table v1.11.4  (27 May 2018)
 
 1. Empty RHS of `:=` is no longer an error when the `i` clause returns no rows to assign to anyway, [#2829](https://github.com/Rdatatable/data.table/issues/2829). Thanks to @cguill95 for reporting and to @MarkusBonsch for fixing.
 
@@ -1148,7 +1150,7 @@ has a better chance of working on Mac.
 4. Around 1 billion very small groups (of size 1 or 2 rows) could result in `"Failed to realloc working memory"` even when plenty of memory is available, [#2777](https://github.com/Rdatatable/data.table/issues/2777). Thanks once again to @jsams for the detailed report as a follow up to bug fix 40 in v1.11.0.
 
 
-# data.table v1.11.2  (08 May 2018)
+## data.table v1.11.2  (08 May 2018)
 
 1. `test.data.table()` created/overwrote variable `x` in `.GlobalEnv`, [#2828](https://github.com/Rdatatable/data.table/issues/2828); i.e. a modification of user's workspace which is not allowed. Thanks to @etienne-s for reporting.
 
@@ -1159,9 +1161,9 @@ has a better chance of working on Mac.
 4. Fixed some rare memory faults in `fread()` and `rbindlist()` found with `gctorture2()` and [`rchk`](https://github.com/kalibera/rchk), [#2841](https://github.com/Rdatatable/data.table/issues/2841).
 
 
-# data.table v1.11.0  (01 May 2018)
+## data.table v1.11.0  (01 May 2018)
 
-## NOTICE OF INTENDED FUTURE POTENTIAL BREAKING CHANGES
+### NOTICE OF INTENDED FUTURE POTENTIAL BREAKING CHANGES
 
 1. `fread()`'s `na.strings=` argument :
 
@@ -1186,7 +1188,7 @@ has a better chance of working on Mac.
 
 These options are meant for temporary use to aid your migration, [#2652](https://github.com/Rdatatable/data.table/pull/2652). You are not meant to set them to the old default and then not migrate your code that is dependent on the default. Either set the argument explicitly so your code is not dependent on the default, or change the code to cope with the new default. Over the next few years we will slowly start to remove these options, warning you if you are using them, and return to a simple default. See the history of NEWS and NEWS.0 for past migrations that have, generally speaking, been successfully managed in this way. For example, at the end of NOTES for this version (below in this file) is a note about the usage of `datatable.old.unique.by.key` now warning, as you were warned it would do over a year ago. When that change was introduced, the default was changed and that option provided an option to restore the old behaviour. These `fread`/`fwrite` changes are even more cautious and not even changing the default's default yet. Giving you extra warning by way of this notice to move forward. And giving you a chance to object.
 
-## NEW FEATURES
+### NEW FEATURES
 
 1. `fread()`:
     * Efficiency savings at C level including **parallelization** announced [here](https://github.com/Rdatatable/data.table/wiki/talks/BARUG_201704_ParallelFread.pdf); e.g. a 9GB 2 column integer csv input is **50s down to 12s** to cold load on a 4 core laptop with 16GB RAM and SSD. Run `echo 3 >/proc/sys/vm/drop_caches` first to measure cold load time. Subsequent load time (after file has been cached by OS on the first run) **40s down to 6s**.
@@ -1307,7 +1309,7 @@ Thanks to @MichaelChirico for reporting and to @MarkusBonsch for the implementat
 
 20. `as.matrix.data.table` method now has an additional `rownames` argument allowing for a single column to be used as the `rownames` after conversion to a `matrix`. Thanks to @sritchie73 for the suggestion, use cases, [#2692](https://github.com/Rdatatable/data.table/issues/2692) and implementation [PR#2702](https://github.com/Rdatatable/data.table/pull/2702) and @MichaelChirico for additional use cases.
 
-## BUG FIXES
+### BUG FIXES
 
 1. The new quote rules handles this single field `"Our Stock Screen Delivers an Israeli Software Company (MNDO, CTCH)<\/a> SmallCapInvestor.com - Thu, May 19, 2011 10:02 AM EDT<\/cite><\/div>Yesterday in \""Google, But for Finding
  Great Stocks\"", I discussed the value of stock screeners as a powerful tool"`, [#2051](https://github.com/Rdatatable/data.table/issues/2051). Thanks to @scarrascoso for reporting. Example file added to test suite.
@@ -1395,7 +1397,7 @@ Thanks to @sritchie73 for reporting and fixing [PR#2631](https://github.com/Rdat
 
 41. Fix a bug that `print(dt, class=TRUE)` shows only `topn - 1` rows. Thanks to @heavywatal for reporting [#2803](https://github.com/Rdatatable/data.table/issues/2803) and filing [PR#2804](https://github.com/Rdatatable/data.table/pull/2804).
 
-## NOTES
+### NOTES
 
 1. The license has been changed from GPL to MPL (Mozilla Public License). All contributors were consulted and approved. [PR#2456](https://github.com/Rdatatable/data.table/pull/2456) details the reasons for the change.
 
@@ -1431,19 +1433,19 @@ Thanks to @sritchie73 for reporting and fixing [PR#2631](https://github.com/Rdat
 14. `print.data.table()` invisibly returns its first argument instead of `NULL`. This behavior is compatible with the standard `print.data.frame()` and tibble's `print.tbl_df()`. Thanks to @heavywatal for [PR#2807](https://github.com/Rdatatable/data.table/pull/2807)
 
 
-# data.table v1.10.4-3  (20 Oct 2017)
+## data.table v1.10.4-3  (20 Oct 2017)
 
 1. Fixed crash/hang on MacOS when `parallel::mclapply` is used and data.table is merely loaded, [#2418](https://github.com/Rdatatable/data.table/issues/2418). Oddly, all tests including test 1705 (which tests `mclapply` with data.table) passed fine on CRAN. It appears to be some versions of MacOS or some versions of libraries on MacOS, perhaps. Many thanks to Martin Morgan for reporting and confirming this fix works. Thanks also to @asenabouth, Joe Thorley and Danton Noriega for testing, debugging and confirming that automatic parallelism inside data.table (such as `fwrite`) works well even on these MacOS installations. See also news items below for 1.10.4-1 and 1.10.4-2.
 
 
-# data.table v1.10.4-2  (12 Oct 2017)
+## data.table v1.10.4-2  (12 Oct 2017)
 
 1. OpenMP on MacOS is now supported by CRAN and included in CRAN's package binaries for Mac. But installing v1.10.4-1 from source on MacOS failed when OpenMP was not enabled at compile time, [#2409](https://github.com/Rdatatable/data.table/issues/2409). Thanks to Liz Macfie and @fupangpangpang for reporting. The startup message when OpenMP is not enabled has been updated.
 
 2. Two rare potential memory faults fixed, thanks to CRAN's automated use of latest compiler tools; e.g. clang-5 and gcc-7
 
 
-# data.table v1.10.4-1  (09 Oct 2017)
+## data.table v1.10.4-1  (09 Oct 2017)
 
 1. The `nanotime` v0.2.0 update (June 2017) changed from `integer64` to `S4` and broke `fwrite` of `nanotime` columns. Fixed to work with `nanotime` both before and after v0.2.0.
 
@@ -1456,16 +1458,16 @@ Thanks to @sritchie73 for reporting and fixing [PR#2631](https://github.com/Rdat
 5. When `fread()` and `print()` see `integer64` columns are present but package `bit64` is not installed, the warning is now displayed as intended. Thanks to a question by Santosh on r-help and forwarded by Bill Dunlap.
 
 
-# data.table v1.10.4  (01 Feb 2017)
+## data.table v1.10.4  (01 Feb 2017)
 
-## BUG FIXES
+### BUG FIXES
 
 1. The new specialized `nanotime` writer in `fwrite()` type punned using `*(long long *)&REAL(column)[i]` which, strictly, is undefined behaviour under C standards. It passed a plethora of tests on linux (gcc 5.4 and clang 3.8), win-builder and 6 out 10 CRAN flavours using gcc. But failed (wrong data written) with the newest version of clang (3.9.1) as used by CRAN on the failing flavors, and solaris-sparc. Replaced with the union method and added a grep to CRAN_Release.cmd.
 
 
-# data.table v1.10.2  (31 Jan 2017)
+## data.table v1.10.2  (31 Jan 2017)
 
-## NEW FEATURES
+### NEW FEATURES
 
 1. When `j` is a symbol prefixed with `..` it will be looked up in calling scope and its value taken to be column names or numbers.
 
@@ -1496,7 +1498,7 @@ Thanks to @sritchie73 for reporting and fixing [PR#2631](https://github.com/Rdat
     [1] "B" "A"
     ```
 
-## BUG FIXES
+### BUG FIXES
 
 1. Some long-standing potential instability has been discovered and resolved many thanks to a detailed report from Bill Dunlap and Michael Sannella. At C level any call of the form `setAttrib(x, install(), allocVector())` can be unstable in any R package. Despite `setAttrib()` PROTECTing its inputs, the 3rd argument (`allocVector`) can be executed first only for its result to to be released by `install()`'s potential GC before reaching `setAttrib`'s PROTECTion of its inputs. Fixed by either PROTECTing or pre-`install()`ing. Added to CRAN_Release.cmd procedures: i) `grep`s to prevent usage of this idiom in future and ii) running data.table's test suite with `gctorture(TRUE)`.
 
@@ -1504,7 +1506,7 @@ Thanks to @sritchie73 for reporting and fixing [PR#2631](https://github.com/Rdat
 
 3. `fwrite()` could write floating point values incorrectly, [#1968](https://github.com/Rdatatable/data.table/issues/1968). A thread-local variable was incorrectly thread-global. This variable's usage lifetime is only a few clock cycles so it needed large data and many threads for several threads to overlap their usage of it and cause the problem. Many thanks to @mgahan and @jmosser for finding and reporting.
 
-## NOTES
+### NOTES
 
 1. `fwrite()`'s `..turbo` option has been removed as the warning message warned. If you've found a problem, please [report it](https://github.com/Rdatatable/data.table/issues).
 
@@ -1515,9 +1517,9 @@ When `j` is a symbol (as in the quanteda and xgboost examples above) it will con
 3. As before, and as we can see is in common use in CRAN and Bioconductor packages using data.table, `DT[,myCols,with=FALSE]` continues to lookup `myCols` in calling scope and take its value as column names or numbers.  You can move to the new experimental convenience feature `DT[, ..myCols]` if you wish at leisure.
 
 
-# data.table v1.10.0  (03 Dec 2016)
+## data.table v1.10.0  (03 Dec 2016)
 
-## BUG FIXES
+### BUG FIXES
 
 1. `fwrite(..., quote='auto')` already quoted a field if it contained a `sep` or `\n`, or `sep2[2]` when `list` columns are present. Now it also quotes a field if it contains a double quote (`"`) as documented, [#1925](https://github.com/Rdatatable/data.table/issues/1925). Thanks to Aki Matsuo for reporting. Tests added. The `qmethod` tests did test escaping embedded double quotes, but only when `sep` or `\n` was present in the field as well to trigger the quoting of the field.
 
@@ -1533,7 +1535,7 @@ When `j` is a symbol (as in the quanteda and xgboost examples above) it will con
 
 7. New function `rleidv` was ignoring its `cols` argument, [#1942](https://github.com/Rdatatable/data.table/issues/1942). Thanks Josh O'Brien for reporting. Tests added.
 
-## NOTES
+### NOTES
 
 1. It seems OpenMP is not available on CRAN's Mac platform; NOTEs appeared in [CRAN checks](https://cran.r-project.org/web/checks/check_results_data.table.html) for v1.9.8. Moved `Rprintf` from `init.c` to `packageStartupMessage` to avoid the NOTE as requested urgently by Professor Ripley. Also fixed the bad grammar of the message: 'single threaded' now 'single-threaded'. If you have a Mac and run macOS or OS X on it (I run Ubuntu on mine) please contact CRAN maintainers and/or Apple if you'd like CRAN's Mac binary to support OpenMP. Otherwise, please follow [these instructions for OpenMP on Mac](https://github.com/Rdatatable/data.table/wiki/Installation) which people have reported success with.
 
@@ -1546,4 +1548,4 @@ When `j` is a symbol (as in the quanteda and xgboost examples above) it will con
 5. With hindsight, the last release v1.9.8 should have been named v1.10.0 to convey it wasn't just a patch release from .6 to .8 owing to the 'potentially breaking changes' items. Thanks to @neomantic for correctly pointing out. The best we can do now is now bump to 1.10.0.
 
 
-# data.table v1.9.8 (Nov 2016) back to v1.2 (Aug 2008) has been moved to [NEWS.0.md](https://github.com/Rdatatable/data.table/blob/master/NEWS.0.md)
+## data.table v1.9.8 (Nov 2016) back to v1.2 (Aug 2008) has been moved to [NEWS.0.md](https://github.com/Rdatatable/data.table/blob/master/NEWS.0.md)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,10 @@
+# data.table news and updates
+
 **If you are viewing this file on CRAN, please check [latest news on GitHub](https://github.com/Rdatatable/data.table/blob/master/NEWS.md) where the formatting is also better.**
 
-# data.table [v1.17.99](https://github.com/Rdatatable/data.table/milestone/35)  (in development)
+## data.table [v1.17.99](https://github.com/Rdatatable/data.table/milestone/35)  (in development)
 
-## NEW FEATURES
+### NEW FEATURES
 
 1. New `sort_by()` method for data.tables, [#6662](https://github.com/Rdatatable/data.table/issues/6662). It uses `forder()` to improve upon the data.frame method and also match `DT[order(...)]` behavior with respect to locale. Thanks @rikivillalba for the suggestion and PR.
 
@@ -12,7 +14,7 @@
 
 4. `as.Date()` method for `IDate` no longer coerces to `double` [#6922](https://github.com/Rdatatable/data.table/issues/6922). Thanks @MichaelChirico for the report and PR. The only effect should be on overly-strict tests that assert `Date` objects have `double` storage, which is not in general true, especially from R 4.5.0.
 
-## BUG FIXES
+### BUG FIXES
 
 1. Custom binary operators from the `lubridate` package now work with objects of class `IDate` as with a `Date` subclass, [#6839](https://github.com/Rdatatable/data.table/issues/6839). Thanks @emallickhossain for the report and @aitap for the fix.
 
@@ -29,7 +31,7 @@
 7. `fwrite()` now avoids a crash when translating strings into a different encoding, [#6883](https://github.com/Rdatatable/data.table/issues/6883). Thanks @filipemsc for the report and @aitap for the fix.
 
 
-## NOTES
+### NOTES
 
 1. Continued work to remove non-API C functions, [#6180](https://github.com/Rdatatable/data.table/issues/6180). Thanks Ivan Krylov for the PRs and for writing a clear and concise guide about the R API: https://aitap.codeberg.page/R-api/.
 
@@ -40,13 +42,13 @@
    + Argument `in.place` to `droplevels` has been removed.
    + It's now an error to set `datatable.nomatch`, which has been warning since 1.15.0.
 
-# data.table [v1.17.0](https://github.com/Rdatatable/data.table/milestone/34)  (20 Feb 2025)
+## data.table [v1.17.0](https://github.com/Rdatatable/data.table/milestone/34)  (20 Feb 2025)
 
-## POTENTIALLY BREAKING CHANGES
+### POTENTIALLY BREAKING CHANGES
 
 1. In `DT[, variable := value]`, when value is class `POSIXlt`, we automatically coerce it to class `POSIXct` instead, [#1724](https://github.com/Rdatatable/data.table/issues/1724). Thanks to @linzhp for the report, and Benjamin Schwendinger for the fix.
 
-## NEW FEATURES
+### NEW FEATURES
 
 1. New function `rowwiseDT()` for creating a data.table object "row-wise", often convenient for readability of small, literally-defined tables. Thanks to @shrektan for the suggestion and PR and @tdeenes for the idea of the `name=` syntax. Inspired by `tibble::tribble()`.
 
@@ -113,7 +115,7 @@ rowwiseDT(
 
 8. `fwrite()` gains a new parameter `compressLevel` to control compression level for gzip, [#5506](https://github.com/Rdatatable/data.table/issues/5506). This parameter balances compression speed and total compression, and corresponds directly to the analogous command-line parameter, e.g. `compressLevel=4` corresponds to passing `-4`; the default, `6`, matches the command-line default, i.e. equivalent to passing `-6`. Thanks @mgarbuzov for the request and @philippechataignon for implementing.
 
-## BUG FIXES
+### BUG FIXES
 
 1. `fwrite()` respects `dec=','` for timestamp columns (`POSIXct` or `nanotime`) with sub-second accuracy, [#6446](https://github.com/Rdatatable/data.table/issues/6446). Thanks @kav2k for pointing out the inconsistency and @MichaelChirico for the PR.
 
@@ -175,7 +177,7 @@ rowwiseDT(
 
 20. Fixed a memory issue causing segfaults in `forder`, [#6797](https://github.com/Rdatatable/data.table/issues/6797). Thanks @dkutner for the report and @MichaelChirico for the fix.
 
-## NOTES
+### NOTES
 
 1. There is a new vignette on joins! See `vignette("datatable-joins")`. Thanks to Angel Feliz for authoring it! Feedback welcome. This vignette has been highly requested since 2017: [#2181](https://github.com/Rdatatable/data.table/issues/2181).
 
@@ -204,15 +206,15 @@ rowwiseDT(
 
 11. Better handling of multibyte characters in `print()`, added in 1.16.0, has the side effect of possibly ignoring invisible characters like `\n` or `\t` for the purposes of counting width for `datatable.prettyprint.char`. That's because we switched to using `strtrim()` over `substring()`, the latter of which is explicitly discouraged for the purposes of truncating strings, whereas the former of which has platform-dependent behavior for whether invisible characters count towards string width.
 
-# data.table [v1.16.4](https://github.com/Rdatatable/data.table/milestone/36) 4 December 2024
+## data.table [v1.16.4](https://github.com/Rdatatable/data.table/milestone/36) 4 December 2024
 
-## BUG FIXES
+### BUG FIXES
 
 1. Joins on multiple columns, such as `x[y, on=c("x1==y1", "x2==y1")]`, could fail during implicit type coercions if `x1` and `x2` had different but still compatible types, [#6602](https://github.com/Rdatatable/data.table/issues/6602). This was particularly unexpected when columns `x1`, `x2`, and `y1` were all of the same class, e.g. `Date`, but differed in their underlying storage types. Thanks to Benjamin Schwendinger for the report and the fix.
 
-# data.table [v1.16.2](https://github.com/Rdatatable/data.table/milestone/35) (9 October 2024)
+## data.table [v1.16.2](https://github.com/Rdatatable/data.table/milestone/35) (9 October 2024)
 
-## BUG FIXES
+### BUG FIXES
 
 1. Using `print.data.table()` with character truncation using `datatable.prettyprint.char` no longer errors with `NA` entries, [#6441](https://github.com/Rdatatable/data.table/issues/6441). Thanks to @r2evans for the bug report, and @joshhwuu for the fix.
 
@@ -224,7 +226,7 @@ rowwiseDT(
 
 5. Restore some join operations on `x` and `i` (e.g. an anti-join `x[!i]`)  where `i` is an extended data.frame, but not a data.table (e.g. a `tbl`), [#6501](https://github.com/Rdatatable/data.table/issues/6501). Thanks @MichaelChirico for the report and PR.
 
-## NOTES
+### NOTES
 
 1. Fixed a typo in the NEWS for the last release -- that's version 1.16.0, not 1.6.0; apologies. Thanks @r2evans for flagging, [#6443](https://github.com/Rdatatable/data.table/issues/6443).
 
@@ -234,15 +236,15 @@ rowwiseDT(
 
 4. The translations submitted for 1.16.0 are now actually shipped with the package -- our deepest apologies to the translators for the omission. We have added a CI check to ensure that the .mo binaries which get shipped with the package are always up-to-date.
 
-# data.table [v1.16.0](https://github.com/Rdatatable/data.table/milestone/30)  (25 August 2024)
+## data.table [v1.16.0](https://github.com/Rdatatable/data.table/milestone/30)  (25 August 2024)
 
-## BREAKING CHANGES
+### BREAKING CHANGES
 
 1. `droplevels(in.place=TRUE)` is deprecated in favor of calling `setdroplevels()`, [#6014](https://github.com/Rdatatable/data.table/issues/6014). Given the associated risks/pain points, we strongly prefer all in-place/by-reference behavior within data.table come from functions `set*` (and `:=`) to make it as clear as possible that inputs are mutable. See below and `?setdroplevels` for more.
 
 2. `` `[.data.table` `` is un-exported again. This was exported to support an experimental feature (`DT()` functional form of `[`) that never made it to release, but we forgot to claw back this export in the NAMESPACE; sorry about that. We didn't find anyone calling the method directly (which is inadvisable to begin with).
 
-## NEW FEATURES
+### NEW FEATURES
 
 1. We continue to consider user feedback to prioritize development. See [#3189](https://github.com/Rdatatable/data.table/issues/3189) for the current list of most-requested issues. In this release we add five highly-requested features:
 
@@ -310,7 +312,7 @@ rowwiseDT(
 
     e. Displays `integer64` columns correctly by loading {bit64} if needed, [#6224](https://github.com/Rdatatable/data.table/issues/6224). Thanks @renkun-ken for the report and @MichaelChirico for the fix.
 
-## BUG FIXES
+### BUG FIXES
 
 1. `unique()` returns a copy when `nrows(x) <= 1` instead of a mutable alias, [#5932](https://github.com/Rdatatable/data.table/pull/5932). This is consistent with existing `unique()` behavior when the input has no duplicates but more than one row. Thanks to @brookslogan for the report and @dshemetov for the fix.
 
@@ -345,7 +347,7 @@ rowwiseDT(
 
 14. Passing functions programmatically with `env=` doesn't produce an opaque error, e.g. `DT[, f(b), env = list(f=sum)]`, [#6026](https://github.com/Rdatatable/data.table/issues/6026). Note that it's much better to pass functions like `f="sum"` instead. Thanks to @MichaelChirico for the bug report and fix.
 
-## NOTES
+### NOTES
 
 1. `transform()` method for data.table sped up substantially when creating new columns on large tables. Thanks to @OfekShilon for the report and PR. The implemented solution was proposed by @ColeMiller1.
 
@@ -437,7 +439,7 @@ rowwiseDT(
 
 19. `?dcast` has always required `fun.aggregate` to return a single value, and when `fill=NULL`, `dcast` would indeed error if a vector with `length!=1` was returned, but an undefined result was silently returned for non-`NULL` fill. Now `dcast()` will additionally warn that this is undefined behavior when fill is not `NULL`, [#6032](https://github.com/Rdatatable/data.table/issues/6032). In particular, this will warn for `fun.aggregate=identity`, which was observed in several revdeps. We may change this to an error in a future release, so revdeps should fix their code as soon as possible. Thanks to @tdhock for the PR, and @MichaelChirico for analysis of GitHub revdeps.
 
-## TRANSLATIONS
+### TRANSLATIONS
 
 1. Fix a typo in a Mandarin translation of an error message that was hiding the actual error message, [#6172](https://github.com/Rdatatable/data.table/issues/6172). Thanks @trafficfan for the report and @MichaelChirico for the fix.
 
@@ -445,31 +447,31 @@ rowwiseDT(
 
 3. A more helpful error message for using `:=` inside the first argument (`i`) of `[.data.table` is now available in translation, [#6293](https://github.com/Rdatatable/data.table/issues/6293). Previously, the code to display this assumed an earlier message was printed in English. The solution is for calling `:=` directly (i.e., outside the second argument `j` of `[.data.table`) to throw an error of class `dt_invalid_let_error`. Thanks to Spanish translator @rikivillalba for spotting the issue and @MichaelChirico for the fix.
 
-# data.table [v1.15.4](https://github.com/Rdatatable/data.table/milestone/33) (27 March 2024)
+## data.table [v1.15.4](https://github.com/Rdatatable/data.table/milestone/33) (27 March 2024)
 
-## BUG FIXES
+### BUG FIXES
 
 1. Optimized `shift` per group produced wrong results when simultaneously subsetting, for example, `DT[i==1L, shift(x), by=group]`, [#5962](https://github.com/Rdatatable/data.table/issues/5962). Thanks to @renkun-ken for the report and Benjamin Schwendinger for the fix.
 
-## NOTES
+### NOTES
 
 1. Updated a test relying on `>` working for comparing language objects to a string, which will be deprecated by R, [#5977](https://github.com/Rdatatable/data.table/issues/5977); no user-facing effect. Thanks to R-core for continuously improving the language.
 
-# data.table [v1.15.2](https://github.com/Rdatatable/data.table/milestone/32) (27 Feb 2024)
+## data.table [v1.15.2](https://github.com/Rdatatable/data.table/milestone/32) (27 Feb 2024)
 
-## BUG FIXES
+### BUG FIXES
 
 1. An error in `fwrite()` is more robust across platforms -- CRAN found the use of `PRId64` does not always match the output of `xlength()`, e.g. on some Mac M1 builds [#5935](https://github.com/Rdatatable/data.table/issues/5935). Thanks CRAN for identifying the issue and @ben-schwen for the fix.
 
 2. `shift()` of a vector in grouped queries (under GForce) returns a vector, consistent with `shift()` in other contexts, [#5939](https://github.com/Rdatatable/data.table/issues/5939). Thanks @shrektan for the report and @MichaelChirico for the fix.
 
-# data.table [v1.15.0](https://github.com/Rdatatable/data.table/milestone/29)  (30 Jan 2024)
+## data.table [v1.15.0](https://github.com/Rdatatable/data.table/milestone/29)  (30 Jan 2024)
 
-## BREAKING CHANGE
+### BREAKING CHANGE
 
 1. `shift` and `nafill` will now raise error `input must not be matrix or array` when `matrix` or `array` is provided on input, rather than giving useless result, [#5287](https://github.com/Rdatatable/data.table/issues/5287). Thanks to @ethanbsmith for reporting.
 
-## NEW FEATURES
+### NEW FEATURES
 
 1. `nafill()` now applies `fill=` to the front/back of the vector when `type="locf|nocb"`, [#3594](https://github.com/Rdatatable/data.table/issues/3594). Thanks to @ben519 for the feature request. It also now returns a named object based on the input names. Note that if you are considering joining and then using `nafill(...,type='locf|nocb')` afterwards, please review `roll=`/`rollends=` which should achieve the same result in one step more efficiently. `nafill()` is for when filling-while-joining (i.e. `roll=`/`rollends=`/`nomatch=`) cannot be applied.
 
@@ -756,7 +758,7 @@ rowwiseDT(
 
 41. `tables()` is faster by default by excluding the size of character strings in R's global cache (which may be shared) and excluding the size of list column items (which also may be shared). `mb=` now accepts any function which accepts a `data.table` and returns a higher and better estimate of its size in bytes, albeit more slowly; e.g. `mb = utils::object.size`.
 
-## BUG FIXES
+### BUG FIXES
 
 1. `by=.EACHI` when `i` is keyed but `on=` different columns than `i`'s key could create an invalidly keyed result, [#4603](https://github.com/Rdatatable/data.table/issues/4603) [#4911](https://github.com/Rdatatable/data.table/issues/4911). Thanks to @myoung3 and @adamaltmejd for reporting, and @ColeMiller1 for the PR. An invalid key is where a `data.table` is marked as sorted by the key columns but the data is not sorted by those columns, leading to incorrect results from subsequent queries.
 
@@ -1025,7 +1027,7 @@ rowwiseDT(
 
 56. `split.data.table()` works for downstream methods that don't implement `DT[i]` form (i.e., requiring `DT[i, j]` form, like plain `data.frame`s), for example `sf`'s `[.sf`, [#5365](https://github.com/Rdatatable/data.table/issues/5365). Thanks @barryrowlingson for the report and @michaelchirico for the fix.
 
-## NOTES
+### NOTES
 
 1. New feature 29 in v1.12.4 (Oct 2019) introduced zero-copy coercion. Our thinking is that requiring you to get the type right in the case of `0` (type double) vs `0L` (type integer) is too inconvenient for you the user. So such coercions happen in `data.table` automatically without warning. Thanks to zero-copy coercion there is no speed penalty, even when calling `set()` many times in a loop, so there's no speed penalty to warn you about either. However, we believe that assigning a character value such as `"2"` into an integer column is more likely to be a user mistake that you would like to be warned about. The type difference (character vs integer) may be the only clue that you have selected the wrong column, or typed the wrong variable to be assigned to that column. For this reason we view character to numeric-like coercion differently and will warn about it. If it is correct, then the warning is intended to nudge you to wrap the RHS with `as.<type>()` so that it is clear to readers of your code that a coercion from character to that type is intended. For example :
 
@@ -1084,4 +1086,4 @@ rowwiseDT(
 
 20. Some clarity is added to `?GForce` for the case when subtle changes to `j` produce different results because of differences in locale. Because `data.table` _always_ uses the "C" locale, small changes to queries which activate/deactivate GForce might cause confusingly different results when sorting is involved, [#5331](https://github.com/Rdatatable/data.table/issues/5331). The inspirational example compared `DT[, .(max(a), max(b)), by=grp]` and `DT[, .(max(a), max(tolower(b))), by=grp]` -- in the latter case, GForce is deactivated owing to the _ad-hoc_ column, so the result for `max(a)` might differ for the two queries. An example is added to `?GForce`. As always, there are several options to guarantee consistency, for example (1) use namespace qualification to deactivate GForce: `DT[, .(base::max(a), base::max(b)), by=grp]`; (2) turn off all optimizations with `options(datatable.optimize = 0)`; or (3) set your R session to always sort in C locale with `Sys.setlocale("LC_COLLATE", "C")` (or temporarily with e.g. `withr::with_locale()`). Thanks @markseeto for the example and @michaelchirico for the improved documentation.
 
-# data.table v1.14.10 (Dec 2023) back to v1.10.0 (Dec 2016) has been moved to [NEWS.1.md](https://github.com/Rdatatable/data.table/blob/master/NEWS.1.md)
+## data.table v1.14.10 (Dec 2023) back to v1.10.0 (Dec 2016) has been moved to [NEWS.1.md](https://github.com/Rdatatable/data.table/blob/master/NEWS.1.md)


### PR DESCRIPTION
See https://github.com/tidyverse/style/issues/245, https://stat.ethz.ch/pipermail/r-devel/2025-May/084009.html.