### PR TITLE
Remove setnafill() invalid input error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -62,6 +62,8 @@
 
 6. Enhanced tests for OpenMP support, detecting incompatibilities such as R-bundled runtime _vs._ newer Xcode and testing for a manually installed runtime from <https://mac.r-project.org/openmp>, [#6622](https://github.com/Rdatatable/data.table/issues/6622). Thanks to @dvg-p4 for initial report and testing, @twitched for the pointers, @tdhock and @aitap for the fix.
 
+7. setnafill() old non-numeric input error message removed from all .po and .pot files.[#7449](https://github.com/Rdatatable/data.table/issues/7449) This reduces clutter and improves file readability, while keeping the new errors in place.  Thanks to @MichaelChirico for the issue and @deh277 for the fix.
+
 ## data.table [v1.18.2.1](https://github.com/Rdatatable/data.table/milestone/44?closed=1)  (22 January 2026)
 
 ### BUG FIXES

--- a/po/data.table.pot
+++ b/po/data.table.pot
@@ -3296,9 +3296,6 @@ msgid ""
 "data.table"
 msgstr ""
 
-#: nafill.c:117 nafill.c:128
-msgid "'x' argument must be numeric type, or list/data.table of numeric types"
-msgstr ""
 
 #: nafill.c:185
 msgid ""

--- a/po/es.po
+++ b/po/es.po
@@ -4024,11 +4024,6 @@ msgstr ""
 " El argumento 'x' es un vector atómico, la actualización in situ solo se "
 "admite para list/data.table"
 
-#: nafill.c:117 nafill.c:128
-msgid "'x' argument must be numeric type, or list/data.table of numeric types"
-msgstr ""
-"'x' argumento debe ser de tipo numérico, o lista/datos.tabla de tipos "
-"numéricos"
 
 #: nafill.c:185
 msgid ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -4128,12 +4128,6 @@ msgstr ""
 "l'argument 'x' est un vecteur atomique, la mise à jour sur place n'est "
 "possible que pour list/data.table"
 
-#: nafill.c:117 nafill.c:128
-msgid "'x' argument must be numeric type, or list/data.table of numeric types"
-msgstr ""
-"l'argument 'x' doit être un type numérique ou une liste/data.table de types "
-"numériques"
-
 #: nafill.c:185
 msgid ""
 "fill must be a vector of length 1 or a list of length of x. Consider "

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -4023,12 +4023,6 @@ msgstr ""
 "argumento 'x' é um vetor atômico, a atualização no local é suportada apenas "
 "para list/data.table"
 
-#: nafill.c:117 nafill.c:128
-msgid "'x' argument must be numeric type, or list/data.table of numeric types"
-msgstr ""
-"argumento 'x' deve ser do tipo numérico ou uma lista/data.table de tipos "
-"numéricos"
-
 #: nafill.c:185
 msgid ""
 "fill must be a vector of length 1 or a list of length of x. Consider "

--- a/po/ru.po
+++ b/po/ru.po
@@ -4020,10 +4020,6 @@ msgstr ""
 "Аргумент 'x' - атомарный вектор; обновление на месте поддерживается только "
 "для списка/data.table"
 
-#: nafill.c:117 nafill.c:128
-msgid "'x' argument must be numeric type, or list/data.table of numeric types"
-msgstr ""
-"Аргумент 'x' должен быть численным или списком/data.table численных векторов"
 
 #: nafill.c:185
 msgid ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -3801,10 +3801,6 @@ msgid ""
 "data.table"
 msgstr "参数'x'是一个原子型矢量，原位的更新只为list 或 data.table提供"
 
-#: nafill.c:117 nafill.c:128
-msgid "'x' argument must be numeric type, or list/data.table of numeric types"
-msgstr "参数'x'必须是数字类型，或者是数字类型的list/data.table"
-
 #: nafill.c:185
 #, fuzzy
 #| msgid "fill must be a vector of length 1 or a list of length of x"


### PR DESCRIPTION
Closes #7449 

Removed an unused error message from the po and pot files so they are less cluttered and more accurate. The error message removed (“‘x’ argument must be numeric type, or list/data.table of numeric types") is no longer being used since #3992 has changed nafill to allow non-numeric types. We made sure to run the test suite on our repository and everything passed on our end. 

Worked on by @deh277 and @shantz14