### PR TITLE
adapt header for cc

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -1,5 +1,5 @@
 #ifndef _WIN32
-#  define _POSIX_C_SOURCE 200809L // required for non-POSIX features in is_direct_child e.g. 'siginfo_t'
+#  define _POSIX_C_SOURCE 200809L // required for POSIX (not standard C) features in is_direct_child e.g. 'siginfo_t'
 #  include <sys/wait.h>
 #endif
 


### PR DESCRIPTION
Closes #7512 

Follows #7428 since I cannot `cc()` after that

```bash
gcc -I"/usr/share/R/include" -DNDEBUG      -fopenmp  -fpic  -fopenmp -std=c11 -O3 -pipe -Wall -pedantic -Wstrict-prototypes -isystem /usr/share/R/include  -fno-common -c utils.c -o utils.o
gcc -I"/usr/share/R/include" -DNDEBUG      -fopenmp  -fpic  -fopenmp -std=c11 -O3 -pipe -Wall -pedantic -Wstrict-prototypes -isystem /usr/share/R/include  -fno-common -c vecseq.c -o vecseq.o
gcc -I"/usr/share/R/include" -DNDEBUG      -fopenmp  -fpic  -fopenmp -std=c11 -O3 -pipe -Wall -pedantic -Wstrict-prototypes -isystem /usr/share/R/include  -fno-common -c wrappers.c -o wrappers.o
utils.c: In function ‘is_direct_child’:
utils.c:692:3: error: unknown type name ‘siginfo_t’
  692 |   siginfo_t info;
      |   ^~~~~~~~~
utils.c:694:15: warning: implicit declaration of function ‘waitid’; did you mean ‘waitpid’? [-Wimplicit-function-declaration]
  694 |     pret[i] = waitid(P_PID, ppids[i], &info, WCONTINUED | WEXITED | WNOHANG | WNOWAIT | WSTOPPED) == 0;
      |               ^~~~~~
      |               waitpid
utils.c:694:22: error: ‘P_PID’ undeclared (first use in this function)
  694 |     pret[i] = waitid(P_PID, ppids[i], &info, WCONTINUED | WEXITED | WNOHANG | WNOWAIT | WSTOPPED) == 0;
      |                      ^~~~~
utils.c:694:22: note: each undeclared identifier is reported only once for each function it appears in
utils.c:694:46: error: ‘WCONTINUED’ undeclared (first use in this function)
  694 |     pret[i] = waitid(P_PID, ppids[i], &info, WCONTINUED | WEXITED | WNOHANG | WNOWAIT | WSTOPPED) == 0;
      |                                              ^~~~~~~~~~
utils.c:694:59: error: ‘WEXITED’ undeclared (first use in this function); did you mean ‘WIFEXITED’?
  694 |     pret[i] = waitid(P_PID, ppids[i], &info, WCONTINUED | WEXITED | WNOHANG | WNOWAIT | WSTOPPED) == 0;
      |                                                           ^~~~~~~
      |                                                           WIFEXITED
utils.c:694:79: error: ‘WNOWAIT’ undeclared (first use in this function)
  694 |     pret[i] = waitid(P_PID, ppids[i], &info, WCONTINUED | WEXITED | WNOHANG | WNOWAIT | WSTOPPED) == 0;
      |                                                                               ^~~~~~~
utils.c:694:89: error: ‘WSTOPPED’ undeclared (first use in this function); did you mean ‘WIFSTOPPED’?
  694 |     pret[i] = waitid(P_PID, ppids[i], &info, WCONTINUED | WEXITED | WNOHANG | WNOWAIT | WSTOPPED) == 0;
      |                                                                                         ^~~~~~~~
      |                                                                                         WIFSTOPPED
```