### PR TITLE
Removes unnecessary `data.table` call from as.data.table.array

### DIFF
--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -251,19 +251,17 @@ test.list <- atime::atime_test_list(
     Before = "f339aa64c426a9cd7cf2fcb13d91fc4ed353cd31", # Parent of the first commit https://github.com/Rdatatable/data.table/commit/fcc10d73a20837d0f1ad3278ee9168473afa5ff1 in the PR https://github.com/Rdatatable/data.table/pull/6393/commits with major change to fwrite with gzip.
     PR = "3630413ae493a5a61b06c50e80d166924d2ef89a"), # Close-to-last merge commit in the PR.
 
-  tests=extra.test.list)
-
-
-  # Test case created directly using the atime code below (not adapted from any other benchmark), based on the issue/fix PR https://github.com/Rdatatable/data.table/pull/5054#issue-930603663 "melt should be more efficient when there are missing input columns."
+  # Test case created directly using the atime code below (not adapted from any other benchmark), based on the PR  Removes unnecessary data.table call from as.data.table.array https://github.com/Rdatatable/data.table/pull/7010 
   "as.data.table.array improved in #7010" = atime::atime_test(
     setup = {
       dims = c(50, 50, 300, 10)
       arr = array(1:prod(dims), dim = dims)
     },
     expr = data.table:::as.data.table(arr),
-    Slow = "73d79edf8ff8c55163e90631072192301056e336", 
-    Fast = "8397dc3c993b61a07a81c786ca68c22bc589befc"), # Merge commit of the PR (https://github.com/Rdatatable/data.table/pull/5054) that fixes the issue  # Test case created directly using the atime code below (not adapted from any other benchmark), based on the issue/fix PR https://github.com/Rdatatable/data.table/pull/5054#issue-930603663 "melt should be more efficient when there are missing input columns."
+    Slow = "73d79edf8ff8c55163e90631072192301056e336",   # Parent of the first commit https://github.com/Rdatatable/data.table/tree/73d79edf8ff8c55163e90631072192301056e336
+    Fast = "8397dc3c993b61a07a81c786ca68c22bc589befc"),  # Merge commit of the PR (https://github.com/Rdatatable/data.table/pull/5054) that fixes the issue 
 
+    tests=extra.test.list)
 # nolint end: undesirable_operator_linter.
 
 

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -252,4 +252,19 @@ test.list <- atime::atime_test_list(
     PR = "3630413ae493a5a61b06c50e80d166924d2ef89a"), # Close-to-last merge commit in the PR.
 
   tests=extra.test.list)
+
+
+  # Test case created directly using the atime code below (not adapted from any other benchmark), based on the issue/fix PR https://github.com/Rdatatable/data.table/pull/5054#issue-930603663 "melt should be more efficient when there are missing input columns."
+  "as.data.table.array improved in #7010" = atime::atime_test(
+    setup = {
+      dims = c(50, 50, 300, 10)
+      arr = array(1:prod(dims), dim = dims)
+    },
+    expr = data.table:::as.data.table(arr),
+    Slow = "73d79edf8ff8c55163e90631072192301056e336", 
+    Fast = "8397dc3c993b61a07a81c786ca68c22bc589befc"), # Merge commit of the PR (https://github.com/Rdatatable/data.table/pull/5054) that fixes the issue  # Test case created directly using the atime code below (not adapted from any other benchmark), based on the issue/fix PR https://github.com/Rdatatable/data.table/pull/5054#issue-930603663 "melt should be more efficient when there are missing input columns."
+
 # nolint end: undesirable_operator_linter.
+
+
+

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 
 4. `as.Date()` method for `IDate` no longer coerces to `double` [#6922](https://github.com/Rdatatable/data.table/issues/6922). Thanks @MichaelChirico for the report and PR. The only effect should be on overly-strict tests that assert `Date` objects have `double` storage, which is not in general true, especially from R 4.5.0.
 
+5. `as.data.table()` is slightly faster at converting arrays to data.tables. Thanks @eliocamp. 
+
 ### BUG FIXES
 
 1. Custom binary operators from the `lubridate` package now work with objects of class `IDate` as with a `Date` subclass, [#6839](https://github.com/Rdatatable/data.table/issues/6839). Thanks @emallickhossain for the report and @aitap for the fix.

--- a/R/as.data.table.R
+++ b/R/as.data.table.R
@@ -107,7 +107,8 @@ as.data.table.array = function(x, keep.rownames=FALSE, key=NULL, sorted=TRUE, va
   if (value.name %chin% names(val))
     stopf("Argument 'value.name' should not overlap with column names in result: %s", brackify(rev(names(val))))
   N = NULL
-  ans = data.table(do.call(CJ, c(val, sorted=FALSE)), N=as.vector(x))
+  ans = do.call(CJ, c(val, sorted=FALSE))
+  set(ans, j = "N", value = as.vector(x))
   if (isTRUE(na.rm))
     ans = ans[!is.na(N)]
   setnames(ans, "N", value.name)


### PR DESCRIPTION
I noticed that as.data.table() was quite slow and after a quick look at the code I noticed that there's a line that calls `data.table()` on the output of `CJ()`, which seems to be adding some extra overhead. Removing that call and adding that extra column by reference gives some small improvement

``` r
dims <- c(50, 50, 300, 10)
arr <- array(1:prod(dims), dim = dims)

bench::mark(as.data.table.array(arr),
            old_as.data.table.array(arr)
          )
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 2 × 6
#>   expression                        min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                   <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 as.data.table.array(arr)        1.29s    1.29s     0.773     503MB     2.32
#> 2 old_as.data.table.array(arr)    1.87s    1.87s     0.536     610MB     2.14
```

It’s still much slower than this simpler implementation, but maybe it’s an unfair comparison because as.data.table.array does more stuff. There is a bunch of reordering in `as.data.table.array()`, for example. 

``` r
.melt_array <- function(array, dims, value.name = "V1", sorted = TRUE) {

  dims <- c(dims[length(dims):1], sorted = sorted)
  grid <- do.call(data.table::CJ, dims)
  grid[, c(value.name) := c(array)][]

  return(grid)
}
          

bench::mark(as.data.table.array(arr, na.rm = FALSE),
            .melt_array(arr, lapply(dims, seq_len), value.name = "N"),
          check = FALSE)
#> # A tibble: 2 × 6
#>   expression                            min  median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                          <bch> <bch:t>     <dbl> <bch:byt>    <dbl>
#> 1 "as.data.table.array(arr, na.rm = … 991ms 990.9ms      1.01     207MB      0  
#> 2 ".melt_array(arr, lapply(dims, seq…  55ms  56.8ms     17.6      143MB     23.5
```

<sup>Created on 2025-05-22 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>