### PR TITLE
`.ci/lint.R`: fix `--help` behaviour

### DIFF
--- a/.ci/lint.R
+++ b/.ci/lint.R
@@ -6,7 +6,8 @@ if (identical(args, '--help')) {
     'Usage: Rscript .ci/lint.R .ci/linters/<KIND> <WHERE> <WHAT>',
     'KIND must name the directory containing the *.R files defining the linter functions.',
     'WHERE must name the directory containing the files to lint, e.g. "po", or "src".',
-    "WHAT must contain the regular expression matching the files to lint, e.g., '[.]po$', or '[.][ch]$'."
+    "WHAT must contain the regular expression matching the files to lint, e.g., '[.]po$', or '[.][ch]$'.",
+    NULL
   ))
   q('no')
 }


### PR DESCRIPTION
Missed two problems in #7077:

```
$ Rscript .ci/lint.R 
Error: Invalid arguments, see .ci/lint.R --help
Execution halted
$ Rscript .ci/lint.R --help
Error in c("Usage: Rscript .ci/lint.R .ci/linters/<KIND> <WHERE> <WHAT> [PREPROCESS]",  : 
  argument 5 is empty
Calls: writeLines
Execution halted
```

Remove the `[PREPROCESS]` and the empty argument to `c()`.