### PR TITLE
Clarify behavior of first() and last()

### DIFF
--- a/man/last.Rd
+++ b/man/last.Rd
@@ -19,7 +19,7 @@ of \code{xts::first} is deployed. }
 are passed through to \code{xts}'s first/last. }
 }
 \details{
-Note: \code{first(x)} is not an exact replacement for \code{x[1]}. It differs in its handling of zero-length vectors (returning a zero-length vector instead of \code{NA}) and does not preserve attributes like names.
+Note: \code{first(x)} and \code{last(x)} are not exact replacements for \code{x[1]} and \code{x[length(x)]}. They differ in handling of zero-length vectors (returning a zero-length vector instead of \code{NA}) and do not preserve attributes like names.
 }
 \value{
 If no other arguments are supplied it depends on the type of \code{x}. The first/last item

--- a/man/last.Rd
+++ b/man/last.Rd
@@ -19,7 +19,7 @@ of \code{xts::first} is deployed. }
 are passed through to \code{xts}'s first/last. }
 }
 \details{
-Note: \code{first(x)} and \code{last(x)} are designed to behave like \code{head(x, 1)} and \code{tail(x, 1)}, respectively. Consequently, they differ from base R subsetting (\code{x[1]}): they return a zero-length vector for empty inputs (instead of \code{NA}) and do not preserve attributes like names.
+Note: \code{first(x)} and \code{last(x)} differ from base R subsetting (e.g. \code{x[1]}). In its handling of zero-length vectors, \code{first(x)} is designed to behave like \code{head(x, 1)}, returning an empty vector instead of \code{NA}. However, unlike both \code{head(x, 1)} and \code{x[1]}, \code{first(x)} strips attributes like names for performance.
 }
 \value{
 If no other arguments are supplied it depends on the type of \code{x}. The first/last item

--- a/man/last.Rd
+++ b/man/last.Rd
@@ -18,6 +18,9 @@ of \code{xts::first} is deployed. }
 \item{\dots}{ Not applicable for \code{data.table} first/last. Any arguments here
 are passed through to \code{xts}'s first/last. }
 }
+\details{
+Note: \code{first(x)} is not an exact replacement for \code{x[1]}. It differs in its handling of zero-length vectors (returning a zero-length vector instead of \code{NA}) and does not preserve attributes like names.
+}
 \value{
 If no other arguments are supplied it depends on the type of \code{x}. The first/last item
 of a vector or list. The first/last row of a \code{data.frame} or \code{data.table}.

--- a/man/last.Rd
+++ b/man/last.Rd
@@ -19,7 +19,7 @@ of \code{xts::first} is deployed. }
 are passed through to \code{xts}'s first/last. }
 }
 \details{
-Note: \code{first(x)} and \code{last(x)} are not exact replacements for \code{x[1]} and \code{x[length(x)]}. They differ in handling of zero-length vectors (returning a zero-length vector instead of \code{NA}) and do not preserve attributes like names.
+Note: \code{first(x)} and \code{last(x)} are designed to behave like \code{head(x, 1)} and \code{tail(x, 1)}, respectively. Consequently, they differ from base R subsetting (\code{x[1]}): they return a zero-length vector for empty inputs (instead of \code{NA}) and do not preserve attributes like names.
 }
 \value{
 If no other arguments are supplied it depends on the type of \code{x}. The first/last item

--- a/man/last.Rd
+++ b/man/last.Rd
@@ -19,7 +19,7 @@ of \code{xts::first} is deployed. }
 are passed through to \code{xts}'s first/last. }
 }
 \details{
-Note: \code{first(x)} and \code{last(x)} differ from base R subsetting (e.g. \code{x[1]}). In its handling of zero-length vectors, \code{first(x)} is designed to behave like \code{head(x, 1)}, returning an empty vector instead of \code{NA}. However, unlike both \code{head(x, 1)} and \code{x[1]}, \code{first(x)} strips attributes like names for performance.
+Note: For zero-length vectors, \code{first(x)} and \code{last(x)} mimic \code{head(x, 1)} and \code{tail(x, 1)} by returning an empty vector instead of \code{NA}. However, unlike \code{head()}/\code{tail()} and base R subsetting (e.g., \code{x[1]}), they do not preserve attributes like names.
 }
 \value{
 If no other arguments are supplied it depends on the type of \code{x}. The first/last item


### PR DESCRIPTION
Closes #2002 and #2487 

Adds a note to the documentation for `first()` and `last()` to clarify they are not direct replacements for base R subsetting (i.e., `x[1]` and `x[length(x)]`).

The note explains the different handling of zero-length vectors and the stripping of attributes. This helps prevent common user errors.

@tdhock @jangorecki @Anirban166 could you please review these docs update.