### PR TITLE
Two more fixes for non-UTF-8 tests

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -13506,7 +13506,7 @@ alloc.col(ans)
 test(1965.3, setDT(list(1:2, M)), ans, warning='Some columns are a multi-column type.*for example column 2')
 
 # fread/fwrite file name in native and utf-8 encoding, #3078
-if (.Platform$OS.type=="windows") {
+if (.Platform$OS.type=="windows" && utf8_check("\u00c3\u00b6\u00fc")) {
   f = tempfile("\u00f6"); cat("3.14", file = f)
   fn = enc2native(f); f8 = enc2utf8(f)
   test(1966.1, fread(fn), data.table(V1=3.14))

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -4243,7 +4243,7 @@ test(1163, last(x), character(0))
 # Bug fix for #5159 - chmatch and character encoding (for some reason this seems to pass the test on a mac as well)
 a = c("a","\u00E4","\u00DF","z")
 au = iconv(a,"UTF8","latin1")
-test(1164.1, requires_utf8=c("\u00E4", "\u00DF"), chmatch(a, au), match(a, au))
+test(1164.1, chmatch(a, au), match(a, au))
 
 # Bug fix for #73 - segfault when rbindlist on empty data.tables
 x <- as.data.table(BOD)


### PR DESCRIPTION
Tests `1966.*` failed on my Windows 7 VM where I test `data.table` with old versions of R. `ö` cannot be represented in CP1251, and `enc2native()` converted it to a plain unaccented `o`. If the characters cannot be represented in the ANSI encoding, we might as well skip the tests. (What if it returns `NA` or `?` on a different system?)

Test `1164.1` shouldn't require the characters to be represented in the native encoding, because it only uses UTF-8 and Latin-1. Both `match()` and `chmatch()` offer a strong enough guarantee. Tested on the same Windows 7 VM, and also using `LC_ALL=zh_CN.gb2312 luit R CMD check` (GB2312 doesn't have `ä` or `ß`) and `LC_ALL=C` on GNU/Linux.