### PR TITLE
Clarified setindex vs setkey subsetting behavior

### DIFF
--- a/man/data.table.Rd
+++ b/man/data.table.Rd
@@ -174,7 +174,7 @@ data.table(\dots, keep.rownames=FALSE, check.names=FALSE, key=NULL, stringsAsFac
             \item For convenience during interactive scenarios, it is also possible to use \code{.()} syntax as \code{X[Y, on=.(a, b)]}.
             \item From v1.9.8, (non-equi) joins using binary operators \code{>=, >, <=, <} are also possible, e.g., \code{X[Y, on=c("x>=a", "y<=b")]}, or for interactive use as \code{X[Y, on=.(x>=a, y<=b)]}.
         }
-        See examples as well as \href{../doc/datatable-secondary-indices-and-auto-indexing.html}{\code{vignette("datatable-secondary-indices-and-auto-indexing")}}.
+        Note that providing \code{on} is \emph{required} for \code{X[Y]} joins when \code{X} is unkeyed. See examples as well as \href{../doc/datatable-secondary-indices-and-auto-indexing.html}{\code{vignette("datatable-secondary-indices-and-auto-indexing")}}.
     }
 
   \item{env}{ List or an environment, passed to \code{\link{substitute2}} for substitution of parameters in \code{i}, \code{j} and \code{by} (or \code{keyby}). Use \code{verbose} to preview constructed expressions. For more details see \href{../doc/datatable-programming.html}{\code{vignette("datatable-programming")}}. }
@@ -298,7 +298,9 @@ DT[, sum(v), by=x][order(x)]   # same but by chaining expressions together
 
 # fast ad hoc row subsets (subsets as joins)
 DT["a", on="x"]                # same as x == "a" but uses binary search (fast)
+                               #   NB: requires DT to be keyed!
 DT["a", on=.(x)]               # same, for convenience, no need to quote every column
+                               #   NB: works regardless of whether or not DT is keyed!
 DT[.("a"), on="x"]             # same
 DT[x=="a"]                     # same, single "==" internally optimised to use binary search (fast)
 DT[x!="b" | y!=3]              # not yet optimized, currently vector scan subset
@@ -349,24 +351,6 @@ v="x"
 setkeyv(kDT,v)                        # same
 haskey(kDT)                           # TRUE
 key(kDT)                              # "x"
-
-# Keyed subsetting (no 'on' needed)
-setkey(DT, x)                        # Set a key on column 'x'
-DT[.("a")]                            # Returns all rows where x = "a"
-
-# Indexed subsetting (requires 'on')
-setindex(DT, x)                       # Set an index on column 'x'
-DT[.("b"), on = "x"]                  # Works, returns all rows where x = "b" (for detailed explanation visit setkey.rd)
-# DT[.("b")]                          # this will throw error
-
-# single and multiple indices
-# index on a single column ('y')
-setindex(DT, y)
-indices(DT)
-
-# multi-column index
-setindexv(DT, list("x", c("x", "y")))
-indices(DT)                           # Shows an index on 'x' and a composite index on '(x,y)'
 
 # fast *keyed* subsets
 kDT["a"]                              # subset-as-join on *key* column 'x'

--- a/man/data.table.Rd
+++ b/man/data.table.Rd
@@ -351,22 +351,22 @@ haskey(kDT)                           # TRUE
 key(kDT)                              # "x"
 
 # Keyed subsetting (no 'on' needed)
-setkey(kDT, x)                        # Set a key on column 'x'
-kDT[.("a")]                            # Returns all rows where x = "a"
+setkey(DT, x)                        # Set a key on column 'x'
+DT[.("a")]                            # Returns all rows where x = "a"
 
 # Indexed subsetting (requires 'on')
-setindex(kDT, x)                       # Set an index on column 'x'
-kDT[.("b"), on = "x"]                  # Works, returns all rows where x = "b" (for detailed explanation visit setkey.rd)
-# kDT[.("b")]                          # this will throw error
+setindex(DT, x)                       # Set an index on column 'x'
+DT[.("b"), on = "x"]                  # Works, returns all rows where x = "b" (for detailed explanation visit setkey.rd)
+# DT[.("b")]                          # this will throw error
 
 # single and multiple indices
 # index on a single column ('y')
-setindex(kDT, y)
-indices(kDT)
+setindex(DT, y)
+indices(DT)
 
 # multi-column index
-setindexv(kDT, list("x", c("x", "y")))
-indices(kDT)                           # Shows an index on 'x' and a composite index on '(x,y)'
+setindexv(DT, list("x", c("x", "y")))
+indices(DT)                           # Shows an index on 'x' and a composite index on '(x,y)'
 
 # fast *keyed* subsets
 kDT["a"]                              # subset-as-join on *key* column 'x'

