### PR TITLE
Improved verbosity of data.table:::test() function for mismatched expected warnings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,8 @@
 
 9. `fread()` no longer replaces a literal header column name `"NA"` with an auto-generated `Vn` name when `na.strings` includes `"NA"`, [#5124](https://github.com/Rdatatable/data.table/issues/5124). Data rows still continue to parse `"NA"` as missing. Thanks @Mashin6 for the report and @shrektan for the fix.
 
+10. `test()` now reports multiple expected warnings more clearly when `warning=` has length greater than 1L, instead of printing a collapsed or repeated mismatch summary after messages like `Test 1 produced 1 warnings but expected 2`, [#7092](https://github.com/Rdatatable/data.table/issues/7092). Expected and observed warnings are now printed on separate aligned lines, making small differences easier to spot. Thanks @MichaelChirico for the report,@ben-schwen for assistance, and @lucaslarson25 @tjdavis51 @D3VTHSTVR @car723 for the fix.
+
 ### Notes
 
 1. {data.table} now depends on R 3.5.0 (2018).

--- a/NEWS.md
+++ b/NEWS.md
@@ -50,7 +50,7 @@
 
 9. `fread()` no longer replaces a literal header column name `"NA"` with an auto-generated `Vn` name when `na.strings` includes `"NA"`, [#5124](https://github.com/Rdatatable/data.table/issues/5124). Data rows still continue to parse `"NA"` as missing. Thanks @Mashin6 for the report and @shrektan for the fix.
 
-10. `test()` now reports multiple expected warnings more clearly when `warning=` has length greater than 1L, instead of printing a collapsed or repeated mismatch summary after messages like `Test 1 produced 1 warnings but expected 2`, [#7092](https://github.com/Rdatatable/data.table/issues/7092). Expected and observed warnings are now printed on separate aligned lines, making small differences easier to spot. Thanks @MichaelChirico for the report,@ben-schwen for assistance, and @lucaslarson25 @tjdavis51 @D3VTHSTVR @car723 for the fix.
+10. `test()` now reports multiple expected warnings more clearly when `warning=` has length greater than 1L, instead of printing a collapsed or repeated mismatch summary after messages like `Test 1 produced 1 warnings but expected 2`, [#7092](https://github.com/Rdatatable/data.table/issues/7092). Expected and observed warnings are now printed on separate aligned lines, making small differences easier to spot. Thanks @MichaelChirico for the report, @ben-schwen for assistance, and @lucaslarson25, @tjdavis51, @D3VTHSTVR, and @car723 for the fix.
 
 ### Notes
 

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -576,7 +576,16 @@ test = function(num, x, y=TRUE,
     }
     if (length(expected) != length(observed) && (!foreign || is.null(ignore.warning))) {
       # nocov start
-      catf("Test %s produced %d %ss but expected %d\n%s\n%s\n", numStr, length(observed), type, length(expected), paste("Expected:", expected), paste("Observed:", observed, collapse = "\n"))
+      align_messages = function(label, x) paste(
+        c(
+          paste0(label, x[1L]),
+          if (length(x) > 1L) paste0(strrep(" ", nchar(label)), x[-1L])
+        ),
+        collapse = "\n"
+      )
+      expected_text = align_messages("Expected: ", expected)
+      observed_text = align_messages("Observed: ", observed)
+      catf("Test %s produced %d %ss but expected %d\n%s\n%s\n", numStr, length(observed), type, length(expected), expected_text, observed_text)
       fail = TRUE
       # nocov end
     } else if (!foreign) {

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -21583,3 +21583,9 @@ close(con)
 file.create(f <- tempfile())
 test(2367.6, fread(file(f)), data.table(), warning="Connection has size 0.")
 unlink(f)
+
+# multiple expected/observed warnings in test() are printed on aligned lines, #7092
+test(2368.1, test(0, {warning("a"); 2L}, 2L, warning=c("a", "b")), FALSE,
+             output="Test 0 produced 1 warnings but expected 2\nExpected: a\n          b\nObserved: a")
+test(2368.2, test(0, {warning("a"); warning("b"); 2L}, 2L, warning="a"), FALSE,
+             output="Test 0 produced 2 warnings but expected 1\nExpected: a\nObserved: a\n          b")


### PR DESCRIPTION
Closes #7092.

Previously, the data.table:::test() function would print out expected warnings separately:
```
data.table:::test(1, {warning('a'); 2}, 2, warning=c('a', 'b'))
# Test 1 produced 1 warnings but expected 2
# Expected: a
# Observed: a
#  Test 1 produced 1 warnings but expected 2
# Expected: b
# Observed: a
```
This was caused by using paste() with the array of expected warnings. To fix this, we collapse these arrays using a new function `align_messages`.
This behavior was caused by multiple expected warnings, or multiple observed warnings in the test function.
Now the test function will output multiple expected and/or observed warnings correctly:
```
data.table:::test(1, {warning('a'); 2}, 2, warning=c('a', 'b'))
# Test 1 produced 1 warnings but expected 2
# Expected: a
#           b
# Observed: a
```

Also, created new tests in inst/tests/tests.Rraw file as well as updated the NEWS.md file.