### PR TITLE
Remove Unused HAVE_LONG_DOUBLE Conditional and Use sqrtl Directly 

### DIFF
--- a/src/gsumm.c
+++ b/src/gsumm.c
@@ -21,13 +21,6 @@ static int *oo = NULL;
 static int *ff = NULL;
 static int isunsorted = 0;
 
-// from R's src/cov.c (for variance / sd)
-#ifdef HAVE_LONG_DOUBLE
-# define SQRTL sqrtl
-#else
-# define SQRTL sqrt
-#endif
-
 static int nbit(int n)
 {
   // returns position of biggest bit; i.e. floor(log2(n))+1 without using fpa
@@ -1060,7 +1053,7 @@ static SEXP gvarsd1(SEXP x, SEXP narmArg, bool isSD)
           v += (subd[j]-(double)m) * (subd[j]-(double)m);
         }
         ansd[i] = (double)v/(nna-1);
-        if (isSD) ansd[i] = SQRTL(ansd[i]);
+        if (isSD) ansd[i] = sqrtl(ansd[i]);
       }
     }}
     break;
@@ -1091,7 +1084,7 @@ static SEXP gvarsd1(SEXP x, SEXP narmArg, bool isSD)
           v += (subd[j]-(double)m) * (subd[j]-(double)m);
         }
         ansd[i] = (double)v/(nna-1);
-        if (isSD) ansd[i] = SQRTL(ansd[i]);
+        if (isSD) ansd[i] = sqrtl(ansd[i]);
       }
     }}
     break;

--- a/src/gsumm.c
+++ b/src/gsumm.c
@@ -1053,7 +1053,7 @@ static SEXP gvarsd1(SEXP x, SEXP narmArg, bool isSD)
           v += (subd[j]-(double)m) * (subd[j]-(double)m);
         }
         ansd[i] = (double)v/(nna-1);
-        if (isSD) ansd[i] = sqrtl(ansd[i]);
+        if (isSD) ansd[i] = (double)sqrtl((long double)ansd[i]);
       }
     }}
     break;
@@ -1084,7 +1084,7 @@ static SEXP gvarsd1(SEXP x, SEXP narmArg, bool isSD)
           v += (subd[j]-(double)m) * (subd[j]-(double)m);
         }
         ansd[i] = (double)v/(nna-1);
-        if (isSD) ansd[i] = sqrtl(ansd[i]);
+        if (isSD) ansd[i] = (double)sqrtl((long double)ansd[i]);
       }
     }}
     break;


### PR DESCRIPTION
Closes #6938

This PR addresses the unused HAVE_LONG_DOUBLE conditional in src/gsumm.c and simplifies the handling of square root calculations for variance and standard deviation. The following changes have been implemented:
- Removed Unused Conditional Compilation Block:
- The preprocessor block checking for HAVE_LONG_DOUBLE (which was never defined in the package) has been removed to eliminate dead code and potential confusion.

Direct Use of sqrtl:
- All occurrences of the SQRTL macro have been replaced with direct calls to sqrtl. This ensures that calculations use the higher-precision long double square root function, aligning with R's original intent for statistical computations.

All tests pass locally, and there are no regressions in numerical results.

Kindly review when you have time.
Thank you!