### PR TITLE
Use linear probing instead of double hashing

### DIFF
--- a/src/hash.c
+++ b/src/hash.c
@@ -7,7 +7,7 @@ struct hash_pair {
     R_xlen_t value;
 };
 struct hash_tab {
-  size_t size, free, mask;
+  size_t size, free;
   int shift;
   struct hash_pair *table;
 };
@@ -49,7 +49,6 @@ static hashtab * hash_create_(size_t n, double load_factor) {
   size_t n_full = get_full_size(n, load_factor);
   hashtab *ret = (hashtab *)R_alloc(sizeof(hashtab), 1);
   ret->size = n_full;
-  ret->mask = n_full - 1;
   ret->free = (size_t)(n_full * load_factor);
 
   int k = 0;
@@ -78,8 +77,8 @@ static R_INLINE hashtab *hash_rehash(const hashtab *h) {
 }
 
 static bool hash_set_(hashtab *h, SEXP key, R_xlen_t value) {
+  size_t mask = h->size - 1;
   size_t idx = hash_index(key, h->shift);
-  size_t mask = h->mask;
   while (true) {
     if (!h->table[idx].key) {
       if (h->free == 0) return false; // table full -> need rehash
@@ -113,8 +112,8 @@ hashtab *hash_set_shared(hashtab *h, SEXP key, R_xlen_t value) {
 }
 
 R_xlen_t hash_lookup(const hashtab *h, SEXP key, R_xlen_t ifnotfound) {
+  size_t mask = h->size - 1;
   size_t idx = hash_index(key, h->shift);
-  size_t mask = h->mask;
   while (true) {
     if (h->table[idx].key == key) return h->table[idx].value;
     if (h->table[idx].key == NULL) return ifnotfound;


### PR DESCRIPTION
I reran with linear probing and masking. Together with #7454 it looks like we even will become faster after this :)

I did not dive deeper into it yet, but I guess the magnitude we are slower with `double_hashing` to `linear_probing` (in forderv: all unique strings) now is because we do not use the `free` var and do not rehash the hash table until it bursts. Moreover, if we want to use it effectively we probably need to set it somehow to display the free spaces according to the load factor, right?

https://github.com/Rdatatable/data.table/blob/7c1cdb256c18912e744904646ad4244a4695465c/src/hash.c#L43

<img width="1683" height="1345" alt="image" src="https://github.com/user-attachments/assets/d2696f53-5c75-4081-b711-9aeeea0d0978" />

<img width="1681" height="1346" alt="image" src="https://github.com/user-attachments/assets/b6589872-b4ee-4cd2-93ce-60cccce1e263" />

<img width="1681" height="1344" alt="image" src="https://github.com/user-attachments/assets/e2a11348-71ed-403c-82a5-160a133adea2" />
