### PR TITLE
tests: don't use `.Date()`

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -6852,11 +6852,12 @@ test(1463.79, shift(x,-1L,   type="cyclic"), as.raw(c(2:5, 1)))
 test(1463.80, shift(x,-(1:2),type="cyclic"), list(as.raw(c(2:5, 1)), as.raw(c(3:5,1:2))))
 
 # shift incompatible types (e.g. Date and POSIXct)
-d = .Date(0:4)
+# TODO(R>=3.5): use .Date() instead of setting class by hand
+d = structure(0:4, class="Date")
 p = .POSIXct(1:5)
 test(1463.81, shift(d, fill=p[1L]), error="Filling Date with POSIXct .* unsupported.*")
 test(1463.82, shift(p, fill=d[1L]), error="Filling POSIXct with Date .* unsupported.*")
-test(1463.83, shift(d, fill=as.IDate(2000L)), .Date(c(2000L, 0:3)))
+test(1463.83, shift(d, fill=as.IDate(2000L)), structure(c(2000L, 0:3), class="Date"))
 
 # FR #686
 DT = data.table(a=rep(c("A", "B", "C", "A", "B"), c(2,2,3,1,2)), foo=1:10)


### PR DESCRIPTION
Currently, `tests.Rraw` [fails on R-3.4](https://rdatatable.gitlab.io/data.table/web/checks/data.table/test-lin-ancient-cran/tests/main.Rout.fail) due to missing `.Date()`:

```
  Error in .Date(0:4) : could not find function ".Date"

  Error in test.data.table() :
    Failed in 13.4s elapsed (15.0s cpu) after test 1463.8 before the next test() call in .../data.table.Rcheck/data.table/tests/tests.Rraw
```

Since `.Date()` is only available in R ≥ 3.5, construct the objects by hand instead. Other places in `tests.Rraw` use `` `class<-`(..., "Date") `` instead of `structure(..., class = "Date")`.