### PR TITLE
Add tools and parallel to Suggests, #7288

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Version: 1.17.99
 Title: Extension of `data.frame`
 Depends: R (>= 3.4.0)
 Imports: methods
-Suggests: bit64 (>= 4.0.0), bit (>= 4.0.4), R.utils (>= 2.13.0), xts, zoo (>= 1.8-1), yaml, knitr, markdown
+Suggests: bit64 (>= 4.0.0), bit (>= 4.0.4), R.utils (>= 2.13.0), xts, zoo (>= 1.8-1), yaml, knitr, markdown, tools, parallel
 Description: Fast aggregation of large data (e.g. 100GB in RAM), fast ordered joins, fast add/modify/delete of columns by group using no copies at all, list columns, friendly and fast character-separated-value read/write. Offers a natural and flexible syntax, for faster development.
 License: MPL-2.0 | file LICENSE
 URL: https://r-datatable.com, https://Rdatatable.gitlab.io/data.table, https://github.com/Rdatatable/data.table

--- a/NEWS.md
+++ b/NEWS.md
@@ -367,6 +367,8 @@ See [#2611](https://github.com/Rdatatable/data.table/issues/2611) for details. T
 
 7. In rare situations a data.table object may lose its internal attribute that holds a self-reference. New helper function `.selfref.ok()` tests just that. It is only intended for technical use cases. See manual for examples.
 
+8. `tools` and `parallel` packages added to Suggests, [#7288](https://github.com/Rdatatable/data.table/issues/7288). These are used internally by `fread` and `frollapply`. Thanks to @jangorecki for identifying this dependency issue.
+
 ## data.table [v1.17.8](https://github.com/Rdatatable/data.table/milestone/41) (6 July 2025)
 
 1. Internal functions used to signal errors are now marked as non-returning, silencing a compiler warning about potentially unchecked allocation failure. Thanks to Prof. Brian D. Ripley for the report and @aitap for the fix, [#7070](https://github.com/Rdatatable/data.table/pull/7070).

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -21855,3 +21855,24 @@ test(2344.03, setkey(d1[, .(V1, label = c("one", "zero", "one"), V2)][data.table
 # keep sub-key in case of multiple keys, even with new columns and changing column order
 DT = data.table(V1 = 1:2, V2 = 3:4, V3 = 5:6, key = c("V1", "V2", "V3"))
 test(2344.04, key(DT[, .(V4 = c("b", "a"), V2, V5 = c("y", "x"), V1)]), c("V1", "V2"))
+
+# #7288: tools and parallel packages used by fread and frollapply
+# Test 1: fread works when tools package is available
+test(2345.01, {
+  tf = tempfile()
+  writeLines("a,b,c\n1,2,3\n4,5,6", tf)
+  dt = fread(tf)
+  unlink(tf)
+  all(dim(dt) == c(2,3))
+}, TRUE)
+# Test 2: frollapply works when parallel package is available
+test(2345.02, {
+  x = 1:20
+  result = frollapply(x, N=5, FUN=sum)
+  is.numeric(result) && length(result) == 20
+}, TRUE)
+# Test 3: Check tools namespace is available
+test(2345.03, requireNamespace("tools", quietly=TRUE), TRUE)
+# Test 4: Check parallel namespace is available
+test(2345.04, requireNamespace("parallel", quietly=TRUE), TRUE)
+


### PR DESCRIPTION
Fix #7288

## Summary
Adds `tools` and `parallel` packages to the Suggests field in DESCRIPTION as these packages are used internally but were not declared as dependencies.

## Changes
- ✅ Added `tools` and `parallel` to DESCRIPTION Suggests field
- ✅ Added 4 tests (2345.01-2345.04) in tests.Rraw to verify functionality  
- ✅ Updated NEWS.md with entry for this change

## Package Usage
- `tools`: used internally by `fread` and `frollapply`
- `parallel`: used internally by `frollapply`

## Testing
**Local test results:** All 12,072 tests pass including new tests 2345.01-2345.04

<img width="3072" height="1920" alt="Screenshot From 2025-10-29 15-25-32" src="https://github.com/user-attachments/assets/8f940bb0-320d-4dc8-92a8-2c42d502cbbe" />

## Note on Codecov
As mentioned by @jangorecki in the issue, adding `parallel` to Suggests may cause codecov CI jobs to hang. This is a known upstream issue with the `covr` package that will need to be monitored in CI. If the hang occurs, a minimal reproducible example should be submitted to the covr repository as suggested in the issue discussion.
- tools used in fread and frollapply
- parallel used in frollapply
- Added 4 tests (2345.01-2345.04) to verify functionality
- Updated NEWS.md with change notes

These packages were being used without being declared in DESCRIPTION. Note: adding parallel to Suggests may affect codecov CI jobs per issue discussion - this requires monitoring.



