### PR TITLE
fix rounding warning in atime test for [.data.table

### DIFF
--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -177,8 +177,9 @@ test.list <- atime::atime_test_list(
   # Fixed in https://github.com/Rdatatable/data.table/pull/4558
   "DT[by] fixed in #4558" = atime::atime_test(
     setup = {
+      N9 <- as.integer(N * 0.9)
       d <- data.table(
-        id = sample(c(seq.int(N * 0.9), sample(N * 0.9, N * 0.1, TRUE))),
+        id = sample(c(seq.int(N9), sample(N9, N-N9, TRUE))),
         v1 = sample(5L, N, TRUE),
         v2 = sample(5L, N, TRUE)
       )


### PR DESCRIPTION
I was getting an off by one warning due to rounding, which below is converted to error with options(warn=2)
```r
> N <- 5623
> d <- data.table(
+ id = sample(c(seq.int(N * 0.9), sample(N * 0.9, N * 0.1, TRUE))),
+ v1 = sample(5L, N, TRUE),
+ v2 = sample(5L, N, TRUE)
+ )
Erreur dans as.data.table.list(x, keep.rownames = keep.rownames, check.names = check.names,  : 
  (converti depuis l'avis) L'élément 1 a 5622 lignes mais l'élément le plus long en a 5623 ; Il est recyclé avec le reste.
```
This PR fixes that warning.