### PR TITLE
Removes unnecessary `data.table` call from as.data.table.array

### DIFF
--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -251,19 +251,17 @@ test.list <- atime::atime_test_list(
     Before = "f339aa64c426a9cd7cf2fcb13d91fc4ed353cd31", # Parent of the first commit https://github.com/Rdatatable/data.table/commit/fcc10d73a20837d0f1ad3278ee9168473afa5ff1 in the PR https://github.com/Rdatatable/data.table/pull/6393/commits with major change to fwrite with gzip.
     PR = "3630413ae493a5a61b06c50e80d166924d2ef89a"), # Close-to-last merge commit in the PR.
 
-  tests=extra.test.list)
-
-
-  # Test case created directly using the atime code below (not adapted from any other benchmark), based on the issue/fix PR https://github.com/Rdatatable/data.table/pull/5054#issue-930603663 "melt should be more efficient when there are missing input columns."
+  # Test case created directly using the atime code below (not adapted from any other benchmark), based on the PR  Removes unnecessary data.table call from as.data.table.array https://github.com/Rdatatable/data.table/pull/7010 
   "as.data.table.array improved in #7010" = atime::atime_test(
     setup = {
       dims = c(50, 50, 300, 10)
       arr = array(1:prod(dims), dim = dims)
     },
     expr = data.table:::as.data.table(arr),
-    Slow = "73d79edf8ff8c55163e90631072192301056e336", 
-    Fast = "8397dc3c993b61a07a81c786ca68c22bc589befc"), # Merge commit of the PR (https://github.com/Rdatatable/data.table/pull/5054) that fixes the issue  # Test case created directly using the atime code below (not adapted from any other benchmark), based on the issue/fix PR https://github.com/Rdatatable/data.table/pull/5054#issue-930603663 "melt should be more efficient when there are missing input columns."
+    Slow = "73d79edf8ff8c55163e90631072192301056e336",   # Parent of the first commit https://github.com/Rdatatable/data.table/tree/73d79edf8ff8c55163e90631072192301056e336
+    Fast = "8397dc3c993b61a07a81c786ca68c22bc589befc"),  # Merge commit of the PR (https://github.com/Rdatatable/data.table/pull/5054) that fixes the issue 
 
+    tests=extra.test.list)
 # nolint end: undesirable_operator_linter.
 
 

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -259,7 +259,7 @@ test.list <- atime::atime_test_list(
     },
     expr = data.table:::as.data.table.array(arr, na.rm=FALSE),
     Slow = "73d79edf8ff8c55163e90631072192301056e336",   # Parent of the first commit in the PR (https://github.com/Rdatatable/data.table/commit/8397dc3c993b61a07a81c786ca68c22bc589befc)
-    Fast = "653e2eee6d280335fe4be60845e037c039b66b38"),  # Last commit in the PR (https://github.com/Rdatatable/data.table/pull/7019/commits) that fixes the slow code
+    Fast = "8397dc3c993b61a07a81c786ca68c22bc589befc"),  # Commit in the PR (https://github.com/Rdatatable/data.table/pull/7019/commits) that removes inefficiency
 
     tests=extra.test.list)
 # nolint end: undesirable_operator_linter.

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -260,7 +260,7 @@ test.list <- atime::atime_test_list(
     },
     expr = data.table::as.data.table(arr),
     Slow = "73d79edf8ff8c55163e90631072192301056e336",   # Parent of the first commit https://github.com/Rdatatable/data.table/tree/73d79edf8ff8c55163e90631072192301056e336
