### PR TITLE
add general message for integer64 columns (issue #3611)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,8 @@
 
 4. `rowwiseDT()` now provides a helpful error message when a complex object that is not a list (e.g., a function) is provided as a cell value, instructing the user to wrap it in `list()`, [#7219](https://github.com/Rdatatable/data.table/issues/7219). Thanks @kylebutts for the report and @venom1204 for the fix.
 
+5. `fread()` now messages when integer64 columns are produced and reminds how to adjust via `integer64=`, [#3611](https://github.com/Rdatatable/data.table/issues/3611). Thanks @stefanfritsch for the report and @AmanKashyap0807 for the fix.
+
 ### Notes
 
 1. {data.table} now depends on R 3.5.0 (2018).

--- a/R/fread.R
+++ b/R/fread.R
@@ -313,6 +313,11 @@ yaml=FALSE, tmpdir=tempdir(), tz="UTC")
     set(ans, j = j, value = new_v)  # aside: new_v == v if the coercion was aborted
   }
   setattr(ans, "colClassesAs", NULL)
+  # message for integer64 columns #3611
+  hasInt64 = any(vapply_1b(ans, inherits, "integer64"))
+  if (hasInt64) {
+    messagef("fread() created integer64 columns; base R may not fully support them. Consider integer64= to choose another type.")
+  }
 
   if (stringsAsFactors) {
     if (is.double(stringsAsFactors)) { #2025

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -2610,7 +2610,7 @@ if (test_bit64) {
                    c=sample(c("foo","bar","baz"),n,replace=TRUE) )
   fwrite(DT,f<-tempfile())
   test(897, class(DT$b), "integer64")
-  test(898, fread(f), DT)
+  test(898, suppressMessages(fread(f)), DT)  #3611 message not under test
   unlink(f)
   DT[ , a2 := as.integer64(a)][112L, a2 := as.integer64(12345678901234)]   # start on row 112 to avoid the first 100
   DT[ , a3 := as.double(a)   ][113L, a3 := 3.14]
@@ -2620,9 +2620,9 @@ if (test_bit64) {
   DT[ , r := a/100]
   DT[ , r2 := as.character(r)][117L, r2 := "3.14A"]
   fwrite(DT,f<-tempfile())
-  test(899.1, fread(f, verbose=TRUE), DT, output="Rereading 6 columns.*out-of-sample.*Column 4.*a2.*int32.*int64.*<<12345678901234>>.*Column 10.*r2.*float64.*string.*<<3.14A>>")
-  test(899.2, fread(f, colClasses=list(character=c("a4","b3","r2"), integer64="a2", double=c("a3","b2")), verbose=TRUE),
-              DT, output="Rereading 0 columns due to out-of-sample type exceptions")
+  test(899.1, suppressMessages(fread(f, verbose=TRUE)), DT, output="Rereading 6 columns.*out-of-sample.*Column 4.*a2.*int32.*int64.*<<12345678901234>>.*Column 10.*r2.*float64.*string.*<<3.14A>>")  # message regards integer64 creation #3611
+  test(899.2, suppressMessages(fread(f, colClasses=list(character=c("a4","b3","r2"), integer64="a2", double=c("a3","b2")), verbose=TRUE)),
+              DT, output="Rereading 0 columns due to out-of-sample type exceptions") 
   test(899.3, fread(f, integer64="character", select=c("a","b","c")), DT[, .(a, b=as.character(b), c)])
   # leaving integer64='character' version of 899.1,899.2 until #2749 is fixed
   unlink(f)
@@ -2993,13 +2993,13 @@ DT = data.table( A=as.character(x), B=1:100)
 DT[115, A:="123456789123456"]  # row 115 is outside the 100 rows at 10 points.
 fwrite(DT,f<-tempfile())
 if (test_bit64) {
-  test(1016.1, sapply(fread(f,verbose=TRUE),"class"), c(A="integer64", B="integer"),
+  test(1016.1, sapply(suppressMessages(fread(f,verbose=TRUE)),"class"), c(A="integer64", B="integer"),  # message regarding integer64 creation (#3611)
                output="Rereading 1 columns.*Column 1.*A.*bumped.*int32.*int64.*<<123456789123456>>")
 }
 test(1016.2, fread(f, colClasses = c(A="numeric"), verbose=TRUE), copy(DT)[,A:=as.numeric(A)], output="Rereading 0 columns")
 DT[90, A:="321456789123456"]   # inside the sample
 write.table(DT,f,sep=",",row.names=FALSE,quote=FALSE)
-if (test_bit64) test(1017.1, fread(f), copy(DT)[,A:=as.integer64(A)])
+if (test_bit64) test(1017.1, suppressMessages(fread(f)), copy(DT)[,A:=as.integer64(A)])  #3611 not testing message here
 test(1017.2, fread(f, integer64="character"), DT)
 unlink(f)
 
@@ -3012,6 +3012,11 @@ test(1017.3, fread(f, integer64="numeric"), fread(f, colClasses=c("integer", "nu
 test(1017.4, fread(f, integer64="character"), fread(f, colClasses=c("integer", "character")))
 
 unlink(f)
+# general message for integer64 columns #3611
+if (test_bit64) {
+  test(1017.5, fread("A\n123456789123456\n"), data.table(A=as.integer64("123456789123456")), message="integer64")
+}
+test(1017.6, fread("A\n123456789123456\n", integer64="character"), data.table(A="123456789123456"))
 
 # ERANGE errno handled, #106 #4165
 test(1018.1, identical(fread("1.46761e-313\n"), data.table(V1=1.46761e-313)))
@@ -7113,12 +7118,13 @@ test(1499, ans1, ans2)
 
 # Fix for #488
 if (test_bit64) {
-  test(1500.1, fread("x,y\n3,\n", colClasses = list(integer64 = "y")),
-          data.table(x=3L, y=as.integer64(NA)))
+    test(1500.1, suppressMessages(fread("x,y\n3,\n", colClasses = list(integer64 = "y"))),
+      data.table(x=3L, y=as.integer64(NA)))  #3611 message not under test
   # more tests after new fix
-  test(1500.2, fread("x,y\n0,12345678901234\n0,\n0,\n0,\n0,\n,\n,\n,\n,\n,\n,\n,\n,\n,\n,\n,\n12345678901234,\n0,\n0,\n0,\n0,\n0,\n"),
-      data.table(x=as.integer64(c(rep(0L, 5L), rep(NA, 11), 12345678901234, rep(0L,5L))),
-                 y=as.integer64(c(12345678901234, rep(NA,21)))))
+    test(1500.2, fread("x,y\n0,12345678901234\n0,\n0,\n0,\n0,\n,\n,\n,\n,\n,\n,\n,\n,\n,\n,\n,\n12345678901234,\n0,\n0,\n0,\n0,\n0,\n"),
+        data.table(x = as.integer64(c(rep(0L, 5L), rep(NA, 11), 12345678901234, rep(0L,5L))),
+                   y = as.integer64(c(12345678901234, rep(NA,21)))),
+                   message = "integer64"   #3611 integer64 message expected)
 
   x = c("12345678901234", rep("NA", 178), "a")
   y = sample(letters, length(x), TRUE)


### PR DESCRIPTION
closes #3611

## Overview
PR addresses issue #3611 by adding a notification when `fread()` automatically creates `interger64` columns.

## Changes 
- fread.R : added a check to identify if any columns were read as integer64, if detected a message is emitted.
- tests.Rraw :  added new tests (1017.5 and 1017.6) to verify the message emitted.
updated existing tests that use `integer64` data to suppress this new message where it is not the focus of the test
- NEWS.md : added an entry under big fixes.

---

## Reproduction
issue #3611

env : windows 11, R 4.5.2, data.table 1.18.2.1 (installed from CRAN)

<img width="328" height="90" alt="Screenshot 2026-02-08 221821" src="https://github.com/user-attachments/assets/aa4c3682-6b14-41c8-9e14-3895dd43c258" />
<img width="468" height="193" alt="Screenshot 2026-02-08 221855" src="https://github.com/user-attachments/assets/9287c348-90d0-4d25-8a8a-757da8b72b87" />

 <p>fread() automatically creats interger64 columns when reading large instegers but does not emit any warning or message.</p>
 
---

I also reproduced the same behavior using the current github codebase (by compiliing data.table from source) , the behavious is identical 
<img width="817" height="97" alt="Screenshot 2026-02-09 051425" src="https://github.com/user-attachments/assets/f1a9af9b-f94c-455d-a43f-b553f0b6c7e5" />

<img width="470" height="215" alt="Screenshot 2026-02-09 050413" src="https://github.com/user-attachments/assets/c9f3cd98-4585-4888-9d5b-a136e3f253b5" />

---


