### PR TITLE
Update GitLab CI rules

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -116,7 +116,6 @@ test-lin-rel:
     OPENBLAS_MAIN_FREE: "1"
   script:
     - *install-deps
-    - R -q -s -e 'install.packages(c("xml2", "commonmark", "curl", "V8"))'
     - echo 'CFLAGS=-g -O3 -flto=auto -fno-common -fopenmp -Wall -Wvla -pedantic -fstack-protector-strong -D_FORTIFY_SOURCE=2' > ~/.R/Makevars
     - echo 'CXXFLAGS=-g -O3 -flto=auto -fno-common -fopenmp -Wall -Wvla -pedantic -fstack-protector-strong -D_FORTIFY_SOURCE=2' >> ~/.R/Makevars
     - echo '_R_CHECK_COMPILATION_FLAGS_KNOWN_=-Wvla' >> ~/.Renviron
@@ -159,7 +158,7 @@ test-lin-rel-cran:
     - echo 'CXXFLAGS=-g -O2 -fopenmp -Wall -pedantic -fstack-protector-strong -D_FORTIFY_SOURCE=2' >> ~/.R/Makevars
     - |
         res1=0; R CMD check --as-cran $(ls -1t data.table_*.tar.gz | head -n 1) || res1=$?
-        res2=0; Rscript -e 'l=tail(readLines("data.table.Rcheck/00check.log"), 1L); if (!identical(l, "Status: 2 NOTEs")) stop("Last line of ", shQuote("00check.log"), " is not ", shQuote("Status: 2 NOTEs"), " (non-API, V8) but ", shQuote(l))' || res2=$?
+        res2=0; Rscript -e 'l=tail(readLines("data.table.Rcheck/00check.log"), 1L); if (!identical(l, "Status: 1 NOTE")) stop("Last line of ", shQuote("00check.log"), " is not ", shQuote("Status: 1 NOTE"), " (non-API) but ", shQuote(l))' || res2=$?
         if [ $res1 -ne 0 ] || [ $res2 -ne 0 ]; then exit 1; fi
 
 ## R-devel on Linux gcc strict


### PR DESCRIPTION
- Updated R versions, which fixes CI for R-devel on Windows
- Unlike R-3.3, R-3.4 tries to make use of `PACKAGES.rds`, which failed due to format version differences, so make sure to prepare a compatible version
- Updates to `test-lin-rel`:
  - As the most comprehensive check,  run all `--as-cran` checks, including URL validity
    - Which unfortunately fails due to the many StackOverflow links now being Cloudflare'd, adding one more expected NOTE
  - Make sure that `-Wvla` doesn't count towards the "non-portable compilation flags" WARNING
- `test-lin-rel-cran`: allow the non-API NOTE for now
- `test-lin-dev-gcc-strict-cran`, `test-lin-dev-gcc-strict-cran`: R ≥ 4.5 gives a NOTE about missing `V8` package. Since the few uses of `\eqn{}` are checked by `test-lin-rel-cran`, save CI time and allow this NOTE.
- `macos`:
  - make sure to install `gettext`, which `data.table` depends upon
  - fail CI if results are worse than NOTE
- Still unsure what to do about `test-lin-rel-vanilla`. Our tests don't really work in the `C` locale, so it's broken as usual.

[Here](https://gitlab.com/Rdatatable/data.table/-/pipelines/1869852948)'s what the check results looked like for month-old `master`. The macOS checks correctly fail for both [old](https://gitlab.com/Rdatatable/data.table/-/pipelines/1869852948) and [release](https://gitlab.com/Rdatatable/data.table/-/jobs/10351277486) versions of R due to compiler warnings.

[Here](https://gitlab.com/Rdatatable/data.table/-/pipelines/1869870279)'s what the check results look for recent `master`:
 - [`test-lin-dev-clang-cran`](https://gitlab.com/Rdatatable/data.table/-/jobs/10351345676) correctly fails due to #7042
 - [`test-lin-dev-gcc-strict-cran`](https://gitlab.com/Rdatatable/data.table/-/jobs/10351345675), [`test-lin-rel`](https://gitlab.com/Rdatatable/data.table/-/jobs/10351345671), [`test-lin-rel-cran`](https://gitlab.com/Rdatatable/data.table/-/jobs/10351345674) correctly fail due to https://github.com/Rdatatable/data.table/pull/7003#issuecomment-2913382190

Closes: #6984