### PR TITLE
Suggest fcoalesce() as an alternative for some nafill() errors

### DIFF
--- a/inst/tests/nafill.Rraw
+++ b/inst/tests/nafill.Rraw
@@ -114,8 +114,9 @@ test(3.02, setnafill(list(copy(x)), "locf", fill=0L), list(x))
 test(3.03, setnafill(x, "locf"), error="in-place update is supported only for list")
 test(3.04, nafill(letters[1:5], fill=0), error="must be numeric type, or list/data.table")
 test(3.05, setnafill(list(letters[1:5]), fill=0), error="must be numeric type, or list/data.table")
-test(3.06, nafill(x, fill=1:2), error="fill must be a vector of length 1")
-test(3.07, nafill(x, fill="asd"), x, warning=c("Coercing.*character.*integer","NAs introduced by coercion"))
+test(3.06, nafill(x, fill=1:2), error="fill must be a vector of length 1.*fcoalesce")
+test(3.07, nafill(x, "locf", fill=1:2), error="fill must be a vector of length 1.*x\\.$")
+test(3.08, nafill(x, fill="asd"), x, warning=c("Coercing.*character.*integer","NAs introduced by coercion"))
 
 # colnamesInt helper
 dt = data.table(a=1, b=2, d=3)

--- a/src/nafill.c
+++ b/src/nafill.c
@@ -180,8 +180,13 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP nan_is_na_arg, SEXP inplace, S
     isInt64[i] = INHERITS(VECTOR_ELT(x, i), char_integer64);
   const void **fillp = (const void **)R_alloc(nx, sizeof(*fillp)); // fill is (or will be) a list of length nx of matching types, scalar values for each column, this pointer points to each of those columns data pointers
   if (hasFill) {
-    if (nx!=length(fill) && length(fill)!=1)
-      error(_("fill must be a vector of length 1 or a list of length of x"));
+    if (nx!=length(fill) && length(fill)!=1) {
+      if (itype == 0) {
+        error(_("fill must be a vector of length 1 or a list of length of x. Consider fcoalesce() to specify element-wise replacements."));
+      } else {
+        error(_("fill must be a vector of length 1 or a list of length of x."));
+      }
+    }
     if (!isNewList(fill)) {
       SEXP fill1 = fill;
       fill = PROTECT(allocVector(VECSXP, nx)); protecti++;


### PR DESCRIPTION
`fcoalesce(x, y)` is equivalent to `nafill(x, type="const", fill=y)` when `length(y)==1`; the former is more general, though, in supporting `length(x)==length(y)` as well.

This change just points the user to the former when possibly misusing `nafill()`.