### PR TITLE
RFC: fail `test.data.table()` if non-test code produces warnings

### DIFF
--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -205,14 +205,14 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
   }
   # nocov end
 
-  warnings = list()
+  env$warnings = list()
   err = try(
     withCallingHandlers(
       sys.source(fn, envir=env),
       warning=function(w) {
         # nocov start
         if (!silent && showProgress) print(w)
-        warnings <<- c(warnings, list(list(env$prevtest, toString(w))))
+        env$warnings = c(env$warnings, list(list(env$prevtest, toString(w))))
         invokeRestart("muffleWarning")
         # nocov end
       }
@@ -275,9 +275,9 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
     # important to stopf() here, so that 'R CMD check' fails
     # nocov end
   }
-  if (length(warnings)) {
+  if (length(env$warnings)) {
     # nocov start
-    warnings = rbindlist(warnings)
+    warnings = rbindlist(env$warnings)
     setnames(warnings, c("after test", "warning"))
     catf(
       ngettext(length(warnings),

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -290,7 +290,7 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
     warnings = rbindlist(env$warnings)
     setnames(warnings, c("after test", "warning", "calls"))
     catf(
-      ngettext(length(warnings),
+      ngettext(nrow(warnings),
         "Caught %d warning outside the test() calls:\n",
         "Caught %d warnings outside the test() calls:\n"
       ),

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -284,7 +284,7 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
         "Caught %d warning outside the test() calls:\n",
         "Caught %d warnings outside the test() calls:\n"
       ),
-      length(warnings)
+      nrow(warnings)
     )
     print(warnings)
     stopf("Tests succeeded, but non-test code caused warnings. Search %s for tests shown above.", names(fn))

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -213,10 +213,10 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
         # nocov start
         if (!silent && showProgress) print(w)
         env$warnings = c(env$warnings, list(list(
-          env$prevtest, toString(w),
-          paste(
+          "after test"=env$prevtest, warning=conditionMessage(w),
+          calls=paste(
             vapply_1c(sys.calls(), function(call) {
-              if (length(call) && is.name(call[[1]])) {
+              if (is.name(call[[1]])) {
                 as.character(call[[1]])
               } else "..."
             }),
@@ -288,15 +288,15 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
   if (length(env$warnings)) {
     # nocov start
     warnings = rbindlist(env$warnings)
-    setnames(warnings, c("after test", "warning", "calls"))
     catf(
       ngettext(nrow(warnings),
         "Caught %d warning outside the test() calls:\n",
         "Caught %d warnings outside the test() calls:\n"
       ),
-      nrow(warnings)
+      nrow(warnings),
+      domain=NA
     )
-    print(warnings)
+    print(warnings, nrows = nrow(warnings))
     stopf("Tests succeeded, but non-test code caused warnings. Search %s for tests shown above.", names(fn))
     # nocov end
   }

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -205,7 +205,20 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
   }
   # nocov end
 
-  err = try(sys.source(fn, envir=env), silent=silent)
+  warnings = list()
+  err = try(
+    withCallingHandlers(
+      sys.source(fn, envir=env),
+      warning=function(w) {
+        # nocov start
+        if (!silent && showProgress) print(w)
+        warnings <<- c(warnings, list(list(env$prevtest, toString(w))))
+        invokeRestart("muffleWarning")
+        # nocov end
+      }
+    ),
+    silent=silent
+  )
 
   options(oldOptions)
   for (i in oldEnv) {
@@ -260,6 +273,21 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
       nfail, ntest, names(fn), toString(env$whichfail), timetaken(env$started.at), domain=NA
     )
     # important to stopf() here, so that 'R CMD check' fails
+    # nocov end
+  }
+  if (length(warnings)) {
+    # nocov start
+    warnings = rbindlist(warnings)
+    setnames(warnings, c("after test", "warning"))
+    catf(
+      ngettext(length(warnings),
+        "Caught %d warning outside the test() calls:\n",
+        "Caught %d warnings outside the test() calls:\n"
+      ),
+      length(warnings)
+    )
+    print(warnings)
+    stopf("Tests succeeded, but non-test code caused warnings. Search %s for tests shown above.", names(fn))
     # nocov end
   }
 

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -212,7 +212,17 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
       warning=function(w) {
         # nocov start
         if (!silent && showProgress) print(w)
-        env$warnings = c(env$warnings, list(list(env$prevtest, toString(w))))
+        env$warnings = c(env$warnings, list(list(
+          env$prevtest, toString(w),
+          paste(
+            vapply_1c(sys.calls(), function(call) {
+              if (length(call) && is.name(call[[1]])) {
+                as.character(call[[1]])
+              } else "..."
+            }),
+            collapse=" -> "
+          )
+        )))
         invokeRestart("muffleWarning")
         # nocov end
       }
@@ -278,7 +288,7 @@ test.data.table = function(script="tests.Rraw", verbose=FALSE, pkg=".", silent=F
   if (length(env$warnings)) {
     # nocov start
     warnings = rbindlist(env$warnings)
-    setnames(warnings, c("after test", "warning"))
+    setnames(warnings, c("after test", "warning", "calls"))
     catf(
       ngettext(length(warnings),
         "Caught %d warning outside the test() calls:\n",

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -16996,7 +16996,8 @@ if (.Platform$OS.type=="windows") local({
     LC_TIME = "Chinese (Simplified)_China.936"
   )
   x_old = Map(Sys.getlocale, names(x))
-  invisible(Map(Sys.setlocale, names(x), x))
+  # setlocale() warns for non-UTF-8 locales in modern versions of R, #7210
+  suppressWarnings(invisible(Map(Sys.setlocale, names(x), x)))
   on.exit(Map(Sys.setlocale, names(x_old), x_old))
   # triggered segfault here in #4402, Windows-only under translation.
   # test that the argument order changes correctly (the 'item 2' moves to the beginning of the message)
@@ -18620,6 +18621,7 @@ local(if (l10n_info()$`UTF-8` || {
   lc_wantctype = 'en_US.UTF-8'
   # Japanese multibyte characters require utf8. As of 2025, we're likely to be already running in a UTF-8 locale, but if not, try this setlocale() call as a last chance.
   # Unfortunately, there is no guaranteed, portable way of switching to UTF-8 US English.
+  # Avoid the warning upon possible failure, #7210.
   lc_newctype = suppressWarnings(Sys.setlocale('LC_CTYPE', lc_wantctype))
   if (identical(lc_newctype, lc_wantctype)) {
     on.exit(Sys.setlocale('LC_CTYPE', lc_ctype))

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18615,12 +18615,17 @@ test(2252.2, dt[, let(b=2L)], error = "\\[ was called on a data.table.*not data.
 rm(.datatable.aware)
 
 # tests for trunc.char handling wide characters # 5096
-local({
+local(if (l10n_info()$`UTF-8` || {
   lc_ctype = Sys.getlocale('LC_CTYPE')
+  lc_wantctype = 'en_US.UTF-8'
   # Japanese multibyte characters require utf8. As of 2025, we're likely to be already running in a UTF-8 locale, but if not, try this setlocale() call as a last chance.
   # Unfortunately, there is no guaranteed, portable way of switching to UTF-8 US English.
-  if (!l10n_info()$`UTF-8`) Sys.setlocale('LC_CTYPE', "en_US.UTF-8")
-  on.exit(Sys.setlocale('LC_CTYPE', lc_ctype))
+  lc_newctype = suppressWarnings(Sys.setlocale('LC_CTYPE', lc_wantctype))
+  if (identical(lc_newctype, lc_wantctype)) {
+    on.exit(Sys.setlocale('LC_CTYPE', lc_ctype))
+    TRUE
+  } else FALSE
+}) {
   accented_a = "\u0061\u0301"
   ja_ichi = "\u4E00"
   ja_ni = "\u4E8C"
@@ -18670,6 +18675,8 @@ local({
     paste0(c(ja_ko, ja_n, accented_a), dots, collapse=" ")))
   # test for data.table with NA, #6441
   test(2253.20, options=list(datatable.prettyprint.char = 1L), data.table(a = c("abc", NA)), output="      a\n1: a...\n2: <NA>")
+} else {
+  cat("Tests 2253* skipped because they need a UTF-8 locale.\n")
 })
 
 # allow 1-D matrix in j for consistency, #783


### PR DESCRIPTION
Related to #7209. I happened to notice the warning while looking at unrelated failures. Should `test.data.table()` explicitly go looking for warnings produced by code outside the `test()` calls and fail `R CMD check` because of them?

Pros: sometimes there's a good reason to fix the warning (like #7209).

Cons: sometimes warnings happen for stupid reasons outside our direct control. For example, a system that neither currently has a UTF-8 locale set nor has `en_US.UTF-8` installed will cause a warning between tests 2252.2 and 2253.01, because the `setlocale()` call will fail:

https://github.com/Rdatatable/data.table/blob/63339e1bf4a65b1821c0c5a7019270d34e63346e/inst/tests/tests.Rraw#L18619-L18623