### PR TITLE
Add error handling for gzipped file decompression and external command failures in fread()

### DIFF
--- a/R/fread.R
+++ b/R/fread.R
@@ -70,9 +70,13 @@ yaml=FALSE, tmpdir=tempdir(), tz="UTC")
     }
   }
   if (!is.null(cmd)) {
-    (if (.Platform$OS.type == "unix") system else shell)(paste0('(', cmd, ') > ', tmpFile<-tempfile(tmpdir=tmpdir)))
+    tmpFile = tempfile(tmpdir=tmpdir)
+    on.exit(unlink(tmpFile), add=TRUE)  
+    status = suppressWarnings((if (.Platform$OS.type == "unix") system else shell)(paste0('(', cmd, ') > ', tmpFile)))
+    if (status != 0) {
+      stopf("External command failed with exit code %d. This can happen when the disk is full in the temporary directory ('%s'). See ?fread for the tmpdir argument.", status, tmpdir)
+    }
     file = tmpFile
-    on.exit(unlink(tmpFile), add=TRUE)
   }
   if (!is.null(file)) {
     if (!is.character(file) || length(file)!=1L)
@@ -116,9 +120,14 @@ yaml=FALSE, tmpdir=tempdir(), tz="UTC")
       if (!requireNamespace("R.utils", quietly = TRUE))
         stopf("To read %s files directly, fread() requires 'R.utils' package which cannot be found. Please install 'R.utils' using 'install.packages('R.utils')'.", if (w<=2L || gzsig) "gz" else "bz2") # nocov
       FUN = if (w<=2L || gzsig) gzfile else bzfile
-      R.utils::decompressFile(file, decompFile<-tempfile(tmpdir=tmpdir), ext=NULL, FUN=FUN, remove=FALSE)   # ext is not used by decompressFile when destname is supplied, but isn't optional
-      file = decompFile   # don't use 'tmpFile' symbol again, as tmpFile might be the http://domain.org/file.csv.gz download
-      on.exit(unlink(decompFile), add=TRUE)
+      decompFile = tempfile(tmpdir=tmpdir)
+      on.exit(unlink(decompFile), add=TRUE)  
+      tryCatch({
+        R.utils::decompressFile(file, decompFile, ext=NULL, FUN=FUN, remove=FALSE)
+      }, error = function(e) {
+        stopf("Failed to decompress file '%s'. This can happen when the disk is full in the temporary directory ('%s'). See ?fread for the tmpdir argument.", file, tmpdir)
+      })
+      file = decompFile
     }
     file = enc2native(file) # CfreadR cannot handle UTF-8 if that is not the native encoding, see #3078.
 


### PR DESCRIPTION
 fixes #5415 

This PR enhances `fread()`'s error handling to provide actionable error messages when system commands fail or file decompression encounters issues (like disk full scenarios). Previously, these failures could result in warnings or silent truncation.

The current implementation of `fread()` has two silent failure modes that can lead to data corruption and hard-to-debug issues:

- **Gzipped file decompression failures:** When `R.utils::decompressFile()` fails due to insufficient disk space or other issues, the function silently continues with a truncated file, leading to partial data reads and warnings that are easily missed in non-interactive sessions.

- **External command failures:** When using the `cmd` parameter, failed external commands (non-zero exit codes) are not detected, potentially leading to processing of empty or incomplete files.


**Solution-**
- As `R.utils::decompressFile()` is called without error handling, allowing silent failures so I wrapped `R.utils::decompressFile()` in `tryCatch()` to catch decompression failures and added comprehensive error message that explains the likely cause (disk full) and mention disc space and `tmpdir` argument.

- And System command exit codes are not checked thus missing command failures, so to fix - Captured the return status from `system()` command and added exit code validation with error message.

- Also in both modifications - moved `on.exit(unlink(tmpFile), add=TRUE)` before command execution to prevent storage leaks.


@tdhock @jangorecki @Anirban166 @joshhwuu can you please review.