### PR TITLE
Assign coerceAs within other.Rraw suite

### DIFF
--- a/inst/tests/other.Rraw
+++ b/inst/tests/other.Rraw
@@ -18,6 +18,7 @@ if (exists("test.data.table",.GlobalEnv,inherits=FALSE) ||
 }
 
 test = data.table:::test
+coerceAs = data.table:::coerceAs
 INT = data.table:::INT
 
 if (anyDuplicated(pkgs)) stop("Packages defined to be loaded for integration tests in 'inst/tests/other.Rraw' contains duplicates.")


### PR DESCRIPTION
Currently the suite fails on `master`:

```
Running test id 27.21         Test 27.21 produced 1 errors but expected 0
Expected: 
Observed: could not find function "coerceAs"
Output captured before unexpected warning/error/message:
<simpleError in coerceAs(x, 1): could not find function "coerceAs">
Running test id 27.22         Test 27.22 produced 1 errors but expected 0
Expected: 
Observed: could not find function "coerceAs"
Output captured before unexpected warning/error/message:
<simpleError in coerceAs(x, 1L): could not find function "coerceAs">
Running test id 27.23         Test 27.23 produced 1 errors but expected 0
Expected: 
Observed: could not find function "coerceAs"
Output captured before unexpected warning/error/message:
<simpleError in coerceAs(x, "1"): could not find function "coerceAs">
Running test id 27.24         Test 27.24 produced 1 errors but expected 0
Expected: 
Observed: could not find function "coerceAs"
Output captured before unexpected warning/error/message:
<simpleError in coerceAs(1, x): could not find function "coerceAs">
Running test id 27.25         Test 27.25 produced 1 errors but expected 0
Expected: 
Observed: could not find function "coerceAs"
Output captured before unexpected warning/error/message:
<simpleError in coerceAs(1L, x): could not find function "coerceAs">
Running test id 27.26         Test 27.26 produced 0 warnings but expected 1
Expected: Coercing.*character
Observed: 
Test 27.26 produced 1 errors but expected 0
Expected: 
Observed: could not find function "coerceAs"
Output captured before unexpected warning/error/message:
<simpleError in coerceAs("1", x): could not find function "coerceAs">
Running test id 31            NAME     NROW NCOL   MB                  COLS    KEY
1:   DT 20000000   15 2288 V1,V2,V3,V4,V5,V6,... [NULL]
Total: 2,288MB using type_size
Running test id 32         
Sun Jun 29 18:29:22 2025  endian==little, sizeof(long double)==16, longdouble.digits==64, sizeof(pointer)==8, TZ==unset, Sys.timezone()=='America/Los_Angeles', Sys.getlocale()=='LC_CTYPE=en_SG.UTF-8;LC_NUMERIC=C;LC_TIME=en_SG.UTF-8;LC_COLLATE=en_SG.UTF-8;LC_MONETARY=en_SG.UTF-8;LC_MESSAGES=en_SG.UTF-8;LC_PAPER=en_SG.UTF-8;LC_NAME=C;LC_ADDRESS=C;LC_TELEPHONE=C;LC_MEASUREMENT=en_SG.UTF-8;LC_IDENTIFICATION=C', l10n_info()=='MBCS=TRUE; UTF-8=TRUE; Latin-1=FALSE; codeset=UTF-8', getDTthreads()=='OpenMP version (_OPENMP)==201511; omp_get_num_procs()==8; R_DATATABLE_NUM_PROCS_PERCENT==unset (default 50); R_DATATABLE_NUM_THREADS==unset; R_DATATABLE_THROTTLE==unset (default 1024); omp_get_thread_limit()==2147483647; omp_get_max_threads()==8; OMP_THREAD_LIMIT==unset; OMP_NUM_THREADS==unset; RestoreAfterFork==true; data.table is using 2 threads with throttle==1024. See ?setDTthreads.', .libPaths()=='/home/michael/R/x86_64-pc-linux-gnu-library/4.4','/usr/local/lib/R/site-library','/usr/local/lib/R/library', zlibVersion()==1.2.11 ZLIB_VERSION==1.2.11
Error in test.data.table("other.Rraw") : 
  6 errors out of 160. Search tests/other.Rraw for test numbers 27.21, 27.22, 27.23, 27.24, 27.25, 27.26. Duration: 15.1s elapsed (13.8s cpu).
```

This gets it back running on my machine