### PR TITLE
macos CI: let openmp curl fail graciously

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -80,20 +80,14 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           if clang --version | grep 'clang version 17'; then
-            if ! openmp_tarball=$(
-              apple_clang_series=$(clang --version | sed -nE 's/.*\(clang-([0-9]{4})\..*/\1/p')
-              APPLE_CLANG_SERIES="${apple_clang_series}" \
-              curl --fail --location --retry 3 --retry-all-errors --connect-timeout 20 --max-time 180 \
-                https://mac.r-project.org/openmp/ |
-              perl -0ne 'if (m{<tr>\s*<td[^>]*>.*?Apple clang \Q$ENV{APPLE_CLANG_SERIES}\E\.x.*?</td>\s*<td[^>]*>.*?<a[^>]*href="(openmp-[^"]+-darwin[^"]*-Release\.tar\.gz)"[^>]*>}si) { print $1; exit 0 } exit 1;'
-            ); then
-              echo "Failed to resolve OpenMP runtime from https://mac.r-project.org/openmp/"
-              exit 1
+            openmp_tarball=openmp-19.1.5-darwin20-Release.tar.gz
+            if curl --fail --location --retry 3 --retry-all-errors --connect-timeout 20 --max-time 180 \
+              -O "https://mac.r-project.org/openmp/${openmp_tarball}"; then
+              sudo tar fvxz "${openmp_tarball}" -C /
+              rm -f "${openmp_tarball}"
+            else
+              echo "Warning: failed to fetch OpenMP runtime from https://mac.r-project.org/openmp/; continuing without it"
             fi
-            curl --fail --location --retry 3 --retry-all-errors --connect-timeout 20 --max-time 180 \
-              -O "https://mac.r-project.org/openmp/${openmp_tarball}"
-            sudo tar fvxz "${openmp_tarball}" -C /
-            rm -f "${openmp_tarball}"
           fi # otherwise R-bundled runtime is fine
 
       - name: Install dependencies


### PR DESCRIPTION
Follows #7318

~Fixes macOS CI by selecting the OpenMP runtime from [mac.r-project.org/openmp/](mac.r-project.org/openmp/) for the detected Apple clang version.
Avoids breakage when the pinned tarball changes (which it apparently does often for the new clang version).~

The pinned OpenMP tarball still appears to exist, but GitHub Actions runners are timing out when connecting to [mac.r-project.org](mac.r-project.org). This change fails gracefully and falls back when the runtime cannot be fetched.