### PR TITLE
Skip ALTREP tests on R < 3.5

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -2290,29 +2290,31 @@ test(754.04, DT[, b := a][3, b := 6L], data.table(a=INT(4,2,3),b=INT(4,2,6)))
 test(754.05, DT[, a := as.numeric(a), verbose=TRUE], output="Direct plonk.*no copy")
 RHS = as.integer(DT$a)
 test(754.06, DT[, a:= RHS, verbose=TRUE], output="RHS for item 1 has been duplicated")
-# Expand ALTREPS in assign.c, #5400
-# String conversion gets deferred
-## first, a regression test of R itself -- we want to make sure our own test continues to be useful & testing its intended purpose
-test(754.07, {a = 1:10; .Internal(inspect(a)); b = as.character(a); .Internal(inspect(b))}, output = "\\bcompact\\b.*\\bdeferred string conversion\\b")
-test(754.08, DT[, a := as.character(a), verbose=TRUE], output="RHS for item 1 has been duplicated")
-# Executing the code inside of test expands the ALTREP so we repeat the code
-# in order to check the result after a further assignment
-DT = data.table(a=1:3)
-DT[, b := as.character(a)]
-DT[, a := 5L]
-test(754.09, DT, data.table(a=5L, b=as.character(1:3)))
-# This function returns an ALTREP wrapper if the input is at least length 64
-testFun = function(x) {
-  x[FALSE] = 1
-  x
+if (getRversion() >= "3.5.0") { # TODO(R>=3.5.0): test unconditionally
+  # Expand ALTREPS in assign.c, #5400
+  # String conversion gets deferred
+  ## first, a regression test of R itself -- we want to make sure our own test continues to be useful & testing its intended purpose
+  test(754.07, {a = 1:10; .Internal(inspect(a)); b = as.character(a); .Internal(inspect(b))}, output = "\\bcompact\\b.*\\bdeferred string conversion\\b")
+  test(754.08, DT[, a := as.character(a), verbose=TRUE], output="RHS for item 1 has been duplicated")
+  # Executing the code inside of test expands the ALTREP so we repeat the code
+  # in order to check the result after a further assignment
+  DT = data.table(a=1:3)
+  DT[, b := as.character(a)]
+  DT[, a := 5L]
+  test(754.09, DT, data.table(a=5L, b=as.character(1:3)))
+  # This function returns an ALTREP wrapper if the input is at least length 64
+  testFun = function(x) {
+    x[FALSE] = 1
+    x
+  }
+  DT = data.table(id=1:64, col1=0, col2=0)
+  test(754.10, DT[, col1 := testFun(col2), verbose = TRUE], output="RHS for item 1 has been duplicated")
+  DT = data.table(id=1:64, col1=0, col2=0)
+  DT[, col1 := testFun(col2)]
+  DT[, col2 := 999]
+  test(754.11, DT, data.table(id=1:64, col1=0, col2=999))
+  rm(testFun)
 }
-DT = data.table(id=1:64, col1=0, col2=0)
-test(754.10, DT[, col1 := testFun(col2), verbose = TRUE], output="RHS for item 1 has been duplicated")
-DT = data.table(id=1:64, col1=0, col2=0)
-DT[, col1 := testFun(col2)]
-DT[, col2 := 999]
-test(754.11, DT, data.table(id=1:64, col1=0, col2=999))
-rm(testFun)
 
 # Used to test warning on redundant by (#2282) but by=.EACHI has now superseded
 DT = data.table(a=letters[1:3],b=rep(c("d","e"),each=3),x=1:6,key=c('a', 'b'))


### PR DESCRIPTION
Our "ancient R" tests ignore the vignettes, but don't ignore the main tests, and those currently fail on R-3.4 because there's no ALTREP there. Let's skip the tests for ALTREP behaviour on R-3.4.