### PR TITLE
Drop gettext and use stopf directly

### DIFF
--- a/R/fcast.R
+++ b/R/fcast.R
@@ -185,7 +185,7 @@ dcast.data.table = function(data, formula, fun.aggregate = NULL, sep = "_", ...,
     fun.call = aggregate_funs(fun.call, lvals, sep, ...)
     maybe_err = function(list.of.columns) {
       if (!all(lengths(list.of.columns) == 1L)) {
-        stopf("Aggregating functions should take a vector as input and return a single value (length=1), but they do not, so the result is undefined. Please fix by modifying your function so that a single value is always returned.", call. = FALSE)
+        stopf("Aggregating functions should take a vector as input and return a single value (length=1), but they do not, so the result is undefined. Please fix by modifying your function so that a single value is always returned.")
       }
       list.of.columns
     }


### PR DESCRIPTION
Minor change for consistency.

This could have been part of #7260 -- there, `gettext()` was used since the message would be passed to either `stop()` or `warning()`; now, it's always passed to `stop()`, so we don't need to separate into two steps.