### PR TITLE
Add more path filters and manual triggers to GitHub Actions workflows

### DIFF
--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -1,6 +1,7 @@
 on:
   schedule:
    - cron: '17 13 23 * *' # 23rd of month at 13:17 UTC
+  workflow_dispatch:
 
 # A more complete suite of checks to run monthly; each PR/merge need not pass all these, but they should pass before CRAN release
 name: R-CMD-check-occasional

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
 
 name: R-CMD-check
 

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -2,6 +2,7 @@ on:
   push:
     branches: [master]
   pull_request:
+  workflow_dispatch:
 
 name: code-quality
 

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -10,6 +10,7 @@ on:
       - 'R/**'
       - 'src/**'
       - '.ci/atime/**'
+  workflow_dispatch:
 
 jobs:
   comment:

--- a/.github/workflows/rchk.yaml
+++ b/.github/workflows/rchk.yaml
@@ -18,7 +18,14 @@
 on:
   push:
     branches: [master]
+    paths:
+      - '.github/workflows/rchk.yaml'
+      - 'src/**'
   pull_request:
+    paths:
+      - '.github/workflows/rchk.yaml'
+      - 'src/**'
+  workflow_dispatch:
 
 name: 'rchk'
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -3,7 +3,20 @@
 on:
   push:
     branches: [master]
+    paths:
+      - '.github/workflows/test-coverage.yaml'
+      - 'inst/tests/**'
+      - 'R/**'
+      - 'src/**'
+      - 'tests/**'
   pull_request:
+    paths:
+      - '.github/workflows/test-coverage.yaml'
+      - 'inst/tests/**'
+      - 'R/**'
+      - 'src/**'
+      - 'tests/**'
+  workflow_dispatch:
 
 name: test-coverage.yaml
 


### PR DESCRIPTION
I noticed that in my previous PR to fix a minor formatting typo that a lot of CI was run (https://github.com/Rdatatable/data.table/pull/7276). To reduce the required resources and also increase the speed of development, I added some more path-based filters to the GitHub Actions workflow triggers. Specifically:

* Only run `rchk` if a file in `src/` is updated
* Only run coverage if a file in `inst/tests/`, `R/`, `src/`, or `tests/` is updated

I also added the manual trigger `workflow_dispatch`. This is convenient when preparing a PR. As a developer, I can manually run a workflow on my feature branch in my feedstock (ie not the master branch), prior to opening the PR.

I didn't add any path filters to `code-quality.yaml` or `R-CMD-check.yaml` so that a baseline of CI is still run for every PR, but I could add them if requested.