### PR TITLE
Implement all=TRUE argument for rleid (#1963)

### DIFF
--- a/R/data.table.R
+++ b/R/data.table.R
@@ -3091,11 +3091,11 @@ rowidv = function(x, cols=seq_along(x), prefix=NULL) {
 }
 
 # FR #686
-rleid = function(..., prefix=NULL) {
-  rleidv(list(...), prefix=prefix)
+rleid = function(..., prefix=NULL,all=FALSE) {
+  rleidv(list(...), prefix=prefix, all=all)
 }
 
-rleidv = function(x, cols=seq_along(x), prefix=NULL) {
+rleidv = function(x, cols=seq_along(x), prefix=NULL, all = FALSE) {
   if (!is.null(prefix) && (!is.character(prefix) || length(prefix) != 1L))
     stopf("'prefix' must be NULL or a character vector of length 1.")
   if (is.atomic(x)) {
@@ -3109,6 +3109,9 @@ rleidv = function(x, cols=seq_along(x), prefix=NULL) {
   cols = colnamesInt(x, cols, check_dups=FALSE)
   ids = .Call(Crleid, x, cols)
   if (!is.null(prefix)) ids = paste0(prefix, ids)
+  if (isTRUE(all)) {
+    return(c(x, list(ids)))
+  }
   ids
 }
 


### PR DESCRIPTION
#1963

This PR adds the all argument to rleid and rleidv.
- When all = TRUE, the function returns a list containing the original input vectors alongside the generated IDs.
- original compatibility is maintained (default is all = FALSE).
