### PR TITLE
Provide R < 4.6 entry points for older versions of `data.table` in `atime` tests

### DIFF
--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -129,6 +129,77 @@ test.list <- atime::atime_test_list(
       "NAMESPACE",
       sprintf('useDynLib\\("?%s"?', Package_regex),
       paste0('useDynLib(', new.Package_))
+    backports = c(
+      "src/data.table.h" = '
+        #if R_VERSION >= R_Version(4, 6, 0)
+        // backports.c
+        void SETLENGTH(SEXP x, R_xlen_t n);
+        R_xlen_t TRUELENGTH(SEXP x);
+        void SET_TRUELENGTH(SEXP x, R_xlen_t n);
+        void SET_GROWABLE_BIT(SEXP);
+        int LEVELS(SEXP);
+        int NAMED(SEXP);
+        #define isFrame(x) isDataFrame(x)
+        #define GetOption(x, none) GetOption1(x)
+        #endif
+      ',
+      "src/backports.c" = '
+        #include "data.table.h"
+        #if R_VERSION >= R_Version(4, 6, 0)
+        #define NAMED_BITS 16
+        struct sxpinfo_struct {
+          SEXPTYPE type      :  TYPE_BITS; // in Rinternals.h
+          unsigned int scalar:  1;
+          unsigned int obj   :  1;
+          unsigned int alt   :  1;
+          unsigned int gp    : 16;
+          unsigned int mark  :  1;
+          unsigned int debug :  1;
+          unsigned int trace :  1;
+          unsigned int spare :  1;
+          unsigned int gcgen :  1;
+          unsigned int gccls :  3;
+          unsigned int named : NAMED_BITS;
+          unsigned int extra : 32 - NAMED_BITS;
+        };
+
+        struct vecsxp_struct {
+          R_xlen_t length;
+          R_xlen_t truelength;
+        };
+
+        typedef struct VECTOR_SEXPREC {
+          struct sxpinfo_struct sxpinfo;
+          SEXP attrib;
+          SEXP gengc_next_node, gengc_prev_node;
+          struct vecsxp_struct vecsxp;
+        } *VECSEXP;
+
+        void SETLENGTH(SEXP x, R_xlen_t n) {
+          ((VECSEXP)x)->vecsxp.length = n;
+        }
+        R_xlen_t TRUELENGTH(SEXP x) {
+          return ((VECSEXP)x)->vecsxp.truelength;
+        }
+        void SET_TRUELENGTH(SEXP x, R_xlen_t n) {
+          ((VECSEXP)x)->vecsxp.truelength = n;
+        }
+        void SET_GROWABLE_BIT(SEXP x) {
+          ((VECSEXP)x)->sxpinfo.gp |= 0x20;
+        }
+        int LEVELS(SEXP x) {
+          return ((VECSEXP)x)->sxpinfo.gp;
+        }
+        int NAMED(SEXP x) {
+          return ((VECSEXP)x)->sxpinfo.named;
+        }
+        #endif
+      ')
+    for (n in names(backports)) {
+      f = file(file.path(new.pkg.path, n), "a")
+      writeLines(backports[[n]], f)
+      close(f)
+    }
   },
 
   # Constant overhead improvement https://github.com/Rdatatable/data.table/pull/6925

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -148,6 +148,8 @@ test.list <- atime::atime_test_list(
         void SET_OBJECT(SEXP, int);
         #define isFrame(x) isDataFrame(x)
         #define GetOption(x, none) GetOption1(x)
+        #undef findVar // Rf_ mapping remains
+        #define findVar(sym, env) R_getVar(sym, env, FALSE)
         #endif
       ',
       "src/backports.c" = '

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -142,6 +142,8 @@ test.list <- atime::atime_test_list(
         void SET_GROWABLE_BIT(SEXP);
         int LEVELS(SEXP);
         int NAMED(SEXP);
+        SEXP ATTRIB(SEXP);
+        void SET_ATTRIB(SEXP, SEXP);
         #define isFrame(x) isDataFrame(x)
         #define GetOption(x, none) GetOption1(x)
         #endif
@@ -195,6 +197,12 @@ test.list <- atime::atime_test_list(
         }
         int NAMED(SEXP x) {
           return ((VECSEXP)x)->sxpinfo.named;
+        }
+        SEXP ATTRIB(SEXP x) {
+          return ((VECSEXP)x)->attrib;
+        }
+        void SET_ATTRIB(SEXP x, SEXP att) {
+          ((VECSEXP)x)->attrib = att;
         }
         #endif
       ')

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -158,6 +158,8 @@ test.list <- atime::atime_test_list(
         void SET_TYPEOF(SEXP, int);
         #define VECTOR_ELT(x, i) VECTOR_ELT_(x, i)
         SEXP VECTOR_ELT_(SEXP, R_xlen_t);
+        #define VECTOR_PTR(x) ((SEXP*)DATAPTR_RO(x))
+        #define DATAPTR(x) ((void*)DATAPTR_RO(x))
         #endif
       ',
       "src/backports.c" = '

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -143,6 +143,7 @@ test.list <- atime::atime_test_list(
         void SET_GROWABLE_BIT(SEXP);
         int LEVELS(SEXP);
         int NAMED(SEXP);
+        #define REFCNT(x) NAMED(x)
         SEXP ATTRIB(SEXP);
         void SET_ATTRIB(SEXP, SEXP);
         int OBJECT(SEXP);

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -155,6 +155,8 @@ test.list <- atime::atime_test_list(
         void SET_S4_OBJECT(SEXP);
         void UNSET_S4_OBJECT(SEXP);
         void SET_TYPEOF(SEXP, int);
+        #define VECTOR_ELT(x, i) VECTOR_ELT_(x, i)
+        SEXP VECTOR_ELT_(SEXP, R_xlen_t);
         #endif
       ',
       "src/backports.c" = '
@@ -231,6 +233,9 @@ test.list <- atime::atime_test_list(
         }
         void SET_TYPEOF(SEXP x, int type) {
           ((VECSEXP)x)->sxpinfo.type = type;
+        }
+        SEXP VECTOR_ELT_(SEXP x, R_xlen_t i) {
+          return ALTREP(x) ? (VECTOR_ELT)(x, i) : ((SEXP*)DATAPTR_RO(x))[i];
         }
         #endif
       ')

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -134,6 +134,7 @@ test.list <- atime::atime_test_list(
       "@PKG_CFLAGS@", "@PKG_CFLAGS@ -DSTRING_PTR_RO=STRING_PTR_RO")
     backports = c(
       "src/data.table.h" = '
+        #include <Rversion.h>
         #if R_VERSION >= R_Version(4, 6, 0)
         // backports.c
         void SETLENGTH(SEXP x, R_xlen_t n);

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -150,6 +150,10 @@ test.list <- atime::atime_test_list(
         #define GetOption(x, none) GetOption1(x)
         #undef findVar // Rf_ mapping remains
         #define findVar(sym, env) R_getVar(sym, env, FALSE)
+        #define STRING_PTR(x) ((SEXP *)STRING_PTR_RO(x))
+        int IS_S4_OBJECT(SEXP);
+        void SET_S4_OBJECT(SEXP);
+        void UNSET_S4_OBJECT(SEXP);
         #endif
       ',
       "src/backports.c" = '
@@ -213,6 +217,16 @@ test.list <- atime::atime_test_list(
         }
         void SET_ATTRIB(SEXP x, SEXP att) {
           ((VECSEXP)x)->attrib = att;
+        }
+        #define S4_OBJECT (1<<4)
+        int IS_S4_OBJECT(SEXP x) {
+          return ((VECSEXP)x)->sxpinfo.gp & S4_OBJECT;
+        }
+        void SET_S4_OBJECT(SEXP x) {
+          ((VECSEXP)x)->sxpinfo.gp |= S4_OBJECT;
+        }
+        void UNSET_S4_OBJECT(SEXP x) {
+          ((VECSEXP)x)->sxpinfo.gp &= ~S4_OBJECT;
         }
         #endif
       ')

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -154,6 +154,7 @@ test.list <- atime::atime_test_list(
         int IS_S4_OBJECT(SEXP);
         void SET_S4_OBJECT(SEXP);
         void UNSET_S4_OBJECT(SEXP);
+        void SET_TYPEOF(SEXP, int);
         #endif
       ',
       "src/backports.c" = '
@@ -227,6 +228,9 @@ test.list <- atime::atime_test_list(
         }
         void UNSET_S4_OBJECT(SEXP x) {
           ((VECSEXP)x)->sxpinfo.gp &= ~S4_OBJECT;
+        }
+        void SET_TYPEOF(SEXP x, int type) {
+          ((VECSEXP)x)->sxpinfo.type = type;
         }
         #endif
       ')

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -129,6 +129,9 @@ test.list <- atime::atime_test_list(
       "NAMESPACE",
       sprintf('useDynLib\\("?%s"?', Package_regex),
       paste0('useDynLib(', new.Package_))
+    pkg_find_replace(
+      file.path("src", "Makevars.*in"),
+      "@PKG_CFLAGS@", "@PKG_CFLAGS@ -DSTRING_PTR_RO=STRING_PTR_RO")
     backports = c(
       "src/data.table.h" = '
         #if R_VERSION >= R_Version(4, 6, 0)

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -144,6 +144,8 @@ test.list <- atime::atime_test_list(
         int NAMED(SEXP);
         SEXP ATTRIB(SEXP);
         void SET_ATTRIB(SEXP, SEXP);
+        int OBJECT(SEXP);
+        void SET_OBJECT(SEXP, int);
         #define isFrame(x) isDataFrame(x)
         #define GetOption(x, none) GetOption1(x)
         #endif
@@ -197,6 +199,12 @@ test.list <- atime::atime_test_list(
         }
         int NAMED(SEXP x) {
           return ((VECSEXP)x)->sxpinfo.named;
+        }
+        int OBJECT(SEXP x) {
+          return ((VECSEXP)x)->sxpinfo.obj;
+        }
+        void SET_OBJECT(SEXP x, int o) {
+          ((VECSEXP)x)->sxpinfo.obj = o;
         }
         SEXP ATTRIB(SEXP x) {
           return ((VECSEXP)x)->attrib;


### PR DESCRIPTION
Fixes: #7693

With these changes, `atime::atime_pkg()` passes for me on R-4.6.0 and R-devel.