### PR TITLE
Remove '__' from identifier names

### DIFF
--- a/src/data.table.h
+++ b/src/data.table.h
@@ -46,8 +46,8 @@
 #define IS_FALSE(x) (TYPEOF(x)==LGLSXP && LENGTH(x)==1 && LOGICAL(x)[0]==FALSE)
 #define IS_TRUE_OR_FALSE(x) (TYPEOF(x)==LGLSXP && LENGTH(x)==1 && LOGICAL(x)[0]!=NA_LOGICAL)
 
-#define SIZEOF(x) __sizes[TYPEOF(x)]
-#define TYPEORDER(x) __typeorder[x]
+#define RTYPE_SIZEOF(x) r_type_sizes[TYPEOF(x)]
+#define RTYPE_ORDER(x) r_type_order[x]
 
 #ifdef MIN
 #  undef MIN
@@ -120,8 +120,8 @@ extern SEXP sym_as_posixct;
 extern double NA_INT64_D;
 extern long long NA_INT64_LL;
 extern Rcomplex NA_CPLX;  // initialized in init.c; see there for comments
-extern size_t __sizes[100];     // max appears to be FUNSXP = 99, see Rinternals.h
-extern size_t __typeorder[100]; // __ prefix otherwise if we use these names directly, the SIZEOF define ends up using the local one
+extern size_t r_type_sizes[100]; // max appears to be FUNSXP = 99, see Rinternals.h
+extern size_t r_type_order[100];
 
 long long DtoLL(double x);
 double LLtoD(long long x);

--- a/src/dogroups.c
+++ b/src/dogroups.c
@@ -101,7 +101,7 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
     copyMostAttrib(VECTOR_ELT(groups, j), VECTOR_ELT(BY,i));  // not names, otherwise test 778 would fail
     SET_STRING_ELT(bynames, i, STRING_ELT(getAttrib(groups,R_NamesSymbol), j));
     defineVar(install(CHAR(STRING_ELT(bynames,i))), VECTOR_ELT(BY,i), env);      // by vars can be used by name in j as well as via .BY
-    if (SIZEOF(VECTOR_ELT(BY,i))==0)
+    if (RTYPE_SIZEOF(VECTOR_ELT(BY,i))==0)
       internal_error(__func__, "unsupported size-0 type '%s' in column %d of 'by' should have been caught earlier", type2char(TYPEOF(VECTOR_ELT(BY, i))), i+1); // # nocov
     SET_TRUELENGTH(VECTOR_ELT(BY,i), -1); // marker for anySpecialStatic(); see its comments
   }
