### PR TITLE
removed macro `internalErrSize`

### DIFF
--- a/src/fread.c
+++ b/src/fread.c
@@ -2238,7 +2238,7 @@ int freadMain(freadMainArgs _args) {
   double tRead = 0, tReread = 0;
   double thRead = 0, thPush = 0;  // reductions of timings within the parallel region
   int max_col = 0;
-  char *typeBumpMsg = NULL;  size_t typeBumpMsgSize=0;
+  char *typeBumpMsg = NULL;  size_t typeBumpMsgSize = 0;
   int typeCounts[NUMTYPE];  // used for verbose output; needs populating after first read and before reread (if any) -- see later comment
   char internalErr[256] = "";  // must be compile time size: the message is generated and we can't free before STOP
 

--- a/src/fread.c
+++ b/src/fread.c
@@ -2257,8 +2257,7 @@ int freadMain(freadMainArgs _args) {
   int max_col=0;
   char *typeBumpMsg=NULL;  size_t typeBumpMsgSize=0;
   int typeCounts[NUMTYPE];  // used for verbose output; needs populating after first read and before reread (if any) -- see later comment
-  #define internalErrSize 1000
-  char internalErr[internalErrSize+1]="";  // must be compile time size: the message is generated and we can't free before STOP
+  char internalErr[1001]="";  // must be compile time size: the message is generated and we can't free before STOP
   int64_t DTi = 0;                  // the current row number in DT that we are writing to
   const char *headPos = pos;       // the jump start corresponding to DTi
   int nSwept = 0;                  // count the number of dirty jumps that were swept
@@ -2314,7 +2313,7 @@ int freadMain(freadMainArgs _args) {
         nth = omp_get_num_threads();
         if (me!=0) {
           // # nocov start
-          snprintf(internalErr, internalErrSize, "Master thread is not thread 0 but thread %d.\n", me); // # notranslate
+          snprintf(internalErr, sizeof(internalErr) - 1, "Master thread is not thread 0 but thread %d.\n", me); // # notranslate
           stopTeam = true;
           // # nocov end
         }
@@ -2583,7 +2582,7 @@ int freadMain(freadMainArgs _args) {
           }
           else if (headPos!=thisJumpStart && nrowLimit>0) { // do not care for dirty jumps since we do not read data and only want to know types
              // # nocov start
-            snprintf(internalErr, internalErrSize, "invalid head position. jump=%d, headPos=%p, thisJumpStart=%p, sof=%p", jump, headPos, thisJumpStart, sof); // # notranslate
+            snprintf(internalErr, sizeof(internalErr) - 1, "invalid head position. jump=%d, headPos=%p, thisJumpStart=%p, sof=%p", jump, headPos, thisJumpStart, sof); // # notranslate
             stopTeam = true;
             // # nocov end
           }

--- a/src/fread.c
+++ b/src/fread.c
@@ -2257,7 +2257,7 @@ int freadMain(freadMainArgs _args) {
   int max_col=0;
   char *typeBumpMsg=NULL;  size_t typeBumpMsgSize=0;
   int typeCounts[NUMTYPE];  // used for verbose output; needs populating after first read and before reread (if any) -- see later comment
-  char internalErr[1001]="";  // must be compile time size: the message is generated and we can't free before STOP
+  char internalErr[256]="";  // must be compile time size: the message is generated and we can't free before STOP
   int64_t DTi = 0;                  // the current row number in DT that we are writing to
   const char *headPos = pos;       // the jump start corresponding to DTi
   int nSwept = 0;                  // count the number of dirty jumps that were swept
@@ -2313,7 +2313,7 @@ int freadMain(freadMainArgs _args) {
         nth = omp_get_num_threads();
         if (me!=0) {
           // # nocov start
-          snprintf(internalErr, sizeof(internalErr) - 1, "Master thread is not thread 0 but thread %d.\n", me); // # notranslate
+          snprintf(internalErr, sizeof(internalErr), "Master thread is not thread 0 but thread %d.\n", me); // # notranslate
           stopTeam = true;
           // # nocov end
         }
@@ -2582,7 +2582,7 @@ int freadMain(freadMainArgs _args) {
           }
           else if (headPos!=thisJumpStart && nrowLimit>0) { // do not care for dirty jumps since we do not read data and only want to know types
              // # nocov start
-            snprintf(internalErr, sizeof(internalErr) - 1, "invalid head position. jump=%d, headPos=%p, thisJumpStart=%p, sof=%p", jump, headPos, thisJumpStart, sof); // # notranslate
+            snprintf(internalErr, sizeof(internalErr), "invalid head position. jump=%d, headPos=%p, thisJumpStart=%p, sof=%p", jump, headPos, thisJumpStart, sof); // # notranslate
             stopTeam = true;
             // # nocov end
           }

--- a/src/fread.c
+++ b/src/fread.c
@@ -2530,7 +2530,7 @@ int freadMain(freadMainArgs _args) {
                 // Can't print because we're likely not master. So accumulate message and print afterwards.
                 if (thisType < joldType) {   // thisType<0 (type-exception)
                   if (verbose) {
-                    char buffer[250];
+                    char buffer[256];
                     int len = snprintf(buffer, sizeof(buffer),
                       _("Column %d%s%.*s%s bumped from '%s' to '%s' due to <<%.*s>> on row %"PRId64"\n"),
                       j+1, colNames?" <<":"", colNames?(colNames[j].len):0, colNames?(colNamesAnchor+colNames[j].off):"", colNames?">>":"",

--- a/src/fread.c
+++ b/src/fread.c
@@ -2524,7 +2524,7 @@ int freadMain(freadMainArgs _args) {
                       _("Column %d%s%.*s%s bumped from '%s' to '%s' due to <<%.*s>> on row %"PRId64"\n"),
                       j + 1, colNames ? " <<" : "", colNames ? (colNames[j].len) : 0, colNames ? (colNamesAnchor + colNames[j].off) : "", colNames ? ">>" : "",
                       typeName[IGNORE_BUMP(joldType)], typeName[IGNORE_BUMP(thisType)],
-                      (int)(tch-fieldStart), fieldStart, (int64_t)(ctx.DTi + myNrow));
+                      (int)(tch - fieldStart), fieldStart, (int64_t)(ctx.DTi + myNrow));
                     
                     len = iminInt(len, sizeof(buffer));
 

--- a/src/fread.c
+++ b/src/fread.c
@@ -2238,7 +2238,7 @@ int freadMain(freadMainArgs _args) {
   double tRead = 0, tReread = 0;
   double thRead = 0, thPush = 0;  // reductions of timings within the parallel region
   int max_col = 0;
-  char *typeBumpMsg = NULL;  size_t typeBumpMsgSize = 0;
+  char *typeBumpMsg = NULL; size_t typeBumpMsgSize = 0;
   int typeCounts[NUMTYPE];  // used for verbose output; needs populating after first read and before reread (if any) -- see later comment
   char internalErr[256] = "";  // must be compile time size: the message is generated and we can't free before STOP
 

--- a/src/fread.c
+++ b/src/fread.c
@@ -2530,18 +2530,18 @@ int freadMain(freadMainArgs _args) {
                 // Can't print because we're likely not master. So accumulate message and print afterwards.
                 if (thisType < joldType) {   // thisType<0 (type-exception)
                   if (verbose) {
-                    char temp[1001];
-                    int len = snprintf(temp, 1000,
+                    char buffer[250];
+                    int len = snprintf(buffer, sizeof(buffer),
                       _("Column %d%s%.*s%s bumped from '%s' to '%s' due to <<%.*s>> on row %"PRId64"\n"),
                       j+1, colNames?" <<":"", colNames?(colNames[j].len):0, colNames?(colNamesAnchor+colNames[j].off):"", colNames?">>":"",
                       typeName[IGNORE_BUMP(joldType)], typeName[IGNORE_BUMP(thisType)],
                       (int)(tch-fieldStart), fieldStart, (int64_t)(ctx.DTi+myNrow));
-                    if (len > 1000) len = 1000;
-                    if (len > 0) {
-                      typeBumpMsg = realloc(typeBumpMsg, typeBumpMsgSize + len + 1);
-                      strcpy(typeBumpMsg+typeBumpMsgSize, temp);
-                      typeBumpMsgSize += len;
-                    }
+
+                    len = min(len, sizeof(buffer));
+
+                    typeBumpMsg = realloc(typeBumpMsg, typeBumpMsgSize + len + 1);
+                    strcpy(typeBumpMsg+typeBumpMsgSize, buffer);
+                    typeBumpMsgSize += len;
                   }
                   nTypeBump++;
                   if (joldType>0) nTypeBumpCols++;

--- a/src/fread.c
+++ b/src/fread.c
@@ -190,6 +190,7 @@ bool freadCleanup(void)
 static inline uint64_t umax(uint64_t a, uint64_t b) { return a > b ? a : b; }
 static inline uint64_t umin(uint64_t a, uint64_t b) { return a < b ? a : b; }
 static inline  int64_t imin( int64_t a,  int64_t b) { return a < b ? a : b; }
+static inline   int iminInt(     int a,      int b) { return a < b ? a : b; }
 
 /** Return value of `x` clamped to the range [upper, lower] */
 static inline int64_t clamp_i64t(int64_t x, int64_t lower, int64_t upper) {
@@ -2537,7 +2538,7 @@ int freadMain(freadMainArgs _args) {
                       typeName[IGNORE_BUMP(joldType)], typeName[IGNORE_BUMP(thisType)],
                       (int)(tch-fieldStart), fieldStart, (int64_t)(ctx.DTi+myNrow));
 
-                    len = min(len, sizeof(buffer));
+                    len = iminInt(len, sizeof(buffer));
 
                     typeBumpMsg = realloc(typeBumpMsg, typeBumpMsgSize + len + 1);
                     strcpy(typeBumpMsg+typeBumpMsgSize, buffer);


### PR DESCRIPTION
In the interest of continued improvements to readability, I've removed the unnecessary `internalErrSize` macro constant.