### PR TITLE
Document how j results are combined with by via rbindlist (issue #7643)

### DIFF
--- a/man/data.table.Rd
+++ b/man/data.table.Rd
@@ -97,7 +97,7 @@ data.table(\dots, keep.rownames=FALSE, check.names=FALSE, key=NULL, stringsAsFac
 
     See \href{../doc/datatable-intro.html}{\code{vignette("datatable-intro")}} and \code{example(data.table)}.}
 
-    \item{by}{ Column names are seen as if they are variables (as in \code{j} when \code{with=TRUE}). The \code{data.table} is then grouped by the \code{by} and \code{j} is evaluated within each group. The order of the rows within each group is preserved, as is the order of the groups. The results are combined using \code{\link{rbindlist}}. \code{by} accepts:
+    \item{by}{ Column names are seen as if they are variables (as in \code{j} when \code{with=TRUE}). The \code{data.table} is then grouped by the \code{by} and \code{j} is evaluated within each group. The order of the rows within each group is preserved, as is the order of the groups. The results are combined using \code{\link{rbindlist}} with \code{use.names=FALSE}. \code{by} accepts:
 
     \itemize{
         \item A single unquoted column name: e.g., \code{DT[, .(sa=sum(a)), by=x]}


### PR DESCRIPTION
This PR updates the `?data.table` documentation to clarify how per‑group `j` results are combined when `by` is used.

The new paragraph explains that `j` is evaluated once per group and the results are bound row‑wise using `rbindlist` with `use.names = FALSE`, so columns are matched by position and the first group’s column names are kept. This makes the behavior in cases like #7643 explicit.

A small test in `tests/by-rbindlist-use-names-false.R` is given to capture the current behavior so the documentation and implementation stay in sync.

Closes #7643.