@@ -143,7 +143,7 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
 
   for(int i=0; i<length(SDall); ++i) {
     SEXP this = VECTOR_ELT(SDall, i);
-    if (SIZEOF(this)==0 && TYPEOF(this)!=EXPRSXP)
+    if (RTYPE_SIZEOF(this)==0 && TYPEOF(this)!=EXPRSXP)
       internal_error(__func__, "size-0 type %d in .SD column %d should have been caught earlier", TYPEOF(this), i); // # nocov
     if (LENGTH(this) != maxGrpSize)
       internal_error(__func__, "SDall %d length = %d != %d", i+1, LENGTH(this), maxGrpSize); // # nocov
@@ -158,7 +158,7 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
     internal_error(__func__, "length(xknames)!=length(xSD)"); // # nocov
   SEXP *xknameSyms = (SEXP *)R_alloc(length(xknames), sizeof(*xknameSyms));
   for(int i=0; i<length(xSD); ++i) {
-    if (SIZEOF(VECTOR_ELT(xSD, i))==0)
+    if (RTYPE_SIZEOF(VECTOR_ELT(xSD, i))==0)
       internal_error(__func__, "type %d in .xSD column %d should have been caught by now", TYPEOF(VECTOR_ELT(xSD, i)), i); // # nocov
     xknameSyms[i] = install(CHAR(STRING_ELT(xknames, i)));
   }
@@ -541,11 +541,11 @@ SEXP growVector(SEXP x, const R_len_t newlen)
     return newx;
   }
   switch (TYPEOF(x)) {
-  case RAWSXP:  memcpy(RAW(newx),     RAW_RO(x),     len*SIZEOF(x)); break;
-  case LGLSXP:  memcpy(LOGICAL(newx), LOGICAL_RO(x), len*SIZEOF(x)); break;
-  case INTSXP:  memcpy(INTEGER(newx), INTEGER_RO(x), len*SIZEOF(x)); break;
-  case REALSXP: memcpy(REAL(newx),    REAL_RO(x),    len*SIZEOF(x)); break;
-  case CPLXSXP: memcpy(COMPLEX(newx), COMPLEX_RO(x), len*SIZEOF(x)); break;
+  case RAWSXP:  memcpy(RAW(newx),     RAW_RO(x),     len*RTYPE_SIZEOF(x)); break;
+  case LGLSXP:  memcpy(LOGICAL(newx), LOGICAL_RO(x), len*RTYPE_SIZEOF(x)); break;
+  case INTSXP:  memcpy(INTEGER(newx), INTEGER_RO(x), len*RTYPE_SIZEOF(x)); break;
+  case REALSXP: memcpy(REAL(newx),    REAL_RO(x),    len*RTYPE_SIZEOF(x)); break;
+  case CPLXSXP: memcpy(COMPLEX(newx), COMPLEX_RO(x), len*RTYPE_SIZEOF(x)); break;
   case STRSXP : {
     const SEXP *xd = SEXPPTR_RO(x);
     for (int i=0; i<len; ++i)

--- a/src/fmelt.c
+++ b/src/fmelt.c
@@ -524,7 +524,7 @@ SEXP getvaluecols(SEXP DT, SEXP dtnames, Rboolean valfactor, Rboolean verbose, s
           ithisidx = INTEGER(thisidx);
           thislen = length(thisidx);
         }
-        size_t size = SIZEOF(thiscol);
+        size_t size = RTYPE_SIZEOF(thiscol);
         switch (TYPEOF(target)) {
         case VECSXP :
           if (data->narm) {
@@ -697,7 +697,7 @@ SEXP getidcols(SEXP DT, SEXP dtnames, Rboolean verbose, struct processData *data
   for (int i=0; i<data->lids; ++i) {
     int counter = 0;
     SEXP thiscol = VECTOR_ELT(DT, INTEGER(data->idcols)[i]-1);
-    size_t size = SIZEOF(thiscol);
+    size_t size = RTYPE_SIZEOF(thiscol);
     SEXP target;
     SET_VECTOR_ELT(ansids, i, target=allocVector(TYPEOF(thiscol), data->totlen) );
     copyMostAttrib(thiscol, target); // all but names,dim and dimnames. And if so, we want a copy here, not keepattr's SET_ATTRIB.

--- a/src/forder.c
+++ b/src/forder.c
@@ -1429,7 +1429,7 @@ SEXP issorted(SEXP x, SEXP by)
     int c = INTEGER(by)[j];
     if (c<1 || c>length(x)) STOP(_("issorted 'by' [%d] out of range [1,%d]"), c, length(x));
     SEXP col = VECTOR_ELT(x, c-1);
-    sizes[j] = SIZEOF(col);
+    sizes[j] = RTYPE_SIZEOF(col);
     switch(TYPEOF(col)) {
     case INTSXP: case LGLSXP:
       types[j] = 0;

--- a/src/freadR.c
+++ b/src/freadR.c
@@ -479,7 +479,7 @@ size_t allocateDT(int8_t *typeArg, int8_t *sizeArg, int ncolArg, int ndrop, size
     else if (selectRank) setAttrib(DT, sym_colClassesAs, subsetVector(colClassesAs, selectRank));  // reorder the colClassesAs
   }
   // TODO: move DT size calculation into a separate function (since the final size is different from the initial size anyways)
-  size_t DTbytes = SIZEOF(DT)*(ncol-ndrop)*2; // the VECSXP and its column names (exclude global character cache usage)
+  size_t DTbytes = RTYPE_SIZEOF(DT)*(ncol-ndrop)*2; // the VECSXP and its column names (exclude global character cache usage)
 
   // For each column we could have one of the following cases:
   //   * if the DataTable is "new", then make a new vector
@@ -520,7 +520,7 @@ size_t allocateDT(int8_t *typeArg, int8_t *sizeArg, int ncolArg, int ndrop, size
         setAttrib(thiscol, sym_tzone, ScalarString(char_UTC)); // see news for v1.13.0
       }
       SET_TRUELENGTH(thiscol, allocNrow);
-      DTbytes += SIZEOF(thiscol)*allocNrow;
+      DTbytes += RTYPE_SIZEOF(thiscol)*allocNrow;
     }
     resi++;
   }

--- a/src/init.c
+++ b/src/init.c
@@ -46,8 +46,8 @@ SEXP sym_as_posixct;
 double NA_INT64_D;
 long long NA_INT64_LL;
 Rcomplex NA_CPLX;
-size_t __sizes[100];
-size_t __typeorder[100];
+size_t r_type_sizes[100];
+size_t r_type_order[100];
 
 static const
 R_CallMethodDef callMethods[] = {
@@ -160,15 +160,15 @@ R_ExternalMethodDef externalMethods[] = {
 };
 
 static void setSizes(void) {
-  for (int i=0; i<100; ++i) { __sizes[i]=0; __typeorder[i]=0; }
+  for (int i=0; i<100; ++i) { r_type_sizes[i]=0; r_type_order[i]=0; }
   // only these types are currently allowed as column types :
-  __sizes[LGLSXP] =  sizeof(int);       __typeorder[LGLSXP] =  0;
-  __sizes[RAWSXP] =  sizeof(Rbyte);     __typeorder[RAWSXP] =  1;
-  __sizes[INTSXP] =  sizeof(int);       __typeorder[INTSXP] =  2;   // integer and factor
-  __sizes[REALSXP] = sizeof(double);    __typeorder[REALSXP] = 3;   // numeric and integer64
-  __sizes[CPLXSXP] = sizeof(Rcomplex);  __typeorder[CPLXSXP] = 4;
-  __sizes[STRSXP] =  sizeof(SEXP *);    __typeorder[STRSXP] =  5;
-  __sizes[VECSXP] =  sizeof(SEXP *);    __typeorder[VECSXP] =  6;   // list column
+  r_type_sizes[LGLSXP] =  sizeof(int);       r_type_order[LGLSXP] =  0;
+  r_type_sizes[RAWSXP] =  sizeof(Rbyte);     r_type_order[RAWSXP] =  1;
+  r_type_sizes[INTSXP] =  sizeof(int);       r_type_order[INTSXP] =  2;   // integer and factor
+  r_type_sizes[REALSXP] = sizeof(double);    r_type_order[REALSXP] = 3;   // numeric and integer64
+  r_type_sizes[CPLXSXP] = sizeof(Rcomplex);  r_type_order[CPLXSXP] = 4;
+  r_type_sizes[STRSXP] =  sizeof(SEXP *);    r_type_order[STRSXP] =  5;
+  r_type_sizes[VECSXP] =  sizeof(SEXP *);    r_type_order[VECSXP] =  6;   // list column
   if (sizeof(char *)>8) error(_("Pointers are %zu bytes, greater than 8. We have not tested on any architecture greater than 64bit yet."), sizeof(char *));
   // One place we need the largest sizeof is the working memory malloc in reorder.c
 }

--- a/src/rbindlist.c
+++ b/src/rbindlist.c
@@ -297,8 +297,8 @@ SEXP rbindlist(SEXP l, SEXP usenamesArg, SEXP fillArg, SEXP idcolArg, SEXP ignor
       }
       SEXP thisCol = VECTOR_ELT(li, w);
       int thisType = TYPEOF(thisCol);
-      // Use >= for #546 -- TYPEORDER=0 for both LGLSXP and EXPRSXP (but also NULL)
-      if (TYPEORDER(thisType)>=TYPEORDER(maxType) && !isNull(thisCol)) maxType=thisType;
+      // Use >= for #546 -- RTYPE_ORDER=0 for both LGLSXP and EXPRSXP (but also NULL)
+      if (RTYPE_ORDER(thisType)>=RTYPE_ORDER(maxType) && !isNull(thisCol)) maxType=thisType;
       if (isFactor(thisCol)) {
         if (isNull(getAttrib(thisCol,R_LevelsSymbol))) error(_("Column %d of item %d has type 'factor' but has no levels; i.e. malformed."), w+1, i+1);
         factor = true;
@@ -497,7 +497,7 @@ SEXP rbindlist(SEXP l, SEXP usenamesArg, SEXP fillArg, SEXP idcolArg, SEXP ignor
                   }
                 }
               } else {
-                memcpy(targetd+ansloc, id, thisnrow*SIZEOF(thisCol));
+                memcpy(targetd+ansloc, id, thisnrow*RTYPE_SIZEOF(thisCol));
               }
             }
           } else {

--- a/src/reorder.c
+++ b/src/reorder.c
@@ -18,20 +18,20 @@ SEXP reorder(SEXP x, SEXP order)
     ncol = length(x);
     for (int i=0; i<ncol; i++) {
       SEXP v = VECTOR_ELT(x,i);
-      if (SIZEOF(v)!=4 && SIZEOF(v)!=8 && SIZEOF(v)!=16 && SIZEOF(v)!=1)
-        error(_("Item %d of list is type '%s' which isn't yet supported (SIZEOF=%zu)"), i+1, type2char(TYPEOF(v)), SIZEOF(v));
+      if (RTYPE_SIZEOF(v)!=4 && RTYPE_SIZEOF(v)!=8 && RTYPE_SIZEOF(v)!=16 && RTYPE_SIZEOF(v)!=1)
+        error(_("Item %d of list is type '%s' which isn't yet supported (RTYPE_SIZEOF=%zu)"), i+1, type2char(TYPEOF(v)), RTYPE_SIZEOF(v));
       if (length(v)!=nrow)
         error(_("Column %d is length %d which differs from length of column 1 (%d). Invalid data.table."), i+1, length(v), nrow);
-      if (SIZEOF(v) > maxSize)
-        maxSize=SIZEOF(v);
+      if (RTYPE_SIZEOF(v) > maxSize)
+        maxSize=RTYPE_SIZEOF(v);
       if (ALTREP(v)) SET_VECTOR_ELT(x, i, copyAsPlain(v));
     }
     copySharedColumns(x); // otherwise two columns which point to the same vector would be reordered and then re-reordered, issues linked in PR#3768
   } else {
-    if (SIZEOF(x)!=4 && SIZEOF(x)!=8 && SIZEOF(x)!=16 && SIZEOF(x)!=1)
-      error(_("reorder accepts vectors but this non-VECSXP is type '%s' which isn't yet supported (SIZEOF=%zu)"), type2char(TYPEOF(x)), SIZEOF(x));
+    if (RTYPE_SIZEOF(x)!=4 && RTYPE_SIZEOF(x)!=8 && RTYPE_SIZEOF(x)!=16 && RTYPE_SIZEOF(x)!=1)
+      error(_("reorder accepts vectors but this non-VECSXP is type '%s' which isn't yet supported (RTYPE_SIZEOF=%zu)"), type2char(TYPEOF(x)), RTYPE_SIZEOF(x));
     if (ALTREP(x)) internal_error(__func__, "cannot reorder an ALTREP vector. Please see NEWS item 2 in v1.11.4"); // # nocov
-    maxSize = SIZEOF(x);
+    maxSize = RTYPE_SIZEOF(x);
     nrow = length(x);
     ncol = 1;
   }
@@ -67,7 +67,7 @@ SEXP reorder(SEXP x, SEXP order)
 
   for (int i=0; i<ncol; ++i) {
     const SEXP v = isNewList(x) ? VECTOR_ELT(x,i) : x;
-    const size_t size = SIZEOF(v);    // size_t, otherwise #61 (integer overflow in memcpy)
+    const size_t size = RTYPE_SIZEOF(v);    // size_t, otherwise #61 (integer overflow in memcpy)
     if (size==4) {
       const int *restrict vd = DATAPTR_RO(v);
       int *restrict tmp = (int *)TMP;

--- a/src/shift.c
+++ b/src/shift.c
@@ -38,7 +38,7 @@ SEXP shift(SEXP obj, SEXP k, SEXP fill, SEXP type)
   SEXP ans = PROTECT(allocVector(VECSXP, nk * nx)); nprotect++;
   for (int i=0; i<nx; i++) {
     SEXP elem  = VECTOR_ELT(x, i);
-    size_t size  = SIZEOF(elem);
+    size_t size  = RTYPE_SIZEOF(elem);
     R_xlen_t xrows = xlength(elem);
     SEXP thisfill = PROTECT(coerceAs(fill, elem, ScalarLogical(0)));  // #4865 use coerceAs for type coercion
     switch (TYPEOF(elem)) {


### PR DESCRIPTION
Closes #7036

I guess the comment is referring to conflict of the global `sizes` and any locally-defined object with the same name (and/or ditto for `typeorder`). cc @badasahog 

Testing that by using a more globally-unique name for these objects instead (it's also clearer what these mean now).