### PR TITLE
Define `typeof` for C < 23

### DIFF
--- a/src/fread.c
+++ b/src/fread.c
@@ -117,6 +117,9 @@ static void Field(FieldParseContext *ctx);
 #define IGNORE_BUMP(x) abs(x)
 #define TOGGLE_BUMP(x) (-x)
 
+#if !defined(__STDC_VERSION__) || __STDC_VERSION__ < 202311L
+#  define typeof(x) __typeof__(x) // nonstandard but widely supported extension
+#endif
 #define OFFSET_POINTER(x, offset) ((typeof(x))((char*)x + (offset)))
 
 //=================================================================================================


### PR DESCRIPTION
This prevents [failures when compiling with `--std=c$V` for `$V` < 23](https://rdatatable.gitlab.io/data.table/web/checks/data.table/test-lin-dev-clang-cran/log). (`typeof` is part of C23.) While this is still non-standard C, the `__typeof__` extension is supported very widely, probably wider than the platforms where R itself is ported to, to the point where the recommendation on `#gcc` at [libera.chat](https://libera.chat) was to just switch to `__typeof__`.

There are alternative options mentioned at https://github.com/Rdatatable/data.table/issues/7042#issuecomment-2927723557, but this one has the smallest diff.

Fixes: #7042.