### PR TITLE
Use an absolute URL to link GOVERNANCE

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 [//]: # (numfocus-fiscal-sponsor-attribution)
 
-The `data.table` project uses a [custom governance agreement](https://github.com/Rdatatable/data.table/blob/master/GOVERNANCE.md) 
+The `data.table` project uses a [custom governance agreement](https://rdatatable.gitlab.io/data.table/GOVERNANCE.html) 
 and is fiscally sponsored by [NumFOCUS](https://numfocus.org/). Consider making 
 a [tax-deductible donation](https://numfocus.org/project/data-table) to help the project 
 pay for developer time, professional services, travel, workshops, and a variety of other needs.


### PR DESCRIPTION
As highlighted during CRAN release:

https://github.com/Rdatatable/data.table/issues/7494#issuecomment-3680827959

It might actually be preferable to publish the .md to the pkgdown site instead. Filing this PR first to get the ball rolling.