### PR TITLE
Define RO accessors for RAW, LOGICAL

### DIFF
--- a/src/data.table.h
+++ b/src/data.table.h
@@ -10,6 +10,8 @@
 #  define INTEGER_RO INTEGER
 #  define REAL_RO REAL
 #  define COMPLEX_RO COMPLEX
+#  define RAW_RO RAW
+#  define LOGICAL_RO LOGICAL
 #  define R_Calloc(x, y) Calloc(x, y)         // #6380
 #  define R_Realloc(x, y, z) Realloc(x, y, z)
 #  define R_Free(x) Free(x)


### PR DESCRIPTION
Like other `_RO` accessors, these are also not available on R < 3.5. We make use of them since #6907.