### PR TITLE
Fixes confusing documentation in help text of ?data.table for `with`

### DIFF
--- a/man/data.table.Rd
+++ b/man/data.table.Rd
@@ -119,7 +119,7 @@ data.table(\dots, keep.rownames=FALSE, check.names=FALSE, key=NULL, stringsAsFac
 
     \item{with}{ By default \code{with=TRUE} and \code{j} is evaluated within the frame of \code{x}; column names can be used as variables. In case of overlapping variables names inside dataset and in parent scope you can use double dot prefix \code{..cols} to explicitly refer to \code{cols} variable parent scope and not from your dataset.
 
-        When \code{j} is a character vector of column names, a numeric vector of column positions to select or of the form \code{startcol:endcol}, and the value returned is always a \code{data.table}. \code{with=FALSE} is not necessary anymore to select columns dynamically. Note that \code{x[, cols]} is equivalent to \code{x[, ..cols]} and to \code{x[, cols, with=FALSE]} and to \code{x[, .SD, .SDcols=cols]}.}
+        When \code{j} is a character vector of column names, a numeric vector of column positions to select or of the form \code{startcol:endcol}, and the value returned is always a \code{data.table}. \code{with=FALSE} is not necessary anymore to select columns dynamically. Note that for \code{data.frame}s, \code{df[, cols]} works when \code{cols} is a variable; for \code{data.table}s, \code{x[, cols]} will look for a column literally named "cols", so use \code{x[, ..cols]} or \code{x[, cols, with=FALSE]} or \code{x[, .SD, .SDcols=cols]} instead.}
 
     \item{nomatch}{ When a row in \code{i} has no match to \code{x}, \code{nomatch=NA} (default) means \code{NA} is returned. \code{NULL} (or \code{0} for backward compatibility) means no rows will be returned for that row of \code{i}. }
 

--- a/man/data.table.Rd
+++ b/man/data.table.Rd
@@ -117,9 +117,11 @@ data.table(\dots, keep.rownames=FALSE, check.names=FALSE, key=NULL, stringsAsFac
 
     \item{keyby}{ Same as \code{by}, but with an additional \code{setkey()} run on the \code{by} columns of the result, for convenience. It is common practice to use \code{keyby=} routinely when you wish the result to be sorted. May also be \code{TRUE} or \code{FALSE} when \code{by} is provided as an alternative way to accomplish the same operation.}
 
-    \item{with}{ By default \code{with=TRUE} and \code{j} is evaluated within the frame of \code{x}; column names can be used as variables. In case of overlapping variables names inside dataset and in parent scope you can use double dot prefix \code{..cols} to explicitly refer to \code{cols} variable parent scope and not from your dataset.
+    \item{with}{ By default \code{with=TRUE} and \code{j} is evaluated within the frame of \code{x}; column names can be used as variables. In the case of overlapping variable names inside \code{x} and in parent scope, you can use the double dot prefix \code{..cols} to explicitly refer to the \code{cols} variable in parent scope and not from \code{x}.
 
-        When \code{j} is a character vector of column names, a numeric vector of column positions to select or of the form \code{startcol:endcol}, and the value returned is always a \code{data.table}. \code{with=FALSE} is not necessary anymore to select columns dynamically. Note that for \code{data.frame}s, \code{df[, cols]} works when \code{cols} is a variable; for \code{data.table}s, \code{x[, cols]} will look for a column literally named "cols", so use \code{x[, ..cols]} or \code{x[, cols, with=FALSE]} or \code{x[, .SD, .SDcols=cols]} instead.}
+        When \code{j} is a character vector of column names, a numeric vector of column positions to select, or of the form \code{startcol:endcol}, the value returned is always a \code{data.table}.
+
+        New code should rarely use this argument, which was originally needed for similarity to data.frame. For example, to select columns from a character vector \code{cols}, in data.frame we do \code{x[, cols]}, which has several equivalents in data.table: \code{x[, .SD, .SDcols=cols]}, \code{x[, ..cols]}, \code{x[, cols, env = list(cols = I(cols))]}, or \code{x[, cols, with=FALSE]}.}
 
     \item{nomatch}{ When a row in \code{i} has no match to \code{x}, \code{nomatch=NA} (default) means \code{NA} is returned. \code{NULL} (or \code{0} for backward compatibility) means no rows will be returned for that row of \code{i}. }
 


### PR DESCRIPTION
Closes #4955

Fixes confusing documentation in the `with` parameter that incorrectly suggested `x[, cols]` and `x[, ..cols]` are equivalent when `cols` is a variable.

Problem:
The original text stated that `x[, cols]` is equivalent to `x[, ..cols]`, which is misleading because:
- `x[, cols]` looks for a column literally named "cols"
- `x[, ..cols]` looks up the variable `cols` in the parent scope

This caused confusion for users transitioning from data.frame to data.table.

Solution:
Updated documentation to clearly explain:
- How data.frame handles `df[, cols]` when `cols` is a variable
- How data.table differs: `x[, cols]` looks for literal column name "cols"
- use these alternatives `x[, ..cols]`, `x[, cols, with=FALSE]`, or `x[, .SD, .SDcols=cols]`

@MichaelChirico @jangorecki can you please review.