### PR TITLE
Follow-up to const clean-up feedback

### DIFF
--- a/src/fread.c
+++ b/src/fread.c
@@ -293,7 +293,7 @@ static inline bool end_of_field(const char *ch)
   // default, and therefore characters in the range 0x80-0xFF are negative.
   // We use eol() because that looks at eol_one_r inside it w.r.t. \r
   // \0 (maybe more than one) before eof are part of field and do not end it; eol() returns false for \0 but the ch==eof will return true for the \0 at eof.
-  return *ch == sep || (*ch <= 13 && (ch == eof || eol(&ch)));
+  return *ch == sep || ((uint8_t)*ch <= 13 && (ch == eof || eol(&ch)));
 }
 
 static inline const char *end_NA_string(const char *start)

--- a/src/freadR.c
+++ b/src/freadR.c
@@ -457,8 +457,8 @@ size_t allocateDT(int8_t *typeArg, int8_t *sizeArg, int ncolArg, int ndrop, size
       if (colClassesAs) setAttrib(DT, sym_colClassesAs, colClassesAs);
     } else {
       int nprotect = 0;
-      SEXP tt = PROTECT(allocVector(STRSXP, ncol - ndrop));
-      setAttrib(DT, R_NamesSymbol, tt); nprotect++;
+      SEXP tt = PROTECT(allocVector(STRSXP, ncol - ndrop)); nprotect++;
+      setAttrib(DT, R_NamesSymbol, tt);
       
       SEXP ss;
       if (colClassesAs) {


### PR DESCRIPTION
Follow-up to #7138. Better to leave the `uint8_t` cast intact barring specific profiled benchmarks demonstrating it's not needed. If the `[-128,0)` part doesn't matter, I can't imagine `(13,256)` do either.