### PR TITLE
tests: avoid invalid UTF-8 warning

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -21554,12 +21554,18 @@ test(2332.81, {M1[]=frev(M1); M1}, {M2[]=rev(M2); M2})
 test(2333, as.expression(data.table(a = 1))[["a"]], 1)
 
 # regression test for hexdigits subscript overrun (uint8_t wraps over 255, unsigned overflow is well defined in c)
-f = tempfile()
-ff = file(f, encoding = "")
-writeLines(c('a', rep('0x1.ffffp0', 10000L), `Encoding<-`('0x1.ff\x9fp0', 'bytes'), rep('0x1.ffffp0', 20000L)), ff)
-close(ff)
-test(2334, names(fread(f)), "a")
-unlink(f)
+local({
+	f = tempfile()
+	on.exit(unlink(f))
+	# the line is likely invalid in current encoding, so disable any translation, #7209
+	# test.data.table() sets options(encoding="UTF-8"), so go the long way around.
+	ff = file(f, encoding = "")
+	tryCatch(
+		writeLines(c('a', rep('0x1.ffffp0', 10000L), `Encoding<-`('0x1.ff\x9fp0', 'bytes'), rep('0x1.ffffp0', 20000L)), ff),
+		finally = close(ff)
+	)
+	test(2334, names(fread(f)), "a")
+})
 
 # Tests for new isoyear() helper (complement to isoweek) #7154
 test(2335.1, isoyear(as.IDate("2019-12-30")), 2020L)  # End of year edge case


### PR DESCRIPTION
It turns out that my test case from https://github.com/Rdatatable/data.table/pull/7138#discussion_r2193521976 causes a warning, but only if run under `test.data.table()`. The underlying cause is `options(encoding = "UTF-8")` being in effect for the duration of the test:
https://github.com/Rdatatable/data.table/blob/63339e1bf4a65b1821c0c5a7019270d34e63346e/R/test.data.table.R#L92-L94

We need to write a byte with the most significant bit set, and `file(encoding = getOption('encoding'))` opened by `writeLines()` trying to convert that byte from the current encoding to UTF-8 doesn't help. Avoid the warning by explicitly opening a file connection with `encoding=""` (no conversion) and marking the payload line as `"bytes"`.