### PR TITLE
Missing backslash in `\code{}` markup

### DIFF
--- a/man/fctr.Rd
+++ b/man/fctr.Rd
@@ -3,7 +3,7 @@
 \alias{factor}
 \title{Create a factor retaining original ordering}
 \description{
-  Creates a \code{\link[base:factor]{factor}}.
+  Creates a \code{\link[base]{factor}}.
 
   By default, the output will have its levels in the original order, i.e., \code{levels = unique(x)}, as opposed to \code{factor}'s default where \code{levels = sort(unique(x))}.
 }
@@ -13,7 +13,7 @@ fctr(x, levels=unique(x), ..., sort=FALSE, rev=FALSE)
 \arguments{
   \item{x}{ Object to be turned into a factor. }
   \item{levels}{ Levels for the new factor; \code{unique(x)} by default. }
-  \item{\dots}{ Other arguments passed to \code{\link[base:factor]{factor}}. }
+  \item{\dots}{ Other arguments passed to \code{\link[base]{factor}}. }
   \item{sort}{ Logical, default \code{FALSE}. Should \code{levels} be sorted? }
   \item{rev}{ Logical, default \code{FALSE}. Should \code{levels} be reversed? Applied \emph{after} \code{sort}. }
 }


### PR DESCRIPTION
Two backslashes were forgotten in a recent PR, giving a NOTE:

```
* checking Rd files ... NOTE
checkRd: (-1) fctr.Rd:6: Lost braces
     6 |   Creates a code{\link[base:factor]{factor}}.
       |                 ^
checkRd: (-1) fctr.Rd:16: Lost braces
    16 |   \item{\dots}{ Other arguments passed to code{\link[base:factor]{factor}}. }
       |                                               ^
```

2b4b3ed95f5cb295d2f1aaf629cc7fc88426a1ad is only there because I consider this style [more DRY](https://github.com/Rdatatable/data.table/issues/7095#issuecomment-3023541305), but it can be reverted.