### PR TITLE
localize reused object cumSum + general vicinity cleanup

### DIFF
--- a/src/fsort.c
+++ b/src/fsort.c
@@ -1,6 +1,6 @@
 #include "data.table.h"
 
-#define INSERT_THRESH 200  // TODO: expose via api and test
+static const int INSERT_THRESH = 200;  // TODO: expose via api and test
 
 static void dinsert(double *x, const int n) {   // TODO: if and when twiddled, double => ull
   if (n<2) return;
@@ -43,13 +43,10 @@ static void dradix_r(  // single-threaded recursive worker
     return;
   }
 
-  uint64_t cumSum=0;
-  for (uint64_t i=0; cumSum<n; ++i) { // cumSum<n better than i<width as may return early
-    uint64_t tmp;
-    if ((tmp=counts[i])) {  // don't cumulate through 0s, important below to save a wasteful memset to zero
-      counts[i] = cumSum;
-      cumSum += tmp;
-    }
+  for (uint64_t i = 0, cumSum = 0; cumSum < n; ++i) { // cumSum<n better than i<width as may return early
+    if (!counts[i]) continue; // don't cumulate through 0s, important below to save a wasteful memset to zero
+    counts[i] = cumSum;
+    cumSum += counts[i];
   } // leaves cumSum==n && 0<i && i<=width
 
   tmp=in;
@@ -71,10 +68,9 @@ static void dradix_r(  // single-threaded recursive worker
     return;
   }
 
-  cumSum=0;
-  for (int i=0; cumSum<n; ++i) {   // again, cumSum<n better than i<width as it can return early
+  for (uint64_t i = 0, cumSum = 0; cumSum < n; i++) {   // again, cumSum<n better than i<width as it can return early
     if (counts[i] == 0) continue;
-    uint64_t thisN = counts[i] - cumSum;  // undo cummulate; i.e. diff
+    const uint64_t thisN = counts[i] - cumSum;  // undo cummulate; i.e. diff
     if (thisN <= INSERT_THRESH) {
       dinsert(in+cumSum, thisN);  // for thisN==1 this'll return instantly. Probably better than several branches here.
     } else {


### PR DESCRIPTION
Making `cumSum` local to the for loop makes it easier to identify its purpose.