### PR TITLE
rename to correct name and simplify website for R 4.4+

### DIFF
--- a/.github/workflows/pkgup.yaml
+++ b/.github/workflows/pkgup.yaml
@@ -12,7 +12,7 @@ on:
     branches:
       - 'master'
 
-name: pkgdown-deploy
+name: pkgup-deploy
 
 jobs:
   build:
@@ -47,16 +47,9 @@ jobs:
       - name: manual
         if: github.ref == 'refs/heads/master'
         run: |
-          cp -R ${{ env.R_LIBS_USER }} library
-          R CMD INSTALL --library="library" $(ls -1t data.table_*.tar.gz | head -n 1) --html
-          mkdir -p doc/html
-          cp $(R RHOME)/doc/html/{left.jpg,up.jpg,Rlogo.svg,R.css,index.html} doc/html
-          Rscript -e 'utils::make.packages.html("library", docdir="doc")'
-          sed -i "s|file://|../..|g" doc/html/packages.html
+          R CMD INSTALL $(ls -1t data.table_*.tar.gz | head -n 1)
           mkdir -p public
-          mv doc public/doc
-          cp -r --parents library/*/{html,help,doc,demo,DESCRIPTION,README,NEWS,README.md,NEWS.md} public 2>/dev/null || :
-          sed -i 's|"/doc/html/|"/data.table/doc/html/|g' public/library/data.table/doc/index.html 2>/dev/null || :
+          Rscript -e 'tools::pkg2HTML("data.table", out="public/index.html")'
       - name: repo
         if: github.ref == 'refs/heads/master'
         run: |


### PR DESCRIPTION
not sure why it was named pkgdown... now fixed :)
Also uses R 4.4+ new function `tools::pkg2HTML`