### PR TITLE
`fread`: avoid UB in leap year cycle calculation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,8 @@
 
 9. `fread()` no longer replaces a literal header column name `"NA"` with an auto-generated `Vn` name when `na.strings` includes `"NA"`, [#5124](https://github.com/Rdatatable/data.table/issues/5124). Data rows still continue to parse `"NA"` as missing. Thanks @Mashin6 for the report and @shrektan for the fix.
 
+10. `fread()` no longer misreads dates with negative years, [#7704](https://github.com/Rdatatable/data.table/issues/7704). Thanks to @kevinushey for the report and @aitap for the fix.
+
 ### Notes
 
 1. {data.table} now depends on R 3.5.0 (2018).

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -21587,4 +21587,7 @@ test(2367.6, fread(file(f)), data.table(), warning="Connection has size 0.")
 unlink(f)
 
 # negative years caused UB in leap year calculation, #7704
-test(2368, format(fread("a\n-1-01-01")$a), "-1-01-01")
+x = fread("x\n-1-01-01")$x
+test(2368.1, year(x), -1L)
+test(2368.2, month(x), 1L)
+test(2368.3, mday(x),  1L)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -21585,3 +21585,6 @@ close(con)
 file.create(f <- tempfile())
 test(2367.6, fread(file(f)), data.table(), warning="Connection has size 0.")
 unlink(f)
+
+# negative years caused UB in leap year calculation, #7704
+test(2368, format(fread("a\n-1-01-01")$a), "-1-01-01")

--- a/src/fread.c
+++ b/src/fread.c
@@ -1087,9 +1087,13 @@ static void parse_iso8601_date_core(const char **pch, int32_t *target)
   if (day == NA_INT32 || day < 1 || (day > (isLeapYear ? leapYearDays[month - 1] : normYearDays[month - 1])))
     return;
 
+  int32_t cycle_year = year % 400;
+  if (cycle_year < 0) cycle_year += 400;
+  int32_t cycle = (year - cycle_year) / 400;
+
   *target =
-    (year / 400 - 4) * cumDaysCycleYears[400] + // days to beginning of 400-year cycle
-    cumDaysCycleYears[year % 400] + // days to beginning of year within 400-year cycle
+    (cycle - 4) * cumDaysCycleYears[400] + // days to beginning of 400-year cycle
+    cumDaysCycleYears[cycle_year] + // days to beginning of year within 400-year cycle
     (isLeapYear ? cumDaysCycleMonthsLeap[month - 1] : cumDaysCycleMonthsNorm[month - 1]) + // days to beginning of month within year
     day - 1; // day within month (subtract 1: 1970-01-01 -> 0)
 


### PR DESCRIPTION
Use the fix suggested by @kevinushey. Since R's `Date` class (and thus IDate) uses [year zero](https://en.wikipedia.org/wiki/Year_zero), the resulting calculations agree with the system tzcode, although the `Date` class generally doesn't like to parse negative years:

```
$ TZ=UTC LC_ALL=C date -d '0004-02-29 -8year 12:00:00'
Thu Feb 29 12:00:00 UTC -004
$ R -q -s -e 'data.table::fread("-4-02-29 12:00:00\n")'
         V1       V2
     <IDat>   <char>
1: -4-02-29 12:00:00
```

Fixes: #7704