### PR TITLE
Refine mention of ancient version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ pay for developer time, professional services, travel, workshops, and a variety 
 * fast and feature rich **reshaping** data: **[`?dcast`](https://rdatatable.gitlab.io/data.table/reference/dcast.data.table.html)** (_pivot/wider/spread_) and **[`?melt`](https://rdatatable.gitlab.io/data.table/reference/melt.data.table.html)** (_unpivot/longer/gather_)
 * **any R function from any R package** can be used in queries not just the subset of functions made available by a database backend, also columns of type `list` are supported
 * has **[no dependencies](https://en.wikipedia.org/wiki/Dependency_hell)** at all other than base R itself, for simpler production/maintenance
-* the R dependency is **as old as possible for as long as possible**, dated April 2014, and we continuously test against that version; e.g. v1.11.0 released on 5 May 2018 bumped the dependency up from 5 year old R 3.0.0 to 4 year old R 3.1.0
+* the R dependency is **as old as possible for as long as possible**, currently R 3.5.0 (2018), and we continuously test against that version
 
 ## Installation
 


### PR DESCRIPTION
Should be more future-proof this way. When updating, I do regex searches, e.g. for `3[._][45]` in the recent upgrade, which would now catch this.