### PR TITLE
renamed `_const_cast` to `const_cast`

### DIFF
--- a/src/fread.c
+++ b/src/fread.c
@@ -127,7 +127,7 @@ static void Field(FieldParseContext *ctx);
  * Drops `const` qualifier from a `const char*` variable, equivalent of
  * `const_cast<char*>` in C++.
  */
-static char* _const_cast(const char *ptr) {
+static char* const_cast(const char *ptr) {
   union { const char *a; char *b; } tmp = { ptr };
   return tmp.b;
 }
@@ -1570,7 +1570,7 @@ int freadMain(freadMainArgs _args) {
           DTPRINT(_("Avoidable file copy in RAM took %.3f seconds. %s.\n"), time_taken, msg);  // # nocov. not warning as that could feasibly cause CRAN tests to fail, say, if test machine is heavily loaded
       }
     }
-    *_const_cast(eof) = '\0';  // cow page
+    *const_cast(eof) = '\0';  // cow page
   }
   // else char* input already guaranteed to end with \0. We do not modify direct char* input at all, ever.
   // We have now ensured the input ends on eof and that *eof=='\0' too. Normally, lastEOLreplaced will be true.
@@ -1862,8 +1862,8 @@ int freadMain(freadMainArgs _args) {
       if (verbose) DTPRINT(_("  1-column file ends with 2 or more end-of-line. Restoring last eol using extra byte in cow page.\n"));
       eof++;
     }
-    *_const_cast(eof-1) = eol_one_r ? '\r' : '\n';
-    *_const_cast(eof) = '\0';
+    *const_cast(eof-1) = eol_one_r ? '\r' : '\n';
+    *const_cast(eof) = '\0';
   }
   }
 

--- a/src/freadR.c
+++ b/src/freadR.c
@@ -708,7 +708,7 @@ void progress(int p, int eta) {
 }
 // # nocov end
 
-void __halt(bool warn, const char *format, ...) {
+void halt__(bool warn, const char *format, ...) {
   // Solves: http://stackoverflow.com/questions/18597123/fread-data-table-locks-files
   // TODO: always include fnam in the STOP message. For log files etc.
   va_list args;

--- a/src/freadR.h
+++ b/src/freadR.h
@@ -19,12 +19,12 @@
 // However, msg has to be manually constructed first (rather than simply leaving construction to snprintf inside warning()
 // or error()) because the msg usually points to substrings from the mmp (which is invalid after close).
 // Where no halt is happening, we can just use raw Rprintf() or warning()
-void __halt(bool warn, const char *format, ...);   // see freadR.c
-#define STOP(...)   __halt(0, __VA_ARGS__)
+void halt__(bool warn, const char *format, ...);   // see freadR.c
+#define STOP(...)   halt__(0, __VA_ARGS__)
 static char internal_error_buff[1001] __attribute__((unused)); // match internalErrSize // todo: fix imports such that compiler warns correctly #6468
-#define INTERNAL_STOP(...) do {snprintf(internal_error_buff, 1000, __VA_ARGS__); __halt(0, "%s %s: %s. %s", _("Internal error in"), __func__, internal_error_buff, _("Please report to the data.table issues tracker"));} while (0)
+#define INTERNAL_STOP(...) do {snprintf(internal_error_buff, 1000, __VA_ARGS__); halt__(0, "%s %s: %s. %s", _("Internal error in"), __func__, internal_error_buff, _("Please report to the data.table issues tracker"));} while (0)
 #define DTPRINT     Rprintf
-#define DTWARN(...) warningsAreErrors ? __halt(1, __VA_ARGS__) : warning(__VA_ARGS__)
+#define DTWARN(...) warningsAreErrors ? halt__(1, __VA_ARGS__) : warning(__VA_ARGS__)
 
 #endif
 


### PR DESCRIPTION
starting a global identifier with an underscore is undefined behavior.

related to #6980