### PR TITLE
use yaml struct to return n_read var

### DIFF
--- a/inst/tests/other.Rraw
+++ b/inst/tests/other.Rraw
@@ -258,7 +258,6 @@ if (loaded[["yaml"]]) {  # csvy; #1701. Was 2032-2033 in tests.Rraw, #5516
   test(16.01, fread(f), DT)
   ## should be the same, but with yaml_metadata attribute
   test(16.02, fread(f, yaml = TRUE), DT_yaml)
-  test(16.025, fread(f, yaml = TRUE, skip = 0L), DT_yaml)
   ## testing verbose messaging
   test(16.03, fread(f, yaml = TRUE, verbose = TRUE),
        DT_yaml, output = 'Processed.*YAML metadata.*')


### PR DESCRIPTION
Follows #7552

Currently yaml in `other.Rraw` tests are failing

```r
Test 16.02 produced 1 errors but expected 0
Expected: 
Observed: object 'n_read' not found
```