### PR TITLE
fread: consider quoted `na.strings` in text columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,8 @@
 
 11. Out of sample type bumps now respect `integer64=` selection, [#7032](https://github.com/Rdatatable/data.table/pull/7032).
 
+12. `fread()` now handles the `na.strings` argument for quoted text columns, making it possible to specify `na.strings = '""'` and read empty quoted strings as `NA`s, [#6974](https://github.com/Rdatatable/data.table/issues/6974). Thanks to @AngelFelizR for the report and @aitap for the PR.
+
 ### NOTES
 
 1. Continued work to remove non-API C functions, [#6180](https://github.com/Rdatatable/data.table/issues/6180). Thanks Ivan Krylov for the PRs and for writing a clear and concise guide about the R API: https://aitap.codeberg.page/R-api/.

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -21157,3 +21157,18 @@ test(2317.6, DT1[DF1, on='a', .(d = x.a + i.d)]$d, 5)
 test(2317.7, DT1[DF2, on='a', e := i.e]$e, 5)
 test(2317.8, DT1[DF2, on='a', e2 := x.a + i.e]$e2, 6)
 test(2317.9, DT1[DF2, on='a', .(e = x.a + i.e)]$e, 6)
+
+# allow na.strings to be quoted, #6974
+f = tempfile()
+DT = data.table(
+  "Date Example" = c("12/5/2012", NA),
+  "Question 1" = c("Yes", NA),
+  "Question 2" = c("Yes", NA),
+  "Site: Country" = c("Chile", "Virgin Islands, British")
+)
+fwrite(DT, f, na = '""')
+test(2318.1, fread(f, na.strings = '""'), DT)
+unlink(f)
+test(2318.2,
+     fread('"foo","bar","baz"\n"a","b","c"', na.strings = c('"foo"', '"bar"', '"baz"'), header = FALSE),
+     data.table(V1 = c(NA, "a"), V2 = c(NA, "b"), V3 = c(NA, "c")))

--- a/src/fread.c
+++ b/src/fread.c
@@ -525,6 +525,8 @@ static void Field(FieldParseContext *ctx)
   //    the field is quoted and quotes are correctly escaped (quoteRule 0 and 1)
   // or the field is quoted but quotes are not escaped (quoteRule 2)
   // or the field is not quoted but the data contains a quote at the start (quoteRule 2 too)
+  // What if this string signifies an NA? Will find out after we're done parsing quotes
+  const char *field_after_NA = end_NA_string(fieldStart);
   fieldStart++;  // step over opening quote
   switch(quoteRule) {
   case 0:  // quoted with embedded quotes doubled; the final unescaped " must be followed by sep|eol
@@ -583,6 +585,8 @@ static void Field(FieldParseContext *ctx)
     if (ch==eof && quoteRule!=2) { target->off--; target->len++; }   // test 1324 where final field has open quote but not ending quote; include the open quote like quote rule 2
     while(target->len>0 && ((ch[-1]==' ' && stripWhite) || ch[-1]=='\0')) { target->len--; ch--; }  // test 1551.6; trailing whitespace in field [67,V37] == "\"\"A\"\" ST       "
   }
+  // Does end-of-field correspond to end-of-possible-NA?
+  if (field_after_NA == ch) target->len = INT32_MIN;
 }
 
 static void str_to_i32_core(const char **pch, int32_t *target, bool parse_date)


### PR DESCRIPTION
Previously, `Field()` only called `end_NA_string()` for non-quoted fields, making it impossible to set `na.strings='""'` and parse empty quoted strings as missing.

Fixes: #6974