### PR TITLE
Improve flow of the froll docs

### DIFF
--- a/man/froll.Rd
+++ b/man/froll.Rd
@@ -45,36 +45,36 @@
 }
 \arguments{
   \item{x}{ Integer, numeric or logical vector, coerced to numeric, on which sliding window calculates an aggregate function. It supports vectorized input, then it needs to be a \code{data.table}, \code{data.frame} or a \code{list}, in which case a rolling function is applied to each column/vector. }
-  \item{n}{ Integer, non-negative, non-NA, rolling window size. This is the \emph{total} number of included values in aggregate function. In case of an adaptive rolling function window size has to be provided as a vector for each indivdual value of \code{x}. It supports vectorized input, then it needs to be a vector, or in case of an adaptive rolling a \code{list} of vectors. }
-  \item{fill}{ Numeric; value to pad by for an incomplete window iterations. Defaults to \code{NA}. When partial=TRUE this argument is ignored. }
+  \item{n}{ Integer, non-negative, non-NA, rolling window size. This is the \emph{total} number of included values in aggregate function. In case of an adaptive rolling function, the window size has to be provided as a vector for each individual value of \code{x}. It supports vectorized input, then it needs to be a vector, or in case of an adaptive rolling a \code{list} of vectors. }
+  \item{fill}{ Numeric; value to pad by for an incomplete window iteration. Defaults to \code{NA}. When partial=TRUE this argument is ignored. }
   \item{algo}{ Character, default \code{"fast"}. When set to \code{"exact"}, a slower (in some cases more accurate) algorithm is used. It will use multiple cores where available. See Details for more information. }
   \item{align}{ Character, specifying the "alignment" of the rolling window, defaulting to \code{"right"}. \code{"right"} covers preceding rows (the window \emph{ends} on the current value); \code{"left"} covers following rows (the window \emph{starts} on the current value); \code{"center"} is halfway in between (the window is \emph{centered} on the current value, biased towards \code{"left"} when \code{n} is even). }
   \item{na.rm}{ Logical, default \code{FALSE}. Should missing values be removed when calculating aggregate function on a window? }
   \item{has.nf}{ Logical. If it is known whether \code{x} contains non-finite values (\code{NA}, \code{NaN}, \code{Inf}, \code{-Inf}), then setting this to \code{TRUE} or \code{FALSE} may speed up computation. Defaults to \code{NA}. See \emph{has.nf argument} section below for details. }
   \item{adaptive}{ Logical, default \code{FALSE}. Should the rolling function be calculated adaptively? See \emph{Adaptive rolling functions} section below for details. }
-  \item{partial}{ Logical, default \code{FALSE}. Should the rolling window size(s) provided in \code{n} be computed also for leading incomplete running window. See \emph{\code{partial} argument} section below for details. }
+  \item{partial}{ Logical, default \code{FALSE}. Should the rolling window size(s) provided in \code{n} be computed also for leading incomplete running window? See \emph{\code{partial} argument} section below for details. }
   \item{give.names}{ Logical, default \code{FALSE}. When \code{TRUE}, names are automatically generated corresponding to names of \code{x} and names of \code{n}. If answer is an atomic vector, then the argument is ignored, see examples. }
   \item{hasNA}{ Logical. Deprecated, use \code{has.nf} argument instead. }
 }
 \details{
-  \code{froll*} functions accept vector, list, \code{data.frame} or \code{data.table}. Functions operate on a single vector; when passing a non-atomic input, then function is applied column-by-column, not to the complete set of columns at once.
+  \code{froll*} functions accept vector, list, \code{data.frame} or \code{data.table}. Functions operate on a single vector; when passing a non-atomic input, then the function is applied column-by-column, not to the complete set of columns at once.
 
   Argument \code{n} allows multiple values to apply rolling function on multiple window sizes. If \code{adaptive=TRUE}, then \code{n} can be a list to specify multiple window sizes for adaptive rolling computation. See \emph{Adaptive rolling functions} section below for details.
 
-  When multiple columns or multiple windows width are provided, then they are run in parallel. The exception is for \code{algo="exact"} or \code{adaptive=TRUE}, which runs in parallel even for single column and single window width. By default, data.table uses only half of available CPUs, see \code{\link{setDTthreads}} for details on how to tune CPU usage.
+  When multiple columns or multiple window widths are provided, then they are run in parallel. The exception is for \code{algo="exact"} or \code{adaptive=TRUE}, which runs in parallel even for single column and single window width. By default, data.table uses only half of available CPUs, see \code{\link{setDTthreads}} for details on how to tune CPU usage.
 
   Setting \code{options(datatable.verbose=TRUE)} will display various information about how rolling function processed. It will not print information in real-time but only at the end of the processing.
 }
 \value{
-  For a non \emph{vectorized} input (\code{x} is not a list, and \code{n} specify single rolling window) a \code{vector} is returned, for convenience. Thus, rolling functions can be used conveniently within \code{data.table} syntax. For a \emph{vectorized} input a list is returned.
+  For a non \emph{vectorized} input (\code{x} is not a list, and \code{n} specifies a single rolling window) a \code{vector} is returned, for convenience. Thus, rolling functions can be used conveniently within \code{data.table} syntax. For a \emph{vectorized} input a list is returned.
 }
 \note{
-  Be aware that rolling functions operate on the physical order of input. If the intent is to roll values in a vector by a logical window, for example an hour, or a day, then one has to ensure that there are no gaps in the input, or use adaptive rolling function to handle gaps, for which we provide helper function \code{\link{frolladapt}} to generate adaptive window size.
+  Be aware that rolling functions operate on the physical order of input. If the intent is to roll values in a vector by a logical window, for example an hour, or a day, then one has to ensure that there are no gaps in the input, or use an adaptive rolling function to handle gaps, for which we provide helper function \code{\link{frolladapt}} to generate adaptive window size.
 }
 \section{\code{has.nf} argument}{
   \code{has.nf} can be used to speed up processing in cases when it is known if \code{x} contains (or not) non-finite values (\code{NA}, \code{NaN}, \code{Inf}, \code{-Inf}).
   \itemize{
-    \item Default \code{has.nf=NA} uses faster implementation that does not support non-finite values, but when non-finite values are detected it will re-run non-finite supported implementation.
+    \item Default \code{has.nf=NA} uses faster implementation that does not support non-finite values, but when non-finite values are detected it will re-run non-finite aware implementation.
     \item \code{has.nf=TRUE} uses non-finite aware implementation straightaway.
     \item \code{has.nf=FALSE} uses faster implementation that does not support non-finite values. Then depending on the rolling function it will either:
     \itemize{
@@ -82,7 +82,7 @@
       \item (\emph{max, min, median}) does not detect non-finites and may silently produce an incorrect answer.
     }
   }
-  In general \code{has.nf=FALSE && any(!is.finite(x))} should be considered as undefined behavior. Therefore \code{has.nf=FALSE} should be used with care.
+  In general \code{has.nf=FALSE && any(!is.finite(x))} should be considered undefined behavior. Therefore \code{has.nf=FALSE} should be used with care.
 }
 \section{Implementation}{
   Most of the rolling functions have 4 different implementations. First factor that decides which implementation is used is the \code{adaptive} argument (either \code{TRUE} or \code{FALSE}), see section below for details. Then for each of those two algorithms there are usually two implementations depending on the \code{algo} argument.
@@ -96,7 +96,7 @@
     }
     \item \code{algo="exact"} will make the rolling functions use a more computationally-intensive algorithm. For each observation in the input vector it will compute a function on a rolling window from scratch (complexity \eqn{O(n^2)}).
     \itemize{
-      \item Depeneding on the function, this algorithm may suffers less from floating point rounding error (the same consideration applies to base \code{\link[base]{mean}}).
+      \item Depending on the function, this algorithm may suffer less from floating point rounding error (the same consideration applies to base \code{\link[base]{mean}}).
       \item In case of \emph{mean}, it will additionally make an extra pass to perform floating point error correction. Error corrections might not be truly exact on some platforms (like Windows) when using multiple threads.
     }
   }
