### PR TITLE
take out macro definitions from inside the froll functions

### DIFF
--- a/src/froll.c
+++ b/src/froll.c
@@ -10,29 +10,6 @@
     sequentially in memory to compute the rolling statistic.
 */
 
-#undef SUM_WINDOW_STEP_FRONT
-#define SUM_WINDOW_STEP_FRONT                                  \
-if (R_FINITE(x[i])) {                                          \
-  w += x[i];                                                   \
-} else if (ISNAN(x[i])) {                                      \
-  nc++;                                                        \
-} else if (x[i]==R_PosInf) {                                   \
-  pinf++;                                                      \
-} else if (x[i]==R_NegInf) {                                   \
-  ninf++;                                                      \
-}
-#undef SUM_WINDOW_STEP_BACK
-#define SUM_WINDOW_STEP_BACK                                   \
-if (R_FINITE(x[i-k])) {                                        \
-  w -= x[i-k];                                                 \
-} else if (ISNAN(x[i-k])) {                                    \
-  nc--;                                                        \
-} else if (x[i-k]==R_PosInf) {                                 \
-  pinf--;                                                      \
-} else if (x[i-k]==R_NegInf) {                                 \
-  ninf--;                                                      \
-}
-
 /* rolling fun - router for fun and algo
  * early stopping for window bigger than input
  * handles 'align' in single place for center or left
@@ -107,6 +84,62 @@ void frollfun(rollfun_t rfun, unsigned int algo, const double *x, uint64_t nx, a
     snprintf(end(ans->message[0]), 500, _("%s: processing fun %d algo %u took %.3fs\n"), __func__, rfun, algo, omp_get_wtime()-tic);
 }
 
+#undef SUM_WINDOW_STEP_FRONT
+#define SUM_WINDOW_STEP_FRONT                                  \
+  if (R_FINITE(x[i])) {                                        \
+    w += x[i];                                                 \
+  } else if (ISNAN(x[i])) {                                    \
+    nc++;                                                      \
+  } else if (x[i]==R_PosInf) {                                 \
+    pinf++;                                                    \
+  } else if (x[i]==R_NegInf) {                                 \
+    ninf++;                                                    \
+  }
+#undef SUM_WINDOW_STEP_BACK
+#define SUM_WINDOW_STEP_BACK                                   \
+  if (R_FINITE(x[i-k])) {                                      \
+    w -= x[i-k];                                               \
+  } else if (ISNAN(x[i-k])) {                                  \
+    nc--;                                                      \
+  } else if (x[i-k]==R_PosInf) {                               \
+    pinf--;                                                    \
+  } else if (x[i-k]==R_NegInf) {                               \
+    ninf--;                                                    \
+  }
+#undef MEAN_WINDOW_STEP_VALUE
+#define MEAN_WINDOW_STEP_VALUE                                 \
+  if (nc == 0) {                                               \
+    if (pinf == 0) {                                           \
+      if (ninf == 0) {                                         \
+        ans->dbl_v[i] = (double) (w / k);                      \
+      } else {                                                 \
+        ans->dbl_v[i] = R_NegInf;                              \
+      }                                                        \
+    } else if (ninf == 0) {                                    \
+      ans->dbl_v[i] = R_PosInf;                                \
+    } else {                                                   \
+      ans->dbl_v[i] = R_NaN;                                   \
+    }                                                          \
+  } else if (nc == k) {                                        \
+    ans->dbl_v[i] = narm ? R_NaN : NA_REAL;                    \
+  } else {                                                     \
+    if (narm) {                                                \
+      if (pinf == 0) {                                         \
+        if (ninf == 0) {                                       \
+          ans->dbl_v[i] = (double) (w / (k - nc));             \
+        } else {                                               \
+          ans->dbl_v[i] = R_NegInf;                            \
+        }                                                      \
+      } else if (ninf == 0) {                                  \
+        ans->dbl_v[i] = R_PosInf;                              \
+      } else {                                                 \
+        ans->dbl_v[i] = R_NaN;                                 \
+      }                                                        \
+    } else {                                                   \
+      ans->dbl_v[i] = NA_REAL;                                 \
+    }                                                          \
+  }
+
 /* fast rolling mean - fast
  * when no info on NF (has.nf argument) then assume no NFs run faster version
  * rollmean implemented as single pass sliding window for align="right"
@@ -157,41 +190,6 @@ void frollmeanFast(const double *x, uint64_t nx, ans_t *ans, int k, double fill,
   if (truehasnf) {
     int nc = 0, pinf = 0, ninf = 0;                             // NA counter within sliding window
     int i;                                                      // iterator declared here because it is being used after for loop
-
-#undef MEAN_WINDOW_STEP_VALUE
-#define MEAN_WINDOW_STEP_VALUE                                 \
-  if (nc == 0) {                                               \
-    if (pinf == 0) {                                           \
-      if (ninf == 0) {                                         \
-        ans->dbl_v[i] = (double) (w / k);                      \
-      } else {                                                 \
-        ans->dbl_v[i] = R_NegInf;                              \
-      }                                                        \
-    } else if (ninf == 0) {                                    \
-      ans->dbl_v[i] = R_PosInf;                                \
-    } else {                                                   \
-      ans->dbl_v[i] = R_NaN;                                   \
-    }                                                          \
-  } else if (nc == k) {                                        \
-    ans->dbl_v[i] = narm ? R_NaN : NA_REAL;                    \
-  } else {                                                     \
-    if (narm) {                                                \
-      if (pinf == 0) {                                         \
-        if (ninf == 0) {                                       \
-          ans->dbl_v[i] = (double) (w / (k - nc));             \
-        } else {                                               \
-          ans->dbl_v[i] = R_NegInf;                            \
-        }                                                      \
-      } else if (ninf == 0) {                                  \
-        ans->dbl_v[i] = R_PosInf;                              \
-      } else {                                                 \
-        ans->dbl_v[i] = R_NaN;                                 \
-      }                                                        \
-    } else {                                                   \
-      ans->dbl_v[i] = NA_REAL;                                 \
-    }                                                          \
-  }
-
     for (i=0; i<k-1; i++) {                                     // loop over leading observation, all partial window only; #loop_counter_not_local_scope_ok
       SUM_WINDOW_STEP_FRONT
       ans->dbl_v[i] = fill;                                     // partial window fill all
@@ -299,6 +297,40 @@ void frollmeanExact(const double *x, uint64_t nx, ans_t *ans, int k, double fill
   }
 }
 
+#undef SUM_WINDOW_STEP_VALUE
+#define SUM_WINDOW_STEP_VALUE                                    \
+  if (nc == 0) {                                                 \
+    if (pinf == 0) {                                             \
+      if (ninf == 0) {                                           \
+        ans->dbl_v[i] = (double) w;                              \
+      } else {                                                   \
+        ans->dbl_v[i] = R_NegInf;                                \
+      }                                                          \
+    } else if (ninf == 0) {                                      \
+      ans->dbl_v[i] = R_PosInf;                                  \
+    } else {                                                     \
+      ans->dbl_v[i] = R_NaN;                                     \
+    }                                                            \
+  } else if (nc == k) {                                          \
+    ans->dbl_v[i] = narm ? 0.0 : NA_REAL;                        \
+  } else {                                                       \
+    if (narm) {                                                  \
+      if (pinf == 0) {                                           \
+        if (ninf == 0) {                                         \
+          ans->dbl_v[i] = (double) w;                            \
+        } else {                                                 \
+          ans->dbl_v[i] = R_NegInf;                              \
+        }                                                        \
+      } else if (ninf == 0) {                                    \
+        ans->dbl_v[i] = R_PosInf;                                \
+      } else {                                                   \
+        ans->dbl_v[i] = R_NaN;                                   \
+      }                                                          \
+    } else {                                                     \
+      ans->dbl_v[i] = NA_REAL;                                   \
+    }                                                            \
+  }
+
 /* fast rolling sum - fast
  * same as mean fast
  */
