### PR TITLE
Fix fread clipboard handling on Windows (fixes #1292)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -40,7 +40,7 @@
 
 5. Non-equi joins combining an equality condition with two inequality conditions on the same column (e.g., `on = .(id == id, val >= lo, val <= hi)`) no longer error, [#7641](https://github.com/Rdatatable/data.table/issues/7641). The internal `chmatchdup` remapping of duplicate `rightcols` was overwriting the original column indices, causing downstream code to reference non-existent columns. Thanks @tarun-t for the report and fix, and @aitap for the diagnosis.
 
-6. `fread("clipboard")` now works on Linux (via `xclip`, `xsel`, or `wl-paste`), macOS (via `pbpaste`), and Windows, [#1292](https://github.com/Rdatatable/data.table/issues/1292). Thanks @mbacou for the report, @ben-schwen for the suggestion, and @AmanKashyap0807 for the fix.
+`fread()` now supports reading from the system clipboard by passing `input="clipboard"`, implemented for Windows, macOS (via `pbpaste`), and Linux (via `wl-paste`, `xclip`, or `xsel`), [#1292](https://github.com/Rdatatable/data.table/issues/1292). Thanks @mbacou for the report, @ben-schwen and @aitab for the suggestion, and @AmanKashyap0807 for the fix.
 
 ### Notes
 

--- a/R/fread.R
+++ b/R/fread.R
@@ -63,21 +63,24 @@ yaml=FALSE, tmpdir=tempdir(), tz="UTC")
       # input is data itself containing at least one \n or \r
     } else if (startsWith(input, " ")) {
       stopf("input= contains no \\n or \\r, but starts with a space. Please remove the leading space, or use text=, file= or cmd=")
-    } else if (grepl("^clipboard(-[0-9]+)?$", tolower(input))) {
+    } else if (identical(tolower(input), "clipboard")) {
       os_type = .Platform$OS.type
       if (identical(os_type, "windows")) {
         clip = tryCatch(utils::readClipboard(),
           error = function(e) stopf("Reading clipboard failed on Windows: %s", conditionMessage(e))
         )
       } else if (identical(os_type, "unix")) {
-        sysname = Sys.info()[["sysname"]]
-        clip_cmd = if (identical(sysname, "Darwin")) {
+        # Valid on macOS, Linux, BSD, etc.
+        clip_cmd = if (nzchar(Sys.which("pbpaste"))) {
           "pbpaste"
-        } else if (identical(sysname, "Linux")) {
-          if (nzchar(Sys.which("wl-paste"))) "wl-paste --no-newline"
-          else if (nzchar(Sys.which("xclip"))) "xclip -o -selection clipboard"
-          else if (nzchar(Sys.which("xsel"))) "xsel --clipboard --output"
-          else stopf("Clipboard reading on Linux requires 'xclip', 'xsel', or 'wl-paste' to be installed and on PATH.")
+        } else if (nzchar(Sys.which("wl-paste"))) {
+          "wl-paste --no-newline"
+        } else if (nzchar(Sys.which("xclip"))) {
+          "xclip -o -selection clipboard"
+        } else if (nzchar(Sys.which("xsel"))) {
+          "xsel --clipboard --output"
+        } else {
+          stopf("Clipboard reading on Unix-like systems requires 'pbpaste', 'wl-paste', 'xclip', or 'xsel' to be installed.")
         }
         clip = tryCatch(system(clip_cmd, intern = TRUE),
           error = function(e) stopf("Reading clipboard failed: %s", conditionMessage(e))
@@ -88,11 +91,14 @@ yaml=FALSE, tmpdir=tempdir(), tz="UTC")
         }
       } else {
         warning("Clipboard reading is not supported on this platform.", call. = FALSE)
+        return(data.table())
       }
       if (!length(clip) || !any(nzchar(trimws(clip)))) {
         stopf("Clipboard is empty.")
       }
-      input = paste(clip, collapse = "\n")
+      writeLines(clip, tmpFile <- tempfile(tmpdir=tmpdir))
+      file = tmpFile
+      on.exit(unlink(tmpFile), add=TRUE)
     } else if (length(grep(' ', input, fixed=TRUE)) && !file.exists(gsub("^file://", "", input))) {  # file name or path containing spaces is not a command. file.exists() doesn't understand file:// (#7550)
       cmd = input
       if (input_has_vars && getOption("datatable.fread.input.cmd.message", TRUE)) {

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -21526,7 +21526,7 @@ if (.Platform$OS.type == "windows") local({
   temp = c("a\tb", "1\t2")
   utils::writeClipboard(temp)
   on.exit(utils::writeClipboard(""), add = TRUE)
-  test(2366, fread("clipboard-128"), data.table(a = 1L, b = 2L))
+  test(2366, fread("clipboard"), data.table(a = 1L, b = 2L))
 })
 
 # Test fread clipboard input on macOS (issue #1292)


### PR DESCRIPTION
Closes #1292

Fix fread clipboard handling on Windows using `readClipboard()`, add test (#2366), and update NEWS.

Changed files :
- **R/fread.R**  :  Added logic to detect `clipboard` inputs on Windows, reading it by using readClipboard(), handle errors and process clipboard content as a temporary file for parsing.
- **inst/tests/tests.Rraw :** Added test 2366 for clipboard functionality.
- Updated **NEWS.md** with a brief entry under BUG FIXES.

To keep the scope of issue #1292, I only solved it for Windows. I'd be happy to submit another PR for macOS and Linux later.

Reproduction:

```r
# Write tab delimited data to clipboard
writeLines("a\tb\n1\t4\n2\t5\n3\t6\n", "clipboard")

# read.delim works
read.delim("clipboard-128")
# [1] read.delim.clipboard.128.
# <0 rows> (or 0-length row.names)
# Warning message:
# In read.table(file = file, header = header, sep = sep, quote = quote,  :
#   incomplete final line found by readTableHeader on 'clipboard'

# fread fails
library(data.table)
fread("clipboard-128")
# Error in fread("clipboard-128") : 
#   File 'clipboard-128' does not exist or is non-readable. getwd()=='D:/OpenSource/data.table'
```
`fread()` does not recognize `"clipboard"` / `"clipboard-128"` as clipboard input on Windows. Due to the long period since the issue was reported, there might have been some changes in fread() over time, which is why the error message differs now, but the core problem is the same, clipboard input is not detected.

Environment:
- OS: Windows
- R: 4.5.2

Please let me know if any changes are needed.