### PR TITLE
Mark `internal_error` and friends as `__noreturn__`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,7 +42,7 @@
 
 11. Out of sample type bumps now respect `integer64=` selection, [#7032](https://github.com/Rdatatable/data.table/pull/7032).
 
-12. Internal functions used to signal errors are now marked as non-returning, silencing a compiler warning about potentially unchecked allocation failure. Thanks to Prof. Brian D. Ripley for the report and @aitap for the fix, #7070.
+12. Internal functions used to signal errors are now marked as non-returning, silencing a compiler warning about potentially unchecked allocation failure. Thanks to Prof. Brian D. Ripley for the report and @aitap for the fix, [#7070](https://github.com/Rdatatable/data.table/pull/7070).
 
 ### NOTES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,8 @@
 
 11. Out of sample type bumps now respect `integer64=` selection, [#7032](https://github.com/Rdatatable/data.table/pull/7032).
 
+12. Internal functions used to signal errors are now marked as non-returning, silencing a compiler warning about potentially unchecked allocation failure. Thanks to Prof. Brian D. Ripley for the report and @aitap for the fix, #7070.
+
 ### NOTES
 
 1. Continued work to remove non-API C functions, [#6180](https://github.com/Rdatatable/data.table/issues/6180). Thanks Ivan Krylov for the PRs and for writing a clear and concise guide about the R API: https://aitap.codeberg.page/R-api/.

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -78,6 +78,15 @@
 #define NEED2UTF8(s) !(IS_ASCII(s) || (s)==NA_STRING || IS_UTF8(s))
 #define ENC2UTF8(s) (!NEED2UTF8(s) ? (s) : mkCharCE(translateCharUTF8(s), CE_UTF8))
 
+// R has been providing a widely portable definition, but since that's not documented, define our own too
+#ifndef NORET
+# if defined(__GNUC__) && __GNUC__ >= 3
+#  define NORET __attribute__((__noreturn__))
+# else
+#  define NORET
+# endif
+#endif
+
 // init.c
 extern SEXP char_integer64;
 extern SEXP char_ITime;
@@ -147,7 +156,7 @@ uint64_t dtwiddle(double x);
 SEXP forder(SEXP DT, SEXP by, SEXP retGrpArg, SEXP retStatsArg, SEXP sortGroupsArg, SEXP ascArg, SEXP naArg);
 SEXP forderReuseSorting(SEXP DT, SEXP by, SEXP retGrpArg, SEXP retStatsArg, SEXP sortGroupsArg, SEXP ascArg, SEXP naArg, SEXP reuseSortingArg); // reuseSorting wrapper to forder
 int getNumericRounding_C(void);
-void internal_error_with_cleanup(const char *call_name, const char *format, ...);
+NORET void internal_error_with_cleanup(const char *call_name, const char *format, ...);
 
 // reorder.c
 SEXP reorder(SEXP x, SEXP order);
@@ -263,7 +272,7 @@ SEXP islockedR(SEXP x);
 bool need2utf8(SEXP x);
 SEXP coerceUtf8IfNeeded(SEXP x);
 SEXP coerceAs(SEXP x, SEXP as, SEXP copyArg);
-void internal_error(const char *call_name, const char *format, ...);
+NORET void internal_error(const char *call_name, const char *format, ...);
 
 // types.c
 char *end(char *start);


### PR DESCRIPTION
This prevents a false-positive warning seen with GCC `-fsanitize=...` where an allocation checked using `internal_error()` is considered to be possibly of size zero.

Fixes: #7070