### PR TITLE
frollapply simplify more conservative

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -177,20 +177,20 @@
     ```r
     x = data.table(v1=rnorm(120), v2=rnorm(120))
     f = function(x) coef(lm(v2 ~ v1, data=x))
-    coef.fill = c("(Intercept)"=NA_real_, "v1"=NA_real_)
-    frollapply(x, 4, f, by.column=FALSE, fill=coef.fill)
+    frollapply(x, 4, f, by.column=FALSE)
     #     (Intercept)         v1
+    #           <num>      <num>
     #  1:          NA         NA
     #  2:          NA         NA
     #  3:          NA         NA
-    #  4:  0.65456931  0.3138012
-    #  5: -1.07977441 -2.0588094
+    #  4: -0.04648236 -0.6349687
+    #  5:  0.09208733 -0.4964023
     #---
-    #116:  0.15828417  0.3570216
-    #117: -0.09083424  1.5494507
-    #118: -0.18345878  0.6424837
-    #119: -0.28964772  0.6116575
-    #120: -0.40598313  0.6112854
+    #116: -0.21169439  0.7421358
+    #117: -0.19729119  0.4926939
+    #118: -0.04217896  0.0452713
+    #119:  0.22472549 -0.5245874
+    #120:  0.54540359 -0.1638333
     ```
     - uses multiple CPU threads (on a decent OS); evaluation of UDF is inherently slow so this can be a great help.
     ```r

--- a/R/frollapply.R
+++ b/R/frollapply.R
@@ -1,57 +1,116 @@
+all_atomic = function(x) all(vapply_1b(x, is.atomic, use.names=FALSE))
+all_data.frame = function(x) all(vapply_1b(x, is.data.frame, use.names=FALSE))
+all_list = function(x) all(vapply_1b(x, is.list, use.names=FALSE))
+all_types = function(x) vapply_1c(x, typeof, use.names=FALSE)
+all_names = function(x) lapply(x, names)
+len_unq = function(x) length(unique(x))
+any_NA_neg = function(x) anyNA(x) || any(x < 0L)
+any_NA_names = function(x) anyNA(names(x))
+all_NULL_names = function(x) all(vapply_1b(x, function(y) is.null(names(y)), use.names=FALSE))
+equal.lengths = function(x) len_unq(lengths(x)) <= 1L
+equal.nrows = function(x) len_unq(lapply(x, nrow)) <= 1L
+equal.dims = function(x) len_unq(lapply(x, dim)) <= 1L
+equal.types = function(x) len_unq(all_types(x)) <= 1L
+equal.names = function(x) len_unq(all_names(x)) <= 1L
+
 ## ansmask is to handle leading values from fill to match type of the ans
 simplifylist = function(x, fill, ansmask) {
-  all.t = vapply_1c(x, typeof, use.names=FALSE)
+  all.t = all_types(x)
   all.ut = unique(all.t)
   if (length(all.ut) > 1L) {
-    ans.t = vapply_1c(x[ansmask], typeof, use.names=FALSE)
-    ans.ut = unique(ans.t)
-    ## ans postprocessing to match types
-    if ((length(ans.ut) == 2L) && all(ans.ut %in% c("double","integer","logical"))) { ## align numeric and integer when function is not type stable: median #7313
-      if ("double" %in% ans.ut) {
-        if ("integer" %in% ans.ut)
-          x[ansmask & all.t=="integer"] = lapply(x[ansmask & all.t=="integer"], as.numeric) ## coerce integer to double
-        if ("logical" %in% ans.ut)
-          x[ansmask & all.t=="logical"] = lapply(x[ansmask & all.t=="logical"], as.numeric) ## coerce logical to double
-        ans.ut = "double"
-      } else if ("integer" %in% ans.ut) {
-        if ("logical" %in% ans.ut)
-          x[ansmask & all.t=="logical"] = lapply(x[ansmask & all.t=="logical"], as.integer) ## coerce logical to integer
-        else
-          internal_error("simplifylist aligning return types, at that place there should have been some logical types in the answer") # nocov
-        ans.ut = "integer"
-      }
+    ans.ut = unique(all_types(x[ansmask]))
+    ## coerce int to double when varies within answer results: median #7313
+    if ( 
+      length(ans.ut) == 2L &&                   ## simplifylist(list(NA, 1, 1L, TRUE), NA, ansmask=c(F,T,T,T))
+      all(c("double","integer") %in% ans.ut) && ## simplifylist(list(NA, 1, TRUE), NA, ansmask=c(F,T,T))
+      equal.lengths(x[ansmask])                 ## simplifylist(list(NA, 1, 1:2), NA, ansmask=c(F,T,T))
+    ) {
+      x[ansmask & all.t=="integer"] = lapply(x[ansmask & all.t=="integer"], as.numeric) ## coerce integer to double
+      ans.ut = "double"
     }
-    ## file postprocessing to match types
-    if (length(ans.ut) == 1L && equal.lengths(x[ansmask])) {
-      if (identical(fill, NA)) { ## different typeof of ans and default fill=NA and lengths of ans equal
-        filli = which(!ansmask)
-        ans1 = x[[which.first(ansmask)]] ## first ans from full window
-        x[filli] = rep_len(list(ans1[NA]), length(filli)) ## this will make NA of matching type to ans1 and recycle for all filli
-        all.ut = ans.ut
-      } else if (typeof(fill) != ans.ut && all(c(typeof(fill), ans.ut) %in% c("double","integer","logical"))) { ## fill=-2, ans=1L
-        filli = which(!ansmask)
-        cast = switch(ans.ut, double = as.numeric, integer = as.integer, logical = as.logical)
-        x[filli] = rep_len(list(cast(fill)), length(filli))
-        all.ut = ans.ut
+    ## coerce fill to answers type and length
+    if (
+      length(ans.ut) == 1L &&      ## simplifylist(list(NA, 1, TRUE), NA, ansmask=c(F,T,T))
+      equal.lengths(x[ansmask]) && ## simplifylist(list(NA, 1L, 1:2), NA, ansmask=c(F,T,T))
+      is.atomic(fill)              ## simplifylist(list(list(NA), list(1), list(2)), list(NA), ansmask=c(F,T,T))
+    ) {
+      fill.t = typeof(fill)
+      ans1 = x[[which.first(ansmask)]] ## first ans from full window, all ans same type by now
+      ## coerce fill to type
+      if (identical(fill, NA)) {
+        if (ans.ut == "list") {
+          fill = lapply(ans1, `[`, NA) ## we want list(NA) rather than list(NULL), this also propagates names
+        } else {
+          fill = setNames(ans1[NA], names(ans1))
+        }
+        fill.t = ans.ut
+      } else if (
+        fill.t != ans.ut &&                  ## simplifylist(list(-1, 1, 2), -1, ansmask=c(F,T,T))
+        fill.t %in% c("double","integer") && ## simplifylist(list(NULL, 1, 2), NULL, ansmask=c(F,T,T))
+        ans.ut %in% c("double","integer")    ## simplifylist(list(1, "a", "b"), 1, ansmask=c(F,T,T))
+      ) { ## fill=-2, ans=1L
+        if (fill.t == "integer" && ans.ut == "double") {
+          fill = as.double(fill)
+        } else if (fill.t == "double" && ans.ut == "integer") {
+          fill = as.integer(fill)
+        } else {
+          internal_error("coerce fill type reached a branch of unexpected fill type and answer type") # nocov
+        }
+        fill.t = ans.ut
+      }
+      ## name fill if all ans have same names
+      if (
+        ans.ut != "list" &&
+        is.null(names(fill)) &&
+        !is.null(names(ans1)) &&                                             ## simplifylist(list(NA, c(1,2), c(1,2)), NA, ansmask=c(F,T,T))
+        len_unq(vapply_1b(x[ansmask], any_NA_names, use.names=FALSE)) <= 1L && ## simplifylist(list(NA, c(a=1,b=2), setNames(c(1, 2), c(NA,"b"))), NA, ansmask=c(F,T,T))
+        equal.names(x[ansmask])                                              ## simplifylist(list(NA, c(a=1,b=2), c(x=1,y=2)), NA, ansmask=c(F,T,T))
+      ) {
+        fill = setNames(fill, names(ans1))
+      }
+      ## recycle fill
+      filli = which(!ansmask)
+      x[filli] = rep_len(list(fill), length(filli))
+    }
+    all.ut = unique(all_types(x))
+  }
+  if (
+    !is.null(names(fill)) &&
+    all_NULL_names(x[ansmask]) &&
+    equal.lengths(x)
+  ) {
+    nm = names(fill)
+    x[ansmask] = lapply(x[ansmask], `names<-`, nm)
+  }
+  if (length(all.ut) == 1L) {
+    if (all.ut %in% c("integer","logical","double","complex","character","raw")) {
+      if (identical(unique(lengths(x)), 1L)) { ## all length 1
+        return(unlist(x, recursive=FALSE, use.names=FALSE))
+      } else if (
+        equal.lengths(x) &&
+        equal.names(x)
+      ) { ## length 2+ and equal
+        return(rbindlist(lapply(x, as.list)))
+      }
+    } else if (identical(all.ut,"list")) {
+      if (
+        all_data.frame(x) && ## simplifylist(list(NA, list(a=1L, b=2L), data.table(a=1L, b=2L)), NA, ansmask=c(F,T,T))
+        equal.dims(x) &&     ## simplifylist(list(NA, data.table(a=1L, b=2L), data.table(a=1L)), NA, ansmask=c(F,T,T))
+        equal.types(x) &&    ## simplifylist(list(NA, data.table(a=1L, b=2L), data.table(a=1L, b="b")), NA, ansmask=c(F,T,T))
+        equal.names(x)       ## simplifylist(list(NA, data.table(a=1L, b=2L), data.table(x=1L, y=2L)), NA, ansmask=c(F,T,T))
+      ) {
+        return(rbindlist(x))
+      } else if (
+        equal.lengths(x) &&
+        len_unq(lapply(x, lengths, use.names=FALSE)) <= 1L && ## nested lengths
+        len_unq(lapply(lapply(x, unlist, recursive=FALSE, use.names=FALSE), typeof)) <= 1L &&
+        equal.names(x)
+      ) { ## same length lists: list(list(1:2, 1:2), list(2:3, 2:3))
+        return(rbindlist(x))  ## simplifylist(list(NA, list(1:2, 1:2), list(2:3, 2:3)), NA, ansmask=c(F,T,T))
       }
     }
   }
-  all.ut = unique(vapply_1c(x, typeof, use.names=FALSE))
-  if ((length(all.ut) == 1L) && all(all.ut %in% c("integer","logical","double","complex","character","raw"))) {
-    if (identical(unique(lengths(x)), 1L)) { ## length 1
-      return(unlist(x, recursive=FALSE, use.names=FALSE))
-    } else if (equal.lengths(x)) { ## length 2+ and equal
-      return(rbindlist(lapply(x, as.list)))
-    }
-  } else if (identical(all.ut, "list")) {
-    if (all_data.frame(x)) ## list(data.table(...), data.table(...))
-      return(rbindlist(x))
-    if (equal.lengths(x)) ## same length lists: list(list(1:2, 1:2), list(2:3, 2:3))
-      return(rbindlist(x))
-  }
-  ## not simplified, return as is
-  # not length stable
-  # not type stable
+  ## not simplified, return as is, see #7317
   # NULL, closure, special, builtin, environment, S4, ...
   x
 }
@@ -64,13 +123,6 @@ fixselfref = function(x) {
   }
   x
 }
-
-all_atomic = function(x) all(vapply_1b(x, is.atomic, use.names=FALSE))
-all_data.frame = function(x) all(vapply_1b(x, is.data.frame, use.names=FALSE))
-all_list = function(x) all(vapply_1b(x, is.list, use.names=FALSE))
-equal.lengths = function(x) length(unique(lengths(x))) <= 1L
-equal.nrows = function(x) length(unique(vapply(x, nrow, 0L))) <= 1L
-anyNAneg = function(x) anyNA(x) || any(x < 0L)
 
 frollapply = function(X, N, FUN, ..., by.column=TRUE, fill=NA, align=c("right","left","center"), adaptive=FALSE, partial=FALSE, give.names=FALSE, simplify=TRUE, x, n) {
   if (!missing(x)) {
@@ -159,7 +211,7 @@ frollapply = function(X, N, FUN, ..., by.column=TRUE, fill=NA, align=c("right","
     nnam = names(N) ## used for give.names
     if (!is.integer(N))
       N = as.integer(N)
-    if (anyNAneg(N))
+    if (any_NA_neg(N))
       stopf("'N' must be non-negative integer values (>= 0)")
     nn = length(N) ## top level loop for vectorized n
   } else {
@@ -170,7 +222,7 @@ frollapply = function(X, N, FUN, ..., by.column=TRUE, fill=NA, align=c("right","
         stopf("length of integer vector(s) provided as list to 'N' argument must be equal to number of observations provided in 'X'")
       if (!is.integer(N))
         N = as.integer(N)
-      if (anyNAneg(N))
+      if (any_NA_neg(N))
         stopf("'N' must be non-negative integer values (>= 0)")
       nn = 1L
       N = list(N)
@@ -184,7 +236,7 @@ frollapply = function(X, N, FUN, ..., by.column=TRUE, fill=NA, align=c("right","
         stopf("'N' must be an integer vector or list of integer vectors")
       if (!all(vapply_1b(N, is.integer, use.names=FALSE)))
         N = lapply(N, as.integer)
-      if (any(vapply_1b(N, anyNAneg, use.names=FALSE)))
+      if (any(vapply_1b(N, any_NA_neg, use.names=FALSE)))
         stopf("'N' must be non-negative integer values (>= 0)")
       nn = length(N)
       nnam = names(N)

--- a/inst/tests/froll.Rraw
+++ b/inst/tests/froll.Rraw
@@ -1580,9 +1580,9 @@ test(6010.103, frollapply(c(1,2,1,1,1,2,3,2), 3, uniqueN), c(NA,NA,2L,2L,1L,2L,3
 test(6010.104, frollapply(c(1,2,1,1,NA,2,NA,2), 3, anyNA), c(NA,NA,FALSE,FALSE,TRUE,TRUE,TRUE,TRUE))
 f = function(x) {
   n = length(x) # double type will be returned only for first iteration
-  if (n==x[n]) 1 else NA # NA logical coerced properly
+  if (n==x[n]) 1 else NA
 }
-test(6010.105, frollapply(1:5, 3, f), c(NA,NA,1,NA,NA))
+test(6010.105, frollapply(1:5, 3, f), list(NA,NA,1,NA,NA)) ## this demands user to write type aware NA inside FUN, which is mentioned as recommendation in ?frollapply
 
 ## partial
 x = 1:6/2
@@ -1737,8 +1737,15 @@ test(6010.621, as.data.table(iris)[, "flow" := frollapply(.(Sepal.Length, Sepal.
 test(6010.622, as.data.table(iris)[, "flow" := frollapply(data.frame(Sepal.Length, Sepal.Width), 2L, flow, by.column=FALSE), by = Species]$flow[idx], ans)
 test(6010.623, as.data.table(iris)[, "flow" := unlist(lapply(split(data.frame(Sepal.Length, Sepal.Width), Species), frollapply, 2L, flow, by.column=FALSE))]$flow[idx], ans)
 f = function(l) as.list(range(l[[1L]])-range(l[[2L]]))
-test(6010.624, frollapply(list(1:5, 5:1), c(2,2,3,3,4), f, adaptive=TRUE, by.column=FALSE, fill=list(NA,NA)), data.table(V1=c(NA,-3L,-2L,0L,1L), V2=c(NA,-3L,-2L,0L,1L)))
-test(6010.625, frollapply(list(1:5, 5:1), c(2,2,3,3,4), f, align="left", adaptive=TRUE, by.column=FALSE, fill=list(NA,NA)), data.table(V1=c(-3L,-1L,2L,NA,NA), V2=c(-3L,-1L,2L,NA,NA)))
+test(6010.624, frollapply(list(1:5, 5:1), c(2,2,3,3,4), f, adaptive=TRUE, by.column=FALSE, fill=list(NA,NA)), list(list(NA, NA), list(-3L, -3L), list(-2L, -2L), list(0L, 0L), list(1L, 1L)))
+test(6010.6241, frollapply(list(1:5, 5:1), c(2,2,3,3,4), f, adaptive=TRUE, by.column=FALSE), data.table(V1=c(NA,-3L,-2L,0L,1L), V2=c(NA,-3L,-2L,0L,1L)))
+f = function(l) range(l[[1L]])-range(l[[2L]])
+test(6010.6242, frollapply(list(1:5, 5:1), c(2,2,3,3,4), f, adaptive=TRUE, by.column=FALSE), data.table(V1=c(NA,-3L,-2L,0L,1L), V2=c(NA,-3L,-2L,0L,1L)))
+f = function(l) as.list(range(l[[1L]])-range(l[[2L]]))
+test(6010.625, frollapply(list(1:5, 5:1), c(2,2,3,3,4), f, align="left", adaptive=TRUE, by.column=FALSE, fill=list(NA,NA)), list(list(-3L, -3L), list(-1L, -1L), list(2L, 2L), list(NA, NA), list(NA, NA)))
+test(6010.6251, frollapply(list(1:5, 5:1), c(2,2,3,3,4), f, align="left", adaptive=TRUE, by.column=FALSE), data.table(V1 = c(-3L, -1L, 2L, NA, NA), V2 = c(-3L, -1L, 2L, NA, NA)))
+f = function(l) range(l[[1L]])-range(l[[2L]])
+test(6010.6252, frollapply(list(1:5, 5:1), c(2,2,3,3,4), f, align="left", adaptive=TRUE, by.column=FALSE), data.table(V1=c(-3L,-1L,2L,NA,NA), V2=c(-3L,-1L,2L,NA,NA)))
 #### list of df/lists
 x = list(data.table(x=1:2, y=2:3), data.table(z=3:5))
 test(6010.631, frollapply(x, 2, tail, 1, by.column=FALSE, fill=data.table(), simplify=function(x) rbindlist(x, fill=TRUE)), list(data.table(x=2L, y=3L), data.table(z=4:5)))
@@ -1773,7 +1780,14 @@ test(6010.705, frollapply(1:5, 2, range, simplify=FALSE), list(NA,1:2,2:3,3:4,4:
 test(6010.706, frollapply(1:5, 2, range, fill=c(NA_integer_,NA_integer_)), data.table(V1=c(NA,1:4), V2=c(NA,2:5)))
 test(6010.707, frollapply(1:5, 2, range, fill=c(min=NA_integer_, max=NA_integer_)), data.table(min=c(NA,1:4), max=c(NA,2:5)))
 test(6010.708, frollapply(1:5, 2, range, fill=c(min=NA_integer_, max=NA_integer_), simplify=function(x) rbindlist(lapply(x, as.list))), data.table(min=c(NA,1:4), max=c(NA,2:5)))
-test(6010.709, frollapply(1:5, 2, function(x) as.list(range(x)), fill=list(min=NA_integer_, max=NA_integer_)), data.table(min=c(NA,1:4), max=c(NA,2:5)))
+test(6010.7091, frollapply(1:5, 2, function(x) as.list(range(x))), data.table(c(NA,1:4), c(NA,2:5)))
+test(6010.7092, frollapply(1:5, 2, function(x) as.list(range(x)), fill=list(min=NA_integer_, max=NA_integer_)), data.table(min=c(NA,1:4), max=c(NA,2:5)))
+test(6010.7093, frollapply(1:5, 2, function(x) as.list(setNames(range(x), c("min","max")))), data.table(min=c(NA,1:4), max=c(NA,2:5)))
+test(6010.7094, frollapply(1:5, 2, function(x) as.list(setNames(range(x), c("v1","v2"))), fill=list(min=NA_integer_, max=NA_integer_)), list(list(min = NA_integer_, max = NA_integer_), list(v1 = 1L, v2 = 2L), list(v1 = 2L, v2 = 3L), list(v1 = 3L, v2 = 4L), list(v1 = 4L, v2 = 5L)))
+test(6010.7095, frollapply(1:5, 2, function(x) range(x)), data.table(c(NA,1:4), c(NA,2:5)))
+test(6010.7096, frollapply(1:5, 2, function(x) range(x), fill=c(min=NA_integer_, max=NA_integer_)), data.table(min=c(NA,1:4), max=c(NA,2:5)))
+test(6010.7097, frollapply(1:5, 2, function(x) setNames(range(x), c("min","max"))), data.table(min=c(NA,1:4), max=c(NA,2:5)))
+test(6010.7098, frollapply(1:5, 2, function(x) setNames(range(x), c("v1","v2")), fill=c(min=NA_integer_, max=NA_integer_)), list(c(min = NA_integer_, max = NA_integer_), c(v1=1L, v2=2L), c(v1=2L, v2=3L), c(v1=3L, v2=4L), c(v1=4L, v2=5L)))
 test(6010.710, frollapply(1:5, 2, function(x) as.list(range(x)), fill=list(min=NA_integer_, max=NA_integer_), simplify=rbindlist), data.table(min=c(NA,1:4), max=c(NA,2:5)))
 test(6010.711, frollapply(1:5, 2, function(x) as.list(range(x)), fill=list(NA_integer_, NA_integer_), simplify=FALSE), list(list(NA_integer_, NA_integer_), as.list(1:2), as.list(2:3), as.list(3:4), as.list(4:5)))
 test(6010.712, as.null(frollapply(1:3, 1, function(x) if (x==1L) sum else if (x==2L) mean else `[`, simplify=TRUE)), NULL) ## as.null as we are only interested in codecov here
@@ -1783,27 +1797,29 @@ test(6010.751, frollapply(FUN=median, adaptive=TRUE, list(1:3,2:4), list(c(2,0,2
 test(6010.752, frollapply(FUN=median, adaptive=TRUE, 1:3, c(2,0,2), fill=99), c(99,NA_real_,2.5))
 test(6010.753, frollapply(FUN=median, adaptive=TRUE, c(1L,2L,4L), c(2,0,2), fill=99L), c(99,NA_real_,3))
 test(6010.754, frollapply(FUN=median, adaptive=TRUE, c(1L,2L,3L), c(2,0,2), fill=99), c(99,NA_real_,2.5))
-test(6010.755, frollapply(1:2, 1, function(i) if (i==1L) 1L else FALSE), c(1L,0L))
-test(6010.756, frollapply(1:3, 2, fill=9, function(i) if (i[1L]==1L) 1L else FALSE), c(9L,1L,0L)) ## matches fun answer
-test(6010.757, frollapply(1:3, 2, fill=9L, function(i) if (i[1L]==1L) 1 else FALSE), c(9,1,0)) ## matches fun answer
-test(6010.758, frollapply(1:3, 2, fill=0, function(i) TRUE), c(FALSE,TRUE,TRUE)) ## matches fun answer
+test(6010.755, frollapply(1:2, 1, function(i) if (i==1L) 1L else NA), list(1L,NA))
+test(6010.756, frollapply(1:3, 2, fill=9, function(i) if (i[1L]==1L) 1L else NA), list(9,1L,NA))
+test(6010.757, frollapply(1:3, 2, fill=9, function(i) if (i[1L]==1L) 1L else 2L), c(9L,1L,2L)) ## matches fun answer
+test(6010.758, frollapply(1:3, 2, fill=9L, function(i) if (i[1L]==1L) 1 else FALSE), list(9L,1,FALSE))
+test(6010.759, frollapply(1:3, 2, fill=0, function(i) TRUE), list(0,TRUE,TRUE))
 
 #### mutlithreading throttle caveats from manual: copy, fixing .internal.selfref
 use.fork = .Platform$OS.type!="windows" && getDTthreads()>1L
 if (use.fork) {
-  setDTthreads(throttle=1) ## disable throttle
   old = setDTthreads(1)
   test(6010.761, frollapply(c(1, 9), N=1L, FUN=identity), c(9,9)) ## unexpected
   test(6010.762, frollapply(c(1, 9), N=1L, FUN=list), data.table(V1=c(9,9))) ## unexpected
-  setDTthreads(2)
+  setDTthreads(2, throttle=1) ## disable throttle
   test(6010.763, frollapply(c(1, 9), N=1L, FUN=identity), c(1,9)) ## good only because threads >= input
   test(6010.764, frollapply(c(1, 5, 9), N=1L, FUN=identity), c(5,5,9)) ## unexpected again
   is.ok = function(x) {stopifnot(is.data.table(x)); capture.output(print(attr(x, ".internal.selfref", TRUE)))!="<pointer: (nil)>"}
+  ans = frollapply(1:2, 2, data.table)
+  test(6010.769, is.ok(ans)) ## frollapply will fix DT in most cases
   ans = frollapply(1:2, 2, data.table, simplify=FALSE) ## default: fill=NA
   test(6010.770, is.ok(ans[[2L]])) ## frollapply detected DT and fixed
-  ans = frollapply(1:2, 2, data.table, fill=data.table(NA)) ## fill type match
+  ans = frollapply(1:2, 2, data.table, fill=data.table(c(NA,NA))) ## fill size match
   test(6010.771, is.ok(ans)) ## simplify=TRUE did run rbindlist, but frollapply fixed anyway
-  ans = frollapply(1:2, 2, data.table, fill=data.table(NA), simplify=FALSE)
+  ans = frollapply(1:2, 2, data.table, fill=data.table(NA)) ## fill size not match, no rbindlist, but frollapply fixed anyway
   test(6010.772, is.ok(ans[[2L]]))
   ans = frollapply(1:2, 2, function(x) list(data.table(x)), fill=list(data.table(NA)), simplify=FALSE)
   test(6010.773, !is.ok(ans[[2L]][[1L]]))
@@ -1817,7 +1833,7 @@ if (use.fork) {
   test(6010.776, !is.ok(ans[[3L]]))
   ans = frollapply(1:3, 2, f, fill=data.table(NA), simplify=function(x) lapply(x, function(y) if (is.data.table(y)) setDT(y) else y))
   test(6010.777, is.ok(ans[[3L]])) ## fix inside frollapply via simplify
-  setDTthreads(throttle=1024) ## re-enable throttle
+  setDTthreads(old, throttle=1024) ## re-enable throttle
 }
 
 ## partial adaptive

--- a/man/frollapply.Rd
+++ b/man/frollapply.Rd
@@ -40,7 +40,8 @@
   Setting \code{by.column} to \code{FALSE} allows to apply function on multiple variables rather than a single vector. Then \code{X} expects to be data.table, data.table or a list of equal length vectors, and window size provided in \code{N} refers to number of rows (or length of a vectors in a list). See examples for use cases. Error \emph{"incorrect number of dimensions"} can be commonly observed when \code{by.column} was not set to \code{FALSE} when \code{FUN} expects its input to be a data.frame/data.table.
 }
 \section{\code{simplify} argument}{
-  One should avoid \code{simplify=TRUE} when writing robust code. One reason is performance, as explained in \emph{Performance consideration} section below. Another is backward compatibility. If results are not automatically simplified when \code{simplify=TRUE} then, for backward compatibility, one should use \code{simplify=FALSE} explicitly. In future version we may improve internal \code{simplifylist} function, then \code{simplify=TRUE} may return object of a different type, breaking downstream code. If results are already simplified with \code{simplify=TRUE}, then it can be considered backward compatible.
+  When set to \code{TRUE}, the default, results from rolling function which are normally stored in a list may be simplified either with \code{unlist} or \code{rbindlist}. It also attempts to match type, size and names of \code{fill} argument to the results of a function.
+  One should avoid \code{simplify=TRUE} when writing robust code. One reason is performance, as explained in \emph{Performance consideration} section below. Another is backward compatibility. For backward compatibility and performance one should always provide desired function to \code{simplify} explicitly. In future version we may change internal \code{simplifylist} function, then \code{simplify=TRUE} may return object of a different type, breaking downstream code.
 }
 \section{Caveats}{
   With great power comes great responsibility.
@@ -57,7 +58,7 @@ frollapply(c(1, 9), N=1L, FUN=list) ## unexpected
 #2:     9
 setDTthreads(2, throttle=1) ## disable throttle
 frollapply(c(1, 9), N=1L, FUN=identity) ## good only because threads >= input
-#[1] 1 9
+#[1] 1 9                                ## on Linux and Macos
 frollapply(c(1, 5, 9), N=1L, FUN=identity) ## unexpected again
 #[1] 5 5 9
 }
@@ -88,10 +89,10 @@ is.ok = function(x) {stopifnot(is.data.table(x)); format(attr(x, ".internal.self
 
 setDTthreads(2, throttle=1) ## disable throttle
 ## frollapply will fix DT in most cases
-ans = frollapply(1:2, 2, data.table, fill=data.table(NA))
+ans = frollapply(1:2, 2, data.table)
 is.ok(ans)
 #[1] TRUE
-ans = frollapply(1:2, 2, data.table, fill=data.table(NA), simplify=FALSE)
+ans = frollapply(1:2, 2, data.table, simplify=FALSE)
 is.ok(ans[[2L]])
 #[1] TRUE
 
@@ -124,6 +125,8 @@ simplifix = function(x) lapply(x, function(y) if (is.data.table(y)) setDT(y) els
 ans = frollapply(1:3, 2, f, fill=data.table(NA), simplify=simplifix)
 is.ok(ans[[3L]])
 #[1] TRUE
+
+setDTthreads(2, throttle=1024) ## enable throttle
 }
     }
     \item Due to possible future improvements of handling simplification of results returned from rolling function, the default \code{simplify=TRUE} may not be backward compatible for functions that produce results that haven't been already automatically simplified. See \emph{\code{simplify} argument} section for details.
@@ -139,10 +142,10 @@ x = setDT(lapply(1:1000, function(x) as.double(rep.int(x,1e4L))))
 f = function(x) sum(x$V1 * x$V2)
 system.time(frollapply(x, 100, f, by.column=FALSE))
 #   user  system elapsed
-#  0.689   0.180   0.164
+#  0.376   0.073   0.233
 system.time(frollapply(x[, c("V1","V2"), with=FALSE], 100, f, by.column=FALSE))
 #   user  system elapsed
-#  0.057   0.142   0.070
+#  0.376   0.073   0.233
 }
     \item Avoid \code{partial} argument, see \emph{\code{partial} argument} section of \code{\link{froll}} manual.
     \item Avoid \code{simplify=TRUE} and provide a function instead:
@@ -150,10 +153,10 @@ system.time(frollapply(x[, c("V1","V2"), with=FALSE], 100, f, by.column=FALSE))
 x = rnorm(1e5)
 system.time(frollapply(x, 2, function(x) 1L, simplify=TRUE))
 #   user  system elapsed
-#  0.212   0.188   0.156
+#  0.227   0.095   0.236
 system.time(frollapply(x, 2, function(x) 1L, simplify=unlist))
 #   user  system elapsed
-#  0.105   0.167   0.056
+#  0.054   0.049   0.091
 }
     \item CPU threads utilization in \code{frollapply} can be controlled by \code{\link{setDTthreads}}, which by default uses half of available CPU threads. Usage of multiple CPU threads will be throttled for small input, as described in \code{\link{setDTthreads}} manual.
     \item Optimization that avoids repeated allocation of a window subset (see \emph{Implementation} section for details), in case of adaptive rolling function, depends on R's \emph{growable bit}. This feature has been added in R 3.4.0. Adaptive \code{frollapply} will still work on older versions of R but, due to repeated allocation of window subset, it will be much slower.
@@ -169,12 +172,12 @@ fun1 = function(x) {tmp=range(x); data.table(min=tmp[1L], max=tmp[2L])}
 fun2 = function(x) {tmp=range(x); list(min=tmp[1L], max=tmp[2L])}
 fill1 = data.table(min=NA_integer_, max=NA_integer_)
 fill2 = list(min=NA_integer_, max=NA_integer_)
-system.time(a<-frollapply(1:1e4, 100, fun1, fill=fill1))
+system.time(a<-frollapply(1:1e4, 100, fun1, fill=fill1, simplify=rbindlist))
 #   user  system elapsed
-#  1.064   0.765   0.421
-system.time(b<-frollapply(1:1e4, 100, fun2, fill=fill2))
+#  0.934   0.347   0.706
+system.time(b<-frollapply(1:1e4, 100, fun2, fill=fill2, simplify=rbindlist))
 #   user  system elapsed
-#  0.082   0.221   0.112
+#  0.010   0.033   0.094
 all.equal(a, b)
 #[1] TRUE
 }
@@ -264,8 +267,7 @@ x[, "flow" := frollapply(.(Sepal.Length, Sepal.Width), 2L, flow, by.column=FALSE
 ## rolling regression: by.column=FALSE
 f = function(x) coef(lm(v2 ~ v1, data=x))
 x = data.table(v1=rnorm(120), v2=rnorm(120))
-coef.fill = c("(Intercept)"=NA_real_, "v1"=NA_real_)
-frollapply(x, 4, f, by.column=FALSE, fill=coef.fill)
+frollapply(x, 4, f, by.column=FALSE)
 }
 \seealso{
   \code{\link{froll}}, \code{\link{frolladapt}}, \code{\link{shift}}, \code{\link{data.table}}, \code{\link{setDTthreads}}


### PR DESCRIPTION
closes #7317

In general much less objects might get simplified now
but some features have been added
- matching names between `fill` and FUN results - this allowed to simplified examples
- more flexible recycling of default fill=NA