### PR TITLE
Enable dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# This Dependabot configuration is designed to keep GitHub Actions dependencies up-to-date
+# by running weekly checks and creating pull requests to update them as needed.
+#
+# This ensures that the GitHub Actions workflows remain compatible with the latest versions
+# of their dependencies, potentially improving the stability and security of automation processes.
+#
+# For more, see:
+# https://docs.github.com/en/code-security/dependabot/dependabot-alerts/about-dependabot-alerts
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This is a nice automated tool to keep the various GitHub Actions dependencies up-to-date without needing to monitor them.

E.g., I noticed we are on v4 of this action which has current 'latest' version v6:

https://github.com/Rdatatable/data.table/blob/458d12a9af8622de6ce1dcfd487b267afd585ec2/.github/workflows/rchk.yaml#L36

Example dependabot PR from {lintr}:

https://github.com/r-lib/lintr/pull/2992

It's generally a good idea to scan the update log -- an automation tool like this introduces some risk of getting exposed to a security issue (while also removing the security risk of continuing to use versions with known flaws). The actions we use are among the highest-volume actions, so I think that risk is low.

Documentation: https://github.com/dependabot/dependabot-core?tab=readme-ov-file

I already enabled this in the repo settings.