### PR TITLE
`test.data.table(testPattern=)`: preserve `names(fn)`

### DIFF
--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -197,7 +197,7 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
     tryCatch(error = function(c) warningf("Attempt to subset to %d tests matching '%s' failed, running full suite.", length(keep_test_ids), testPattern), {
       new_script = file_lines[c(header_lines, keep_lines)]
       parse(text = new_script) # as noted above the static approach is not fool-proof (yet?), so force the script to at least parse before continuing.
-      fn = tempfile()
+      fn = setNames(tempfile(), names(fn))
       on.exit(unlink(fn), add=TRUE)
       catf("Running %d of %d tests matching '%s'\n", length(keep_test_ids), nrow(test_calls), testPattern)
       writeLines(new_script, fn)


### PR DESCRIPTION
Otherwise, failing a test results in a zero-length error message that itself errors out.

Fixes: #7167