--- a/man/data.table.Rd
+++ b/man/data.table.Rd
@@ -350,6 +350,24 @@ setkeyv(kDT,v)                        # same
 haskey(kDT)                           # TRUE
 key(kDT)                              # "x"
 
+# Keyed subsetting (no 'on' needed)
+setkey(kDT, x)                        # Set a key on column 'x'
+kDT[.("a")]                            # Returns all rows where x = "a"
+
+# Indexed subsetting (requires 'on')
+setindex(kDT, x)                       # Set an index on column 'x'
+kDT[.("b"), on = "x"]                  # Works, returns all rows where x = "b" (for detailed explanation visit setkey.rd)
+# kDT[.("b")]                          # this will throw error
+
+# single and multiple indices
+# index on a single column ('y')
+setindex(kDT, y)
+indices(kDT)
+
+# multi-column index
+setindexv(kDT, list("x", c("x", "y")))
+indices(kDT)                           # Shows an index on 'x' and a composite index on '(x,y)'
+
 # fast *keyed* subsets
 kDT["a"]                              # subset-as-join on *key* column 'x'
 kDT["a", on="x"]                      # same, being explicit using 'on=' (preferred)

--- a/man/setkey.Rd
+++ b/man/setkey.Rd
@@ -155,23 +155,6 @@ setindex(DT, A)
 setindex(DT, B)
 indices(DT)           # get indices single vector
 indices(DT, vectors = TRUE) # get indices list
-
-# Keyed subsetting (no 'on' needed)
-DT = data.table(A=5:1,B=letters[5:1])
-setkey(DT, B)
-DT[.("e")]  # Returns row where B = "e"
-
-# Indexed subsetting (requires 'on')
-DT = data.table(A=5:1,B=letters[5:1])
-setindex(DT, B)
-DT[.("e"), on = "B"]  # Works
-# DT[.("e")]           # Would error (missing 'on')
-
-DT <- data.table(a = c(1,2,1,2), b = c("x", "x", "y", "y"), val = 1:4)
-# Set an index on a single column
-setindex(DT, a)
-# Set multiple indices at once using setindexv
-setindexv(DT, list("a", c("a", "b")))
   
 # Setting multiple indices at once
 DT = data.table(A = 5:1, B = letters[5:1], C = 10:6)

--- a/man/setkey.Rd
+++ b/man/setkey.Rd
@@ -39,6 +39,20 @@ ordering vector of the dataset's rows according to the provided columns. This or
 is stored as an attribute of the \code{data.table} and the dataset retains the original order
 of rows in memory. See the \href{../doc/datatable-secondary-indices-and-auto-indexing.html}{\code{vignette("datatable-secondary-indices-and-auto-indexing")}} for more details.
 
+\subsection{Key vs. Index Subsetting}{
+When using \code{setkey}:
+\itemize{
+  \item Subsetting can omit \code{on} (e.g., \code{DT[.(value)]})
+  \item Data is physically reordered in RAM
+}
+When using \code{setindex}:
+\itemize{
+  \item Must specify \code{on} (e.g., \code{DT[.(value), on = "col"]})
+  \item Multiple indices can coexist via \code{setindexv(x, list(cols))}
+  \item Original row order is preserved
+}
+}
+
 \code{key} returns the \code{data.table}'s key if it exists; \code{NULL} if none exists.
 
 \code{haskey} returns \code{TRUE}/\code{FALSE} if the \code{data.table} has a key.
@@ -141,6 +155,15 @@ setindex(DT, A)
 setindex(DT, B)
 indices(DT)           # get indices single vector
 indices(DT, vectors = TRUE) # get indices list
+
+# Keyed subsetting (no 'on' needed)
+setkey(DT, B)
+DT[.("e")]  # Returns row where B = "e"
+
+# Indexed subsetting (requires 'on')
+setindex(DT, B)
+DT[.("e"), on = "B"]  # Works
+# DT[.("e")]           # Would error (missing 'on')
 
 # Setting multiple indices at once
 DT = data.table(A = 5:1, B = letters[5:1], C = 10:6)

--- a/man/setkey.Rd
+++ b/man/setkey.Rd
@@ -149,7 +149,6 @@ setindex(DT, A)
 setindex(DT, B)
 indices(DT)           # get indices single vector
 indices(DT, vectors = TRUE) # get indices list
-  
 # Setting multiple indices at once
 DT = data.table(A = 5:1, B = letters[5:1], C = 10:6)
 setindexv(DT, list(c("A", "B"), c("B", "C")))

