### PR TITLE
Fix warnings and truncations around `filesize_to_str()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -43,6 +43,12 @@
 
 3. {data.table} now depends on R 3.4.0 (2017).
 
+4. Changes to `fread()` output and errors:
+
+   + When the size of the file exceeds the size of the address space, `fread()` now signals an informative error instead of trying to map its size modulo the address space.
+   + On non-Windows systems, `fread()` now prints the reason why the file couldn't be opened, which could also be due to it being too large to map.
+   + With `verbose=TRUE`, file sizes are now printed using binary SI prefixes, since it's always used powers of `2^10` as multipliers.
+
 # data.table [v1.17.0](https://github.com/Rdatatable/data.table/milestone/34)  (20 Feb 2025)
 
 ## POTENTIALLY BREAKING CHANGES

--- a/NEWS.md
+++ b/NEWS.md
@@ -51,7 +51,7 @@
 
    + When the size of the file exceeds the size of the address space, `fread()` now signals an informative error instead of trying to map its size modulo the address space.
    + On non-Windows systems, `fread()` now prints the reason why the file couldn't be opened, which could also be due to it being too large to map.
-   + With `verbose=TRUE`, file sizes are now printed using binary SI prefixes, since it's always used powers of `2^10` as multipliers.
+   + With `verbose=TRUE`, file sizes are now printed using correct binary SI prefixes (the sizes have always been reported as bytes denominated in powers of `2^10`, so e.g. `1024*1024` bytes was reported as `1 MB` where `1 MiB` or `1.05 MB` is correct).
 
 ## data.table [v1.17.0](https://github.com/Rdatatable/data.table/milestone/34)  (20 Feb 2025)
 

--- a/src/fread.c
+++ b/src/fread.c
@@ -1421,11 +1421,11 @@ int freadMain(freadMainArgs _args) {
         close(fd);                                                     // # nocov
         STOP(_("Opened file ok but couldn't obtain its size: %s"), fnam); // # nocov
       }
-      if (verbose) DTPRINT(_("  File opened, size = %s.\n"), filesize_to_str(stat_buf.st_size));
       if (stat_buf.st_size > SIZE_MAX) {
         close(fd);                              // # nocov
-        STOP(_("File is too large: %s"), fnam); // # nocov
+        STOP(_("File is too large [%s > %s]: %s"), filesize_to_str(stat_buf.st_size), filesize_to_str(SIZE_MAX), fnam); // # nocov
       }
+      if (verbose) DTPRINT(_("  File opened, size = %s.\n"), filesize_to_str(stat_buf.st_size));
       fileSize = (size_t) stat_buf.st_size;
       if (fileSize == 0) {close(fd); STOP(_("File is empty: %s"), fnam);}
 

--- a/src/fread.c
+++ b/src/fread.c
@@ -1423,7 +1423,7 @@ int freadMain(freadMainArgs _args) {
       }
       if (stat_buf.st_size > SIZE_MAX) {
         close(fd);                              // # nocov
-        STOP(_("File is too large [%s > %s]: %s"), filesize_to_str(stat_buf.st_size), filesize_to_str(SIZE_MAX), fnam); // # nocov
+        STOP(_("File size [%s] exceeds the address space: %s"), filesize_to_str(stat_buf.st_size), fnam); // # nocov
       }
       fileSize = (size_t) stat_buf.st_size;
       if (fileSize == 0) {close(fd); STOP(_("File is empty: %s"), fnam);}
@@ -1459,7 +1459,7 @@ int freadMain(freadMainArgs _args) {
       if (GetFileSizeEx(hFile,&liFileSize)==0) { CloseHandle(hFile); STOP(_("GetFileSizeEx failed (returned 0) on file: %s"), fnam); }
       if (liFileSize.QuadPart > SIZE_MAX) {
         CloseHandle(hFile); // # nocov
-        STOP(_("File is too large [%s > %s]: %s"), filesize_to_str(stat_buf.st_size), filesize_to_str(SIZE_MAX), fnam); // # nocov
+        STOP(_("File size [%s] exceeds the address space: %s"), filesize_to_str(liFileSize.QuadPart), fnam); // # nocov
       }
       fileSize = (size_t)liFileSize.QuadPart;
       if (fileSize==0) { CloseHandle(hFile); STOP(_("File is empty: %s"), fnam); }

--- a/src/fread.c
+++ b/src/fread.c
@@ -413,7 +413,7 @@ double wallclock(void)
  * multiple threads at the same time, or hold on to the value returned for
  * extended periods of time.
  */
-static const char* filesize_to_str(const size_t fsize)
+static const char* filesize_to_str(const uint64_t fsize)
 {
   static const char suffixes[] = {'T', 'G', 'M', 'K'};
   static char output[100];
@@ -427,7 +427,7 @@ static const char* filesize_to_str(const size_t fsize)
     if (ndigits == 0 || (fsize == (fsize >> shift << shift))) {
       if (i < sizeof(suffixes)) {
         snprintf(output, sizeof(output), "%"PRIu64"%cB (%"PRIu64" bytes)", // # notranslate
-                 (fsize >> shift), suffixes[i], fsize);
+                 fsize >> shift, suffixes[i], fsize);
         return output;
       }
     } else {

--- a/src/fread.c
+++ b/src/fread.c
@@ -402,10 +402,10 @@ double wallclock(void)
 /**
  * Helper function to print file's size in human-readable format. This will
  * produce strings such as:
- *     44.74GB (48043231704 bytes)
- *     921MB (965757797 bytes)
- *     2.206MB (2313045 bytes)
- *     38.69KB (39615 bytes)
+ *     44.74GiB (48043231704 bytes)
+ *     921MiB (965757797 bytes)
+ *     2.206MiB (2313045 bytes)
+ *     38.69KiB (39615 bytes)
  *     214 bytes
  *     0 bytes
  * The function returns a pointer to a static string buffer, so the caller
@@ -426,12 +426,12 @@ static const char* filesize_to_str(const uint64_t fsize)
     }
     if (ndigits == 0 || (fsize == (fsize >> shift << shift))) {
       if (i < sizeof(suffixes)) {
-        snprintf(output, sizeof(output), "%"PRIu64"%cB (%"PRIu64" bytes)", // # notranslate
+        snprintf(output, sizeof(output), "%"PRIu64"%ciB (%"PRIu64" bytes)", // # notranslate
                  fsize >> shift, suffixes[i], fsize);
         return output;
       }
     } else {
-      snprintf(output, sizeof(output), "%.*f%cB (%"PRIu64" bytes)", // # notranslate
+      snprintf(output, sizeof(output), "%.*f%ciB (%"PRIu64" bytes)", // # notranslate
                ndigits, (double)fsize / (1LL << shift), suffixes[i], fsize);
       return output;
     }


### PR DESCRIPTION
<ul><li> Seen on 32-bit Windows and Linux:

```r
library(data.table)
fwrite(mtcars, "mtcars")
data.table::fread("mtcars", verbose=TRUE) |> capture.output() |> grepv("bytes", x = _, value = TRUE)
# [1] "  File opened, size = 0.000TB (1281 bytes)."
# [2] "  Number of sampling jump points = 1 because (1280 bytes from row 1 to eof) / (2 * 1280 jump0size) == 0"
# [3] "Read 32 rows x 11 columns from 0.000TB (1281 bytes) file in 00:00.000 wall clock time"
```

Performing a 40-bit shift on a 32-bit `size_t` is undefined behaviour; things go downhill from there. Accept `uint64_t` instead of `size_t` for a file size, since it's still possible for a file to exceed the address space in size.
</li><li>
This will also fix the warnings noted in #6984, where a <code>size_t</code> was passed to the <code>PRIu64</code> size specifier:

```
  fread.c:422:18: warning: format specifies type 'unsigned long long' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
  fread.c:422:49: warning: format specifies type 'unsigned long long' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
  fread.c:427:70: warning: format specifies type 'unsigned long long' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
  fread.c:432:55: warning: format specifies type 'unsigned long long' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
```
This warning ends up being harmless even on 32-bit systems, but it's still undefined behaviour.
</li><li>
Make use of this on both Windows and non-Windows. Instead of blindly reading the file size modulo 4 GiB, check that the file at least has a chance to fit into the address space. On Linux with <code>glibc</code>, we default to 32-bit <code>off_t</code> and thus fail to open files that are too large, but guard against this anyway in case some other POSIX system behaves differently.
</li><li>
Since we already make use of powers of two in the size printouts, print the <a href="https://en.wikipedia.org/wiki/Binary_prefix">binary SI prefixes</a>.
</li></ul>