@@ -347,41 +379,6 @@ void frollsumFast(const double *x, uint64_t nx, ans_t *ans, int k, double fill, 
   if (truehasnf) {
     int nc = 0, pinf = 0, ninf = 0;                             // NA counter within sliding window
     int i;                                                      // iterator declared here because it is being used after for loop
-
-#undef SUM_WINDOW_STEP_VALUE
-#define SUM_WINDOW_STEP_VALUE                                  \
-if (nc == 0) {                                                 \
-  if (pinf == 0) {                                             \
-    if (ninf == 0) {                                           \
-      ans->dbl_v[i] = (double) w;                              \
-    } else {                                                   \
-      ans->dbl_v[i] = R_NegInf;                                \
-    }                                                          \
-  } else if (ninf == 0) {                                      \
-    ans->dbl_v[i] = R_PosInf;                                  \
-  } else {                                                     \
-    ans->dbl_v[i] = R_NaN;                                     \
-  }                                                            \
-} else if (nc == k) {                                          \
-  ans->dbl_v[i] = narm ? 0.0 : NA_REAL;                        \
-} else {                                                       \
-  if (narm) {                                                  \
-    if (pinf == 0) {                                           \
-      if (ninf == 0) {                                         \
-        ans->dbl_v[i] = (double) w;                            \
-      } else {                                                 \
-        ans->dbl_v[i] = R_NegInf;                              \
-      }                                                        \
-    } else if (ninf == 0) {                                    \
-      ans->dbl_v[i] = R_PosInf;                                \
-    } else {                                                   \
-      ans->dbl_v[i] = R_NaN;                                   \
-    }                                                          \
-  } else {                                                     \
-    ans->dbl_v[i] = NA_REAL;                                   \
-  }                                                            \
-}
-
     for (i=0; i<k-1; i++) {                                     // loop over leading observation, all partial window only; #loop_counter_not_local_scope_ok
       SUM_WINDOW_STEP_FRONT
       ans->dbl_v[i] = fill;                                     // partial window fill all
@@ -471,7 +468,6 @@ void frollsumExact(const double *x, uint64_t nx, ans_t *ans, int k, double fill,
     }
   }
 }
-
 
 static inline void wmax(const double * restrict x, uint64_t o, int k, double * restrict w, uint64_t *iw, bool narm) {
   if (narm) {
@@ -888,6 +884,50 @@ void frollminExact(const double *x, uint64_t nx, ans_t *ans, int k, double fill,
   }
 }
 
+#undef PROD_WINDOW_STEP_FRONT
+#define PROD_WINDOW_STEP_FRONT                                   \
+  if (R_FINITE(x[i])) {                                          \
+    w *= x[i];                                                   \
+  } else if (ISNAN(x[i])) {                                      \
+    nc++;                                                        \
+  } else if (x[i]==R_PosInf) {                                   \
+    pinf++;                                                      \
+  } else if (x[i]==R_NegInf) {                                   \
+    ninf++;                                                      \
+  }
+#undef PROD_WINDOW_STEP_BACK
+#define PROD_WINDOW_STEP_BACK                                    \
+  if (R_FINITE(x[i-k])) {                                        \
+    w /= x[i-k];                                                 \
+  } else if (ISNAN(x[i-k])) {                                    \
+    nc--;                                                        \
+  } else if (x[i-k]==R_PosInf) {                                 \
+    pinf--;                                                      \
+  } else if (x[i-k]==R_NegInf) {                                 \
+    ninf--;                                                      \
+  }
+#undef PROD_WINDOW_STEP_VALUE
+#define PROD_WINDOW_STEP_VALUE                                   \
+  if (nc == 0) {                                                 \
+    if (pinf == 0 && ninf == 0) {                                \
+      ans->dbl_v[i] = (double) w;                                \
+    } else {                                                     \
+      ans->dbl_v[i] = (ninf+(w<0))%2 ? R_NegInf : R_PosInf;      \
+    }                                                            \
+  } else if (nc == k) {                                          \
+    ans->dbl_v[i] = narm ? 1.0 : NA_REAL;                        \
+  } else {                                                       \
+    if (narm) {                                                  \
+      if (pinf == 0 && ninf == 0) {                              \
+        ans->dbl_v[i] = (double) w;                              \
+      } else {                                                   \
+        ans->dbl_v[i] = (ninf+(w<0))%2 ? R_NegInf : R_PosInf;    \
+      }                                                          \
+    } else {                                                     \
+      ans->dbl_v[i] = NA_REAL;                                   \
+    }                                                            \
+  }
+
 /* fast rolling prod - fast
  * same as mean fast
  */
@@ -936,51 +976,6 @@ void frollprodFast(const double *x, uint64_t nx, ans_t *ans, int k, double fill,
   if (truehasnf) {
     int nc = 0, pinf = 0, ninf = 0;                             // NA counter within sliding window
     int i;                                                      // iterator declared here because it is being used after for loop
-
-#undef PROD_WINDOW_STEP_FRONT
-#define PROD_WINDOW_STEP_FRONT                                      \
-    if (R_FINITE(x[i])) {                                          \
-      w *= x[i];                                                   \
-    } else if (ISNAN(x[i])) {                                      \
-      nc++;                                                        \
-    } else if (x[i]==R_PosInf) {                                   \
-      pinf++;                                                      \
-    } else if (x[i]==R_NegInf) {                                   \
-      ninf++;                                                      \
-    }
-#undef PROD_WINDOW_STEP_BACK
-#define PROD_WINDOW_STEP_BACK                                     \
-  if (R_FINITE(x[i-k])) {                                        \
-    w /= x[i-k];                                                 \
-  } else if (ISNAN(x[i-k])) {                                    \
-    nc--;                                                        \
-  } else if (x[i-k]==R_PosInf) {                                 \
-    pinf--;                                                      \
-  } else if (x[i-k]==R_NegInf) {                                 \
-    ninf--;                                                      \
-  }
-#undef PROD_WINDOW_STEP_VALUE
-#define PROD_WINDOW_STEP_VALUE                                   \
-    if (nc == 0) {                                               \
-      if (pinf == 0 && ninf == 0) {                              \
-        ans->dbl_v[i] = (double) w;                              \
-      } else {                                                   \
-        ans->dbl_v[i] = (ninf+(w<0))%2 ? R_NegInf : R_PosInf;    \
-      }                                                          \
-    } else if (nc == k) {                                          \
-      ans->dbl_v[i] = narm ? 1.0 : NA_REAL;                        \
-    } else {                                                       \
-      if (narm) {                                                  \
-        if (pinf == 0 && ninf == 0) {                              \
-          ans->dbl_v[i] = (double) w;                              \
-        } else {                                                   \
-          ans->dbl_v[i] = (ninf+(w<0))%2 ? R_NegInf : R_PosInf;    \
-        }                                                          \
-      } else {                                                     \
-        ans->dbl_v[i] = NA_REAL;                                   \
-      }                                                            \
-    }
-
     for (i=0; i<k-1; i++) {                                     // loop over leading observation, all partial window only; #loop_counter_not_local_scope_ok
       PROD_WINDOW_STEP_FRONT
       ans->dbl_v[i] = fill;                                     // partial window fill all

--- a/src/frollapply.c
+++ b/src/frollapply.c
@@ -1,7 +1,6 @@
 #include "data.table.h"
 
-static inline void memcpy_sexp(SEXP dest, size_t offset, SEXP src, int count)
-{
+static inline void memcpy_sexp(SEXP dest, size_t offset, SEXP src, int count) {
   switch (TYPEOF(dest)) {
   case INTSXP: {
     memcpy(INTEGER(dest), INTEGER_RO(src) + offset, count * sizeof(int));

--- a/src/frollapply.c
+++ b/src/frollapply.c
@@ -1,6 +1,6 @@
 #include "data.table.h"
 
-static inline void MEMCPY_SEXP(SEXP dest, size_t offset, SEXP src, int count)
+static inline void memcpy_sexp(SEXP dest, size_t offset, SEXP src, int count)
 {
   switch (TYPEOF(dest)) {
   case INTSXP: {
@@ -32,7 +32,7 @@ static inline void MEMCPY_SEXP(SEXP dest, size_t offset, SEXP src, int count)
  * we don't call memcpyVector from memcpyDT because they are called in tight loop and we don't want to have extra branches inside
  */
 SEXP memcpyVector(SEXP dest, SEXP src, SEXP offset, SEXP size) {
-  MEMCPY_SEXP(dest, INTEGER_RO(offset)[0] - INTEGER_RO(size)[0], src, LENGTH(dest));
+  memcpy_sexp(dest, INTEGER_RO(offset)[0] - INTEGER_RO(size)[0], src, LENGTH(dest));
   return dest;
 }
 // # nocov start ## does not seem to be reported to codecov most likely due to running in a fork, I manually debugged that it is being called when running froll.Rraw
@@ -41,7 +41,7 @@ SEXP memcpyDT(SEXP dest, SEXP src, SEXP offset, SEXP size) {
   const int ncol = LENGTH(dest);
   const int nrow = LENGTH(VECTOR_ELT(dest, 0));
   for (int i = 0; i < ncol; i++) {
-    MEMCPY_SEXP(VECTOR_ELT(dest, i), INTEGER_RO(offset)[0] - INTEGER_RO(size)[0], VECTOR_ELT(src, i), nrow);
+    memcpy_sexp(VECTOR_ELT(dest, i), INTEGER_RO(offset)[0] - INTEGER_RO(size)[0], VECTOR_ELT(src, i), nrow);
   }
   return dest;
 }
@@ -51,9 +51,9 @@ SEXP memcpyVectoradaptive(SEXP dest, SEXP src, SEXP offset, SEXP size) {
   const size_t oi = INTEGER_RO(offset)[0];
   const int nrow = INTEGER_RO(size)[oi - 1];
   const size_t o = oi - nrow; // oi should always be bigger than nrow because we filter out incomplete window using ansMask
-  SETLENGTH(dest, nrow); // must be before MEMCPY_SEXP because attempt to set index 1/1 in SET_STRING_ELT test 6010.150
+  SETLENGTH(dest, nrow); // must be before memcpy_sexp because attempt to set index 1/1 in SET_STRING_ELT test 6010.150
   if (nrow) { // support k[i]==0
-    MEMCPY_SEXP(dest, o, src, nrow);
+    memcpy_sexp(dest, o, src, nrow);
   }
   return dest;
 }
@@ -68,7 +68,7 @@ SEXP memcpyDTadaptive(SEXP dest, SEXP src, SEXP offset, SEXP size) {
     SEXP d = VECTOR_ELT(dest, i);
     SETLENGTH(d, nrow);
     if (nrow) { // support k[i]==0
-      MEMCPY_SEXP(d, o, VECTOR_ELT(src, i), nrow);
+      memcpy_sexp(d, o, VECTOR_ELT(src, i), nrow);
     }
   }
   return dest;


### PR DESCRIPTION
this PR only

- rename function from MEMCPY_SEXP to lowercase as this is not a macro anymore
- moves around macros definition so code is nicely folding in IDE