--- a/man/setkey.Rd
+++ b/man/setkey.Rd
@@ -39,20 +39,6 @@ ordering vector of the dataset's rows according to the provided columns. This or
 is stored as an attribute of the \code{data.table} and the dataset retains the original order
 of rows in memory. See the \href{../doc/datatable-secondary-indices-and-auto-indexing.html}{\code{vignette("datatable-secondary-indices-and-auto-indexing")}} for more details.
 
-\subsection{Key vs. Index Subsetting}{
-When using \code{setkey}:
-\itemize{
-  \item Subsetting can omit \code{on} (e.g., \code{DT[.(value)]})
-  \item Data is physically reordered in RAM
-}
-When using \code{setindex}:
-\itemize{
-  \item Must specify \code{on} (e.g., \code{DT[.(value), on = "col"]})
-  \item Multiple indices can coexist via \code{setindexv(x, list(cols))}
-  \item Original row order is preserved
-}
-}
-
 \code{key} returns the \code{data.table}'s key if it exists; \code{NULL} if none exists.
 
 \code{haskey} returns \code{TRUE}/\code{FALSE} if the \code{data.table} has a key.
@@ -86,6 +72,20 @@ Note that \code{setkey} always uses "C-locale"; see the Details in the help for 
 The sort is \emph{stable}; i.e., the order of ties (if any) is preserved.
 
 For character vectors, \code{data.table} takes advantage of R's internal global string cache, also exported as \code{\link{chorder}}.
+}
+
+\section{Key vs. Index Subsetting}{
+When using \code{setkey}:
+\itemize{
+  \item Subsetting can omit \code{on} (e.g., \code{DT[.(value)]})
+  \item Data is physically reordered in RAM
+}
+When using \code{setindex}:
+\itemize{
+  \item Must specify \code{on} (e.g., \code{DT[.(value), on = "col"]})
+  \item Multiple indices can coexist via \code{setindexv(x, list(cols))}
+  \item Original row order is preserved
+}
 }
 
 \section{Good practice}{
@@ -157,14 +157,22 @@ indices(DT)           # get indices single vector
 indices(DT, vectors = TRUE) # get indices list
 
 # Keyed subsetting (no 'on' needed)
+DT = data.table(A=5:1,B=letters[5:1])
 setkey(DT, B)
 DT[.("e")]  # Returns row where B = "e"
 
 # Indexed subsetting (requires 'on')
+DT = data.table(A=5:1,B=letters[5:1])
 setindex(DT, B)
 DT[.("e"), on = "B"]  # Works
 # DT[.("e")]           # Would error (missing 'on')
 
+DT <- data.table(a = c(1,2,1,2), b = c("x", "x", "y", "y"), val = 1:4)
+# Set an index on a single column
+setindex(DT, a)
+# Set multiple indices at once using setindexv
+setindexv(DT, list("a", c("a", "b")))
+  
 # Setting multiple indices at once
 DT = data.table(A = 5:1, B = letters[5:1], C = 10:6)
 setindexv(DT, list(c("A", "B"), c("B", "C")))

--- a/man/setkey.Rd
+++ b/man/setkey.Rd
@@ -74,18 +74,12 @@ The sort is \emph{stable}; i.e., the order of ties (if any) is preserved.
 For character vectors, \code{data.table} takes advantage of R's internal global string cache, also exported as \code{\link{chorder}}.
 }
 
