### PR TITLE
Replace the use of `SET_OBJECT`

### DIFF
--- a/src/dogroups.c
+++ b/src/dogroups.c
@@ -510,21 +510,6 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
   return(ans);
 }
 
-SEXP keepattr(SEXP to, SEXP from)
-{
-  // Same as R_copyDFattr in src/main/attrib.c, but that seems not exposed in R's api
-  // Only difference is that we reverse from and to in the prototype, for easier calling above
-  SET_ATTRIB(to, ATTRIB(from));
-  if (isS4(from)) {
-    to = PROTECT(asS4(to, TRUE, 1));
-    SET_OBJECT(to, isObject(from));
-    UNPROTECT(1);
-  } else {
-    SET_OBJECT(to, isObject(from));
-  }
-  return to;
-}
-
 SEXP growVector(SEXP x, const R_len_t newlen)
 {
   // Similar to EnlargeVector in src/main/subassign.c, with the following changes :
@@ -537,7 +522,7 @@ SEXP growVector(SEXP x, const R_len_t newlen)
   PROTECT(newx = allocVector(TYPEOF(x), newlen));   // TO DO: R_realloc(?) here?
   if (newlen < len) len=newlen;   // i.e. shrink
   if (!len) { // cannot memcpy invalid pointer, #6819
-    keepattr(newx, x);
+    SHALLOW_DUPLICATE_ATTRIB(newx, x);
     UNPROTECT(1);
     return newx;
   }
@@ -562,7 +547,7 @@ SEXP growVector(SEXP x, const R_len_t newlen)
   }
   // if (verbose) Rprintf(_("Growing vector from %d to %d items of type '%s'\n"), len, newlen, type2char(TYPEOF(x)));
   // Would print for every column if here. Now just up in dogroups (one msg for each table grow).
-  keepattr(newx,x);
+  SHALLOW_DUPLICATE_ATTRIB(newx, x);
   UNPROTECT(1);
   return newx;
 }


### PR DESCRIPTION
Instead of manually transplanting `ATTRIB` and then restoring the object bits, use `SHALLOW_DUPLICATE_ATTRIB`, which takes care of the bits. (`ATTRIB` and `SET_ATTRIB` are non-API as well, although not on the radar yet.) Unlike `asS4` in some cases, this modifies the target object by reference, although the attributes do get (shallowly) duplicated.

@TysonStanley, if merged into `master`, this will be needed for cherry-picking into the patch branch.