### PR TITLE
Ignore vscode config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ config.log
 .Rproj.user
 data.table.Rproj
 
+# VScode IDE files
+.vscode
+
 # zed editor
 .zed
 


### PR DESCRIPTION
Have seen these pop up by mistake in more PRs lately, I guess VScode is becoming more & more popular for R dev (I use it myself but haven't gotten any of these config folders in my local directory)...