### PR TITLE
`example(groupingsets)`: limit the number of threads

### DIFF
--- a/man/groupingsets.Rd
+++ b/man/groupingsets.Rd
@@ -47,6 +47,7 @@ groupingsets(x, \dots)
 \url{https://www.postgresql.org/docs/9.5/static/functions-aggregate.html#FUNCTIONS-GROUPING-TABLE}
 }
 \examples{
+\dontshow{.dt_threads <- setDTthreads(2)}
 n = 24L
 set.seed(25)
 DT <- data.table(
@@ -83,5 +84,6 @@ cube(DT, j = c(list(count=.N), lapply(.SD, sum)), by = c("color","year","status"
 # groupingsets
 groupingsets(DT, j = c(list(count=.N), lapply(.SD, sum)), by = c("color","year","status"),
              sets = list("color", c("year","status"), character()), id=TRUE)
+\dontshow{setDTthreads(.dt_threads); rm(.dt_threads)}
 }
 \keyword{ data }


### PR DESCRIPTION
https://win-builder.r-project.org/incoming_pretest/data.table_1.18.2.1_20260125_054833/reverseDependencies/package/00check.log
```
* checking examples ... [14s/10s] NOTE
Examples with CPU time > 2.5 times elapsed time
              user system elapsed ratio
groupingsets 4.613  0.144    0.98 4.854
```

Tested manually by setting `DTthreads` to `99` with a debugger, then running `system.time(example(groupingsets))`.