### PR TITLE
fixed `AS_DIGIT` macro

### DIFF
--- a/src/fread.c
+++ b/src/fread.c
@@ -107,7 +107,7 @@ static void Field(FieldParseContext *ctx);
 #define ASSERT(cond, msg, ...) if (!(cond)) INTERNAL_STOP(msg, __VA_ARGS__) // # nocov
 
 #define AS_DIGIT(x) (uint_fast8_t)(x - '0')
-#define IS_DIGIT(x) AS_DIGIT(x) < 10
+#define IS_DIGIT(x) (AS_DIGIT(x) < 10)
 
 //=================================================================================================
 //


### PR DESCRIPTION
Probably no big deal, but this one made me uneasy.

```c
!IS_DIGIT('6');
```

Would evaluate to

```c
!AS_DIGIT(x) < 10;
```

Even if this is unlikely to happen, let's not tempt fate. This kind of thing would not be picked up by static analysis