### PR TITLE
Error on non scalar aggregates regardless of fill

### DIFF
--- a/R/fcast.R
+++ b/R/fcast.R
@@ -186,11 +186,7 @@ dcast.data.table = function(data, formula, fun.aggregate = NULL, sep = "_", ...,
     maybe_err = function(list.of.columns) {
       if (!all(lengths(list.of.columns) == 1L)) {
         msg = gettext("Aggregating functions should take a vector as input and return a single value (length=1), but they do not, so the result is undefined. Please fix by modifying your function so that a single value is always returned.")
-        if (is.null(fill)) { # TODO change to always stopf #6329
-          stop(msg, domain=NA, call. = FALSE)
-        } else {
-          warning(msg, domain=NA, call. = FALSE)
-        }
+        stop(msg, domain=NA, call. = FALSE)
       }
       list.of.columns
     }


### PR DESCRIPTION
closes #6629 

In dcast, fun.aggregate must return length 1. Previously, with fill != NULL, dcast warned but still produced an undefined result [#6032](https://github.com/Rdatatable/data.table/issues/6032). Plan is to turn that into an error

So in this PR
Dcast breaking change(fcast.R)
- fun.aggregate must return length 1. Previously, with fill != NULL, dcast warned but still produced an undefined result (#6032). Now this unconditionally errors and the warn branch is removed.

@tdhock @joshhwuu @Anirban166  please review.
