### PR TITLE
Clarify x/i error prefixes in merge() for incompatible factor joins

### DIFF
--- a/R/bmerge.R
+++ b/R/bmerge.R
@@ -84,7 +84,18 @@ bmerge = function(i, x, icols, xcols, roll, rollends, nomatch, mult, ops, verbos
           next
         }
       }
-      stopf("Incompatible join types: %s (%s) and %s (%s). Factor columns must join to factor or character columns.", xname, x_merge_type, iname, i_merge_type)
+      condition_message = sprintf("Incompatible join types: %s (%s) and %s (%s). Factor columns must join to factor or character columns.", xname, x_merge_type, iname, i_merge_type)
+      condition <- structure(
+        list(
+          message = condition_message,
+          bmerge_x_arg_col_name      = names(x)[xcol],
+          bmerge_x_arg_type          = x_merge_type,
+          bmerge_i_arg_col_name      = names(i)[icol],
+          bmerge_i_arg_type          = i_merge_type
+        ),
+        class = c("bmerge_incompatible_type_error", "data.table_error", "error", "condition")
+      )
+      stop(condition)
     }
     # we check factors first to cater for the case when trying to do rolling joins on factors
     if (x_merge_type == i_merge_type) {


### PR DESCRIPTION
fixes: #6641 

This PR addresses confusing error messages from merge(x, y) when an incompatible factor join occurs ( factor with integer). The original error message used x. and i. prefixes based on the internal y[x] join structure, which was misleading for merge() users as it swapped the references to merge's x and y arguments.

So following are the changes to fix the x/i confusion for merge() users:

`R/bmerge.R`:
- For this incompatible factor join, `bmerge` now signals a custom error object  `bmerge_incompatible_type_error`.
- This error object includes attributes with the column names and types from bmerge's inputs.

`R/merge.R` :
- A `tryCatch` is added around the main internal join call (y[x]) to specifically handle `bmerge_incompatible_type_error`.
- The handler uses the attributes from the caught error object to construct a new error message. This message correctly uses x.colname to refer to merge's first argument (x) and y.colname for its second argument (y). 

@MichaelChirico @jangorecki @tdhock can you please review the modifications.