### PR TITLE
Add a version dependency for R.utils

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Version: 1.17.99
 Title: Extension of `data.frame`
 Depends: R (>= 3.4.0)
 Imports: methods
-Suggests: bit64 (>= 4.0.0), bit (>= 4.0.4), R.utils, xts, zoo (>= 1.8-1), yaml, knitr, markdown
+Suggests: bit64 (>= 4.0.0), bit (>= 4.0.4), R.utils (>= 2.13.0), xts, zoo (>= 1.8-1), yaml, knitr, markdown
 Description: Fast aggregation of large data (e.g. 100GB in RAM), fast ordered joins, fast add/modify/delete of columns by group using no copies at all, list columns, friendly and fast character-separated-value read/write. Offers a natural and flexible syntax, for faster development.
 License: MPL-2.0 | file LICENSE
 URL: https://r-datatable.com, https://Rdatatable.gitlab.io/data.table, https://github.com/Rdatatable/data.table


### PR DESCRIPTION
More than one user has been bitten by the bug in {R.utils} looking like it's a {data.table} bug: #7326, #6962, #5601

Since we only use {R.utils} for `decompressFile()`, I think it's good on balance to include this version requirement.

Technically it only affects users with `{R.utils} < 2.13.0` *AND* `R >= 4.5.0`, but I'm not sure it's worth quibbling given that (1) {R.utils} is in `Suggests` and (2) the new version has been on CRAN for >6 months already.