### PR TITLE
Use read-only accessors for more call sites

### DIFF
--- a/src/forder.c
+++ b/src/forder.c
@@ -723,7 +723,7 @@ SEXP forder(SEXP DT, SEXP by, SEXP retGrpArg, SEXP retStatsArg, SEXP sortGroupsA
 
     switch(TYPEOF(x)) {
     case INTSXP : case LGLSXP : {
-      int32_t *xd = INTEGER(x);
+      const int32_t *xd = INTEGER_RO(x);
       #pragma omp parallel for num_threads(getDTthreads(nrow, true))
       for (int i=0; i<nrow; i++) {
         uint64_t elem=0;
@@ -738,7 +738,7 @@ SEXP forder(SEXP DT, SEXP by, SEXP retGrpArg, SEXP retStatsArg, SEXP sortGroupsA
       break;
     case REALSXP :
       if (inherits(x, "integer64")) {
-        int64_t *xd = (int64_t *)REAL(x);
+        const int64_t *xd = (const int64_t *)REAL_RO(x);
         #pragma omp parallel for num_threads(getDTthreads(nrow, true))
         for (int i=0; i<nrow; i++) {
           uint64_t elem=0;
@@ -751,7 +751,7 @@ SEXP forder(SEXP DT, SEXP by, SEXP retGrpArg, SEXP retStatsArg, SEXP sortGroupsA
           WRITE_KEY
         }
       } else {
-        double *xd = REAL(x);     // TODO: revisit double compression (skip bytes/mult by 10,100 etc) as currently it's often 6-8 bytes even for 3.14,3.15
+        const double *xd = REAL_RO(x);     // TODO: revisit double compression (skip bytes/mult by 10,100 etc) as currently it's often 6-8 bytes even for 3.14,3.15
         #pragma omp parallel for num_threads(getDTthreads(nrow, true))
         for (int i=0; i<nrow; i++) {
           uint64_t elem=0;
@@ -1416,15 +1416,15 @@ SEXP issorted(SEXP x, SEXP by)
     int i=1;
     switch(TYPEOF(x)) {
     case INTSXP : case LGLSXP : {
-      int *xd = INTEGER(x);
+      const int *xd = INTEGER_RO(x);
       while (i<n && xd[i]>=xd[i-1]) i++;
     } break;
     case REALSXP :
       if (inherits(x,"integer64")) {
-        int64_t *xd = (int64_t *)REAL(x);
+        const int64_t *xd = (int64_t *)REAL_RO(x);
         while (i<n && xd[i]>=xd[i-1]) i++;
       } else {
-        double *xd = REAL(x);
+        const double *xd = REAL_RO(x);
         while (i<n && dtwiddle(xd[i])>=dtwiddle(xd[i-1])) i++;  // TODO: change to loop over any NA or -Inf at the beginning and then proceed without dtwiddle() (but rounding)
       }
       break;
@@ -1565,7 +1565,7 @@ SEXP binary(SEXP x)
 static bool all1(SEXP x) {
   if (!isInteger(x))
     internal_error_with_cleanup(__func__, "all1 got non-integer"); // # nocov
-  int *xp = INTEGER(x);
+  const int *xp = INTEGER_RO(x);
   for (int i=0; i<LENGTH(x); ++i) if (xp[i] != 1) return false;
   return true;
 }
@@ -1583,7 +1583,7 @@ bool colsKeyHead(SEXP x, SEXP cols) {
   }
   SEXP keynames = PROTECT(chmatch(key, getAttrib(x, R_NamesSymbol), 0));
   UNPROTECT(1); // key
-  int *keynamesp = INTEGER(keynames), *colsp = INTEGER(cols);
+  const int *keynamesp = INTEGER_RO(keynames), *colsp = INTEGER_RO(cols);
   for (int i=0; i<LENGTH(cols); ++i) {
     if (colsp[i]!=keynamesp[i]) {
       UNPROTECT(1);

--- a/src/fwriteR.c
+++ b/src/fwriteR.c
@@ -270,7 +270,7 @@ SEXP fwriteR(
         if (xlength(rn) != args.nrow)
            // Use (long long) to cast R_xlen_t to a fixed type to robustly avoid -Wformat compiler warnings, see #5768, PRId64 didn't work on M1
           error(_("input has specific integer rownames but their length (%lld) != nrow (%"PRId64")"), (long long)xlength(rn), args.nrow);  // # nocov
-        args.rowNames = INTEGER(rn);
+        args.rowNames = INTEGER_RO(rn);
         args.rowNameFun = WF_Int32;
       }
     } else if (isString(rn)) {

--- a/src/gsumm.c
+++ b/src/gsumm.c
@@ -881,8 +881,8 @@ SEXP gmedian(SEXP x, SEXP narmArg) {
   switch(TYPEOF(x)) {
   case REALSXP: {
     double *subd = REAL(PROTECT(allocVector(REALSXP, maxgrpn))); // allocate once upfront and reuse
-    int64_t *xi64 = (int64_t *)REAL(x);
-    double  *xd = REAL(x);
+    const int64_t *xi64 = (const int64_t *)REAL_RO(x);
+    const double  *xd = REAL_RO(x);
     for (int i=0; i<ngrp; ++i) {
       int thisgrpsize = grpsize[i], nacount=0;
       for (int j=0; j<thisgrpsize; ++j) {
@@ -898,7 +898,7 @@ SEXP gmedian(SEXP x, SEXP narmArg) {
     break;
   case LGLSXP: case INTSXP: {
     int *subi = INTEGER(PROTECT(allocVector(INTSXP, maxgrpn)));
-    int *xi = INTEGER(x);
+    const int *xi = INTEGER_RO(x);
     for (int i=0; i<ngrp; i++) {
       const int thisgrpsize = grpsize[i];
       int nacount=0;

--- a/src/ijoin.c
+++ b/src/ijoin.c
@@ -10,8 +10,8 @@ SEXP lookup(SEXP ux, SEXP xlen, SEXP indices, SEXP gaps, SEXP overlaps, SEXP mul
 
   SEXP vv, tt, lookup, type_lookup;
   R_len_t *idx,*count,*type_count,xrows=INTEGER(xlen)[0],uxrows=LENGTH(VECTOR_ELT(ux, 0)),uxcols=LENGTH(ux);
-  int *from = INTEGER(VECTOR_ELT(indices, 0));
-  int *to   = INTEGER(VECTOR_ELT(indices, 1));
+  const int *from = INTEGER_RO(VECTOR_ELT(indices, 0));
+  const int *to   = INTEGER_RO(VECTOR_ELT(indices, 1));
   clock_t pass1, pass2, pass3, start;
   enum {ALL, FIRST, LAST} mult = ALL;
   enum {ANY, WITHIN, START, END, EQUAL} type = ANY;
@@ -225,10 +225,10 @@ SEXP overlaps(SEXP ux, SEXP imatches, SEXP multArg, SEXP typeArg, SEXP nomatchAr
 
   R_len_t uxcols=LENGTH(ux), rows=length(VECTOR_ELT(imatches,0)), xrows=length(VECTOR_ELT(ux,0));
   int nomatch = INTEGER(nomatchArg)[0], totlen=0, thislen;
-  int *from   = INTEGER(VECTOR_ELT(imatches, 0));
-  int *to     = INTEGER(VECTOR_ELT(imatches, 1));
-  int *count   = INTEGER(VECTOR_ELT(ux, uxcols-2));
-  int *type_count   = INTEGER(VECTOR_ELT(ux, uxcols-1));
+  const int *from   = INTEGER_RO(VECTOR_ELT(imatches, 0));
+  const int *to     = INTEGER_RO(VECTOR_ELT(imatches, 1));
+  const int *count   = INTEGER_RO(VECTOR_ELT(ux, uxcols-2));
+  const int *type_count   = INTEGER_RO(VECTOR_ELT(ux, uxcols-1));
   SEXP lookup = VECTOR_ELT(ux, uxcols-4);
   SEXP type_lookup = VECTOR_ELT(ux, uxcols-3);
   SEXP ans, f1__, f2__, tmp1, tmp2;

--- a/src/nafill.c
+++ b/src/nafill.c
@@ -146,7 +146,7 @@ SEXP nafillR(SEXP obj, SEXP type, SEXP fill, SEXP nan_is_na_arg, SEXP inplace, S
   }
   SEXP ricols = PROTECT(colnamesInt(obj, cols, /* check_dups= */ ScalarLogical(TRUE), /* skip_absent= */ ScalarLogical(FALSE))); protecti++; // nafill cols=NULL which turns into seq_along(obj)
   x = PROTECT(allocVector(VECSXP, length(ricols))); protecti++;
-  int *icols = INTEGER(ricols);
+  const int *icols = INTEGER_RO(ricols);
   bool any_char = false;
   for (int i=0; i<length(ricols); i++) {
     SEXP this_col = VECTOR_ELT(obj, icols[i]-1);

--- a/src/uniqlist.c
+++ b/src/uniqlist.c
@@ -221,7 +221,7 @@ SEXP rleid(SEXP l, SEXP cols) {
     SEXP jcol = VECTOR_ELT(l, icols[0]-1);
     switch (TYPEOF(jcol)) {
     case INTSXP : case LGLSXP : {
-      int *ijcol = INTEGER(jcol);
+      const int *ijcol = INTEGER_RO(jcol);
       for (R_xlen_t i=1; i<nrow; i++) {
         bool same = ijcol[i]==ijcol[i-1];
         ians[i] = (grp+=!same);
@@ -235,14 +235,14 @@ SEXP rleid(SEXP l, SEXP cols) {
       }
     } break;
     case REALSXP : {
-      long long *lljcol = (long long *)REAL(jcol);
+      const long long *lljcol = (const long long *)REAL_RO(jcol);
       for (R_xlen_t i=1; i<nrow; i++) {
         bool same = lljcol[i]==lljcol[i-1];
         ians[i] = (grp+=!same);
       }
     } break;
     case CPLXSXP: {
-      Rcomplex *pzjcol = COMPLEX(jcol);
+      const Rcomplex *pzjcol = COMPLEX_RO(jcol);
       for (R_xlen_t i=1; i<nrow; i++) {
         bool same = memcmp(&pzjcol[i], &pzjcol[i-1], sizeof(Rcomplex))==0;
         ians[i] = (grp += !same);

--- a/src/utils.c
+++ b/src/utils.c
@@ -161,7 +161,7 @@ SEXP colnamesInt(SEXP x, SEXP cols, SEXP check_dups, SEXP skip_absent) {
     if (isNull(xnames))
       error(_("'x' argument data.table has no names"));
     ricols = PROTECT(chmatch(cols, xnames, 0)); protecti++;
-    int *icols = INTEGER(ricols);
+    const int *icols = INTEGER_RO(ricols);
     if (!bskip_absent) {
       for (int i=0; i<nc; ++i) {
         if (icols[i]==0)
@@ -707,7 +707,7 @@ SEXP is_direct_child(SEXP pids) {
 #ifdef _WIN32
   internal_error(__func__, "not implemented on Windows");
 #else
-  int *ppids = INTEGER(pids);
+  const int *ppids = INTEGER_RO(pids);
   R_xlen_t len = xlength(pids);
   SEXP ret = allocVector(LGLSXP, len);
   int *pret = LOGICAL(ret);

--- a/src/wrappers.c
+++ b/src/wrappers.c
@@ -50,7 +50,7 @@ SEXP setlevels(SEXP x, SEXP levels, SEXP ulevels) {
     SET_STRING_ELT(xchar, i, (ixi >= 1 && ixi <= nlevels) ? STRING_ELT(levels, ix[i]-1) : NA_STRING);
   }
   newx = PROTECT(chmatch(xchar, ulevels, NA_INTEGER));
-  int *inewx = INTEGER(newx);
+  const int *inewx = INTEGER_RO(newx);
   for (int i=0; i<nx; ++i) ix[i] = inewx[i];
   setAttrib(x, R_LevelsSymbol, ulevels);
   UNPROTECT(2);


### PR DESCRIPTION
These call sites were identified by `gemini`; it identified the file name & line number of possible sites, and I reviewed and applied the edits. I instructed it to ignore cases like those mentioned in https://github.com/Rdatatable/data.table/pull/7611#issuecomment-3775101675 -- they are quite numerous and of questionable value; anyway, they are easy to find with regex. The goal here was to comb the source for places that require a bit more contextualization to classify.

Currently based against #7611.