### PR TITLE
Remove obsolete workaround for integer64 case

### DIFF
--- a/R/groupingsets.R
+++ b/R/groupingsets.R
@@ -147,12 +147,6 @@ groupingsets.data.table = function(x, j, by, sets, .SDcols, id = FALSE, jj, labe
       warningf("For the following variables, the 'label' value was already in the data: %s", brackify(info))
     }
   }
-  # workaround for rbindlist fill=TRUE on integer64 #1459
-  int64.cols = vapply_1b(empty, inherits, "integer64")
-  int64.cols = names(int64.cols)[int64.cols]
-  if (length(int64.cols) && !requireNamespace("bit64", quietly=TRUE))
-    stopf("Using integer64 class columns require to have 'bit64' package installed.") # nocov
-  int64.by.cols = intersect(int64.cols, by)
   # aggregate function called for each grouping set
   # inline all arguments that might clash with enclosing environment
   pcall = substitute(x[, jj], list(x = x, jj = jj))
@@ -165,11 +159,6 @@ groupingsets.data.table = function(x, j, by, sets, .SDcols, id = FALSE, jj, labe
       # 3267: strtoi("", base = 2L) output apparently unstable across platforms
       i_str = paste(c("1", "0")[by %chin% by.set + 1L], collapse="")
       set(r, j = "grouping", value = if (nzchar(i_str)) strtoi(i_str, base=2L) else 0L)
-    }
-    if (length(int64.by.cols)) {
-      # workaround for rbindlist fill=TRUE on integer64 #1459
-      missing.int64.by.cols = setdiff(int64.by.cols, by.set)
-      if (length(missing.int64.by.cols)) r[, (missing.int64.by.cols) := bit64::as.integer64(NA)]
     }
     if (!is.null(label) && length(by.label.use.vars <- intersect(setdiff(by, by.set), names(label.use))) > 0L)
       r[, (by.label.use.vars) := label.use[by.label.use.vars]]


### PR DESCRIPTION
Closes #6480. I assume existing tests are enough -- R/groupingsets.R has 100% coverage:

https://app.codecov.io/gh/Rdatatable/data.table/blob/master/R%2Fgroupingsets.R

No NEWS since this is purely internal.