### PR TITLE
suspendInterrupts missing on 3.4

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -9,6 +9,7 @@
 if (base::getRversion() < "3.5.0") {
   isTRUE  = function(x) is.logical(x) && length(x)==1L && !is.na(x) && x    # backport R's new implementation of isTRUE
   isFALSE = function(x) is.logical(x) && length(x)==1L && !is.na(x) && !x   # backport isFALSE that was added in R 3.5.0
+  suspendInterrupts = function(expr) expr
 }
 isTRUEorNA    = function(x) is.logical(x) && length(x)==1L && (is.na(x) || x)
 isTRUEorFALSE = function(x) is.logical(x) && length(x)==1L && !is.na(x)


### PR DESCRIPTION
suspendInterrupts() was used in frollapply() but it happens to be not available in R 3.4

this should do