### PR TITLE
`tests/froll.R`: disable `mcparallel` under Valgrind

### DIFF
--- a/tests/froll.R
+++ b/tests/froll.R
@@ -2,9 +2,9 @@
 # exec() is problematic for Valgrind. frollapply() uses
 # parallel::mcparallel(), which causes Valgrind to run
 # Rstd_ReadConsole() incorrectly.
-Sys.setenv(OMP_THREAD_LIMIT = Sys.getenv("OMP_THREAD_LIMIT",
-  if (grepl("valgrind", Sys.getenv("LD_PRELOAD"))) "1" else "2"
-))
+Sys.setenv(OMP_THREAD_LIMIT =
+  if (grepl("valgrind", Sys.getenv("LD_PRELOAD"))) "1" else Sys.getenv("OMP_THREAD_LIMIT", "2")
+)
 require(data.table)
 test.data.table(script="froll.Rraw")
 test.data.table(script="frollBatch.Rraw", optional=TRUE)


### PR DESCRIPTION
Motivation: https://github.com/Rdatatable/data.table/issues/7587#issuecomment-3794413835

There is a bug in Valgrind that makes it run the process slightly wrong when it performs work in child processes after `fork()` without `exec()`. OpenMP threads may be involved too:

```sh
cat >foo.R <<'EOF'
library(parallel)
letters |> sample(1e3, TRUE) |> order(method = 'radix') |> mcparallel() -> p
q <- mccollect(p)
str(q)
EOF
R -q -d valgrind -f foo.R
```

It looks like instead of returning EOF, Valgrind causes `Rstd_ReadConsole` → `fgets` to return some earlier content from the `FILE*` buffer, which R parses and runs again. Note how it runs `mccollect()` and `str()` twice, with different side effects and overall results.

Empirically, Valgrind puts its shared library containing the overrides into `$LD_PRELOAD`, so detect that and disable `mcparallel` in the `frollapply` tests. (The documented way to detect Valgrind would mean performing a [client request](https://valgrind.org/docs/manual/manual-core-adv.html#manual-core-adv.clientreq) from compiled code using Valgrind headers; let's not go there yet.)