### PR TITLE
hide jj folder from R build

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -17,6 +17,7 @@
 ^\.devcontainer$
 ^\.graphics$
 ^\.github$
+^\.jj$
 ^\.vscode$
 ^\.zed$
 ^\.lintr$


### PR DESCRIPTION
This is for `jj`:

https://github.com/jj-vcs/jj