### PR TITLE
chmatch: hash x instead of table

### DIFF
--- a/src/chmatch.c
+++ b/src/chmatch.c
@@ -71,17 +71,23 @@ static SEXP chmatchMain(SEXP x, SEXP table, int nomatch, bool chin, bool chmatch
     for (int i = 0; i < tablelen; ++i) {
       int tl = hash_lookup(marks, td[i], 0);
       if (tl == -1) {
-        hash_set(marks, td[i], chin ? 1 : i + 1);
+        hash_set(marks, td[i], i + 1);
         nuniq--;
         if (nuniq == 0) break; // all found, stop scanning
       }
     }
 
-    const int not_found = chin ? 0 : nomatch;
-    #pragma omp parallel for num_threads(getDTthreads(xlen, true))
-    for (int i = 0; i < xlen; ++i) {
-      int tl = hash_lookup(marks, xd[i], 0);
-      ansd[i] = tl == -1 ? not_found : tl;
+    if (chin) {
+      #pragma omp parallel for num_threads(getDTthreads(xlen, true))
+      for (int i = 0; i < xlen; ++i) {
+        ansd[i] = hash_lookup(marks, xd[i], 0) > 0;
+      }
+    } else {
+      #pragma omp parallel for num_threads(getDTthreads(xlen, true))
+      for (int i = 0; i < xlen; ++i) {
+        const int m = hash_lookup(marks, xd[i], 0);
+        ansd[i] = (m < 0) ? nomatch : m;
+      }
     }
     UNPROTECT(nprotect);
     return ans;


### PR DESCRIPTION
Follows #6694

For `chmatch`, we can speedup the case where table >> x by hashing x (needle) instead of hashing the table. This also cuts down the used memory tremendously.

#### Large Table (900K unique)
<img width="666" height="673" alt="image" src="https://github.com/user-attachments/assets/d3e95687-ebcf-481b-95d9-f719e3e8d745" />

<details>

```r
library(atime)
library(data.table)

pkg.path <- '.'
limit <- 1
# taken from .ci/atime/tests.R
pkg.edit.fun <- function(old.Package, new.Package, sha, new.pkg.path) {
  pkg_find_replace <- function(glob, FIND, REPLACE) {
    atime::glob_find_replace(file.path(new.pkg.path, glob), FIND, REPLACE)
  }
  Package_regex <- gsub(".", "_?", old.Package, fixed = TRUE)
  Package_ <- gsub(".", "_", old.Package, fixed = TRUE)
  new.Package_ <- paste0(Package_, "_", sha)
  pkg_find_replace(
    "DESCRIPTION",
    paste0("Package:\\s+", old.Package),
    paste("Package:", new.Package))
  pkg_find_replace(
    file.path("src", "Makevars.*in"),
    Package_regex,
    new.Package_)
  pkg_find_replace(
    file.path("R", "onLoad.R"),
    Package_regex,
    new.Package_)
  pkg_find_replace(
    file.path("R", "onLoad.R"),
    sprintf('packageVersion\\("%s"\\)', old.Package),
    sprintf('packageVersion\\("%s"\\)', new.Package))
  pkg_find_replace(
    file.path("src", "init.c"),
    paste0("R_init_", Package_regex),
    paste0("R_init_", gsub("[.]", "_", new.Package_)))
  pkg_find_replace(
    "NAMESPACE",
    sprintf('useDynLib\\("?%s"?', Package_regex),
    paste0('useDynLib(', new.Package_))
}

versions <- c(
  master = '3c90b0f80e1d5b54ea97f3b56f28df07b93e820a',
  double_hashing = '66ac645b56cf676a9a0808e74feb6d89ccf203aa',
  hash_needle = 'e5fd0f7c0d57900c9614d4f861d3d3043a83bc34'
)

set.seed(3)
sample_strings = function(N=10, len=4) {
   do.call(paste0, replicate(len, sample(LETTERS, N, TRUE), FALSE))
}

N <- 10^seq(2, 7.5, .25)

# Benchmark 1: Large table 
tab_full = sample_strings(1e6, 10)
tab_small = sample(tab_full, 9e5)
chmatch_work1 <- lapply(setNames(nm = N), \(N)
  sample(tab_full, N, TRUE)
)

chmatch1 <- atime_versions(
  pkg.path, N,
  expr = data.table::chmatch(chmatch_work1[[as.character(N)]], tab_small),
  seconds.limit = limit, verbose = TRUE, sha.vec = versions,
  pkg.edit.fun = pkg.edit.fun
)
plot(chmatch1)
``` 

</details>