### PR TITLE
Add issue template for revdep check failures

### DIFF
--- a/.github/ISSUE_TEMPLATE/revdep-check-failure.md
+++ b/.github/ISSUE_TEMPLATE/revdep-check-failure.md
@@ -1,126 +1,45 @@
 ---
-
 name: Revdep check failure
-
 about: Contact a reverse dependency maintainer about a new check failure caused by data.table changes
-
-title: "\[revdep] YOUR\_PACKAGE: new check failure with data.table master"
-
-labels: \[]
-
-assignees: \[]
-
+title: "[revdep] YOUR_PACKAGE: new check failure with data.table master"
+labels: []
+assignees: []
 ---
-
-
-
 Hi @MAINTAINER,
-
-
-
-After installing \*\*data.table\*\* from GitHub master
-
-
-
+After installing **data.table** from GitHub master
 ```r
-data.table::update\_dev\_pkg()
+data.table::update_dev_pkg()
 ```
-
-
-
-and then running `R CMD check` on \*\*YOUR\_PACKAGE\*\*, I get the following new failure, which is \*\*not present\*\* when using data.table from CRAN.
-
-
-
-
-
-\## Package and environment
-
-
-
-\- Package: YOUR\_PACKAGE
-
-\- Package version: YOUR\_PACKAGE\_VERSION
-
-\- R version(s): R\_RELEASE\_AND\_OR\_R\_DEVEL
-
-\- data.table versions:
-
-  - CRAN: DT\_CRAN\_VERSION
-
-  - GitHub master: DT\_MASTER\_SHA\_OR\_VERSION
-
-\- Platform: OS / architecture (for example, linux-x86\_64)
-
-
-
-\## Related data.table issue and commit
-
-
-
-We track this revdep failure in the data.table issue tracker here:
-
-
-
-\- Data.table issue: https://github.com/Rdatatable/data.table/issues/REVDEP\_ISSUE\_NUMBER
-
-\- First bad commit (from revdep checks): https://github.com/Rdatatable/data.table/commit/FIRST\_BAD\_COMMIT\_SHA
-
-
-
-
-
-\## Check output
-
-
-
+and then running `R CMD check` on **YOUR_PACKAGE**, I get the following new failure, which is **not present** when using data.table from CRAN.
+## Package and environment
+- Package: YOUR_PACKAGE
+- Package version: YOUR_PACKAGE_VERSION
+- R version(s): R_RELEASE_AND_OR_R_DEVEL
+- data.table versions:
+  - CRAN: DT_CRAN_VERSION
+  - GitHub master: DT_MASTER_SHA_OR_VERSION
+- Platform: OS / architecture (for example, linux-x86_64)
+## Related data.table issue and commit
+- Data.table issue: https://github.com/Rdatatable/data.table/issues/REVDEP_ISSUE_NUMBER
+- First bad commit (from revdep checks): https://github.com/Rdatatable/data.table/commit/FIRST_BAD_COMMIT_SHA
+## Check output
 Below is the relevant part of the failing check log:
-
-
-
 ```text
-OUTPUT\_FROM\_FAILING\_CHECK
+OUTPUT_FROM_FAILING_CHECK
 ```
-
-
-
-\## Suggested fix
-
-
-
-Before uploading new versions to CRAN, \*\*data.table\*\* needs to ensure that updates do not break CRAN checks in dependent packages like \*\*YOUR\_PACKAGE\*\*. So can you please submit an updated version of \*\*YOUR\_PACKAGE\*\* to CRAN that fixes this check issue?
-
-
-
+## Suggested fix
+Before uploading new versions to CRAN, **data.table** needs to ensure that updates do not break CRAN checks in dependent packages like **YOUR_PACKAGE**. So can you please submit an updated version of **YOUR_PACKAGE** to CRAN that fixes this check issue?
 In particular, I would suggest to avoid
+> DOING_WHAT_YOU_ARE_DOING_CURRENTLY
+...
+> DOING_SOMETHING_MORE_ROBUST.
+## Additional context (optional)
+- Minimal reproducible example, if available.
+- Links to previous revdep check runs or CRAN check results for YOUR_PACKAGE.
+- Any notes that might help debug.
 
 
 
-> DOING\_WHAT\_YOU\_ARE\_DOING\_CURRENTLY
-
-
-
-and instead
-
-
-
-> DOING\_SOMETHING\_MORE\_ROBUST.
-
-
-
-(If we have a more specific suggestion or PR, we will add it here.)
-
-
-
-\## Additional context (optional)
-
-
-
-\- Minimal reproducible example, if available.
-
-\- Links to previous revdep check runs or CRAN check results for YOUR\_PACKAGE.
-
-\- Any notes that might help debug.
 
 
 


### PR DESCRIPTION
Fixes #7658.

This PR adds an issue template at
`.github/ISSUE_TEMPLATE/revdep-check-failure.md` for reporting
revdep (reverse dependency) check failures that should be fixed
before the next CRAN release.

The template is based on the "revdep issue template" wiki page and
the "Revdep checks" wiki page. It keeps the existing text used to
contact revdep maintainers (MAINTAINER, YOUR_PACKAGE,
REVDEP_ISSUE_NUMBER, etc.) and adds structured sections for
package/environment info, the related data.table issue and first
bad commit, and the failing check output.
