### PR TITLE
`litedown` website: better HTML, cross-references

### DIFF
--- a/site/generate_reference.R
+++ b/site/generate_reference.R
@@ -103,9 +103,11 @@ for (rd_file in rd_files) {
 
   for (link in xml_find_all(html_root, '//a|//link')) {
     href = xml_attr(link, 'href')
-    if (!is.na(href) && !grepl('^https?://', href)) {
-     xml_attr(link, 'href') <- paste0('../', href)
-   }
+    if (!is.na(href))
+      if (startsWith(href, '../../')) # \link[package]{topic}
+        xml_attr(link, 'href') <- NULL
+      else if (!grepl('^https?://', href))
+        xml_attr(link, 'href') <- paste0('../', href)
   }
 
   write_html(html_root, out_file)


### PR DESCRIPTION
* Use the `xml2` package to merge the `Rd2HTML` output with the scripts and templates from `_litedown.yml`.
   This slightly reduces duplication (navigation header, footer, scripts, stylesheets are now loaded from the main configuration file) and makes the output more valid (another `<html><body>` inside the main `<html><body>` only works because the browser developers learned to be lenient during the Geocities time).
* Use the information collected in the `all_info` variable to let `tools::Rd2HTML` know how to link between the `data.table` help pages.
   "External" links still don't work, but we don't have many links to `[base]` or other packages.

Should I add `xml2` to the Docker image used to run the CI?