### PR TITLE
link to CI status dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CRAN status](https://badges.cranchecks.info/flavor/release/data.table.svg)](https://cran.r-project.org/web/checks/check_results_data.table.html)
 [![R-CMD-check](https://github.com/Rdatatable/data.table/workflows/R-CMD-check/badge.svg)](https://github.com/Rdatatable/data.table/actions)
 [![Codecov test coverage](https://codecov.io/github/Rdatatable/data.table/coverage.svg?branch=master)](https://app.codecov.io/github/Rdatatable/data.table?branch=master)
-[![GitLab CI build status](https://gitlab.com/Rdatatable/data.table/badges/master/pipeline.svg)](https://gitlab.com/Rdatatable/data.table/-/pipelines)
+[![GitLab CI build status](https://gitlab.com/Rdatatable/data.table/badges/master/pipeline.svg)](https://rdatatable.gitlab.io/data.table/web/checks/check_results_data.table.html)
 [![downloads](https://cranlogs.r-pkg.org/badges/data.table)](https://www.rdocumentation.org/trends)
 [![CRAN usage](https://jangorecki.gitlab.io/rdeps/data.table/CRAN_usage.svg?sanitize=true)](https://gitlab.com/jangorecki/rdeps)
 [![BioC usage](https://jangorecki.gitlab.io/rdeps/data.table/BioC_usage.svg?sanitize=true)](https://gitlab.com/jangorecki/rdeps)


### PR DESCRIPTION
Thanks for addressing minor issues with CI (updating allowed NOTEs count, fixing compilation warnings, etc.)!
As a result the dashboard is useful again!

I am proposing to change the link for our CI status dashboard rather than CI pipeline list.

Why to change?
- dashboard is much more useful overview than a pipelines list

Why not to change?
- status icon (green/red) is out of sync for the dashboard content
  - if the status icon is red, then it means that dashboard haven't been updated at all, so any information available there refers to latest successful pipeline.
  - if the status icon is green, then dashboard have been updated, but failed might be still present there (as is now).
