### PR TITLE
Only warn once about '...' contents in merge.data.table

### DIFF
--- a/R/merge.R
+++ b/R/merge.R
@@ -76,7 +76,7 @@ merge.data.table = function(x, y, by = NULL, by.x = NULL, by.y = NULL, all = FAL
                                   "merge.data.table() received %d unknown keyword arguments which will be ignored: %s"),
                  n_dots, brackify(nm))
       } else {
-        unnamed_clause <- ngettext(n_unnamed, "%d unnamed argumentin '...'", "%d unnamed arguments in '...'")
+        unnamed_clause <- ngettext(n_dots - n_named, "%d unnamed argumentin '...'", "%d unnamed arguments in '...'")
         named_clause <- ngettext(n_named, "%d unknown keyword argument", "%d unknown keyword argument")
         warningf("merge.data.table() received %s and %s, all of which will be ignored: %s", unnamed_clause, named_clause, brackify(nm[named_idx]))
       }

--- a/R/merge.R
+++ b/R/merge.R
@@ -77,8 +77,8 @@ merge.data.table = function(x, y, by = NULL, by.x = NULL, by.y = NULL, all = FAL
                  n_dots, brackify(nm))
       } else {
         n_named <- sum(named_idx)
-        unnamed_clause <- ngettext(n_dots - n_named, "%d unnamed argumentin '...'", "%d unnamed arguments in '...'")
-        named_clause <- ngettext(n_named, "%d unknown keyword argument", "%d unknown keyword argument")
+        unnamed_clause <- sprintf(ngettext(n_dots - n_named, "%d unnamed argument in '...'", "%d unnamed arguments in '...'"), n_dots - n_named)
+        named_clause <- sprintf(ngettext(n_named, "%d unknown keyword argument", "%d unknown keyword argument"), n_named)
         warningf("merge.data.table() received %s and %s, all of which will be ignored: %s", unnamed_clause, named_clause, brackify(nm[named_idx]))
       }
     }

