### PR TITLE
Fix http: → https: link that is now a redirect

### DIFF
--- a/man/setkey.Rd
+++ b/man/setkey.Rd
@@ -110,7 +110,7 @@ reference.
 \references{
   \url{https://en.wikipedia.org/wiki/Radix_sort}\cr
   \url{https://en.wikipedia.org/wiki/Counting_sort}\cr
-  \url{http://stereopsis.com/radix.html}\cr
+  \url{https://stereopsis.com/radix.html}\cr
   \url{https://codercorner.com/RadixSortRevisited.htm}\cr
   \url{https://cran.r-project.org/package=bit64}\cr
   \url{https://github.com/Rdatatable/data.table/wiki/Presentations}

--- a/man/setorder.Rd
+++ b/man/setorder.Rd
@@ -113,7 +113,7 @@ If you require a copy, take a copy first (using \code{DT2 = copy(DT)}). See
 \references{
   \url{https://en.wikipedia.org/wiki/Radix_sort}\cr
   \url{https://en.wikipedia.org/wiki/Counting_sort}\cr
-  \url{http://stereopsis.com/radix.html}\cr
+  \url{https://stereopsis.com/radix.html}\cr
   \url{https://codercorner.com/RadixSortRevisited.htm}\cr
   \url{https://medium.com/basecs/getting-to-the-root-of-sorting-with-radix-sort-f8e9240d4224}
 }


### PR DESCRIPTION
`R CMD check --as-cran` found yet another link to fix:

> Found the following (possibly) invalid URLs:
>   URL: http://stereopsis.com/radix.html (moved to https://stereopsis.com/radix.html)
>     From: man/setkey.Rd
>           man/setorder.Rd
>     Status: 200
>     Message: OK