### PR TITLE
`mergelist`: `isFrame` -> `isDataFrame`

### DIFF
--- a/src/mergelist.c
+++ b/src/mergelist.c
@@ -32,7 +32,7 @@ void mergeIndexAttrib(SEXP to, SEXP from) {
 }
 
 SEXP cbindlist(SEXP x, SEXP copyArg) {
-  if (!isNewList(x) || isFrame(x))
+  if (!isNewList(x) || isDataFrame(x))
     error(_("'%s' must be a list"), "x");
   bool copy = (bool)LOGICAL(copyArg)[0];
   const bool verbose = GetVerbose();

--- a/src/utils.c
+++ b/src/utils.c
@@ -533,10 +533,8 @@ bool isRectangularList(SEXP x) {
   return isRectangular(x);
 }
 
-// TODO: use isDataFrame (when included in any R release).
-// isDataTable(x) || isFrame(x) || isRectangularList(x)
 bool perhapsDataTable(SEXP x) {
-  return isDataTable(x) || isFrame(x) || isRectangularList(x);
+  return isDataTable(x) || isDataFrame(x) || isRectangularList(x);
 }
 SEXP perhapsDataTableR(SEXP x) {
   return ScalarLogical(perhapsDataTable(x));


### PR DESCRIPTION
`isFrame` was accidentally reintroduced in #6433, together with a TODO to replace `isFrame` when an R version is released with `isDataFrame`. The TODO is now fulfilled.