@@ -105,7 +105,7 @@
   Adaptive rolling functions are a special case where each observation has its own corresponding rolling window width. Therefore, values passed to \code{n} argument must be series corresponding to observations in \code{x}. If multiple windows are meant to be computed, then a list of integer vectors is expected; each list element must be an integer vector of window size corresponding to observations in \code{x}; see Examples. Due to the logic or implementation of adaptive rolling functions, the following restrictions apply:
   \itemize{
     \item \code{align} does not support \code{"center"}.
-    \item if list of vectors is passed to \code{x}, then all vectors within it must have equal length due to the fact that length of adaptive window widths must match the length of vectors in \code{x}.
+    \item if a list of vectors is passed to \code{x}, then all vectors within it must have equal length due to the fact that length of adaptive window widths must match the length of vectors in \code{x}.
   }
 }
 \section{\code{partial} argument}{
@@ -170,7 +170,7 @@ frollsum(list(x=1:5, y=5:1), c(tiny=2, big=4), give.names=TRUE)
 frollmax(c(1,2,NA,4,5), 2)
 frollmax(c(1,2,NA,4,5), 2, has.nf=FALSE)
 
-# use verobse=TRUE for extra insight
+# use verbose=TRUE for extra insight
 .op = options(datatable.verbose = TRUE)
 frollsd(c(1:5,NA,7:8), 4)
 options(.op)

--- a/man/frolladapt.Rd
+++ b/man/frolladapt.Rd
@@ -11,7 +11,7 @@
   \item{x}{ Integer. Must be sorted with no duplicates or missing values. Other objects with numeric storage (including most commonly \code{Date} and \code{POSIXct}) will be coerced to integer, which, for example, in case of \code{POSIXct} means truncating to whole seconds. It does not support vectorized input. }
   \item{n}{ Integer, positive, rolling window size. Up to \code{n} values nearest to each value of \code{x}, with distance in the units of \code{x} and according to the window implied by \code{align}, are included in each rolling aggregation window. Thus when \code{x} is a \code{POSIXct}, \code{n} are seconds, and when \code{x} is a \code{Date}, \code{n} are days. It supports vectorized input, then it needs to be a vector. }
   \item{align}{ Character, default \code{"right"}. Other alignments have not yet been implemented. }
-  \item{partial}{ Logical, default \code{FALSE}. Should the rolling window size(s) provided in \code{n} be trimmed to available observations. For details see \code{\link{froll}}. }
+  \item{partial}{ Logical, default \code{FALSE}. Should the rolling window size(s) provided in \code{n} be trimmed to available observations? For details see \code{\link{froll}}. }
   \item{give.names}{ Logical, default \code{FALSE}. When \code{TRUE}, names are automatically generated corresponding to names of \code{n}. If answer is an integer vector, then the argument is ignored, see examples. }
 }
 \details{

--- a/man/frollapply.Rd
+++ b/man/frollapply.Rd
@@ -12,14 +12,14 @@
 }
 \arguments{
   \item{X}{ Atomic vector, \code{data.frame}, \code{data.table} or a \code{list} on which sliding window calculates \code{FUN} function. How the \code{X} is handled depends on the \code{by.column} argument. It supports vectorized input, for \code{by.column=TRUE} it needs to be a \code{data.table}, \code{data.frame} or a \code{list}, and for \code{by.column=FALSE} list of data.frames/data.tables, but not a list of lists. }
-  \item{N}{ Integer, non-negative, non-NA, rolling window size. This is the \emph{total} number of included values in aggregate function. In case of an adaptive rolling function window size has to be provided as a vector for each indivdual value of \code{X}. It supports vectorized input, then it needs to be a vector, or in case of an adaptive rolling a \code{list} of vectors. }
+  \item{N}{ Integer, non-negative, non-NA, rolling window size. This is the \emph{total} number of included values in aggregate function. In case of an adaptive rolling function window size has to be provided as a vector for each individual value of \code{X}. It supports vectorized input, then it needs to be a vector, or in case of an adaptive rolling a \code{list} of vectors. }
   \item{FUN}{ The function to be applied on subsets of \code{X}. }
   \item{\dots}{ Extra arguments passed to \code{FUN}. Note that argument names passed to \dots should not overlap with arguments of \code{frollapply}. }
   \item{by.column}{ Logical. When \code{TRUE} (default) then \code{X} of types list/data.frame/data.table is treated as vectorized input rather an object to apply rolling window on. Setting to \code{FALSE} allows rolling window to be applied on multiple variables, using data.frame, data.table or a list, as a whole. For details see \emph{\code{by.column} argument} section below. }
-  \item{fill}{ An object; value to pad by. Defaults to \code{NA}. When \code{partial=TRUE} this argument is ignored. }
+  \item{fill}{ An object; value to pad by for an incomplete window iteration. Defaults to \code{NA}. When \code{partial=TRUE} this argument is ignored. }
   \item{align}{ Character, specifying the "alignment" of the rolling window, defaulting to \code{"right"}. For details see \code{\link{froll}}. }
   \item{adaptive}{ Logical, default \code{FALSE}. Should the rolling function be calculated adaptively? For details see \code{\link{froll}}. }
-  \item{partial}{ Logical, default \code{FALSE}. Should the rolling window size(s) provided in \code{N} be trimmed to available observations. For details see \code{\link{froll}}. }
+  \item{partial}{ Logical, default \code{FALSE}. Should the rolling window size(s) provided in \code{N} be trimmed to available observations? For details see \code{\link{froll}}. }
   \item{give.names}{ Logical, default \code{FALSE}. When \code{TRUE}, names are automatically generated corresponding to names of \code{X} and names of \code{N}. If answer is an atomic vector, then the argument is ignored, see examples. }
   \item{simplify}{ Logical or a function. When \code{TRUE} (default) then internal \code{simplifylist} function is applied on a list storing results of all computations. When \code{FALSE} then list is returned without any post-processing. Argument can take a function as well, then the function is applied to a list that would have been returned when \code{simplify=FALSE}. If results are not automatically simplified when \code{simplify=TRUE} then, for backward compatibility, one should use \code{simplify=FALSE} explicitly. See \emph{\code{simplify} argument} section below for details. }
   \item{x}{ Deprecated, use \code{X} instead. }
@@ -70,12 +70,12 @@ frollapply(c(1, 9), N=1L, FUN=function(x) copy(list(x)))
 #1:     1
 #2:     9
 }
