### PR TITLE
Type change from `size_t` to `ptrdiff_t`

### DIFF
--- a/src/assign.c
+++ b/src/assign.c
@@ -408,7 +408,7 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values)
   // FR #2077 - set able to add new cols by reference
   if (isString(cols)) {
     PROTECT(tmp = chmatch(cols, names, 0)); protecti++;
-    buf = (int *) R_alloc(length(cols), sizeof(int));
+    buf = R_alloc(length(cols), sizeof(*buf));
     int k=0;
     for (int i=0; i<length(cols); ++i) {
       if (INTEGER(tmp)[i] == 0) buf[k++] = i;
@@ -707,7 +707,7 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values)
   }
   if (ndelete) {
     // delete any columns assigned NULL (there was a 'continue' earlier in loop above)
-    int *tt = (int *)R_alloc(ndelete, sizeof(int));
+    int *tt = R_alloc(ndelete, sizeof(*tt));
     const int *colsd=INTEGER(cols), ncols=length(cols), ndt=length(dt);
     for (int i=0, k=0; i<ncols; ++i) {   // find which ones to delete and put them in tt
       // Aside: a new column being assigned NULL (something odd to do) would have been warned above, added above, and now deleted. Just

--- a/src/coalesce.c
+++ b/src/coalesce.c
@@ -53,7 +53,7 @@ SEXP coalesce(SEXP x, SEXP inplaceArg) {
     first = PROTECT(copyAsPlain(first)); nprotect++;
     if (verbose) Rprintf(_("coalesce copied first item (inplace=FALSE)\n"));
   }
-  const void **valP = (const void **)R_alloc(nval, sizeof(void *));
+  const void **valP = R_alloc(nval, sizeof(*valP));
   switch(TYPEOF(first)) {
   case LGLSXP:
   case INTSXP: {

--- a/src/dogroups.c
+++ b/src/dogroups.c
@@ -139,7 +139,7 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
   SEXP names = PROTECT(getAttrib(SDall, R_NamesSymbol)); nprotect++;
   if (length(names) != length(SDall))
     internal_error(__func__, "length(names)!=length(SD)"); // # nocov
-  SEXP *nameSyms = (SEXP *)R_alloc(length(names), sizeof(SEXP));
+  SEXP *nameSyms = R_alloc(length(names), sizeof(*nameSyms));
 
   for(int i=0; i<length(SDall); ++i) {
     SEXP this = VECTOR_ELT(SDall, i);
@@ -156,7 +156,7 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
   SEXP xknames = PROTECT(getAttrib(xSD, R_NamesSymbol)); nprotect++;
   if (length(xknames) != length(xSD))
     internal_error(__func__, "length(xknames)!=length(xSD)"); // # nocov
-  SEXP *xknameSyms = (SEXP *)R_alloc(length(xknames), sizeof(SEXP));
+  SEXP *xknameSyms = R_alloc(length(xknames), sizeof(*xknameSyms));
   for(int i=0; i<length(xSD); ++i) {
     if (SIZEOF(VECTOR_ELT(xSD, i))==0)
       internal_error(__func__, "type %d in .xSD column %d should have been caught by now", TYPEOF(VECTOR_ELT(xSD, i)), i); // # nocov

--- a/src/fmelt.c
+++ b/src/fmelt.c
@@ -20,7 +20,7 @@ SEXP set_diff(SEXP x, int n) {
   SEXP table = PROTECT(seq_int(n, 1));       // TODO: using match to 1:n seems odd here, why use match at all
   SEXP xmatch = PROTECT(match(x, table, 0)); // Old comment:took a while to realise: matches vec against x - thanks to comment from Matt in assign.c!
   const int *ixmatch = INTEGER(xmatch);
-  int *buf = (int *) R_alloc(n, sizeof(int));
+  int *buf = R_alloc(n, sizeof(*buf));
   int j=0;
   for (int i=0; i<n; ++i) {
     if (ixmatch[i] == 0) {
@@ -40,7 +40,7 @@ SEXP which(SEXP x, Rboolean val) {
   SEXP ans;
   if (!isLogical(x)) error(_("Argument to 'which' must be logical"));
   const int *ix = LOGICAL(x);
-  int *buf = (int *) R_alloc(n, sizeof(int));
+  int *buf = R_alloc(n, sizeof(*buf));
   for (int i=0; i<n; ++i) {
     if (ix[i] == val) {
       buf[j++] = i+1;
@@ -317,10 +317,10 @@ static void preprocess(SEXP DT, SEXP id, SEXP measure, SEXP varnames, SEXP valna
   }
   if (length(varnames) != 1)
     error(_("'variable.name' must be a character/integer vector of length 1."));
-  data->leach = (int *)R_alloc(data->lvalues, sizeof(int));
-  data->isidentical = (int *)R_alloc(data->lvalues, sizeof(int));
-  data->isfactor = (int *)R_alloc(data->lvalues, sizeof(int));
-  data->maxtype = (SEXPTYPE *)R_alloc(data->lvalues, sizeof(SEXPTYPE));
+  data->leach = R_alloc(data->lvalues, sizeof(*data->leach));
+  data->isidentical = R_alloc(data->lvalues, sizeof(*data->isidentical));
+  data->isfactor = R_alloc(data->lvalues, sizeof(*data->isfactor));
+  data->maxtype = R_alloc(data->lvalues, sizeof(*data->maxtype));
   // first find max type of each output column.
   for (int i=0; i<data->lvalues; ++i) { // for each output column.
     tmp = VECTOR_ELT(data->valuecols, i);
@@ -401,7 +401,7 @@ static SEXP combineFactorLevels(SEXP factorLevels, SEXP target, int * factorType
   if (!isString(target)) internal_error(__func__, "expects a character target to factorize");  // # nocov
   int nrow = length(target);
   SEXP ans = PROTECT(allocVector(INTSXP, nrow));
-  SEXP *levelsRaw = (SEXP *)R_alloc(maxlevels, sizeof(SEXP));  // allocate for worst-case all-unique levels
+  SEXP *levelsRaw = R_alloc(maxlevels, sizeof(*levelsRaw));  // allocate for worst-case all-unique levels
   int *ansd = INTEGER(ans);
   const SEXP *targetd = STRING_PTR_RO(target);
   savetl_init();
@@ -492,7 +492,7 @@ SEXP getvaluecols(SEXP DT, SEXP dtnames, Rboolean valfactor, Rboolean verbose, s
     data->totlen = data->nrow * data->lmax;
   }
   SEXP flevels = PROTECT(allocVector(VECSXP, data->lmax));
-  Rboolean *isordered = (Rboolean *)R_alloc(data->lmax, sizeof(Rboolean));
+  Rboolean *isordered = R_alloc(data->lmax, sizeof(*isordered));
   SEXP ansvals = PROTECT(allocVector(VECSXP, data->lvalues));
   for (int i=0; i<data->lvalues; ++i) {//for each output/value column.
     bool thisvalfactor = (data->maxtype[i] == VECSXP) ? false : valfactor;

--- a/src/forder.c
+++ b/src/forder.c
@@ -1422,9 +1422,9 @@ SEXP issorted(SEXP x, SEXP by)
   const R_xlen_t nrow = xlength(VECTOR_ELT(x,0));
   // ncol>1
   // pre-save lookups to save deep switch later for each column type
-  size_t *sizes =          (size_t *)R_alloc(ncol, sizeof(size_t));
-  const char **ptrs = (const char **)R_alloc(ncol, sizeof(char *));
-  int *types =                (int *)R_alloc(ncol, sizeof(int));
+  size_t *sizes =     R_alloc(ncol, sizeof(*sizes));
+  const char **ptrs = R_alloc(ncol, sizeof(*ptrs));
+  int *types =        R_alloc(ncol, sizeof(*types));
   for (int j=0; j<ncol; ++j) {
     int c = INTEGER(by)[j];
     if (c<1 || c>length(x)) STOP(_("issorted 'by' [%d] out of range [1,%d]"), c, length(x));

--- a/src/fread.c
+++ b/src/fread.c
@@ -1900,12 +1900,12 @@ int freadMain(freadMainArgs _args) {
     tmpType[j] = type[j] = type0;
   }
 
-  size_t jump0size=(size_t)(firstJumpEnd-pos);  // the size in bytes of the first 100 lines from the start (jump point 0)
+  const ptrdiff_t jump0size = firstJumpEnd - pos;  // the size in bytes of the first 100 lines from the start (jump point 0)
   // how many places in the file to jump to and test types there (the very end is added as 11th or 101th)
   // not too many though so as not to slow down wide files; e.g. 10,000 columns.  But for such large files (50GB) it is
   // worth spending a few extra seconds sampling 10,000 rows to decrease a chance of costly reread even further.
   nJumps = 1;
-  size_t sz = (size_t)(eof - pos);
+  const ptrdiff_t sz = eof - pos;
   if (jump0size>0) {
     if (jump0size*100*2 < sz) nJumps=100;  // 100 jumps * 100 lines = 10,000 line sample
     else if (jump0size*10*2 < sz) nJumps=10;
@@ -1918,7 +1918,7 @@ int freadMain(freadMainArgs _args) {
       DTPRINT(_("  Number of sampling jump points = %d because jump0size==0\n"), nJumps);
     } else {
       DTPRINT(_("  Number of sampling jump points = %d because (%"PRIu64" bytes from row 1 to eof) / (2 * %"PRIu64" jump0size) == %"PRIu64"\n"),
-              nJumps, (uint64_t)sz, (uint64_t)jump0size, (uint64_t)(sz/(2*jump0size)));
+              nJumps, sz, jump0size, sz/(2*jump0size));
     }
   }
   nJumps++; // the extra sample at the very end (up to eof) is sampled and format checked but not jumped to when reading

--- a/src/freadR.c
+++ b/src/freadR.c
@@ -147,7 +147,7 @@ SEXP freadR(
   if (!isNull(NAstringsArg) && !isString(NAstringsArg))
     internal_error(__func__, "NAstringsArg is type '%s'. R level catches this", type2char(TYPEOF(NAstringsArg)));  // # nocov
   int nnas = length(NAstringsArg);
-  const char **NAstrings = (const char **)R_alloc((nnas + 1), sizeof(char*));  // +1 for the final NULL to save a separate nna variable
+  const char **NAstrings = R_alloc(nnas + 1, sizeof(*NAstrings));  // +1 for the final NULL to save a separate nna variable
   for (int i=0; i<nnas; i++)
     NAstrings[i] = CHAR(STRING_ELT(NAstringsArg,i));
   NAstrings[nnas] = NULL;

--- a/src/frollR.c
+++ b/src/frollR.c
@@ -86,7 +86,7 @@ SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEX
       }
     }
   }
-  int **ikl = (int**)R_alloc(nk, sizeof(int*));                 // to not recalculate `length(x[[i]])` we store it in extra array
+  int **ikl = R_alloc(nk, sizeof(*ikl));                 // to not recalculate `length(x[[i]])` we store it in extra array
   if (badaptive) {
     for (int j=0; j<nk; j++) ikl[j] = INTEGER(VECTOR_ELT(kl, j));
   }
@@ -115,9 +115,9 @@ SEXP frollfunR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP algo, SEXP align, SEX
   SEXP ans = PROTECT(allocVector(VECSXP, nk * nx)); protecti++; // allocate list to keep results
   if (verbose)
     Rprintf(_("%s: allocating memory for results %dx%d\n"), __func__, nx, nk);
-  ans_t *dans = (ans_t *)R_alloc(nx*nk, sizeof(ans_t));         // answer columns as array of ans_t struct
-  double** dx = (double**)R_alloc(nx, sizeof(double*));         // pointers to source columns
-  uint64_t* inx = (uint64_t*)R_alloc(nx, sizeof(uint64_t));     // to not recalculate `length(x[[i]])` we store it in extra array
+  ans_t *dans = R_alloc(nx*nk, sizeof(*dans));         // answer columns as array of ans_t struct
+  double **dx = R_alloc(nx, sizeof(*dx));         // pointers to source columns
+  uint64_t *inx = R_alloc(nx, sizeof(*inx));     // to not recalculate `length(x[[i]])` we store it in extra array
   for (R_len_t i=0; i<nx; i++) {
     inx[i] = xlength(VECTOR_ELT(x, i));                         // for list input each vector can have different length
     for (R_len_t j=0; j<nk; j++) {
@@ -265,9 +265,9 @@ SEXP frollapplyR(SEXP fun, SEXP obj, SEXP k, SEXP fill, SEXP align, SEXP rho) {
   SEXP ans = PROTECT(allocVector(VECSXP, nk * nx)); protecti++;
   if (verbose)
     Rprintf(_("%s: allocating memory for results %dx%d\n"), __func__, nx, nk);
-  ans_t *dans = (ans_t *)R_alloc(nx*nk, sizeof(ans_t));
-  double** dx = (double**)R_alloc(nx, sizeof(double*));
-  uint64_t* inx = (uint64_t*)R_alloc(nx, sizeof(uint64_t));
+  ans_t *dans = R_alloc(nx*nk, sizeof(*dans));
+  double **dx = R_alloc(nx, sizeof(*dx));
+  uint64_t *inx = R_alloc(nx, sizeof(*inx));
   for (R_len_t i=0; i<nx; i++) {
     inx[i] = xlength(VECTOR_ELT(x, i));
     for (R_len_t j=0; j<nk; j++) {

--- a/src/fsort.c
+++ b/src/fsort.c
@@ -189,7 +189,7 @@ SEXP fsort(SEXP x, SEXP verboseArg) {
   if (verbose)
     Rprintf("maxBit=%d; MSBNbits=%d; shift=%d; MSBsize=%zu\n", maxBit, MSBNbits, shift, MSBsize); // # notranslate
 
-  uint64_t *counts = (uint64_t *)R_alloc(nBatch*MSBsize, sizeof(uint64_t));
+  uint64_t *counts = R_alloc(nBatch*MSBsize, sizeof(*counts));
   memset(counts, 0, nBatch*MSBsize*sizeof(uint64_t));
   // provided MSBsize>=9, each batch is a multiple of at least one 4k page, so no page overlap
 
@@ -248,8 +248,8 @@ SEXP fsort(SEXP x, SEXP verboseArg) {
     uint64_t *msbCounts = counts + (nBatch-1)*MSBsize;
     // msbCounts currently contains the ending position of each MSB (the starting location of the next) even across empty
     if (msbCounts[MSBsize-1] != xlength(x)) internal_error(__func__, "counts[nBatch-1][MSBsize-1] != length(x)"); // # nocov
-    uint64_t *msbFrom = (uint64_t *)R_alloc(MSBsize, sizeof(uint64_t));
-    int *order = (int *)R_alloc(MSBsize, sizeof(int));
+    uint64_t *msbFrom = R_alloc(MSBsize, sizeof(*msbFrom));
+    int *order = R_alloc(MSBsize, sizeof(*order));
     uint64_t cumSum = 0;
     for (int i=0; i<MSBsize; ++i) {
       msbFrom[i] = cumSum;

--- a/src/fwriteR.c
+++ b/src/fwriteR.c
@@ -220,12 +220,12 @@ SEXP fwriteR(
   // allocate new `columns` vector and fetch the DATAPTR_RO() offset once up front here to reduce the complexity
   // in fread.c needing to know about the size of R's header, or calling R API. It won't be slower because only
   // this new vector of pointers is used by fread.c, but it does use a tiny bit more memory (ncol * 8 bytes).
-  args.columns = (void *)R_alloc(args.ncol, sizeof(const void *));
+  args.columns = R_alloc(args.ncol, sizeof(*args.columns));
 
   args.funs = funs;  // funs declared statically at the top of this file
 
   // Allocate and populate lookup vector to writer function for each column, whichFun[]
-  args.whichFun = (uint8_t *)R_alloc(args.ncol, sizeof(uint8_t));
+  args.whichFun = R_alloc(args.ncol, sizeof(*args.whichFun));
 
   // just for use at this level to control whichWriter() when called now for each column and
   // when called later for cell items of list columns (if any)

--- a/src/gsumm.c
+++ b/src/gsumm.c
@@ -81,7 +81,7 @@ SEXP gforce(SEXP env, SEXP jsub, SEXP o, SEXP f, SEXP l, SEXP irowsArg) {
   mask = (1<<bitshift)-1;
   highSize = ((ngrp-1)>>bitshift) + 1;
 
-  grp = (int *)R_alloc(nrow, sizeof(int));   // TODO: use malloc and made this local as not needed globally when all functions here use gather
+  grp = R_alloc(nrow, sizeof(*grp));   // TODO: use malloc and made this local as not needed globally when all functions here use gather
                                              // maybe better to malloc to avoid R's heap. This grp isn't global, so it doesn't need to be R_alloc
   const int *restrict fp = INTEGER(f);
 
@@ -163,15 +163,15 @@ SEXP gforce(SEXP env, SEXP jsub, SEXP o, SEXP f, SEXP l, SEXP irowsArg) {
     //Rprintf(_("gforce assign TMP [ (o,g) pairs ] back to grp took %.3f\n"), wallclock()-started); started=wallclock();
   }
 
-  high = (uint16_t *)R_alloc(nrow, sizeof(uint16_t));  // maybe better to malloc to avoid R's heap, but safer to R_alloc since it's done via eval()
-  low  = (uint16_t *)R_alloc(nrow, sizeof(uint16_t));
+  high = R_alloc(nrow, sizeof(*high));  // maybe better to malloc to avoid R's heap, but safer to R_alloc since it's done via eval()
+  low  = R_alloc(nrow, sizeof(*low));
   // global ghigh and glow because the g* functions (inside jsub) share this common memory
 
-  gx = (char *)R_alloc(nrow, sizeof(Rcomplex));  // enough for a copy of one column (or length(irows) if supplied)
+  gx = R_alloc(nrow, sizeof(*gx));  // enough for a copy of one column (or length(irows) if supplied)
   // TODO: reduce to the largest type present; won't be faster (untouched RAM won't be fetched) but it will increase the largest size that works.
 
-  counts = (int *)S_alloc(nBatch*highSize, sizeof(int));  // (S_ zeros) TODO: cache-line align and make highSize a multiple of 64
-  tmpcounts = (int *)R_alloc(getDTthreads(nBatch, false)*highSize, sizeof(int));
+  counts = S_alloc(nBatch*highSize, sizeof(*counts));  // (S_ zeros) TODO: cache-line align and make highSize a multiple of 64
+  tmpcounts = R_alloc(getDTthreads(nBatch, false)*highSize, sizeof(*tmpcounts));
 
   const int *restrict gp = grp;
   #pragma omp parallel for num_threads(getDTthreads(nBatch, false))   // schedule(dynamic,1)

--- a/src/nafill.c
+++ b/src/nafill.c
@@ -130,12 +130,12 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP nan_is_na_arg, SEXP inplace, S
   }
   R_len_t nx = length(x);
 
-  double **dx = (double**)R_alloc(nx, sizeof(double*));
-  int32_t **ix = (int32_t**)R_alloc(nx, sizeof(int32_t*));
-  int64_t **i64x = (int64_t**)R_alloc(nx, sizeof(int64_t*));
-  uint_fast64_t *inx = (uint_fast64_t*)R_alloc(nx, sizeof(uint_fast64_t));
+  double **dx = R_alloc(nx, sizeof(*dx));
+  int32_t **ix = R_alloc(nx, sizeof(*ix));
+  int64_t **i64x = R_alloc(nx, sizeof(*i64x));
+  uint_fast64_t *inx = R_alloc(nx, sizeof(*inx));
   SEXP ans = R_NilValue;
-  ans_t *vans = (ans_t *)R_alloc(nx, sizeof(ans_t));
+  ans_t *vans = R_alloc(nx, sizeof(*vans));
   for (R_len_t i=0; i<nx; i++) {
     const SEXP xi = VECTOR_ELT(x, i);
     inx[i] = xlength(xi);
@@ -175,10 +175,10 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP nan_is_na_arg, SEXP inplace, S
     internal_error(__func__, "invalid %s argument in %s function should have been caught earlier", "type", "nafillR"); // # nocov
 
   bool hasFill = !isLogical(fill) || LOGICAL(fill)[0]!=NA_LOGICAL;
-  bool *isInt64 = (bool *)R_alloc(nx, sizeof(bool));
+  bool *isInt64 = R_alloc(nx, sizeof(*isInt64));
   for (R_len_t i=0; i<nx; i++)
     isInt64[i] = INHERITS(VECTOR_ELT(x, i), char_integer64);
-  const void **fillp = (const void **)R_alloc(nx, sizeof(void*)); // fill is (or will be) a list of length nx of matching types, scalar values for each column, this pointer points to each of those columns data pointers
+  const void **fillp = R_alloc(nx, sizeof(*fillp)); // fill is (or will be) a list of length nx of matching types, scalar values for each column, this pointer points to each of those columns data pointers
   if (hasFill) {
     if (nx!=length(fill) && length(fill)!=1)
       error(_("fill must be a vector of length 1 or a list of length of x"));

--- a/src/rbindlist.c
+++ b/src/rbindlist.c
@@ -24,7 +24,7 @@ SEXP rbindlist(SEXP l, SEXP usenamesArg, SEXP fillArg, SEXP idcolArg, SEXP ignor
   int64_t nrow=0, upperBoundUniqueNames=1;
   bool anyNames=false;
   int numZero=0, firstZeroCol=0, firstZeroItem=0;
-  int *eachMax = (int *)R_alloc(LENGTH(l), sizeof(int));
+  int *eachMax = R_alloc(LENGTH(l), sizeof(*eachMax));
   // pre-check for any errors here to save having to get cleanup right below when usenames
   for (int i=0; i<LENGTH(l); i++) {  // length(l)>0 checked above
     eachMax[i] = 0;
@@ -180,7 +180,7 @@ SEXP rbindlist(SEXP l, SEXP usenamesArg, SEXP fillArg, SEXP idcolArg, SEXP ignor
 
     // colMapRaw is still allocated. It was allocated with malloc because we needed to catch if the alloc failed.
     // move it to R's heap so it gets automatically free'd on exit, and on any error between now and the end of rbindlist.
-    colMap = (int *)R_alloc(LENGTH(l)*ncol, sizeof(int));
+    colMap = R_alloc(LENGTH(l)*ncol, sizeof(*colMap));
     // This R_alloc could fail with out-of-memory but given it is very small it's very unlikely. If it does fail, colMapRaw will leak.
     //   But colMapRaw leaking now in this very rare situation is better than colMapRaw leaking in the more likely but still rare conditions later.
     //   And it's better than having to trap all exit point from here to the end of rbindlist, which may not be possible; e.g. writeNA() could error inside it with unsupported type.

--- a/src/reorder.c
+++ b/src/reorder.c
@@ -51,7 +51,7 @@ SEXP reorder(SEXP x, SEXP order)
   while (idx[i] == i+1) --i;
   const int end=i, nmid=end-start+1;
 
-  uint8_t *seen = (uint8_t *)R_alloc(nmid, sizeof(uint8_t)); // detect duplicates
+  uint8_t *seen = R_alloc(nmid, sizeof(*seen)); // detect duplicates
   memset(seen, 0, nmid*sizeof(uint8_t));
   for (int i=start; i<=end; ++i) {
     if (idx[i]==NA_INTEGER || idx[i]-1<start || idx[i]-1>end || seen[idx[i]-1-start]++)

--- a/src/subset.c
+++ b/src/subset.c
@@ -215,7 +215,7 @@ SEXP convertNegAndZeroIdx(SEXP idx, SEXP maxArg, SEXP allowOverMax, SEXP allowNA
     }
   } else {
     // idx is all negative without any NA but perhaps some zeros
-    bool *keep = (bool *)R_alloc(max, sizeof(bool));    // 4 times less memory that INTSXP in src/main/subscript.c
+    bool *keep = R_alloc(max, sizeof(*keep));    // 4 times less memory that INTSXP in src/main/subscript.c
     for (int i=0; i<max; i++) keep[i] = true;
     int countRemoved=0, countDup=0, countBeyond=0;   // idx=c(-10,-5,-10) removing row 10 twice
     int firstBeyond=0, firstDup=0;

--- a/src/types.c
+++ b/src/types.c
@@ -67,7 +67,7 @@ SEXP testMsgR(SEXP status, SEXP x, SEXP k) {
 
   // TODO below chunk into allocansList helper, not for 1.12.4
   SEXP ans = PROTECT(allocVector(VECSXP, nk * nx)); protecti++;
-  ans_t *vans = (ans_t *)R_alloc(nx*nk, sizeof(ans_t));
+  ans_t *vans = R_alloc(nx*nk, sizeof(*vans));
   if (verbose)
     Rprintf(_("%s: allocating memory for results %dx%d\n"), __func__, nx, nk);
   for (R_len_t i=0; i<nx; i++) {

--- a/src/uniqlist.c
+++ b/src/uniqlist.c
@@ -100,7 +100,7 @@ SEXP uniqlist(SEXP l, SEXP order)
   } else {
     // ncol>1
     thisi = via_order ? INTEGER(order)[0]-1 : 0;
-    bool *i64 = (bool *)R_alloc(ncol, sizeof(bool));
+    bool *i64 = R_alloc(ncol, sizeof(*i64));
     for (int i=0; i<ncol; i++) i64[i] = INHERITS(VECTOR_ELT(l,i), char_integer64);
     for (int i=1; i<nrow; i++) {
       previ = thisi;
@@ -261,7 +261,7 @@ SEXP nestedid(SEXP l, SEXP cols, SEXP order, SEXP grps, SEXP resetvals, SEXP mul
   R_len_t thisi, previ, ansgrpsize=1000, nansgrp=0;
   R_len_t *ansgrp = R_Calloc(ansgrpsize, R_len_t), starts, grplen; // #3401 fix. Needs to be R_Calloc due to R_Realloc below .. else segfaults.
   R_len_t ngrps = length(grps);
-  bool *i64 = (bool *)R_alloc(ncols, sizeof(bool));
+  bool *i64 = R_alloc(ncols, sizeof(*i64));
   if (ngrps==0) internal_error(__func__, "nrows[%d]>0 but ngrps==0", nrows); // # nocov
   R_len_t resetctr=0, rlen = length(resetvals) ? INTEGER(resetvals)[0] : 0;
   if (!isInteger(cols) || ncols == 0) error(_("cols must be an integer vector with length >= 1"));

--- a/src/utils.c
+++ b/src/utils.c
@@ -265,8 +265,8 @@ SEXP copyAsPlain(SEXP x) {
 void copySharedColumns(SEXP x) {
   const int ncol = length(x);
   if (!isNewList(x) || ncol==1) return;
-  bool *shared = (bool *)R_alloc(ncol, sizeof(bool)); // on R heap in case alloc fails
-  int *savetl = (int *)R_alloc(ncol, sizeof(int));  // on R heap for convenience but could be a calloc
+  bool *shared = R_alloc(ncol, sizeof(*shared)); // on R heap in case alloc fails
+  int *savetl = R_alloc(ncol, sizeof(*savetl));  // on R heap for convenience but could be a calloc
   const SEXP *xp = SEXPPTR_RO(x);
   // first save the truelength, which may be negative on specials in dogroups, and set to zero; test 2157
   // the savetl() function elsewhere is for CHARSXP. Here, we are using truelength on atomic vectors.


### PR DESCRIPTION
The intended purpose of the `size_t` type is to denote the size of an object, or a multiple thereof. It is the evaluated type of the `sizeof` operator.

The `ptrdiff_t` type denotes the difference between two memory addresses.

While they are *usually* identical, they are not intended to be used interchangeably.