--- a/R/merge.R
+++ b/R/merge.R
@@ -66,14 +66,24 @@ merge.data.table = function(x, y, by = NULL, by.x = NULL, by.y = NULL, all = FAL
   # TODO(R >= 3.5.0): use ...length()
   if (n_dots <- length(dots <- list(...))) {
     if (is.null(nm <- names(dots))) {
-      warningf("%d unnamed arguments wound up in '...' and will be ignored.", n_dots)
+      warningf(ngettext(n_dots, "%d unnamed argument wound up in '...' and will be ignored.",
+                                "%d unnamed arguments wound up in '...' and will be ignored."),
+               n_dots)
     } else {
-      named_idx <- nzchar(nm)
+      named_idx = nzchar(nm)
       if (all(named_idx)) {
-        warningf("merge.data.table() received %d unknown keyword arguments which will be ignored: %s", n_dots, brackify(nm))
+        warningf(ngettext(n_dots, "merge.data.table() received %d unknown keyword argument which will be ignored: %s"
+                                  "merge.data.table() received %d unknown keyword arguments which will be ignored: %s"),
+                 n_dots, brackify(nm))
       } else {
-        n_named <- sum(named_idx)
-        warningf("merge.data.table() received %d unnamed arguments in '...' and %d unknown keyword arguments, all of which will be ignored: %s", n_dots - n_named, n_named, brackify(nm[named_idx]))
+        n_named = sum(named_idx)
+        n_unnamed = n_dots - n_named
+        warningf(ngettext(n_named,
+                          ngettext(n_unnamed, "merge.data.table() received %d unnamed argument in '...' and %d unknown keyword argument, all of which will be ignored: %s",
+                                              "merge.data.table() received %d unnamed arguments in '...' and %d unknown keyword argument, all of which will be ignored: %s"),
+                          ngettext(n_unnamed, "merge.data.table() received %d unnamed argument in '...' and %d unknown keyword arguments, all of which will be ignored: %s",
+                                              "merge.data.table() received %d unnamed arguments in '...' and %d unknown keyword arguments, all of which will be ignored: %s")),
+                 n_unnamed, n_named, brackify(nm[named_idx]))
       }
     }
   }

--- a/R/merge.R
+++ b/R/merge.R
@@ -66,8 +66,8 @@ merge.data.table = function(x, y, by = NULL, by.x = NULL, by.y = NULL, all = FAL
   # TODO(R >= 3.5.0): use ...length()
   if (n_dots <- length(dots <- list(...))) {
     if (is.null(nm <- names(dots))) {
-      warningf(ngettext(n_dots, "%d unnamed argument wound up in '...' and will be ignored.",
-                                "%d unnamed arguments wound up in '...' and will be ignored."),
+      warningf(ngettext(n_dots, "merge.data.table() received %d unnamed argument in '...' which will be ignored.",
+                                "merge.data.table() received %d unnamed arguments in '...' which will be ignored."),
                n_dots)
     } else {
       named_idx = nzchar(nm)
@@ -76,14 +76,9 @@ merge.data.table = function(x, y, by = NULL, by.x = NULL, by.y = NULL, all = FAL
                                   "merge.data.table() received %d unknown keyword arguments which will be ignored: %s"),
                  n_dots, brackify(nm))
       } else {
-        n_named = sum(named_idx)
-        n_unnamed = n_dots - n_named
-        warningf(ngettext(n_named,
-                          ngettext(n_unnamed, "merge.data.table() received %d unnamed argument in '...' and %d unknown keyword argument, all of which will be ignored: %s",
-                                              "merge.data.table() received %d unnamed arguments in '...' and %d unknown keyword argument, all of which will be ignored: %s"),
-                          ngettext(n_unnamed, "merge.data.table() received %d unnamed argument in '...' and %d unknown keyword arguments, all of which will be ignored: %s",
-                                              "merge.data.table() received %d unnamed arguments in '...' and %d unknown keyword arguments, all of which will be ignored: %s")),
-                 n_unnamed, n_named, brackify(nm[named_idx]))
+        unnamed_clause <- ngettext(n_unnamed, "%d unnamed argumentin '...'", "%d unnamed arguments in '...'")
+        named_clause <- ngettext(n_named, "%d unknown keyword argument", "%d unknown keyword argument")
+        warningf("merge.data.table() received %s and %s, all of which will be ignored: %s", unnamed_clause, named_clause, brackify(nm[named_idx]))
       }
     }
   }

--- a/R/merge.R
+++ b/R/merge.R
@@ -72,7 +72,7 @@ merge.data.table = function(x, y, by = NULL, by.x = NULL, by.y = NULL, all = FAL
     } else {
       named_idx = nzchar(nm)
       if (all(named_idx)) {
-        warningf(ngettext(n_dots, "merge.data.table() received %d unknown keyword argument which will be ignored: %s"
+        warningf(ngettext(n_dots, "merge.data.table() received %d unknown keyword argument which will be ignored: %s",
                                   "merge.data.table() received %d unknown keyword arguments which will be ignored: %s"),
                  n_dots, brackify(nm))
       } else {

--- a/R/merge.R
+++ b/R/merge.R
@@ -78,7 +78,7 @@ merge.data.table = function(x, y, by = NULL, by.x = NULL, by.y = NULL, all = FAL
       } else {
         n_named <- sum(named_idx)
         unnamed_clause <- sprintf(ngettext(n_dots - n_named, "%d unnamed argument in '...'", "%d unnamed arguments in '...'"), n_dots - n_named)
-        named_clause <- sprintf(ngettext(n_named, "%d unknown keyword argument", "%d unknown keyword argument"), n_named)
+        named_clause <- sprintf(ngettext(n_named, "%d unknown keyword argument", "%d unknown keyword arguments"), n_named)
         warningf("merge.data.table() received %s and %s, all of which will be ignored: %s", unnamed_clause, named_clause, brackify(nm[named_idx]))
       }
     }

--- a/R/merge.R
+++ b/R/merge.R
@@ -63,12 +63,19 @@ merge.data.table = function(x, y, by = NULL, by.x = NULL, by.y = NULL, all = FAL
   }
 
   # warn about unused arguments #2587
-  if (length(list(...))) {
-    ell = as.list(substitute(list(...)))[-1L]
-    for (n in setdiff(names(ell), "")) warningf("Unknown argument '%s' has been passed.", n)
-    unnamed_n = length(ell) - sum(nzchar(names(ell)))
-    if (unnamed_n)
-      warningf("Passed %d unknown and unnamed arguments.", unnamed_n)
+  # TODO(R >= 3.5.0): use ...length()
+  if (n_dots <- length(dots <- list(...))) {
+    if (is.null(nm <- names(dots))) {
+      warningf("%d unnamed arguments wound up in '...' and will be ignored.", n_dots)
+    } else {
+      named_idx <- nzchar(nm)
+      if (all(named_idx)) {
+        warningf("merge.data.table() received %d unknown keyword arguments which will be ignored: %s", n_dots, brackify(nm))
+      } else {
+        n_named <- sum(named_idx)
+        warningf("merge.data.table() received %d unnamed arguments in '...' and %d unknown keyword arguments, all of which will be ignored: %s", n_dots - n_named, n_named, brackify(nm[named_idx]))
+      }
+    }
   }
   # with i. prefix in v1.9.3, this goes away. Left here for now ...
   ## sidestep the auto-increment column number feature-leading-to-bug by

--- a/R/merge.R
+++ b/R/merge.R
@@ -76,6 +76,7 @@ merge.data.table = function(x, y, by = NULL, by.x = NULL, by.y = NULL, all = FAL
                                   "merge.data.table() received %d unknown keyword arguments which will be ignored: %s"),
                  n_dots, brackify(nm))
       } else {
+        n_named <- sum(named_idx)
         unnamed_clause <- ngettext(n_dots - n_named, "%d unnamed argumentin '...'", "%d unnamed arguments in '...'")
         named_clause <- ngettext(n_named, "%d unknown keyword argument", "%d unknown keyword argument")
         warningf("merge.data.table() received %s and %s, all of which will be ignored: %s", unnamed_clause, named_clause, brackify(nm[named_idx]))

--- a/R/merge.R
+++ b/R/merge.R
@@ -63,26 +63,8 @@ merge.data.table = function(x, y, by = NULL, by.x = NULL, by.y = NULL, all = FAL
   }
 
   # warn about unused arguments #2587
-  # TODO(R >= 3.5.0): use ...length()
-  if (n_dots <- length(dots <- list(...))) {
-    if (is.null(nm <- names(dots))) {
-      warningf(ngettext(n_dots, "merge.data.table() received %d unnamed argument in '...' which will be ignored.",
-                                "merge.data.table() received %d unnamed arguments in '...' which will be ignored."),
-               n_dots)
-    } else {
-      named_idx = nzchar(nm)
-      if (all(named_idx)) {
-        warningf(ngettext(n_dots, "merge.data.table() received %d unknown keyword argument which will be ignored: %s",
-                                  "merge.data.table() received %d unknown keyword arguments which will be ignored: %s"),
-                 n_dots, brackify(nm))
-      } else {
-        n_named <- sum(named_idx)
-        unnamed_clause <- sprintf(ngettext(n_dots - n_named, "%d unnamed argument in '...'", "%d unnamed arguments in '...'"), n_dots - n_named)
-        named_clause <- sprintf(ngettext(n_named, "%d unknown keyword argument", "%d unknown keyword arguments"), n_named)
-        warningf("merge.data.table() received %s and %s, all of which will be ignored: %s", unnamed_clause, named_clause, brackify(nm[named_idx]))
-      }
-    }
-  }
+  .maybe_warn_merge_dots(...)
+
   # with i. prefix in v1.9.3, this goes away. Left here for now ...
   ## sidestep the auto-increment column number feature-leading-to-bug by
   ## ensuring no names end in ".1", see unit test
@@ -137,4 +119,29 @@ merge.data.table = function(x, y, by = NULL, by.x = NULL, by.y = NULL, all = FAL
   # retain custom classes of first argument that resulted in dispatch to this method, #1378
   setattr(dt, "class", class_x)
   dt
+}
+
+.maybe_warn_merge_dots <- function(...) {
+  # TODO(R >= 3.5.0): use ...length()
+  n_dots <- length(dots <- list(...))
+  if (!n_dots) return(invisible())
+
+  nm <- names(dots)
+  if (is.null(nm)) {
+    warningf(ngettext(n_dots, "merge.data.table() received %d unnamed argument in '...' which will be ignored.",
+                              "merge.data.table() received %d unnamed arguments in '...' which will be ignored."),
+              n_dots)
+  } else {
+    named_idx = nzchar(nm)
+    if (all(named_idx)) {
+      warningf(ngettext(n_dots, "merge.data.table() received %d unknown keyword argument which will be ignored: %s",
+                                "merge.data.table() received %d unknown keyword arguments which will be ignored: %s"),
+                n_dots, brackify(nm))
+    } else {
+      n_named <- sum(named_idx)
+      unnamed_clause <- sprintf(ngettext(n_dots - n_named, "%d unnamed argument in '...'", "%d unnamed arguments in '...'"), n_dots - n_named)
+      named_clause <- sprintf(ngettext(n_named, "%d unknown keyword argument", "%d unknown keyword arguments"), n_named)
+      warningf("merge.data.table() received %s and %s, all of which will be ignored: %s", unnamed_clause, named_clause, brackify(nm[named_idx]))
+    }
+  }
 }

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -17988,10 +17988,10 @@ test(2230.04, setDF(merge(DT, y, by="k2", incomparables=c(1, NA, 4, 5))), merge(
 test(2230.05, setDF(merge(DT, y, by="k2", incomparables=c(NA, 3, 4, 5))), merge(x, y, by="k2", incomparables=c(NA,3,4,5)))
 test(2230.06, merge(DT, y, by="k2", unk=1), merge(DT, y, by="k2"), warning="1 unknown keyword argument which will be ignored: [unk]")
 test(2230.07, merge(DT, y, by="k2", NULL, NULL, FALSE, FALSE, FALSE, TRUE, c(".x", ".y"), TRUE, getOption("datatable.allow.cartesian"), NULL, 1L),
-              merge(DT, y, by="k2"), warning=c("Supplied both `by` and `by.x`/`by.y`. `by` argument will be ignored.", "1 unnamed argument wound up in '...' and will be ignored."))
+              merge(DT, y, by="k2"), warning=c("Supplied both `by` and `by.x`/`by.y`. `by` argument will be ignored.", "1 unnamed argument in '...' which will be ignored."))
 test(2230.08, merge(DT, y, by="k2", unk1=1, unk2=2), merge(DT, y, by="k2"), warning="2 unknown keyword arguments which will be ignored: [unk1, unk2]")
 test(2230.09, merge(DT, y, by="k2", NULL, NULL, FALSE, FALSE, FALSE, TRUE, c(".x", ".y"), TRUE, getOption("datatable.allow.cartesian"), NULL, 1L, 2L),
-              merge(DT, y, by="k2"), warning=c("Supplied both `by` and `by.x`/`by.y`. `by` argument will be ignored.", "2 unnamed arguments wound up in '...' and will be ignored."))
+              merge(DT, y, by="k2"), warning=c("Supplied both `by` and `by.x`/`by.y`. `by` argument will be ignored.", "2 unnamed arguments in '...' which will be ignored."))
 test(2230.10, merge(DT, y, by="k2", NULL, NULL, FALSE, FALSE, FALSE, TRUE, c(".x", ".y"), TRUE, getOption("datatable.allow.cartesian"), NULL, unk=1L, 2L),
               merge(DT, y, by="k2"), warning=c("Supplied both `by` and `by.x`/`by.y`. `by` argument will be ignored.", "1 unnamed argument .*1 unknown keyword argument,.*\\[unk\\]"))
 test(2230.11, merge(DT, y, by="k2", NULL, NULL, FALSE, FALSE, FALSE, TRUE, c(".x", ".y"), TRUE, getOption("datatable.allow.cartesian"), NULL, unk1=1L, unk2=2L, 3L),

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -17981,14 +17981,26 @@ test(2229.6, fread(testDir("multi-file.zip")), error="Compressed files containin
 x = data.frame(k1 = c(NA,NA,3,4,5), k2 = c(1,NA,NA,4,5), data = 1:5)
 y = data.frame(k1 = c(NA,2,NA,4,5), k2 = c(NA,NA,3,4,5), data = 1:5)
 DT = as.data.table(x)
-test(2230.1, setDF(merge(DT, y, by="k2", incomparables=NA)),         merge(x, y, by="k2", incomparables=NA))
-test(2230.2, setDF(merge(DT, y, by="k2", incomparables=c(NA,4))),    merge(x, y, by="k2", incomparables=c(NA,4)))
-test(2230.3, setDF(merge(DT, y, by="k2", incomparables=c(4,5))),     merge(x, y, by="k2", incomparables=c(4,5)))
-test(2230.4, setDF(merge(DT, y, by="k2", incomparables=c(1, NA, 4, 5))), merge(x, y, by="k2", incomparables=c(1,NA,4,5)))
-test(2230.5, setDF(merge(DT, y, by="k2", incomparables=c(NA, 3, 4, 5))), merge(x, y, by="k2", incomparables=c(NA,3,4,5)))
-test(2230.6, merge(DT, y, by="k2", unk=1), merge(DT, y, by="k2"), warning="1 unknown keyword argument which will be ignored: [unk]")
-test(2230.7, merge(DT, y, by="k2", NULL, NULL, FALSE, FALSE, FALSE, TRUE, c(".x", ".y"), TRUE, getOption("datatable.allow.cartesian"), NULL, 1L),
-             merge(DT, y, by="k2"), warning=c("Supplied both `by` and `by.x`/`by.y`. `by` argument will be ignored.", "1 unnamed arguments wound up in '...' and will be ignored."))
+test(2230.01, setDF(merge(DT, y, by="k2", incomparables=NA)),         merge(x, y, by="k2", incomparables=NA))
+test(2230.02, setDF(merge(DT, y, by="k2", incomparables=c(NA,4))),    merge(x, y, by="k2", incomparables=c(NA,4)))
+test(2230.03, setDF(merge(DT, y, by="k2", incomparables=c(4,5))),     merge(x, y, by="k2", incomparables=c(4,5)))
+test(2230.04, setDF(merge(DT, y, by="k2", incomparables=c(1, NA, 4, 5))), merge(x, y, by="k2", incomparables=c(1,NA,4,5)))
+test(2230.05, setDF(merge(DT, y, by="k2", incomparables=c(NA, 3, 4, 5))), merge(x, y, by="k2", incomparables=c(NA,3,4,5)))
+test(2230.06, merge(DT, y, by="k2", unk=1), merge(DT, y, by="k2"), warning="1 unknown keyword argument which will be ignored: [unk]")
+test(2230.07, merge(DT, y, by="k2", NULL, NULL, FALSE, FALSE, FALSE, TRUE, c(".x", ".y"), TRUE, getOption("datatable.allow.cartesian"), NULL, 1L),
+              merge(DT, y, by="k2"), warning=c("Supplied both `by` and `by.x`/`by.y`. `by` argument will be ignored.", "1 unnamed argument wound up in '...' and will be ignored."))
+test(2230.08, merge(DT, y, by="k2", unk1=1, unk2=2), merge(DT, y, by="k2"), warning="2 unknown keyword arguments which will be ignored: [unk1, unk2]")
+test(2230.09, merge(DT, y, by="k2", NULL, NULL, FALSE, FALSE, FALSE, TRUE, c(".x", ".y"), TRUE, getOption("datatable.allow.cartesian"), NULL, 1L, 2L),
+              merge(DT, y, by="k2"), warning=c("Supplied both `by` and `by.x`/`by.y`. `by` argument will be ignored.", "2 unnamed arguments wound up in '...' and will be ignored."))
+test(2230.10, merge(DT, y, by="k2", NULL, NULL, FALSE, FALSE, FALSE, TRUE, c(".x", ".y"), TRUE, getOption("datatable.allow.cartesian"), NULL, unk=1L, 2L),
+              merge(DT, y, by="k2"), warning=c("Supplied both `by` and `by.x`/`by.y`. `by` argument will be ignored.", "1 unnamed argument .*1 unknown keyword argument,.*\\[unk\\]"))
+test(2230.11, merge(DT, y, by="k2", NULL, NULL, FALSE, FALSE, FALSE, TRUE, c(".x", ".y"), TRUE, getOption("datatable.allow.cartesian"), NULL, unk1=1L, unk2=2L, 3L),
+              merge(DT, y, by="k2"), warning=c("Supplied both `by` and `by.x`/`by.y`. `by` argument will be ignored.", "1 unnamed argument .*2 unknown keyword arguments.*\\[unk1, unk2\\]"))
+test(2230.12, merge(DT, y, by="k2", NULL, NULL, FALSE, FALSE, FALSE, TRUE, c(".x", ".y"), TRUE, getOption("datatable.allow.cartesian"), NULL, unk=1L, 2L, 3L),
+              merge(DT, y, by="k2"), warning=c("Supplied both `by` and `by.x`/`by.y`. `by` argument will be ignored.", "2 unnamed arguments.*1 unknown keyword argument,.*\\[unk\\]"))
+test(2230.13, merge(DT, y, by="k2", NULL, NULL, FALSE, FALSE, FALSE, TRUE, c(".x", ".y"), TRUE, getOption("datatable.allow.cartesian"), NULL, unk1=1L, unk2=2L, 3L, 4L),
+              merge(DT, y, by="k2"), warning=c("Supplied both `by` and `by.x`/`by.y`. `by` argument will be ignored.", "2 unnamed arguments.*2 unknown keyword arguments.*\\[unk1, unk2\\]"))
+
 
 # weighted.mean GForce optimized, #3977
 old = options(datatable.optimize=1L)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -17986,9 +17986,9 @@ test(2230.2, setDF(merge(DT, y, by="k2", incomparables=c(NA,4))),    merge(x, y,
 test(2230.3, setDF(merge(DT, y, by="k2", incomparables=c(4,5))),     merge(x, y, by="k2", incomparables=c(4,5)))
 test(2230.4, setDF(merge(DT, y, by="k2", incomparables=c(1, NA, 4, 5))), merge(x, y, by="k2", incomparables=c(1,NA,4,5)))
 test(2230.5, setDF(merge(DT, y, by="k2", incomparables=c(NA, 3, 4, 5))), merge(x, y, by="k2", incomparables=c(NA,3,4,5)))
-test(2230.6, merge(DT, y, by="k2", unk=1), merge(DT, y, by="k2"), warning="Unknown argument 'unk' has been passed.")
+test(2230.6, merge(DT, y, by="k2", unk=1), merge(DT, y, by="k2"), warning="1 unknown keyword argument which will be ignored: [unk]")
 test(2230.7, merge(DT, y, by="k2", NULL, NULL, FALSE, FALSE, FALSE, TRUE, c(".x", ".y"), TRUE, getOption("datatable.allow.cartesian"), NULL, 1L),
-             merge(DT, y, by="k2"), warning=c("Supplied both `by` and `by.x`/`by.y`. `by` argument will be ignored.", "Passed 1 unknown and unnamed arguments."))
+             merge(DT, y, by="k2"), warning=c("Supplied both `by` and `by.x`/`by.y`. `by` argument will be ignored.", "1 unnamed arguments wound up in '...' and will be ignored."))
 
 # weighted.mean GForce optimized, #3977
 old = options(datatable.optimize=1L)


### PR DESCRIPTION
Step one towards #7088.

First I want to unify warning handling -- it doesn't make sense to throw potentially dozens of warnings for the same fundamental issue (ignored arguments in `...`).