### PR TITLE
Add optional= argument to as.data.frame.ITime to interact better with data.frame()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -70,6 +70,8 @@
 
 14. `data.table()` function is now more aligned with `data.frame()` with respect to the names of the output when one of its inputs is a single-column matrix object, [#4124](https://github.com/Rdatatable/data.table/issues/4124). Thanks @PavoDive for the report and @jangorecki for the PR.
 
+15. Including an `ITime` object as a named input to `data.frame()` respects the provided name, i.e. `data.frame(a = as.ITime(...))` will have column `a`, [#4673](https://github.com/Rdatatable/data.table/issues/4673). Thanks @shrektan for the report and @MichaelChirico for the fix.
+
 ### NOTES
 
 1. Continued work to remove non-API C functions, [#6180](https://github.com/Rdatatable/data.table/issues/6180). Thanks Ivan Krylov for the PRs and for writing a clear and concise guide about the R API: https://aitap.codeberg.page/R-api/.

--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -209,7 +209,7 @@ as.character.ITime = format.ITime = function(x, ...) {
   res
 }
 
-as.data.frame.ITime = function(x, ...) {
+as.data.frame.ITime = function(x, ..., optional=FALSE) {
   # This method is just for ggplot2, #1713
   # Avoids the error "cannot coerce class '"ITime"' into a data.frame", but for some reason
   # ggplot2 doesn't seem to call the print method to get axis labels, so still prints integers.
@@ -219,7 +219,8 @@ as.data.frame.ITime = function(x, ...) {
   # ans = list(as.POSIXct(x,tzone=""))  # ggplot2 gives "Error: Discrete value supplied to continuous scale"
   setattr(ans, "class", "data.frame")
   setattr(ans, "row.names", .set_row_names(length(x)))
-  setattr(ans, "names", "V1")
+  # require 'optional' support for passing back to e.g. data.frame() without overriding names there
+  if (!optional) setattr(ans, "names", "V1")
   ans
 }
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -21246,3 +21246,7 @@ test(2322.12, levels(fctr(c("b","a","c"), rev=NA)), error="TRUE or FALSE")
 test(2322.21, levels(fctr(c("b","a","c"), sort=TRUE)), c("a","b","c"))
 test(2322.22, levels(fctr(c("b","a","c"), sort=NA)), error="TRUE or FALSE")
 test(2322.31, levels(fctr(c("b","a","c"), rev=TRUE, sort=TRUE)), c("c","b","a"))
+
+# data.frame() uses provided names of ITime inputs
+test(2323.1, names(data.frame(COL = as.ITime('00:00:00'))), "COL")
+test(2323.2, names(data.frame(b = 1, COL = as.ITime('00:00:00'))), c("b", "COL"))

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -21248,5 +21248,7 @@ test(2322.22, levels(fctr(c("b","a","c"), sort=NA)), error="TRUE or FALSE")
 test(2322.31, levels(fctr(c("b","a","c"), rev=TRUE, sort=TRUE)), c("c","b","a"))
 
 # data.frame() uses provided names of ITime inputs
-test(2323.1, names(data.frame(COL = as.ITime('00:00:00'))), "COL")
-test(2323.2, names(data.frame(b = 1, COL = as.ITime('00:00:00'))), c("b", "COL"))
+it <- as.ITime('00:00:00')
+test(2323.1, names(data.frame(COL = it)), "COL")
+test(2323.2, names(data.frame(b = 1, COL = it)), c("b", "COL"))
+test(2323.3, names(as.data.frame(it, optional=TRUE)), NULL)


### PR DESCRIPTION
Closes #4673. Supersedes #5301.

I'm somewhat confident we don't need this method anymore, but keeping it here precautiously.