### PR TITLE
GitLab CI: install XQuartz on macOS

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -314,6 +314,8 @@ test-win-old:
   tags:
     - saas-macos-medium-m1
   before_script:
+    - curl -LO https://github.com/XQuartz/XQuartz/releases/download/XQuartz-2.8.5/XQuartz-2.8.5.pkg
+    - sudo installer -pkg "$(ls -1t XQuartz-*.pkg | head -n 1)" -target /
     - curl -O $R_BIN
     - sudo installer -pkg "$(ls -1t R-*-arm64.pkg | head -n 1)" -target /
     - sudo Rscript -e "source('https://mac.R-project.org/bin/install.R'); install.libs('gettext')"


### PR DESCRIPTION
GitLab CI on macOS was broken for a while because the X11-related warnings became fatal ([test-mac-old](https://gitlab.com/Rdatatable/data.table/-/jobs/11347121457), [test-mac-rel](https://gitlab.com/Rdatatable/data.table/-/jobs/11347121456)) after #7210:
```
unable to load shared object '/Library/Frameworks/R.framework/Resources/modules//R_X11.so':
  dlopen(/Library/Frameworks/R.framework/Resources/modules//R_X11.so, 0x0006): Library not loaded: /opt/X11/lib/libSM.6.dylib
```

With XQuartz installed, the tests still fail ([test-mac-old](https://gitlab.com/Rdatatable/data.table/-/jobs/11362613933), [test-mac-rel](https://gitlab.com/Rdatatable/data.table/-/jobs/11362613932)), but for more normal(?) reasons: somehow `.internal.selfref` being a null pointer is not handled in two cases after a forking `frollapply` operation.