-    \item \code{FUN} calls are internally passed to \code{parallel::mcparallel} to evaluate them in parallel. We inherit few limitations from \code{parallel} package explained below. This optimization can be disabled completely by calling \code{setDTthreads(1)}, then limitations listed below do not apply because all iterations of \code{FUN} evaluation will be made sequentially without use of \code{parallel} package. Note that on Windows platform this optimization is always disabled due to lack of \emph{fork} used by \code{parallel} package. One can use \code{options(datatable.verbose=TRUE)} to get extra information if \code{frollapply} is running multithreaded or not.
+    \item \code{FUN} calls are internally passed to \code{parallel::mcparallel} to evaluate them in parallel. We inherit few limitations from \code{parallel} package explained below. This optimization can be disabled completely by calling \code{setDTthreads(1)}, in which case the limitations listed below do not apply because all evaluations of \code{FUN} will be made sequentially without use of \code{parallel} package. Note that on Windows platform this optimization is always disabled due to lack of \emph{fork} used by \code{parallel} package. One can use \code{options(datatable.verbose=TRUE)} to get extra information if \code{frollapply} is running multithreaded or not.
       \itemize{
         \item Warnings produced inside the function are silently ignored; for consistency we ignore warnings also when running single threaded path.
         \item \code{FUN} should not use any on-screen devices, GUI elements, tcltk, multithreaded libraries.
-        \item \code{setDTthreads(1L)} is passed to forked processes, therefore any data.table code inside \code{FUN} will be forced to be single threaded. It is advised to not call \code{setDTthreads} inside \code{FUN}. \code{frollapply} is already parallelized and nested parallelism is rarely a good idea.
-        \item Any operation that could misbehave when run in parallel has to be handled. For example writing to the same file from multiple CPU threads.
+        \item \code{setDTthreads(1L)} is passed to forked processes, therefore any data.table code inside \code{FUN} will be forced to be single threaded. It is advised not to call \code{setDTthreads} inside \code{FUN}. \code{frollapply} is already parallelized, and nested parallelism is rarely a good idea.
+        \item Any operation that could misbehave when run in parallel has to be handled. For example, writing to the same file from multiple CPU threads.
 \preformatted{
 old = setDTthreads(1L)
 frollapply(iris, 5L, by.column=FALSE, FUN=fwrite, file="rolling-data.csv", append=TRUE)
@@ -125,14 +125,14 @@ ans = frollapply(1:3, 2, f, fill=data.table(NA), simplify=simplifix)
 setDTthreads(2, throttle=1024) ## enable throttle
 }
     }
