### PR TITLE
Improve description of nan= and fill= in ?nafill, include example

### DIFF
--- a/man/nafill.Rd
+++ b/man/nafill.Rd
@@ -10,8 +10,8 @@
   Fast fill missing values using constant value, \emph{last observation carried forward} or \emph{next observation carried backward}.
 }
 \usage{
-nafill(x, type=c("const","locf","nocb"), fill=NA, nan=NA)
-setnafill(x, type=c("const","locf","nocb"), fill=NA, nan=NA, cols=seq_along(x))
+nafill(x, type=c("const", "locf", "nocb"), fill=NA, nan=NA)
+setnafill(x, type=c("const", "locf", "nocb"), fill=NA, nan=NA, cols=seq_along(x))
 }
 \arguments{
   \item{x}{ Vector, list, data.frame or data.table of numeric columns. }
@@ -48,6 +48,6 @@ setnafill(dt, "locf", cols=c("v2","v3"))
 dt
 }
 \seealso{
-  \code{\link{shift}}, \code{\link{data.table}}
+  \code{\link{shift}}, \code{\link{data.table}}, \code{\link{fcoalesce}}
 }
 \keyword{ data }

--- a/man/nafill.Rd
+++ b/man/nafill.Rd
@@ -14,11 +14,11 @@ nafill(x, type=c("const","locf","nocb"), fill=NA, nan=NA)
 setnafill(x, type=c("const","locf","nocb"), fill=NA, nan=NA, cols=seq_along(x))
 }
 \arguments{
-  \item{x}{ vector, list, data.frame or data.table of numeric columns. }
-  \item{type}{ character, one of \emph{"const"}, \emph{"locf"} or \emph{"nocb"}. Defaults to \code{"const"}. }
-  \item{fill}{ numeric or integer, value to be used to fill. }
-  \item{nan}{ (numeric \code{x} only) Either \code{NaN} or \code{NA}; if the former, \code{NaN} is treated as distinct from \code{NA}, otherwise, they are treated the same during replacement? }
-  \item{cols}{ numeric or character vector specifying columns to be updated. }
+  \item{x}{ Vector, list, data.frame or data.table of numeric columns. }
+  \item{type}{ Character, one of \emph{"const"}, \emph{"locf"} or \emph{"nocb"}. Defaults to \code{"const"}. }
+  \item{fill}{ Double or integer, value to be used to fill. }
+  \item{nan}{ Either \code{NaN} or \code{NA}; if the former, \code{NaN} is treated as distinct from \code{NA}, otherwise, they are treated the same during replacement. See Examples. }
+  \item{cols}{ Numeric or character vector specifying columns to be updated. }
 }
 \details{
   Only \emph{double} and \emph{integer} data types are currently supported.
@@ -32,6 +32,10 @@ setnafill(x, type=c("const","locf","nocb"), fill=NA, nan=NA, cols=seq_along(x))
 x = 1:10
 x[c(1:2, 5:6, 9:10)] = NA
 nafill(x, "locf")
+
+x = c(1, NA, NaN, 3, NaN, NA, 4)
+nafill(x, "locf")
+nafill(x, "locf", nan=NaN)
 
 dt = data.table(v1=x, v2=shift(x)/2, v3=shift(x, -1L)/2)
 nafill(dt, "nocb")

--- a/man/nafill.Rd
+++ b/man/nafill.Rd
@@ -16,7 +16,7 @@ setnafill(x, type=c("const","locf","nocb"), fill=NA, nan=NA, cols=seq_along(x))
 \arguments{
   \item{x}{ Vector, list, data.frame or data.table of numeric columns. }
   \item{type}{ Character, one of \emph{"const"}, \emph{"locf"} or \emph{"nocb"}. Defaults to \code{"const"}. }
-  \item{fill}{ Double or integer, value to be used to fill. }
+  \item{fill}{ Numeric value to be used to replace missing observations. See examples. }
   \item{nan}{ Either \code{NaN} or \code{NA}; if the former, \code{NaN} is treated as distinct from \code{NA}, otherwise, they are treated the same during replacement. See Examples. }
   \item{cols}{ Numeric or character vector specifying columns to be updated. }
 }
@@ -36,6 +36,10 @@ nafill(x, "locf")
 x = c(1, NA, NaN, 3, NaN, NA, 4)
 nafill(x, "locf")
 nafill(x, "locf", nan=NaN)
+
+# fill= applies to any leftover NA
+nafill(c(NA, x), "locf")
+nafill(c(NA, x), "locf", fill=0)
 
 dt = data.table(v1=x, v2=shift(x)/2, v3=shift(x, -1L)/2)
 nafill(dt, "nocb")


### PR DESCRIPTION
Also be more intentional about using "double" (storage type) vs. "numeric" (more ambiguous term in R, but generally "the `mode()` of integer or double vectors)