-    Fast = "8397dc3c993b61a07a81c786ca68c22bc589befc"),  # Merge commit of the PR (https://github.com/Rdatatable/data.table/pull/5054) that fixes the issue 
+    Fast = "653e2eee6d280335fe4be60845e037c039b66b38"),  # Last commit in the PR (https://github.com/Rdatatable/data.table/pull/7019/commits) that fixes the slow code
 
     tests=extra.test.list)
 # nolint end: undesirable_operator_linter.

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -253,11 +253,12 @@ test.list <- atime::atime_test_list(
 
   # Test case created directly using the atime code below (not adapted from any other benchmark), based on the PR  Removes unnecessary data.table call from as.data.table.array https://github.com/Rdatatable/data.table/pull/7010 
   "as.data.table.array improved in #7010" = atime::atime_test(
+    N = 1:5,
     setup = {
-      dims = c(50, 50, 300, 10)
-      arr = array(1:prod(dims), dim = dims)
+      dims = N * c(10L, 10L, 60L, 2L)
+      arr = array(seq_len(prod(dims)), dim=dims)
     },
-    expr = data.table:::as.data.table(arr),
+    expr = data.table::as.data.table(arr),
     Slow = "73d79edf8ff8c55163e90631072192301056e336",   # Parent of the first commit https://github.com/Rdatatable/data.table/tree/73d79edf8ff8c55163e90631072192301056e336
     Fast = "8397dc3c993b61a07a81c786ca68c22bc589befc"),  # Merge commit of the PR (https://github.com/Rdatatable/data.table/pull/5054) that fixes the issue 
 

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -253,9 +253,9 @@ test.list <- atime::atime_test_list(
 
   # Test case created directly using the atime code below (not adapted from any other benchmark), based on the PR  Removes unnecessary data.table call from as.data.table.array https://github.com/Rdatatable/data.table/pull/7010 
   "as.data.table.array improved in #7010" = atime::atime_test(
-    N = 1:5,
+    N = 1:10,
     setup = {
-      dims = N * c(10L, 10L, 60L, 2L)
+      dims = N * c(5L, 5L, 30L, 1L)
       arr = array(seq_len(prod(dims)), dim=dims)
     },
     expr = data.table::as.data.table(arr),

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -251,15 +251,14 @@ test.list <- atime::atime_test_list(
     Before = "f339aa64c426a9cd7cf2fcb13d91fc4ed353cd31", # Parent of the first commit https://github.com/Rdatatable/data.table/commit/fcc10d73a20837d0f1ad3278ee9168473afa5ff1 in the PR https://github.com/Rdatatable/data.table/pull/6393/commits with major change to fwrite with gzip.
     PR = "3630413ae493a5a61b06c50e80d166924d2ef89a"), # Close-to-last merge commit in the PR.
 
-  # Test case created directly using the atime code below (not adapted from any other benchmark), based on the PR  Removes unnecessary data.table call from as.data.table.array https://github.com/Rdatatable/data.table/pull/7010 
+  # Test case created directly using the atime code below (not adapted from any other benchmark), based on the PR, Removes unnecessary data.table call from as.data.table.array https://github.com/Rdatatable/data.table/pull/7010 
   "as.data.table.array improved in #7010" = atime::atime_test(
-    N = 1:10,
     setup = {
-      dims = N * c(5L, 5L, 30L, 1L)
+      dims = c(N, 1, 1)
       arr = array(seq_len(prod(dims)), dim=dims)
     },
-    expr = data.table::as.data.table(arr),
-    Slow = "73d79edf8ff8c55163e90631072192301056e336",   # Parent of the first commit https://github.com/Rdatatable/data.table/tree/73d79edf8ff8c55163e90631072192301056e336
+    expr = data.table:::as.data.table.array(arr, na.rm=FALSE),
+    Slow = "73d79edf8ff8c55163e90631072192301056e336",   # Parent of the first commit in the PR (https://github.com/Rdatatable/data.table/commit/8397dc3c993b61a07a81c786ca68c22bc589befc)
     Fast = "653e2eee6d280335fe4be60845e037c039b66b38"),  # Last commit in the PR (https://github.com/Rdatatable/data.table/pull/7019/commits) that fixes the slow code
 
     tests=extra.test.list)

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -252,4 +252,19 @@ test.list <- atime::atime_test_list(
     PR = "3630413ae493a5a61b06c50e80d166924d2ef89a"), # Close-to-last merge commit in the PR.
 
   tests=extra.test.list)
+
+
+  # Test case created directly using the atime code below (not adapted from any other benchmark), based on the issue/fix PR https://github.com/Rdatatable/data.table/pull/5054#issue-930603663 "melt should be more efficient when there are missing input columns."
+  "as.data.table.array improved in #7010" = atime::atime_test(
+    setup = {
+      dims = c(50, 50, 300, 10)
+      arr = array(1:prod(dims), dim = dims)
+    },
+    expr = data.table:::as.data.table(arr),
+    Slow = "73d79edf8ff8c55163e90631072192301056e336", 
+    Fast = "8397dc3c993b61a07a81c786ca68c22bc589befc"), # Merge commit of the PR (https://github.com/Rdatatable/data.table/pull/5054) that fixes the issue  # Test case created directly using the atime code below (not adapted from any other benchmark), based on the issue/fix PR https://github.com/Rdatatable/data.table/pull/5054#issue-930603663 "melt should be more efficient when there are missing input columns."
+
 # nolint end: undesirable_operator_linter.
+
+
+

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -263,6 +263,3 @@ test.list <- atime::atime_test_list(
 
     tests=extra.test.list)
 # nolint end: undesirable_operator_linter.
-
-
-

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,7 @@
 
 4. `as.Date()` method for `IDate` no longer coerces to `double` [#6922](https://github.com/Rdatatable/data.table/issues/6922). Thanks @MichaelChirico for the report and PR. The only effect should be on overly-strict tests that assert `Date` objects have `double` storage, which is not in general true, especially from R 4.5.0.
 
-5. `as.data.table()` is slightly faster at converting arrays to data.tables, [#7019](https://github.com/Rdatatable/data.table/pull/7019). Thanks @eliocamp.
+5. `as.data.table()` is slightly more efficient at converting arrays to data.tables, [#7019](https://github.com/Rdatatable/data.table/pull/7019). Thanks @eliocamp.
 
 ### BUG FIXES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,7 @@
 
 4. `as.Date()` method for `IDate` no longer coerces to `double` [#6922](https://github.com/Rdatatable/data.table/issues/6922). Thanks @MichaelChirico for the report and PR. The only effect should be on overly-strict tests that assert `Date` objects have `double` storage, which is not in general true, especially from R 4.5.0.
 
-5. `as.data.table()` is slightly faster at converting arrays to data.tables. Thanks @eliocamp. 
+5. `as.data.table()` is slightly faster at converting arrays to data.tables, [#7019](https://github.com/Rdatatable/data.table/pull/7019). Thanks @eliocamp.
 
 ### BUG FIXES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
 
 4. `as.Date()` method for `IDate` no longer coerces to `double` [#6922](https://github.com/Rdatatable/data.table/issues/6922). Thanks @MichaelChirico for the report and PR. The only effect should be on overly-strict tests that assert `Date` objects have `double` storage, which is not in general true, especially from R 4.5.0.
 
+5. `as.data.table()` is slightly faster at converting arrays to data.tables. Thanks @eliocamp. 
+
 ### BUG FIXES
 
 1. Custom binary operators from the `lubridate` package now work with objects of class `IDate` as with a `Date` subclass, [#6839](https://github.com/Rdatatable/data.table/issues/6839). Thanks @emallickhossain for the report and @aitap for the fix.

--- a/R/as.data.table.R
+++ b/R/as.data.table.R
@@ -107,7 +107,8 @@ as.data.table.array = function(x, keep.rownames=FALSE, key=NULL, sorted=TRUE, va
   if (value.name %chin% names(val))
     stopf("Argument 'value.name' should not overlap with column names in result: %s", brackify(rev(names(val))))
   N = NULL
-  ans = data.table(do.call(CJ, c(val, sorted=FALSE)), N=as.vector(x))
+  ans = do.call(CJ, c(val, sorted=FALSE))
+  set(ans, j = "N", value = as.vector(x))
   if (isTRUE(na.rm))
     ans = ans[!is.na(N)]
   setnames(ans, "N", value.name)

--- a/R/as.data.table.R
+++ b/R/as.data.table.R
@@ -96,9 +96,9 @@ as.data.table.array = function(x, keep.rownames=FALSE, key=NULL, sorted=TRUE, va
   dnx = dimnames(x)
   # NULL dimnames will create integer keys, not character as in table method
   val = if (is.null(dnx)) {
-    lapply(dx, seq.int)
+    lapply(dx, seq_len)
   } else if (any(nulldnx <- vapply_1b(dnx, is.null))) {
-    dnx[nulldnx] = lapply(dx[nulldnx], seq.int) #3636
+    dnx[nulldnx] = lapply(dx[nulldnx], seq_len) #3636
     dnx
   } else dnx
   val = rev(val)

--- a/R/as.data.table.R
+++ b/R/as.data.table.R
@@ -108,7 +108,7 @@ as.data.table.array = function(x, keep.rownames=FALSE, key=NULL, sorted=TRUE, va
     stopf("Argument 'value.name' should not overlap with column names in result: %s", brackify(rev(names(val))))
   N = NULL
   ans = do.call(CJ, c(val, sorted=FALSE))
-  set(ans, j = "N", value = as.vector(x))
+  set(ans, j="N", value=as.vector(x))
   if (isTRUE(na.rm))
     ans = ans[!is.na(N)]
   setnames(ans, "N", value.name)


### PR DESCRIPTION
Re-push of the changes in #7010 (authored by @eliocamp) onto `Rdatatable/data.table` so that we get {atime} results directly here instead of waiting for follow-up.