### PR TITLE
fix internal warning when cc()

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -21589,7 +21589,7 @@ test(2335.5, isoyear("2019-12-30"), 2020L)
 test(2335.6, isoyear(as.Date("2019-12-30")), 2020L)
 
 # t1-t2 for Date/IDate should be consistent, modulo storage mode #4979
-if (getRversion() >= "4.3.0") { ## follow up of #7213, see #7321
+if (base::getRversion() >= "4.3.0") { ## follow up of #7213, see #7321
   t1 = as.IDate("2025-07-01")
   t2 = as.IDate("2025-06-01")
   test(2336.1, all.equal(as.Date(t1) - as.Date(t2), t1 - t2))
@@ -21602,7 +21602,7 @@ if (getRversion() >= "4.3.0") { ## follow up of #7213, see #7321
 
 # fwrite: allow dec=',' with single column, #7227
 test(2337.1, fwrite(data.table(1), dec=","), NULL)
-if (getRversion() >= "4.0.0") { # rely on stopifnot(named = ...) for correct message
+if (base::getRversion() >= "4.0.0") { # rely on stopifnot(named = ...) for correct message
   test(2337.2, fwrite(data.table(0.1, 0.2), dec=",", sep=","), error = "dec and sep must be distinct")
 }
 test(2337.3, is.null(fwrite(data.table(c(0.1, 0.2)), dec=",", sep="\t")))


### PR DESCRIPTION
this fixes error during cc(T)
```
Running test id 2335.6         Error in getRversion() : 
  Reminder to data.table developers: don't use getRversion() internally. Add a behaviour test to .onLoad instead.
```