### PR TITLE
fread can underestimate nrow on rerun when type bump and healing with fill=TRUE

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -333,6 +333,8 @@
 
 19. Ellipsis elements like `..1` are correctly excluded when searching for variables in "up-a-level" syntax inside `[`, [#5460](https://github.com/Rdatatable/data.table/issues/5460). Thanks @ggrothendieck for the report and @MichaelChirico for the fix.
 
+20. `fread()` now adds a small safety margin when reallocating for a reread after out-of-sample type bumps, so that healed rows when `fill=TRUE` cannot outrun the resized table, [#5110](https://github.com/Rdatatable/data.table/issues/5110). Thanks to @kmichelson for the report and @ben-schwen for the fix.
+
 ### NOTES
 
 1. The following in-progress deprecations have proceeded:

--- a/src/fread.c
+++ b/src/fread.c
@@ -2870,7 +2870,9 @@ int freadMain(freadMainArgs _args)
             size[j] = 0;
           }
         }
-        allocateDT(type, size, ncol, ncol - nStringCols - nNonStringCols, DTi);
+        // When type bump with fill occurs, reallocate with DTi (rows read so far) plus a buffer
+        // Using DTi alone could be short #5110
+        allocateDT(type, size, ncol, ncol - nStringCols - nNonStringCols, DTi + (fill > 0 ? (DTi / 10) + 1 : 0));
         // reread from the beginning
         DTi = 0;
         headPos = pos;


### PR DESCRIPTION
Closes #5110 

Still need to come up with a clever test for this.