### PR TITLE
fix gcc flag warnings

### DIFF
--- a/src/fifelse.c
+++ b/src/fifelse.c
@@ -217,14 +217,14 @@ SEXP fcaseR(SEXP rho, SEXP args) {
   int nprotect=0, l;
   int64_t n_ans=0, n_this_arg=0, n_undecided=0;
   SEXP ans=R_NilValue, tracker=R_NilValue, whens=R_NilValue, thens=R_NilValue;
-  SEXP ans_class, ans_levels;
+  SEXP ans_class, ans_levels = R_NilValue;
   PROTECT_INDEX Iwhens, Ithens;
   PROTECT_WITH_INDEX(whens, &Iwhens); nprotect++;
   PROTECT_WITH_INDEX(thens, &Ithens); nprotect++;
   SEXPTYPE ans_type=NILSXP;
   // naout means if the output is scalar logic na
   bool imask = true, naout = false, idefault = false;
-  bool ans_is_factor;
+  bool ans_is_factor = false;
   int *restrict p = NULL;
   const int n = narg/2;
   for (int i=0; i<n; ++i) {

--- a/src/fread.c
+++ b/src/fread.c
@@ -1689,7 +1689,7 @@ int freadMain(freadMainArgs _args)
   if (ch >= eof) STOP(_("Input is either empty, fully whitespace, or skip has been set after the last non-whitespace."));
   if (verbose) {
     if (lineStart > ch) DTPRINT(_("  Moved forward to first non-blank line (%d)\n"), row1line);
-    DTPRINT(_("  Positioned on line %d starting: <<%s>>\n"), row1line, strlim(lineStart, (char[500]) {}, 30));
+    DTPRINT(_("  Positioned on line %d starting: <<%s>>\n"), row1line, strlim(lineStart, (char[500]) {0}, 30));
   }
   ch = pos = lineStart;
   }
@@ -1880,7 +1880,7 @@ int freadMain(freadMainArgs _args)
     if (!fill && tt != ncol) INTERNAL_STOP("first line has field count %d but expecting %d", tt, ncol); // # nocov
     if (verbose) {
       DTPRINT(_("  Detected %d columns on line %d. This line is either column names or first data row. Line starts as: <<%s>>\n"),
-              tt, row1line, strlim(pos, (char[500]) {}, 30));
+              tt, row1line, strlim(pos, (char[500]) {0}, 30));
       DTPRINT(_("  Quote rule picked = %d\n"), quoteRule);
       DTPRINT(_("  fill=%s and the most number of columns found is %d\n"), fill ? "true" : "false", ncol);
     }
@@ -2809,23 +2809,23 @@ int freadMain(freadMainArgs _args)
       while (ch < eof && *ch != '\n' && *ch != '\r') ch++;
       while (ch < eof && isspace(*ch)) ch++;
       if (ch == eof) {
-        DTWARN(_("Discarded single-line footer: <<%s>>"), strlim(skippedFooter, (char[500]) {}, 500));
+        DTWARN(_("Discarded single-line footer: <<%s>>"), strlim(skippedFooter, (char[500]) {0}, 500));
       }
       else {
         ch = headPos;
         int tt = countfields(&ch);
         if (fill > 0) {
           DTWARN(_("Stopped early on line %"PRId64". Expected %d fields but found %d. Consider fill=%d or even more based on your knowledge of the input file. Use fill=Inf for reading the whole file for detecting the number of fields. First discarded non-empty line: <<%s>>"),
-          DTi + row1line, ncol, tt, tt, strlim(skippedFooter, (char[500]) {}, 500));
+          DTi + row1line, ncol, tt, tt, strlim(skippedFooter, (char[500]) {0}, 500));
         } else {
           DTWARN(_("Stopped early on line %"PRId64". Expected %d fields but found %d. Consider fill=TRUE. First discarded non-empty line: <<%s>>"),
-          DTi + row1line, ncol, tt, strlim(skippedFooter, (char[500]) {}, 500));
+          DTi + row1line, ncol, tt, strlim(skippedFooter, (char[500]) {0}, 500));
         }
       }
     }
   }
   if (quoteRuleBumpedCh != NULL && quoteRuleBumpedCh < headPos) {
-    DTWARN(_("Found and resolved improper quoting out-of-sample. First healed line %"PRId64": <<%s>>. If the fields are not quoted (e.g. field separator does not appear within any field), try quote=\"\" to avoid this warning."), quoteRuleBumpedLine, strlim(quoteRuleBumpedCh, (char[500]) {}, 500));
+    DTWARN(_("Found and resolved improper quoting out-of-sample. First healed line %"PRId64": <<%s>>. If the fields are not quoted (e.g. field separator does not appear within any field), try quote=\"\" to avoid this warning."), quoteRuleBumpedLine, strlim(quoteRuleBumpedCh, (char[500]) {0}, 500));
   }
 
   if (verbose) {


### PR DESCRIPTION
Currently we get various warnings when installing due to the `-Wpedantic` and `-Wmaybe-uninitialized` flags. Although those do no harm, they cluster the output with unnecessary warnings.

Example:
```c
  fread.c:2822:71: warning: ISO C forbids empty initializer braces [-Wpedantic]
   2822 |           DTi + row1line, ncol, tt, strlim(skippedFooter, (char[500]) {}, 500));
  fifelse.c:286:10: warning: ‘ans_is_factor’ may be used uninitialized in this function [-Wmaybe-uninitialized]
    286 |       if (!naout && ans_is_factor) {
```