### PR TITLE
replaced `__restrict__` with `restrict`

### DIFF
--- a/src/fread.h
+++ b/src/fread.h
@@ -182,7 +182,7 @@ typedef struct ThreadLocalFreadParsingContext
 {
   // Pointer that serves as a starting point for all offsets within the `lenOff`
   // structs.
-  const char *__restrict__ anchor;
+  const char *restrict anchor;
 
   // Output buffers for values with different alignment requirements. For
   // example all `lenOff` columns, `double` columns and `int64` columns will be
@@ -190,9 +190,9 @@ typedef struct ThreadLocalFreadParsingContext
   // be stored in memory buffer `buff1`.
   // Within each buffer the data is stored in row-major order, i.e. in the same
   // order as in the original CSV file.
-  void *__restrict__ buff8;
-  void *__restrict__ buff4;
-  void *__restrict__ buff1;
+  void * restrict buff8;
+  void * restrict buff4;
+  void * restrict buff1;
 
   // Size (in bytes) for a single row of data within the buffers `buff8`,
   // `buff4` and `buff1` correspondingly.

--- a/src/fread.h
+++ b/src/fread.h
@@ -190,9 +190,9 @@ typedef struct ThreadLocalFreadParsingContext
   // be stored in memory buffer `buff1`.
   // Within each buffer the data is stored in row-major order, i.e. in the same
   // order as in the original CSV file.
-  void * restrict buff8;
-  void * restrict buff4;
-  void * restrict buff1;
+  void *restrict buff8;
+  void *restrict buff4;
+  void *restrict buff1;
 
   // Size (in bytes) for a single row of data within the buffers `buff8`,
   // `buff4` and `buff1` correspondingly.


### PR DESCRIPTION
`__restrict__` appears to be a compiler extension which does the exact same thing as c99's `restrict`.

Since we are targeting c99 it doesn't make sense to use nonstandard extensions like this. The c99 `restrict` keyword is already used elsewhere in the code.