### PR TITLE
GLCI: use an older macOS image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -337,6 +337,7 @@ test-win-old:
 ## R-release on MacOS
 test-mac-rel:
   <<: *test-mac
+  image: macos-14-xcode-15
   variables:
     R_VERSION: "$R_REL_VERSION"
     R_BIN: "$R_REL_MAC_BIN"
@@ -344,6 +345,7 @@ test-mac-rel:
 ## R-oldrel on MacOS
 test-mac-old:
   <<: *test-mac
+  image: macos-14-xcode-15
   variables:
     R_VERSION: "$R_OLD_VERSION"
     R_BIN: "$R_OLD_MAC_BIN"


### PR DESCRIPTION
Currently, GitLab [offers a choice](https://docs.gitlab.com/ci/runners/hosted_runners/macos/) between [macos-14-xcode-15](https://gitlab-org.gitlab.io/ci-cd/shared-runners/images/macos-image-inventory/macos-14-xcode-15/) and [macos-15-xcode-16](https://gitlab-org.gitlab.io/ci-cd/shared-runners/images/macos-image-inventory/macos-15-xcode-16/), and Xcode 16.4 is not compatible with the R-bundled OpenMP runtime, which fails the installation check in GitLab CI.

Solution: switch to the image with Xcode 15.4, with is less incompatible with Xcode 14.2/14.3 used on CRAN. When R updates the toolchain requirements, we'll switch `test-mac-rel` to the newer macOS image.

Tested on GitLab: [test-mac-rel](https://gitlab.com/Rdatatable/data.table/-/jobs/11946938118), [test-mac-old](https://gitlab.com/Rdatatable/data.table/-/jobs/11946938120). I see that on GitLab, the `configure` script thinks it needs the Homebrew `libomp` for some reason. Do the resulting packages actually work together with CRAN binaries? Does this need further investigation?