-\section{Key vs. Index Subsetting}{
-When using \code{setkey}:
-\itemize{
-  \item Subsetting can omit \code{on} (e.g., \code{DT[.(value)]})
-  \item Data is physically reordered in RAM
-}
-When using \code{setindex}:
-\itemize{
-  \item Must specify \code{on} (e.g., \code{DT[.(value), on = "col"]})
-  \item Multiple indices can coexist via \code{setindexv(x, list(cols))}
-  \item Original row order is preserved
-}
+\section{Keys vs. Indices}{
+Setting a key (with \code{setkey}) and an index (with \code{setindex}) are similar, but have very important distinctions.
+
+Setting a key physically reorders the data in RAM.
+
+Setting an index computes the sort order, but instead of applying the reordering, simply \emph{stores} this computed ordering. That means that multiple indices can coexist, and that the original row order is preserved.
 }
 
 \section{Good practice}{

--- a/man/setkey.Rd
+++ b/man/setkey.Rd
@@ -149,6 +149,7 @@ setindex(DT, A)
 setindex(DT, B)
 indices(DT)           # get indices single vector
 indices(DT, vectors = TRUE) # get indices list
+
 # Setting multiple indices at once
 DT = data.table(A = 5:1, B = letters[5:1], C = 10:6)
 setindexv(DT, list(c("A", "B"), c("B", "C")))

--- a/vignettes/datatable-secondary-indices-and-auto-indexing.Rmd
+++ b/vignettes/datatable-secondary-indices-and-auto-indexing.Rmd
@@ -62,6 +62,49 @@ Secondary indices are similar to `keys` in *data.table*, except for two major di
 
 * There can be more than one secondary index for a data.table (as we will see below).
 
+#### 1.1 Keyed vs. Indexed Subsetting
+
+While both **keys** and **indices** enable fast binary search subsetting, they differ critically in usage:
+
+**Keyed subsetting** (implicit column matching)
+```{r}
+DT <- data.table(a = c(TRUE, FALSE), b = 1:2)
+setkey(DT, a)                # Set key
+DT[.(TRUE)]                  # No 'on' needed - key is used
+```
+
+**Indexed subsetting** (explicit column specification)
+
+```{r}
+DT <- data.table(a = c(TRUE, FALSE), b = 1:2)
+setindex(DT, a)              # Set index only (no reorder)
+DT[.(TRUE), on = "a"]        # Must specify 'on'
+```
+
+Always use `on`with indices to avoid errors. Keys establish permanent implicit matching, while indices require explicit direction for each operation.
+
+#### **Hierarchy of Lookup Operations**
+
+When `on` is specified, `data.table` uses this lookup order:
+
+- Existing keys matching `on` columns
+
+- Pre-built secondary indices matching `on` columns
+
+- Temporary auto-generated index (if none exist)
+
+**Example**: Error When Omitting on with Indices
+
+```{r}
+DT <- data.table(a = c(TRUE, FALSE), b = 1:2)
+setindex(DT, a)
+# DT[.(TRUE)] # Uncommenting this line causes: Error - must specify 'on'
+```
+
+- Use `DT[.(value)]` when the table is keyed by the relevant column(s).
+
+- Use `DT[.(value), on = "col"]` when using secondary indices or when no key is set.
+
 ### b) Set and get secondary indices
 
 #### -- How can we set the column `origin` as a secondary index in the *data.table* `flights`?

--- a/vignettes/datatable-secondary-indices-and-auto-indexing.Rmd
+++ b/vignettes/datatable-secondary-indices-and-auto-indexing.Rmd
@@ -67,10 +67,11 @@ Secondary indices are similar to `keys` in *data.table*, except for two major di
 While both **keys** and **indices** enable fast binary search subsetting, they differ significantly in usage:
 
 **Keyed subsetting** (implicit column matching)
+
 ```{r}
 DT = data.table(a = c(TRUE, FALSE), b = 1:2)
-setkey(DT, a)                # Set key
-DT[.(TRUE)]                  # No 'on' needed - key is used
+setkey(DT, a)                # Set key, reordering DT
+DT[.(TRUE)]                  # 'on' is optional; if omitted, the key is used
 ```
 
 **Indexed subsetting** (explicit column specification)
@@ -78,10 +79,8 @@ DT[.(TRUE)]                  # No 'on' needed - key is used
 ```{r}
 DT = data.table(a = c(TRUE, FALSE), b = 1:2)
 setindex(DT, a)              # Set index only (no reorder)
-DT[.(TRUE), on = "a"]        # Must specify 'on'
+DT[.(TRUE), on = "a"]        # 'on' is required
 ```
-
-For join-like operations such as `DT[.(values)]` on an indexed table, the `on=` argument is essential to specify the join column(s). `setindex` does not establish the implicit matching that setkey does; thus, this `explicit` direction is needed.
 
 #### Hierarchy of Lookup Operations
 

--- a/vignettes/datatable-secondary-indices-and-auto-indexing.Rmd
+++ b/vignettes/datatable-secondary-indices-and-auto-indexing.Rmd
@@ -64,11 +64,11 @@ Secondary indices are similar to `keys` in *data.table*, except for two major di
 
 #### 1.1 Keyed vs. Indexed Subsetting
 
-While both **keys** and **indices** enable fast binary search subsetting, they differ critically in usage:
+While both **keys** and **indices** enable fast binary search subsetting, they differ significantly in usage:
 
 **Keyed subsetting** (implicit column matching)
 ```{r}
-DT <- data.table(a = c(TRUE, FALSE), b = 1:2)
+DT = data.table(a = c(TRUE, FALSE), b = 1:2)
 setkey(DT, a)                # Set key
 DT[.(TRUE)]                  # No 'on' needed - key is used
 ```
@@ -76,14 +76,14 @@ DT[.(TRUE)]                  # No 'on' needed - key is used
 **Indexed subsetting** (explicit column specification)
 
 ```{r}
-DT <- data.table(a = c(TRUE, FALSE), b = 1:2)
+DT = data.table(a = c(TRUE, FALSE), b = 1:2)
 setindex(DT, a)              # Set index only (no reorder)
 DT[.(TRUE), on = "a"]        # Must specify 'on'
 ```
 
-Always use `on`with indices to avoid errors. Keys establish permanent implicit matching, while indices require explicit direction for each operation.
+For join-like operations such as `DT[.(values)]` on an indexed table, the `on=` argument is essential to specify the join column(s). `setindex` does not establish the implicit matching that setkey does; thus, this `explicit` direction is needed.
 
-#### **Hierarchy of Lookup Operations**
+#### Hierarchy of Lookup Operations
 
 When `on` is specified, `data.table` uses this lookup order:
 
@@ -91,19 +91,7 @@ When `on` is specified, `data.table` uses this lookup order:
 
 - Pre-built secondary indices matching `on` columns
 
-- Temporary auto-generated index (if none exist)
-
-**Example**: Error When Omitting on with Indices
-
-```{r}
-DT <- data.table(a = c(TRUE, FALSE), b = 1:2)
-setindex(DT, a)
-# DT[.(TRUE)] # Uncommenting this line causes: Error - must specify 'on'
-```
-
-- Use `DT[.(value)]` when the table is keyed by the relevant column(s).
-
-- Use `DT[.(value), on = "col"]` when using secondary indices or when no key is set.
+- Auto-generated secondary index (created if none exist; its optimized ordering is used internally for efficient joins)
 
 ### b) Set and get secondary indices
 

--- a/vignettes/datatable-secondary-indices-and-auto-indexing.Rmd
+++ b/vignettes/datatable-secondary-indices-and-auto-indexing.Rmd
@@ -68,7 +68,7 @@ While both **keys** and **indices** enable fast binary search subsetting, they d
 
 **Keyed subsetting** (implicit column matching)
 
-```{r}
+```{r keyed_operations}
 DT = data.table(a = c(TRUE, FALSE), b = 1:2)
 setkey(DT, a)                # Set key, reordering DT
 DT[.(TRUE)]                  # 'on' is optional; if omitted, the key is used
@@ -76,7 +76,7 @@ DT[.(TRUE)]                  # 'on' is optional; if omitted, the key is used
 
 **Indexed subsetting** (explicit column specification)
 
-```{r}
+```{r unkeyed_operations}
 DT = data.table(a = c(TRUE, FALSE), b = 1:2)
 setindex(DT, a)              # Set index only (no reorder)
 DT[.(TRUE), on = "a"]        # 'on' is required

--- a/vignettes/datatable-secondary-indices-and-auto-indexing.Rmd
+++ b/vignettes/datatable-secondary-indices-and-auto-indexing.Rmd
@@ -62,7 +62,7 @@ Secondary indices are similar to `keys` in *data.table*, except for two major di
 
 * There can be more than one secondary index for a data.table (as we will see below).
 
-#### 1.1 Keyed vs. Indexed Subsetting
+#### Keyed vs. Indexed Subsetting
 
 While both **keys** and **indices** enable fast binary search subsetting, they differ significantly in usage:
 
@@ -81,16 +81,6 @@ DT = data.table(a = c(TRUE, FALSE), b = 1:2)
 setindex(DT, a)              # Set index only (no reorder)
 DT[.(TRUE), on = "a"]        # 'on' is required
 ```
-
-#### Hierarchy of Lookup Operations
-
-When `on` is specified, `data.table` uses this lookup order:
-
-- Existing keys matching `on` columns
-
-- Pre-built secondary indices matching `on` columns
-
-- Auto-generated secondary index (created if none exist; its optimized ordering is used internally for efficient joins)
 
 ### b) Set and get secondary indices
 


### PR DESCRIPTION
closes #5321 

This PR improves documentation to clarify the differences in subsetting behavior when using `setindex` versus `setkey`, particularly regarding the use of the `on=` argument with `DT[.(value)]` syntax.

in this pr i did the following things

- `datatable-secondary-indices-and-auto-indexing.Rmd`: Added a new section "Keyed vs. Indexed Subsetting" with examples and an explanation of the lookup hierarchy.
- `setkey.Rd` : Added a subsection "Key vs. Index Subsetting" to highlight usage differences, particularly the need for `on=` with `setindex` for join-like subsets.


hi @jangorecki ,can you please review this when you have time.
thank you.