### PR TITLE
Fix: prevent frank() from mutating non-data.table inputs by deep copying atomic and list objects

### DIFF
--- a/R/frank.R
+++ b/R/frank.R
@@ -16,11 +16,14 @@ frankv = function(x, cols=seq_along(x), order=1L, na.last=TRUE, ties.method=c("a
     if (!missing(cols) && !is.null(cols))
       stopf("x is a single vector, non-NULL 'cols' doesn't make sense")
     cols = 1L
+    x = copy(x)  # Deep copy atomic vectors
     x = as_list(x)
   } else {
     cols = colnamesInt(x, cols, check_dups=TRUE)
     if (!length(cols))
       stopf("x is a list, 'cols' can not be 0-length")
+    if (!is.data.frame(x))
+      x = copy(x)
   }
   # need to unlock for #4429
   x = .shallow(x, cols, unlock = TRUE) # shallow copy even if list..

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -21167,3 +21167,38 @@ test(2317.6, DT1[DF1, on='a', .(d = x.a + i.d)]$d, 5)
 test(2317.7, DT1[DF2, on='a', e := i.e]$e, 5)
 test(2317.8, DT1[DF2, on='a', e2 := x.a + i.e]$e2, 6)
 test(2317.9, DT1[DF2, on='a', .(e = x.a + i.e)]$e, 6)
+
+# frank() should not strip names from named vector input
+x = c(a = "a", b = "b", c = "a")
+test(2318.01, { frank(x); names(x) }, c("a", "b", "c"))
+
+# frank() should not modify names inside a list of named vectors
+ls = list(a = c(a = 1, b = 2), b = c(a = 2, b = 3))
+frank(ls)
+test(2318.02, names(ls[[1]]), c("a", "b"))
+test(2318.03, names(ls[[2]]), c("a", "b"))
+
+# frank() should not mutate original list (deep equality)
+ls = list(a = c(a = 10, b = 20), b = c(a = 30, b = 40))
+original_ls = list(a = c(a = 10, b = 20), b = c(a = 30, b = 40))
+frank(ls)
+test(2318.04, identical(ls, original_ls), TRUE)
+
+# frank() should not mutate list of unnamed vectors (control)
+ls = list(a = c(1, 2), b = c(2, 3))
+original_ls = list(a = c(1, 2), b = c(2, 3))
+frank(ls)
+test(2318.05, identical(ls, original_ls), TRUE)
+
+# frank() should return correct ranks on data.table column without side effect
+DT = data.table(x = c(3, 2, 1, 3))
+original_x = DT$x
+ranks = frank(DT$x)
+test(2318.06, ranks, c(3.5, 2, 1, 3.5))
+test(2318.07, identical(DT$x, original_x), TRUE)
+
+# frank() should preserve names on factors
+x = factor(c("low", "medium", "high"), levels = c("low", "medium", "high"))
+names(x) = c("a", "b", "c")
+frank(x)
+test(2318.08, names(x), c("a", "b", "c"))


### PR DESCRIPTION
closes #5617

This PR resolves the long-standing issue where frank() modified non-data.table inputs as a side effect — particularly named atomic vectors and lists with named components

Changes made:

Atomic inputs (e.g., named vectors, factors):
- Now explicitly deep copied using copy(x) before converting to list form with as_list(x) to avoid modifying the original input in-place.

List inputs (e.g., list(a = c(a = 1, b = 2), ...)) that are not data.frames:
- Are now deep copied before further processing, ensuring that internal modifications (like setDT) do not mutate the original list or strip names from its components.

Benefits:
- Keeps names and attributes on vectors and lists intact.


Hi @MichaelChirico, @tdhock, @joshhwuu, @jangorecki  — please take a look when you have time. Thanks!
