### PR TITLE
Update atime action to v1.5.0 to support PR from forks & speedup through caching

### DIFF
--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -1,7 +1,7 @@
 name: atime performance tests
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened
@@ -10,14 +10,15 @@ on:
       - 'R/**'
       - 'src/**'
       - '.ci/atime/**'
+  workflow_dispatch:
 
 jobs:
   comment:
-    if: github.repository == 'Rdatatable/data.table'
     runs-on: ubuntu-latest
-    container: ghcr.io/iterative/cml:0-dvc2-base1
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      repo_token: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      pull-requests: write
     steps:
-      - uses: Anirban166/Autocomment-atime-results@v1.4.3
+      - name: Run atime performance analysis
+        uses: Anirban166/Autocomment-atime-results@v1.5.0
+        with:
+          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
cc @tdhock @Anirban166

This PR updates the `Autocomment-atime-results` action to version `v1.5.0`, which brings two key improvements:

1. Secure support for PRs from forks
2. Improved build times via caching of built packages

Due to GitHub's [cache access restrictions](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache), caches created in PRs are **not accessible across workflows or branches**. To work around this, the cache needs to be populated from the base branch (e.g., on a `push` or via `workflow_dispatch`, as currently implemented), so that PRs can reuse it.

The README has also been updated with more information about how caching works:
[Autocomment-atime-results README.md](https://github.com/Anirban166/Autocomment-atime-results?tab=readme-ov-file#caching)

For further context, see the PR which added this change: [https://github.com/Anirban166/Autocomment-atime-results/pull/44](https://github.com/Anirban166/Autocomment-atime-results/pull/44)

Some Stats (Before vs Now):
- First run:  17 minutes -> 10 minutes
- Subsequent runs:  6 minutes -> 3 minutes
Note: Version v1.4.3 already introduced caching via r-lib/actions/setup-r-dependencies@v2, which implicitly cached-R packages by default. With v1.5.0, we now additionally cache libgit, resulting in further reductions in run time.

The first three runs here would be relevant: https://github.com/criticic/data.table-test-work-workflow/actions