-    \item Due to possible future improvements of handling simplification of results returned from rolling function, the default \code{simplify=TRUE} may not be backward compatible for functions that produce results that haven't been already automatically simplified. See \emph{\code{simplify} argument} section for details.
+    \item Due to possible future improvements of handling simplification of results returned from rolling function, the default \code{simplify=TRUE} may not be backward compatible for functions that produce results that haven't been already automatically simplified. See the \emph{\code{simplify} argument} section for details.
   }
 }
 \section{Performance consideration}{
   \code{frollapply} is meant to run any UDF function. If one needs to use a common function like \emph{mean, sum, max}, etc., then we have highly optimized, implemented in C language, rolling functions described in \code{\link{froll}} manual.\cr
-  Most crucial optimizations are the ones to be applied on UDF. Those are discussed in next section \emph{UDF optimization} below.
+  Most crucial optimizations are the ones to be applied on UDF. Those are discussed below in section \emph{UDF optimization}.
   \itemize{
-    \item When using \code{by.column=FALSE} one can subset dataset before passing it to \code{X} to keep only columns relevant for the computation:
+    \item When using \code{by.column=FALSE}, subset the dataset before passing it to \code{X} to keep only columns relevant for the computation:
 \preformatted{
 x = setDT(lapply(1:1000, function(x) as.double(rep.int(x,1e4L))))
 f = function(x) sum(x$V1 * x$V2)
@@ -155,11 +155,11 @@ system.time(frollapply(x, 2, function(x) 1L, simplify=unlist))
 #  0.054   0.049   0.091
 }
     \item CPU threads utilization in \code{frollapply} can be controlled by \code{\link{setDTthreads}}, which by default uses half of available CPU threads. Usage of multiple CPU threads will be throttled for small input, as described in \code{\link{setDTthreads}} manual.
-    \item Parallel computation of \code{FUN} is handled by \code{parallel} package (part of R core since 2.14.0) and its \emph{fork} mechanism. \emph{Fork} is not available on Windows OS therefore it will be always single threaded on that platform.
+    \item Parallel computation of \code{FUN} is handled by \code{parallel} package (part of R core since 2.14.0) and its \emph{fork} mechanism. \emph{Fork} is not available on Windows OS, therefore computations will always be single-threaded on that platform.
   }
 }
 \section{UDF optimization}{
-  FUN will be evaluated many times so should be highly optimized. Tips below are not specific to \code{frollapply} and can be applied to any code is meant to run in many iterations.
+  FUN will be evaluated many times so should be highly optimized. Tips below are not specific to \code{frollapply} and can be applied to any code meant to run in many iterations.
   \itemize{
     \item It is usually better to return the most lightweight objects from \code{FUN}, for example it will be faster to return a list rather a data.table. In the case presented below, \code{simplify=TRUE} is calling \code{rbindlist} on the results anyway, which makes the results equal:
 \preformatted{
@@ -206,7 +206,7 @@ system.time(for (i in 1:1e4) .colSums(x, 2L, 2L))
 #   user  system elapsed
 #  0.010   0.002   0.012
 }
-    \item There are many functions that may be optimized for scaling up for bigger input, yet for a small input they may carry bigger overhead comparing to their simpler counterparts. One may need to experiment on own data, but low overhead functions are likely to be faster when evaluating in many iterations:
+    \item There are many functions that may be optimized for scaling up with larger input, yet for a small input they may incur bigger overhead comparing to simpler counterparts. One may need to experiment on own data, but low overhead functions are likely to be faster when evaluated over many iterations:
 \preformatted{
 ## uniqueN
 x = c(1L,3L,5L)
@@ -233,11 +233,11 @@ system.time(for (i in 1:1e4) x[["v1"]])
     \item No repeated allocation of a rolling window subset.\cr
     Object (type of \code{X} and size of \code{N}) is allocated once (for each CPU thread), and then for each iteration this object is being re-used by copying expected subset of data into it. This means we still have to subset data on each iteration, but we only copy data into pre-allocated window object, instead of allocating in each iteration. Allocation is carrying much bigger overhead than copy. The faster the \code{FUN} evaluates the more relative speedup we are getting, because allocation of a subset does not depend on how fast or slow \code{FUN} evaluates. See \emph{caveats} section for possible edge cases caused by this optimization.
     \item Parallel evaluation of \code{FUN} calls.\cr
-    Until September 2025 all the multithreaded code in data.table was using \emph{OpenMP}. It can be used only in C language and it has very low overhead. Unfortunately it could not be applied in \code{frollapply} because to evaluate UDF from C code one has to call R's C api that is not thread safe (can be run only from single threaded C code). Therefore \code{frollapply} uses \code{\link[parallel]{parallel-package}}, which is included in base R, to provide parallelism on R language level. It uses \emph{fork} parallelism, which has low overhead as well (unless results of computation are big in size which is not an issue for rolling statistics). \emph{Fork} is not available on Windows OS. See \emph{caveats} section for limitations caused by using this optimization.
+    Until September 2025 all the multithreaded code in data.table was using \emph{OpenMP}. It can be used only in C language and it has very low overhead. Unfortunately it could not be applied in \code{frollapply} because to evaluate UDF from C code one has to call R's C api that is not thread safe (can be run only from single threaded C code). Therefore \code{frollapply} uses \code{\link[parallel]{parallel-package}}, which is included in base R, to provide parallelism at the R language level. It uses \emph{fork} parallelism, which has low overhead as well (unless results of computation are big in size which is not an issue for rolling statistics). \emph{Fork} is not available on Windows OS. See \emph{caveats} section for limitations caused by using this optimization.
   }
 }
 \note{
-  Be aware that rolling functions operates on the physical order of input. If the intent is to roll values in a vector by a logical window, for example an hour, or a day, then one has to ensure that there are no gaps in the input, or use adaptive rolling function to handle gaps, for which we provide helper function \code{\link{frolladapt}} to generate adaptive window size.
+  Be aware that rolling functions operate on the physical order of input. If the intent is to roll values in a vector by a logical window, for example an hour, or a day, then one has to ensure that there are no gaps in the input, or use an adaptive rolling function to handle gaps, for which we provide helper function \code{\link{frolladapt}} to generate adaptive window size.
 }
 \examples{
 frollapply(1:16, 4, median)


### PR DESCRIPTION
This provides minimal grammatical correction and a couple of  typo fixes to improve the readability of the `froll*` docs.