### PR TITLE
removing temporary *ch object

### DIFF
--- a/src/fread.c
+++ b/src/fread.c
@@ -242,13 +242,11 @@ static char *typesAsString(int ncol) {
 static inline void skip_white(const char **pch) {
   // skip space so long as sep isn't space and skip tab so long as sep isn't tab
   // always skip any \0 (NUL) that occur before end of file, #3400
-  const char *ch = *pch;
   if (whiteChar == 0) {   // whiteChar==0 means skip both ' ' and '\t';  sep is neither ' ' nor '\t'.
-    while (*ch == ' ' || *ch == '\t' || (*ch == '\0' && ch < eof)) ch++;
+    while (**pch == ' ' || **pch == '\t' || (**pch == '\0' && *pch < eof)) (*pch)++;
   } else {
-    while (*ch == whiteChar || (*ch == '\0' && ch < eof)) ch++;  // sep is ' ' or '\t' so just skip the other one.
+    while (**pch == whiteChar || (**pch == '\0' && *pch < eof)) (*pch)++;  // sep is ' ' or '\t' so just skip the other one.
   }
-  *pch = ch;
 }
 
 /**


### PR DESCRIPTION
I need feedback on this;

I think using a temporary, which gets reassigned to the original is bad practice, but using the double dereference is ugly, too.

In addition, requiring *ch to be copied back to **pch could be dangerous, and cause bugs if the function returns somewhere you didn't expect.

It may also be reasonable to take in a char*, move it, then return it to avoid a double pointer.

I want to know what you guys think is appropriate before I start renovating all the relevant functions.