### PR TITLE
froll fast more friendly for floating point rounding issue

### DIFF
--- a/src/froll.c
+++ b/src/froll.c
@@ -185,8 +185,8 @@ void frollmeanFast(double *x, uint64_t nx, ans_t *ans, int k, double fill, bool 
     SUM_WINDOW_STEP_FRONT                                       // i==k-1
     MEAN_WINDOW_STEP_VALUE
     for (uint64_t i=k; i<nx; i++) {                             // loop over obs, complete window, all remaining after partial window
-      SUM_WINDOW_STEP_FRONT
       SUM_WINDOW_STEP_BACK
+      SUM_WINDOW_STEP_FRONT
       MEAN_WINDOW_STEP_VALUE
     }
   }
@@ -375,8 +375,8 @@ if (nc == 0) {                                                 \
     SUM_WINDOW_STEP_FRONT                                       // i==k-1
     SUM_WINDOW_STEP_VALUE
     for (uint64_t i=k; i<nx; i++) {                             // loop over obs, complete window, all remaining after partial window
-      SUM_WINDOW_STEP_FRONT
       SUM_WINDOW_STEP_BACK
+      SUM_WINDOW_STEP_FRONT
       SUM_WINDOW_STEP_VALUE
     }
   }


### PR DESCRIPTION
we try to operate on smaller numbers, so first we reduce element that is leaving the running window, and then we add the one that is entering