### PR TITLE
Header cleanup

### DIFF
--- a/src/assign.c
+++ b/src/assign.c
@@ -215,7 +215,7 @@ SEXP setdt_nrows(SEXP x)
      *   many operations still work in the presence of NULL columns and it might be convenient
      *   e.g. in package eplusr which calls setDT on a list when parsing JSON. Operations which
      *   fail for NULL columns will give helpful error at that point, #3480 and #3471 */
-    if (Rf_isNull(xi)) continue;
+    if (isNull(xi)) continue;
     if (Rf_inherits(xi, "POSIXlt")) {
       error(_("Column %d has class 'POSIXlt'. Please convert it to POSIXct (using as.POSIXct) and run setDT() again. We do not recommend the use of POSIXlt at all because it uses 40 bytes to store one date."), i+1);
     }

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -12,12 +12,6 @@
 #  define COMPLEX_RO COMPLEX
 #  define RAW_RO RAW
 #  define LOGICAL_RO LOGICAL
-#  define R_Calloc(x, y) Calloc(x, y)         // #6380
-#  define R_Realloc(x, y, z) Realloc(x, y, z)
-#  define R_Free(x) Free(x)
-#endif
-#if R_VERSION < R_Version(3, 4, 0)
-#  define SET_GROWABLE_BIT(x)  // #3292
 #endif
 // TODO: remove the `R_SVN_VERSION` check when R 4.5.0 is released (circa Apr. 2025)
 #if R_VERSION < R_Version(4, 5, 0) || R_SVN_REVISION < 86702

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -13,8 +13,7 @@
 #  define RAW_RO RAW
 #  define LOGICAL_RO LOGICAL
 #endif
-// TODO: remove the `R_SVN_VERSION` check when R 4.5.0 is released (circa Apr. 2025)
-#if R_VERSION < R_Version(4, 5, 0) || R_SVN_REVISION < 86702
+#if R_VERSION < R_Version(4, 5, 0)
 #  define isDataFrame(x) isFrame(x) // #6180
 #endif
 #include <Rinternals.h>
@@ -38,8 +37,7 @@
 /* we mean the encoding bits, not CE_NATIVE in a UTF-8 locale */
 #define IS_UTF8(x)  (getCharCE(x) == CE_UTF8)
 #define IS_LATIN(x) (getCharCE(x) == CE_LATIN1)
-// TODO: remove the `R_SVN_VERSION` check when R 4.5.0 is released (circa Apr. 2025)
-#if R_VERSION < R_Version(4, 5, 0) || R_SVN_REVISION < 86789
+#if R_VERSION < R_Version(4, 5, 0)
 # define IS_ASCII(x) (LEVELS(x) & 64)
 #else
 # define IS_ASCII(x) (Rf_charIsASCII(x)) // no CE_ASCII


### PR DESCRIPTION
 - [x] Drop the compatibility definition of `SET_GROWABLE_BIT` for R < 3.4.0.
 - [x] Drop the definitions of `R_(Calloc|Realloc|Free)`. The macros cause a lot of re-definition warnings on R < 3.5.0 because the definitions already exist, at least as of 3.4.0.
 - [x] Drop the SVN revision checks we needed during the 4.5.0 release cycle.
 - [x] `Rinternals.h` used to omit declarations for remapped functions implemented as macros until [`r80644`](https://github.com/r-devel/r-svn/commit/b38c8bc04a967cb886715b0d413acdd7fc8aec96) (4.2.0) when `USE_RINTERNALS` was defined:
      ```sh
      svn cat src/include/Rinternals.h -r80643 | cpp -DUSE_RINTERNALS -I src/include/ | grep isNull
      # empty!
      svn cat src/include/Rinternals.h -r80644 | cpp -DUSE_RINTERNALS -I src/include/ | grep isNull
      # Rboolean (Rf_isNull)(SEXP s);
      ```
   We define it for R < 3.5.0 (#3301):
   https://github.com/Rdatatable/data.table/blob/c4ea09e099b1833fae0eacb50552bce6f051ed82/src/data.table.h#L5-L7
   and get this implicit declaration warning:
   ```
   assign.c: In function 'setdt_nrows':
   assign.c:218:5: warning: implicit declaration of function 'Rf_isNull' [-Wimplicit-function-declaration]
        if (Rf_isNull(xi)) continue;
        ^
   ```
   This code path isn't actually broken; the implicit prototype happens to be compatible enough. The recommended practice nowadays is, indeed, to use the full `Rf_...` names of the API entry points instead of relying on them being remapped. We could ignore the warning, use `isNull` instead of `Rf_isNull` until we depend on R ≥ 3.5, or drop `USE_RINTERNALS` altogether.