### PR TITLE
frollmedianFast: avoid reading uninitialised array

### DIFF
--- a/src/froll.c
+++ b/src/froll.c
@@ -1707,11 +1707,13 @@ void frollmedianFast(const double *x, uint64_t nx, ans_t *ans, int k, double fil
           snprintf(end(ans->message[3]), 500, _("%s: 's[A] + s[B] == h' is not true\n"), "frollmedianFast");
           return;
         }*/
-        if (n[A]!=tail && m[A] == n[A]) {
-          n[A] = tail;
-        }
-        if (n[B]!=tail && m[B] == n[B]) {
-          n[B] = tail;
+        if (even) {
+          if (n[A]!=tail && m[A] == n[A]) {
+            n[A] = tail;
+          }
+          if (n[B]!=tail && m[B] == n[B]) {
+            n[B] = tail;
+          }
         }
         ansv[j*k+i] = even ? MED2(A, B) : MED(A, B);
       }


### PR DESCRIPTION
The `n` array is only initialised if `even` is true, so skip the comparisons otherwise. Detected by checking with `--use-valgrind` or performing a `frollmedian()` with an odd window size under `R -d valgrind`.

Fixes: #7546