### PR TITLE
remove unused vars

### DIFF
--- a/src/assign.c
+++ b/src/assign.c
@@ -362,10 +362,9 @@ SEXP assign(SEXP dt, SEXP rows, SEXP cols, SEXP newcolnames, SEXP values)
   // cols : column names or numbers corresponding to the values to set
   // rows : row numbers to assign
   R_len_t numToDo, targetlen, vlen, oldncol, oldtncol, coln, protecti=0, newcolnum;
-  SEXP targetcol, nullint, s, colnam, tmp, key, index, a, assignedNames;
+  SEXP targetcol, nullint, colnam, tmp, key, index, assignedNames;
   bool verbose=GetVerbose();
   int ndelete=0;  // how many columns are being deleted
-  const char *c1, *tc1, *tc2;
   int *buf;
   if (isNull(dt)) error(_("assign has been passed a NULL dt"));
   if (TYPEOF(dt) != VECSXP) error(_("dt passed to %s isn't type VECSXP"), "assign");

--- a/src/dogroups.c
+++ b/src/dogroups.c
@@ -77,7 +77,7 @@ SEXP dogroups(SEXP dt, SEXP dtcols, SEXP groups, SEXP grpcols, SEXP jiscols, SEX
 {
   R_len_t ngrp, nrowgroups, njval=0, ngrpcols, ansloc=0, maxn, estn=-1, thisansloc, grpn, thislen, igrp;
   int nprotect=0;
-  SEXP ans=NULL, jval, thiscol, BY, N, I, GRP, iSD, xSD, s, RHS, target, source;
+  SEXP ans=NULL, jval, thiscol, BY, N, I, GRP, iSD, xSD, RHS, target, source;
   Rboolean wasvector, firstalloc=FALSE, NullWarnDone=FALSE;
   const bool verbose = LOGICAL(verboseArg)[0]==1;
   double tstart=0, tblock[10]={0}; int nblock[10]={0}; // For verbose printing, tstart is updated each block


### PR DESCRIPTION
Follows #7487 and removes the following compile warnings

```
assign.c: In function ‘assign’:
assign.c:368:26: warning: unused variable ‘tc2’ [-Wunused-variable]
  368 |   const char *c1, *tc1, *tc2;
      |                          ^~~
assign.c:368:20: warning: unused variable ‘tc1’ [-Wunused-variable]
  368 |   const char *c1, *tc1, *tc2;
      |                    ^~~
assign.c:368:15: warning: unused variable ‘c1’ [-Wunused-variable]
  368 |   const char *c1, *tc1, *tc2;
      |               ^~
assign.c:365:56: warning: unused variable ‘a’ [-Wunused-variable]
  365 |   SEXP targetcol, nullint, s, colnam, tmp, key, index, a, assignedNames;
      |                                                        ^
assign.c:365:28: warning: unused variable ‘s’ [-Wunused-variable]
  365 |   SEXP targetcol, nullint, s, colnam, tmp, key, index, a, assignedNames;
      |                            ^
dogroups.c: In function ‘dogroups’:
dogroups.c:80:58: warning: unused variable ‘s’ [-Wunused-variable]
   80 |   SEXP ans=NULL, jval, thiscol, BY, N, I, GRP, iSD, xSD, s, RHS, target, source;
      |                                                          ^


```