### PR TITLE
Restore `%td` format specifiers in `DTPRINT`

### DIFF
--- a/src/fread.c
+++ b/src/fread.c
@@ -1919,8 +1919,8 @@ int freadMain(freadMainArgs _args) {
     } else if (jump0size==0) {
       DTPRINT(_("  Number of sampling jump points = %d because jump0size==0\n"), nJumps);
     } else {
-      DTPRINT(_("  Number of sampling jump points = %d because (%ld bytes from row 1 to eof) / (2 * %ld jump0size) == %ld\n"),
-              nJumps, (long int)sz, (long int)jump0size, (long int)(sz/(2*jump0size)));
+      DTPRINT(_("  Number of sampling jump points = %d because (%td bytes from row 1 to eof) / (2 * %td jump0size) == %td\n"),
+              nJumps, sz, jump0size, sz/(2*jump0size));
     }
   }
   nJumps++; // the extra sample at the very end (up to eof) is sampled and format checked but not jumped to when reading


### PR DESCRIPTION
`DTPRINT` is `Rprintf`, so goes through R's built-in copy of `trio`, so C99 format specifiers are fine to use in there. On the other hand, `long` is only 32 bits in size on 64-bit Windows and so is unsafe to use for sizes:

```
  File opened, size = 2.160GB (2318802514 bytes).
<...>
  Number of sampling jump points = 100 because (-1976164969 bytes from row 1 to eof) / (2 * 595 jump0size) == 1948573
```
(64-bit Windows, today's development snapshot)

Tested manually with Rtools34 and R-3.4.4. Sorry for creating much more work than I intended to save.