### PR TITLE
warnings ignored in frollapply

### DIFF
--- a/inst/tests/froll.Rraw
+++ b/inst/tests/froll.Rraw
@@ -1165,12 +1165,17 @@ if (use.fork) {
 }
 old = setDTthreads(1L)
 options(datatable.verbose=TRUE)
-test(6010.025, frollapply(1:2, 1, identity), c(2L,2L), output="running on single CPU thread")
+test(6010.025, frollapply(1:2, 1, copy), c(1L,2L), output="running on single CPU thread")
 options(datatable.verbose=FALSE)
-test(6010.026, frollapply(1:2, 1, function(x) {warning("warn"); x}), c(2L,2L), warning="warn")
-test(6010.027, frollapply(1:2, 1, function(x) {warning("warn:", tail(x,1)); x}), c(2L,2L), warning="warn:1\nwarn:2")
-test(6010.028, frollapply(1:2, 1, function(x) {stop("err:", tail(x,1)); x}), error="err:1") ## only first
+test(6010.026, frollapply(1:2, 1, function(x) {warning("warn"); copy(x)}), c(1L,2L))
+test(6010.027, frollapply(1:2, 1, function(x) {warning("warn:", tail(x,1)); copy(x)}), c(1L,2L))
+test(6010.028, frollapply(1:2, 1, function(x) {stop("err:", tail(x,1)); copy(x)}), error="err:1") ## only first
 setDTthreads(old)
+if (getDTthreads()>1L) { ## check for consistency
+  test(6010.036, frollapply(1:2, 1, function(x) {warning("warn"); copy(x)}), c(1L,2L))
+  test(6010.037, frollapply(1:2, 1, function(x) {warning("warn:", tail(x,1)); copy(x)}), c(1L,2L))
+  test(6010.038, frollapply(1:2, 1, function(x) {stop("err:", tail(x,1)); copy(x)}), error="err:1") ## only first
+}
 
 #### corner cases from examples - handled properly after frollapply rewrite to R
 test(6010.101, frollapply(1:5, 3, function(x) head(x, 2)), list(NA, NA, 1:2, 2:3, 3:4))

--- a/man/frollapply.Rd
+++ b/man/frollapply.Rd
@@ -74,7 +74,7 @@ frollapply(c(1, 9), N=1L, FUN=function(x) copy(list(x)))
 }
     \item \code{FUN} calls are internally passed to \code{parallel::mcparallel} to evaluate them in parallel. We inherit few limitations from \code{parallel} package explained below. This optimization can be disabled completely by calling \code{setDTthreads(1)}, then limitations listed below do not apply because all iterations of \code{FUN} evaluation will be made sequentially without use of \code{parallel} package. Note that on Windows platform this optimization is always disabled due to lack of \emph{fork} used by \code{parallel} package. One can use \code{options(datatable.verbose=TRUE)} to get extra information if \code{frollapply} is running multithreaded or not.
       \itemize{
-        \item Warnings produced inside the function are silently ignored.
+        \item Warnings produced inside the function are silently ignored; for consistency we ignore warnings also when running single threaded path.
         \item \code{FUN} should not use any on-screen devices, GUI elements, tcltk, multithreaded libraries. Note that \code{setDTthreads(1L)} is passed to forked processes, therefore any data.table code inside \code{FUN} will be forced to be single threaded. It is advised to not call \code{setDTthreads} inside \code{FUN}. \code{frollapply} is already parallelized and nested parallelism is rarely a good idea.
         \item Any operation that could misbehave when run in parallel has to be handled. For example writing to the same file from multiple CPU threads.
 \preformatted{


### PR DESCRIPTION
Spotted when adding support for n=0, windows was raising warnings as it does not use `parallel` but linux was not raising warnings.
This PR will align behavior between those OSes.
