### PR TITLE
Only export `R_init_data_table`

### DIFF
--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -1,5 +1,5 @@
-PKG_CFLAGS = @PKG_CFLAGS@ @openmp_cflags@ @zlib_cflags@
-PKG_LIBS = @PKG_LIBS@ @openmp_cflags@ @zlib_libs@
+PKG_CFLAGS = $(C_VISIBILITY) @PKG_CFLAGS@ @openmp_cflags@ @zlib_cflags@
+PKG_LIBS = $(C_VISIBILITY) @PKG_LIBS@ @openmp_cflags@ @zlib_libs@
 # See WRE $1.2.1.1. But retain user supplied PKG_* too, #4664.
 # WRE states ($1.6) that += isn't portable and that we aren't allowed to use it.
 # Otherwise we could use the much simpler PKG_LIBS += @openmp_cflags@ -lz.

--- a/src/data.table-win.def
+++ b/src/data.table-win.def
@@ -1,0 +1,3 @@
+LIBRARY data.table.dll
+EXPORTS
+ R_init_data_table


### PR DESCRIPTION
This will avoid name clashes between `data.table` functions (now hidden) and other functions in the global namespace visible to the shared library loader.

Tested on R-4.2/Linux, R-3.5/Windows.

Fixes: #7605