### PR TITLE
GitLab CI: stricter `checkRd()` output in `test-lin-rel`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -114,6 +114,7 @@ test-lin-rel:
   variables:
     _R_CHECK_FORCE_SUGGESTS_: "TRUE"
     OPENBLAS_MAIN_FREE: "1"
+    _R_CHECK_RD_CHECKRD_MINLEVEL_: "-Inf"
   script:
     - *install-deps
     - echo 'CFLAGS=-g -O3 -flto=auto -fno-common -fopenmp -Wall -Wvla -pedantic -fstack-protector-strong -D_FORTIFY_SOURCE=2' > ~/.R/Makevars


### PR DESCRIPTION
Instead of the [default severity](https://github.com/r-devel/r-svn/blob/e3cd4592c695af653d34927dc14786244c945a6e/src/library/tools/R/check.R#L2497-L2500) of -1 or above, complain about all `checkRd()` problems.

[This](https://gitlab.com/Rdatatable/data.table/-/jobs/10823385526) gives us a new NOTE.