### PR TITLE
Added an accessor for `integer64`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -66,6 +66,8 @@
 
 6. Enhanced tests for OpenMP support, detecting incompatibilities such as R-bundled runtime _vs._ newer Xcode and testing for a manually installed runtime from <https://mac.r-project.org/openmp>, [#6622](https://github.com/Rdatatable/data.table/issues/6622). Thanks to @dvg-p4 for initial report and testing, @twitched for the pointers, @tdhock and @aitap for the fix.
 
+7. `integer64` type from {bit64} now has `INTEGER64` and `INTEGER64_RO` accessors in `src/data.table.h` to avoid direct casts and inconsistency issues, providing a standardized accessor to improve readability, [#7618](https://github.com/Rdatatable/data.table/issues/7618). Thanks @MichaelChirico and @ben-schwen for the report, @aksh08022006 and @aitap for assistance, and @brycepanza, @cjl525, @ProjectsByFerm, and @lacyhamilton for the fix.
+
 ## data.table [v1.18.2.1](https://github.com/Rdatatable/data.table/milestone/44?closed=1)  (22 January 2026)
 
 ### BUG FIXES

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -21,6 +21,8 @@
 #endif
 #include <Rinternals.h>
 #define SEXPPTR_RO(x) ((const SEXP *)DATAPTR_RO(x))  // to avoid overhead of looped STRING_ELT and VECTOR_ELT
+#define INTEGER64(x) ((int64_t *)REAL(x))
+#define INTEGER64_RO(x) ((const int64_t *)REAL_RO(x))
 #include <stdint.h>    // for uint64_t rather than unsigned long long
 #include <stdarg.h>    // for va_list, va_start
 #include <stdbool.h>


### PR DESCRIPTION
Closes #7618

Previously, the `integer64` type was used using direct casts that lead to inconsistency, such as:

`(const int64_t *)DATAPTR_RO(x)` and `(int64_t *)DATAPTR(x)` or
`(const int64_t *)REAL(x)` and `(int64_t *)REAL(x)`

This was due to R not natively supporting 64-bit integer type, requiring its definition in the {bit64} pacakge. The direct casting leads to styling differences.

To fix this, we added an accessor for `integer64` type in the `src/data.table.h` .

Now the datatype is accessible using `INTEGER64_RO` / `INTEGER64` to cast to cast from the `REAL_RO` and `REAL` accessors.
We also submitted this in the {bit64} repository for future implementation, they will be looking into this after their next release [#312](https://github.com/r-lib/bit64/issues/312).

Also, per this [comment](https://github.com/Rdatatable/data.table/issues/7618#issuecomment-4304007833) on our original issue we did not include new tests to `inst/tests/test.Rraw`, as our PR adds no new logic, as well as updated the `NEWS.md` file.