### PR TITLE
Improved verbose messages in rolling functions frolladaptivefun and frollfun

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,12 +29,10 @@
 4. `dcast()` and `melt()` "just work" when passed a data.frame, not just data.tables, with no need for coercion, [#7614](https://github.com/Rdatatable/data.table/issues/7614). Thanks @MichaelChirico for the suggestion and @manmita for the PR. Note that to avoid potential conflicts with {reshape2}'s data.frame methods, we do the dispatch to the data.table method manually.
 
 5. `tables()` can now optionally report `data.table` objects stored one level deep inside list objects when `depth=1L`, [#2606](https://github.com/Rdatatable/data.table/issues/2606). Thanks @MichaelChirico for the report and @manmita for the PR
+6. 
+7. `yearqtr()` and `yearmon()` now gain an optional format specifier [#7694](https://github.com/Rdatatable/data.table/issues/7694). 'numeric' is the default, which preserves the original behavior, but 'character' formats `yearqtr()` as YYYYQ# (e.g. 2025Q2) and `yearmon()` as YYYYM## (e.g. 2025M02, 2025M10). Thanks to @jan-swissre for the report and @LunaticSage218 for the implementation.
 
-<<<<<<< HEAD
-6. `frolladaptivefun()` and `frollfun()` adjusted print statements for verbose messages to be more user friendly, [#7021](https://github.com/Rdatatable/data.table/issues/7021) Thanks @jangorecki for initiating the issue.
-=======
-6. `yearqtr()` and `yearmon()` now gain an optional format specifier [#7694](https://github.com/Rdatatable/data.table/issues/7694). 'numeric' is the default, which preserves the original behavior, but 'character' formats `yearqtr()` as YYYYQ# (e.g. 2025Q2) and `yearmon()` as YYYYM## (e.g. 2025M02, 2025M10). Thanks to @jan-swissre for the report and @LunaticSage218 for the implementation.
->>>>>>> be1b189a3d2ae59238c6bde09bf63296d8d849d9
+8. `frolladaptivefun()` and `frollfun()` adjusted print statements for verbose messages to be more user friendly, [#7021](https://github.com/Rdatatable/data.table/issues/7021) Thanks @jangorecki for initiating the issue.
 
 ### BUG FIXES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,7 +29,7 @@
 4. `dcast()` and `melt()` "just work" when passed a data.frame, not just data.tables, with no need for coercion, [#7614](https://github.com/Rdatatable/data.table/issues/7614). Thanks @MichaelChirico for the suggestion and @manmita for the PR. Note that to avoid potential conflicts with {reshape2}'s data.frame methods, we do the dispatch to the data.table method manually.
 
 5. `tables()` can now optionally report `data.table` objects stored one level deep inside list objects when `depth=1L`, [#2606](https://github.com/Rdatatable/data.table/issues/2606). Thanks @MichaelChirico for the report and @manmita for the PR
-   
+
 6. `yearqtr()` and `yearmon()` now gain an optional format specifier [#7694](https://github.com/Rdatatable/data.table/issues/7694). 'numeric' is the default, which preserves the original behavior, but 'character' formats `yearqtr()` as YYYYQ# (e.g. 2025Q2) and `yearmon()` as YYYYM## (e.g. 2025M02, 2025M10). Thanks to @jan-swissre for the report and @LunaticSage218 for the implementation.
 
 7. `frolladaptivefun()` and `frollfun()` adjusted print statements for verbose messages to be more user friendly, [#7021](https://github.com/Rdatatable/data.table/issues/7021) Thanks @jangorecki for initiating the issue.

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,10 +29,10 @@
 4. `dcast()` and `melt()` "just work" when passed a data.frame, not just data.tables, with no need for coercion, [#7614](https://github.com/Rdatatable/data.table/issues/7614). Thanks @MichaelChirico for the suggestion and @manmita for the PR. Note that to avoid potential conflicts with {reshape2}'s data.frame methods, we do the dispatch to the data.table method manually.
 
 5. `tables()` can now optionally report `data.table` objects stored one level deep inside list objects when `depth=1L`, [#2606](https://github.com/Rdatatable/data.table/issues/2606). Thanks @MichaelChirico for the report and @manmita for the PR
-6. 
-7. `yearqtr()` and `yearmon()` now gain an optional format specifier [#7694](https://github.com/Rdatatable/data.table/issues/7694). 'numeric' is the default, which preserves the original behavior, but 'character' formats `yearqtr()` as YYYYQ# (e.g. 2025Q2) and `yearmon()` as YYYYM## (e.g. 2025M02, 2025M10). Thanks to @jan-swissre for the report and @LunaticSage218 for the implementation.
+   
+6. `yearqtr()` and `yearmon()` now gain an optional format specifier [#7694](https://github.com/Rdatatable/data.table/issues/7694). 'numeric' is the default, which preserves the original behavior, but 'character' formats `yearqtr()` as YYYYQ# (e.g. 2025Q2) and `yearmon()` as YYYYM## (e.g. 2025M02, 2025M10). Thanks to @jan-swissre for the report and @LunaticSage218 for the implementation.
 
-8. `frolladaptivefun()` and `frollfun()` adjusted print statements for verbose messages to be more user friendly, [#7021](https://github.com/Rdatatable/data.table/issues/7021) Thanks @jangorecki for initiating the issue.
+7. `frolladaptivefun()` and `frollfun()` adjusted print statements for verbose messages to be more user friendly, [#7021](https://github.com/Rdatatable/data.table/issues/7021) Thanks @jangorecki for initiating the issue.
 
 ### BUG FIXES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -32,7 +32,7 @@
 
 6. `yearqtr()` and `yearmon()` now gain an optional format specifier [#7694](https://github.com/Rdatatable/data.table/issues/7694). 'numeric' is the default, which preserves the original behavior, but 'character' formats `yearqtr()` as YYYYQ# (e.g. 2025Q2) and `yearmon()` as YYYYM## (e.g. 2025M02, 2025M10). Thanks to @jan-swissre for the report and @LunaticSage218 for the implementation.
 
-7. `frolladaptivefun()` and `frollfun()` adjusted print statements for verbose messages to be more user friendly, [#7021](https://github.com/Rdatatable/data.table/issues/7021) Thanks @jangorecki for initiating the issue.
+7. Verbose outputs from `frolladaptivefun()` and `frollfun()` are now clearer and more user friendly [#7021](https://github.com/Rdatatable/data.table/issues/7021). Thanks to @Omartech312, @aidengseay, @kkarissa, and @heb229 for the implementation, to @ben-schwen for the review, and to @jangorecki for the extensive guidance and review.
 
 ### BUG FIXES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -30,7 +30,11 @@
 
 5. `tables()` can now optionally report `data.table` objects stored one level deep inside list objects when `depth=1L`, [#2606](https://github.com/Rdatatable/data.table/issues/2606). Thanks @MichaelChirico for the report and @manmita for the PR
 
+<<<<<<< HEAD
+6. `frolladaptivefun()` and `frollfun()` adjusted print statements for verbose messages to be more user friendly, [#7021](https://github.com/Rdatatable/data.table/issues/7021) Thanks @jangorecki for initiating the issue.
+=======
 6. `yearqtr()` and `yearmon()` now gain an optional format specifier [#7694](https://github.com/Rdatatable/data.table/issues/7694). 'numeric' is the default, which preserves the original behavior, but 'character' formats `yearqtr()` as YYYYQ# (e.g. 2025Q2) and `yearmon()` as YYYYM## (e.g. 2025M02, 2025M10). Thanks to @jan-swissre for the report and @LunaticSage218 for the implementation.
+>>>>>>> be1b189a3d2ae59238c6bde09bf63296d8d849d9
 
 ### BUG FIXES
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -32,8 +32,6 @@
 
 6. `yearqtr()` and `yearmon()` now gain an optional format specifier [#7694](https://github.com/Rdatatable/data.table/issues/7694). 'numeric' is the default, which preserves the original behavior, but 'character' formats `yearqtr()` as YYYYQ# (e.g. 2025Q2) and `yearmon()` as YYYYM## (e.g. 2025M02, 2025M10). Thanks to @jan-swissre for the report and @LunaticSage218 for the implementation.
 
-7. Verbose outputs from `frolladaptivefun()` and `frollfun()` are now clearer and more user friendly [#7021](https://github.com/Rdatatable/data.table/issues/7021). Thanks to @Omartech312, @aidengseay, @kkarissa, and @heb229 for the implementation, to @ben-schwen for the review, and to @jangorecki for the extensive guidance and review.
-
 ### BUG FIXES
 
 1. `fread()` with `skip=0` and `(header=TRUE|FALSE)` no longer skips the first row when it has fewer fields than subsequent rows, [#7463](https://github.com/Rdatatable/data.table/issues/7463). Thanks @emayerhofer for the report and @ben-schwen for the fix.
@@ -61,6 +59,8 @@
 5. `melt()` and `dcast()` no longer provide nudges when receiving incompatible inputs (e.g. data.frames). As of now, we only define methods for `data.table` inputs.
 
 6. Enhanced tests for OpenMP support, detecting incompatibilities such as R-bundled runtime _vs._ newer Xcode and testing for a manually installed runtime from <https://mac.r-project.org/openmp>, [#6622](https://github.com/Rdatatable/data.table/issues/6622). Thanks to @dvg-p4 for initial report and testing, @twitched for the pointers, @tdhock and @aitap for the fix.
+
+7. Verbose outputs from `frolladaptivefun()` and `frollfun()` are now clearer and more user friendly [#7021](https://github.com/Rdatatable/data.table/issues/7021). Thanks to @Omartech312, @aidengseay, @kkarissa, and @heb229 for the implementation, to @ben-schwen for the review, and to @jangorecki for the extensive guidance and review.
 
 ## data.table [v1.18.4](https://github.com/Rdatatable/data.table/milestone/45) (6 May 2026)
 

--- a/inst/tests/froll.Rraw
+++ b/inst/tests/froll.Rraw
@@ -310,7 +310,7 @@ test(6000.0671, frollmean(c(1:2,NA,4:10), 4), c(rep(NA_real_, 6), 5.5, 6.5, 7.5,
   "frollmeanFast: non-finite values are present in input, skip non-finite unaware attempt and run with extra care for NFs straighaway",
   "frollfun: processing fun MEAN algo fast took.*",
   "frollfunR: processing.*took.*"
-))  
+)) 
 test(6000.0672, frollmean(c(1:2,NA,4:10), 4, has.nf=FALSE), c(rep(NA_real_, 6), 5.5, 6.5, 7.5, 8.5), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*sequentially.*single rolling computation.*",

--- a/inst/tests/froll.Rraw
+++ b/inst/tests/froll.Rraw
@@ -310,7 +310,7 @@ test(6000.0671, frollmean(c(1:2,NA,4:10), 4), c(rep(NA_real_, 6), 5.5, 6.5, 7.5,
   "frollmeanFast: non-finite values are present in input, skip non-finite unaware attempt and run with extra care for NFs straighaway",
   "frollfun: processing fun MEAN algo fast took.*",
   "frollfunR: processing.*took.*"
-)) 
+))
 test(6000.0672, frollmean(c(1:2,NA,4:10), 4, has.nf=FALSE), c(rep(NA_real_, 6), 5.5, 6.5, 7.5, 8.5), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*sequentially.*single rolling computation.*",
@@ -319,7 +319,7 @@ test(6000.0672, frollmean(c(1:2,NA,4:10), 4, has.nf=FALSE), c(rep(NA_real_, 6), 
   "frollmeanFast: non-finite values are present in input, skip non-finite unaware attempt and run with extra care for NFs straighaway",
   "frollfun: processing fun MEAN algo fast took.*",
   "frollfunR: processing.*took.*"
-), warning="has.nf=FALSE used but non-finite values are present in input, use default has.nf=NA to avoid this warning")  
+), warning="has.nf=FALSE used but non-finite values are present in input, use default has.nf=NA to avoid this warning")
 test(6000.0673, frollmean(c(1:2,NA,4:10), 2, has.nf=FALSE), c(NA, 1.5, NA, NA, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*sequentially.*single rolling computation.*",
@@ -328,7 +328,7 @@ test(6000.0673, frollmean(c(1:2,NA,4:10), 2, has.nf=FALSE), c(NA, 1.5, NA, NA, 4
   "frollmeanFast: non-finite values are present in input, re-running with extra care for NFs",
   "frollfun: processing fun MEAN algo fast took.*",
   "frollfunR: processing.*took.*"
-), warning="has.nf=FALSE used but non-finite values are present in input, use default has.nf=NA to avoid this warning")  
+), warning="has.nf=FALSE used but non-finite values are present in input, use default has.nf=NA to avoid this warning")
 test(6000.0674, frollmean(c(1:2,NA,4:10), 4, align="center"), c(rep(NA_real_, 4), 5.5, 6.5, 7.5, 8.5, NA, NA), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*sequentially.*single rolling computation.*",
@@ -337,7 +337,7 @@ test(6000.0674, frollmean(c(1:2,NA,4:10), 4, align="center"), c(rep(NA_real_, 4)
   "frollfun: align 0, shift answer by -2",
   "frollfun: processing fun MEAN algo fast took.*",
   "frollfunR: processing.*took.*"
-))  
+))
 options(datatable.verbose=FALSE)
 
 #### fill constant
@@ -438,7 +438,7 @@ test(6000.1196, frollmean(c(1:5,NA), 1:6, algo="exact", na.rm=TRUE, adaptive=TRU
   "frolladaptivemeanExact: non-finite values are present in input, re-running with extra care for NFs",
   "frolladaptivefun: processing fun MEAN algo exact took.*",
   "frollfunR: processing.*took.*"
-))  
+))
 #### exact na.rm=TRUE verbose=TRUE
 test(6000.1197, frollmean(c(1:5,NA), 2, algo="exact", na.rm=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
@@ -676,7 +676,7 @@ test(6000.171, frollmean(x, n), output=c(
   "frollfunR: 1:",
   "frollmeanFast: running for input length 10, window 3, hasnf 0, narm 0",
   "frollfun: processing fun MEAN algo fast took.*",
-  "frollfunR: processing.*took.*"))  
+  "frollfunR: processing.*took.*"))
 test(6000.172, frollmean(list(x, x+1), n), output=c(
   "frollfunR: allocating memory for results 2x1",
   "frollfunR: .*in parallel.*",
@@ -686,7 +686,7 @@ test(6000.172, frollmean(list(x, x+1), n), output=c(
   "frollfunR: 2:",
   "frollmeanFast: running for input length 10, window 3, hasnf 0, narm 0",
   "frollfun: processing fun MEAN algo fast took.*",
-  "frollfunR: processing.*took.*"))  
+  "frollfunR: processing.*took.*"))
 test(6000.173, frollmean(x, c(n, n+1)), output=c(
   "frollfunR: allocating memory for results 1x2",
   "frollfunR: .*in parallel.*",
@@ -696,7 +696,7 @@ test(6000.173, frollmean(x, c(n, n+1)), output=c(
   "frollfunR: 2:",
   "frollmeanFast: running for input length 10, window 4, hasnf 0, narm 0",
   "frollfun: processing fun MEAN algo fast took.*",
-  "frollfunR: processing.*took.*"))  
+  "frollfunR: processing.*took.*"))
 test(6000.174, frollmean(list(x, x+1), c(n, n+1)), output=c(
   "frollfunR: allocating memory for results 2x2",
   "frollfunR: .*in parallel.*",
@@ -712,14 +712,14 @@ test(6000.174, frollmean(list(x, x+1), c(n, n+1)), output=c(
   "frollfunR: 4:",
   "frollmeanFast: running for input length 10, window 4, hasnf 0, narm 0",
   "frollfun: processing fun MEAN algo fast took.*",
-  "frollfunR: processing.*took.*"))  
+  "frollfunR: processing.*took.*"))
 test(6000.175, frollmean(x, n, algo="exact"), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*algo='exact' is already parallelised.*",
   "frollfunR: 1:",
   "frollmeanExact: running in parallel for input length 10, window 3, hasnf 0, narm 0",
   "frollfun: processing fun MEAN algo exact took.*",
-  "frollfunR: processing.*took.*"))  
+  "frollfunR: processing.*took.*"))
 test(6000.176, frollmean(x, n, align="center"), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*sequentially.*single rolling computation.*",
@@ -727,7 +727,7 @@ test(6000.176, frollmean(x, n, align="center"), output=c(
   "frollmeanFast: running for input length 10, window 3, hasnf 0, narm 0",
   "frollfun: align 0, shift answer by -1",
   "frollfun: processing fun MEAN algo fast took.*",
-  "frollfunR: processing.*took.*"))  
+  "frollfunR: processing.*took.*"))
 test(6000.177, frollmean(x, n, align="left"), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*sequentially.*single rolling computation.*",
@@ -735,7 +735,7 @@ test(6000.177, frollmean(x, n, align="left"), output=c(
   "frollmeanFast: running for input length 10, window 3, hasnf 0, narm 0",
   "frollfun: align -1, shift answer by -2",
   "frollfun: processing fun MEAN algo fast took.*",
-  "frollfunR: processing.*took.*"))  
+  "frollfunR: processing.*took.*"))
 nn = c(1:4,2:3,1:4)
 test(6000.178, frollmean(x, nn, adaptive=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
@@ -743,14 +743,14 @@ test(6000.178, frollmean(x, nn, adaptive=TRUE), output=c(
   "frollfunR: 1:",
   "frolladaptivemeanFast: running for input length 10, hasnf 0, narm 0",
   "frolladaptivefun: processing fun MEAN algo fast took.*",
-  "frollfunR: processing.*took.*"))  
+  "frollfunR: processing.*took.*"))
 test(6000.179, frollmean(x, nn, algo="exact", adaptive=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*algo='exact' is already parallelised.*",
   "frollfunR: 1:",
   "frolladaptivemeanExact: running in parallel for input length 10, hasnf 0, narm 0",
   "frolladaptivefun: processing fun MEAN algo exact took.*",
-  "frollfunR: processing.*took.*"))  
+  "frollfunR: processing.*took.*"))
 
 x[8] = NA
 test(6000.180, frollmean(x, n), output=c(
@@ -760,7 +760,7 @@ test(6000.180, frollmean(x, n), output=c(
   "frollmeanFast: running for input length 10, window 3, hasnf 0, narm 0",
   "frollmeanFast: non-finite values are present in input, re-running with extra care for NFs",
   "frollfun: processing fun MEAN algo fast took.*",
-  "frollfunR: processing.*took.*"))  
+  "frollfunR: processing.*took.*"))
 test(6000.181, frollmean(x, n, algo="exact"), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*algo='exact' is already parallelised.*",
@@ -768,7 +768,7 @@ test(6000.181, frollmean(x, n, algo="exact"), output=c(
   "frollmeanExact: running in parallel for input length 10, window 3, hasnf 0, narm 0",
   "frollmeanExact: non-finite values are present in input, na.rm=FALSE and algo='exact' propagates NFs properply, no need to re-run",
   "frollfun: processing fun MEAN algo exact took.*",
-  "frollfunR: processing.*took.*"))  
+  "frollfunR: processing.*took.*"))
 test(6000.182, frollmean(x, nn, adaptive=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*sequentially because adaptive.*",
@@ -776,7 +776,7 @@ test(6000.182, frollmean(x, nn, adaptive=TRUE), output=c(
   "frolladaptivemeanFast: running for input length 10, hasnf 0, narm 0",
   "frolladaptivemeanFast: non-finite values are present in input, re-running with extra care for NFs",
   "frolladaptivefun: processing fun MEAN algo fast took.*",
-  "frollfunR: processing.*took.*"))  
+  "frollfunR: processing.*took.*"))
 test(6000.183, frollmean(x, nn, algo="exact", adaptive=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*algo='exact' is already parallelised.*",
@@ -784,7 +784,7 @@ test(6000.183, frollmean(x, nn, algo="exact", adaptive=TRUE), output=c(
   "frolladaptivemeanExact: running in parallel for input length 10, hasnf 0, narm 0",
   "frolladaptivemeanExact: non-finite values are present in input, na.rm=FALSE and algo='exact' propagates NFs properply, no need to re-run",
   "frolladaptivefun: processing fun MEAN algo exact took.*",
-  "frollfunR: processing.*took.*"))  
+  "frollfunR: processing.*took.*"))
 
 d = as.data.table(list(1:10/2, 10:1/4))
 test(6000.184, frollmean(d[,1], 3, algo="exact"), output=c(
@@ -794,7 +794,7 @@ test(6000.184, frollmean(d[,1], 3, algo="exact"), output=c(
   "frollmeanExact: running in parallel for input length 10, window 3, hasnf 0, narm 0",
   "frollfun: processing fun MEAN algo exact took.*",
   "frollfunR: processing.*took.*"
-))  
+))
 test(6000.185, frollmean(d, 3:4, algo="exact"), output=c(
   "frollfunR: allocating memory for results 2x2",
   "frollfunR: .*sequentially.*algo='exact'.*already parallelised.*",
@@ -811,7 +811,7 @@ test(6000.185, frollmean(d, 3:4, algo="exact"), output=c(
   "frollmeanExact: running in parallel for input length 10, window 4, hasnf 0, narm 0",
   "frollfun: processing fun MEAN algo exact took.*",
   "frollfunR: processing.*took.*"
-))  
+))
 options(datatable.verbose=FALSE)
 
 ## test warnings
@@ -861,9 +861,9 @@ options(datatable.verbose=FALSE)
 
 ## frollmax adaptive
 options(datatable.verbose=TRUE) ## adaptive frollmax no fast algo
-test(6000.3, frollmax(1:4, c(2,2,2,2), adaptive=TRUE), output="frolladaptivefun: algo fast not implemented, fall back to exact")  
-test(6000.3001, frollmax(1:4, c(2,2,2,2), algo="fast", adaptive=TRUE), output="frolladaptivefun: algo fast not implemented, fall back to exact")  
-test(6000.3002, frollmax(1:4, c(2,2,2,2), algo="exact", adaptive=TRUE), notOutput="frolladaptivefun: algo fast not implemented, fall back to exact")  
+test(6000.3, frollmax(1:4, c(2,2,2,2), adaptive=TRUE), output="frolladaptivefun: algo fast not implemented, fall back to exact")
+test(6000.3001, frollmax(1:4, c(2,2,2,2), algo="fast", adaptive=TRUE), output="frolladaptivefun: algo fast not implemented, fall back to exact")
+test(6000.3002, frollmax(1:4, c(2,2,2,2), algo="exact", adaptive=TRUE), notOutput="frolladaptivefun: algo fast not implemented, fall back to exact")
 options(datatable.verbose=FALSE)
 n = c(3,2,2,4,2,1,4,8)
 x = c(7,2,3,6,3,2,6,6) # no NA
@@ -1022,9 +1022,9 @@ test(6000.564, frollapply(FUN=mean, 1:3, list(c(0,-1,1)), adaptive=TRUE), error=
 
 ## frollmin adaptive
 options(datatable.verbose=TRUE) ## adaptive frollmin no fast algo
-test(6000.6, frollmin(1:4, c(2,2,2,2), adaptive=TRUE), output="frolladaptivefun: algo fast not implemented, fall back to exact")  
-test(6000.6001, frollmin(1:4, c(2,2,2,2), algo="fast", adaptive=TRUE), output="frolladaptivefun: algo fast not implemented, fall back to exact")  
-test(6000.6002, frollmin(1:4, c(2,2,2,2), algo="exact", adaptive=TRUE), notOutput="frolladaptivefun: algo fast not implemented, fall back to exact")  
+test(6000.6, frollmin(1:4, c(2,2,2,2), adaptive=TRUE), output="frolladaptivefun: algo fast not implemented, fall back to exact")
+test(6000.6001, frollmin(1:4, c(2,2,2,2), algo="fast", adaptive=TRUE), output="frolladaptivefun: algo fast not implemented, fall back to exact")
+test(6000.6002, frollmin(1:4, c(2,2,2,2), algo="exact", adaptive=TRUE), notOutput="frolladaptivefun: algo fast not implemented, fall back to exact")
 options(datatable.verbose=FALSE)
 n = c(3,2,2,4,2,1,4,8)
 x = c(7,2,3,6,3,2,6,6) # no NA
@@ -1200,7 +1200,7 @@ test(6000.931, frollprod(1:3, 2), c(NA, 2, 6), output="frollprodFast: running fo
 test(6000.932, frollprod(1:3, 2, align="left"), c(2, 6, NA), output="frollfun: align")
 test(6000.933, frollprod(c(1,2,NA), 2), c(NA, 2, NA), output="non-finite values are present in input, re-running with extra care for NFs")
 test(6000.934, frollprod(c(NA,2,3), 2), c(NA, NA, 6), output="non-finite values are present in input, skip non-finite inaware attempt and run with extra care for NFs straighaway")
-test(6000.935, frollprod(1:3, c(2,2,2), adaptive=TRUE), c(NA, 2, 6), output="algo fast not implemented, fall back to exact")  
+test(6000.935, frollprod(1:3, c(2,2,2), adaptive=TRUE), c(NA, 2, 6), output="algo fast not implemented, fall back to exact")
 test(6000.936, frollprod(c(NA,2,3), c(2,2,2), adaptive=TRUE), c(NA, NA, 6), output="non-finite values are present in input, na.rm=FALSE and algo='exact' propagates NFs properply, no need to re-run")
 options(datatable.verbose=FALSE)
 # floating point overflow
@@ -1433,7 +1433,7 @@ test(6001.715, frollvar(1:3, 0, algo="exact"), c(NA_real_,NA_real_,NA_real_), op
 test(6001.716, frollvar(c(1:2,NA), 0, algo="exact"), c(NA_real_,NA_real_,NA_real_))
 test(6001.717, frollvar(c(1:2,NA), 0, algo="exact", na.rm=TRUE), c(NA_real_,NA_real_,NA_real_))
 test(6001.718, frollvar(c(1:2,NA), 2), c(NA,0.5,NA), options=c("datatable.verbose"=TRUE), output="redirecting to frollvarExact")
-test(6001.721, frollvar(adaptive=TRUE, 1:3, c(2,0,2)), c(NA,NA,0.5), options=c("datatable.verbose"=TRUE), output="algo fast not implemented, fall back to exact")  
+test(6001.721, frollvar(adaptive=TRUE, 1:3, c(2,0,2)), c(NA,NA,0.5), options=c("datatable.verbose"=TRUE), output="algo fast not implemented, fall back to exact")
 test(6001.722, frollvar(adaptive=TRUE, 1:3, c(2,0,2), fill=99), c(99,NA,0.5))
 test(6001.723, frollvar(adaptive=TRUE, c(1:2,NA), c(2,0,2)), c(NA_real_,NA_real_,NA_real_))
 test(6001.724, frollvar(adaptive=TRUE, c(1:2,NA), c(2,0,2), na.rm=TRUE), c(NA_real_,NA_real_,NA_real_))
@@ -1492,7 +1492,7 @@ test(6001.8194, frollsd(c(NA,2:3), 2, has.nf=FALSE), c(NA,NA,sqrt(0.5)), warning
 test(6001.8195, frollsd(c(NA,2:3), 2), c(NA,NA,sqrt(0.5)), options=c("datatable.verbose"=TRUE), output="skip non-finite inaware attempt and run with extra care")
 test(6001.8196, frollsd(c(NA,2:3), 2, has.nf=FALSE, algo="exact"), c(NA,NA,sqrt(0.5)), warning="used but non-finite values are present in input")
 test(6001.8197, frollsd(c(NA,2:3), 2, algo="exact", na.rm=TRUE), c(NA,NA,sqrt(0.5)), options=c("datatable.verbose"=TRUE), output="re-running with extra care for NF")
-test(6001.8201, frollsd(adaptive=TRUE, 1:3, c(2,2,2)), c(NA,sqrt(0.5),sqrt(0.5)), options=c("datatable.verbose"=TRUE), output="frolladaptivefun: algo fast not implemented, fall back to exact")  
+test(6001.8201, frollsd(adaptive=TRUE, 1:3, c(2,2,2)), c(NA,sqrt(0.5),sqrt(0.5)), options=c("datatable.verbose"=TRUE), output="frolladaptivefun: algo fast not implemented, fall back to exact")
 test(6001.8202, frollsd(adaptive=TRUE, 1:3, c(2,2,2)), c(NA,sqrt(0.5),sqrt(0.5)), options=c("datatable.verbose"=TRUE), output="frolladaptivesdExact: calling sqrt(frolladaptivevarExact(...))")
 test(6001.821, frollsd(adaptive=TRUE, 1:3, c(2,0,2)), c(NA,NA,sqrt(0.5)))
 test(6001.822, frollsd(adaptive=TRUE, 1:3, c(2,0,2), fill=99), c(99,NA,sqrt(0.5)))

--- a/inst/tests/froll.Rraw
+++ b/inst/tests/froll.Rraw
@@ -310,7 +310,7 @@ test(6000.0671, frollmean(c(1:2,NA,4:10), 4), c(rep(NA_real_, 6), 5.5, 6.5, 7.5,
   "frollmeanFast: non-finite values are present in input, skip non-finite unaware attempt and run with extra care for NFs straighaway",
   "frollfun: processing fun MEAN algo fast took.*",
   "frollfunR: processing.*took.*"
-)) #7021
+))  
 test(6000.0672, frollmean(c(1:2,NA,4:10), 4, has.nf=FALSE), c(rep(NA_real_, 6), 5.5, 6.5, 7.5, 8.5), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*sequentially.*single rolling computation.*",
@@ -319,7 +319,7 @@ test(6000.0672, frollmean(c(1:2,NA,4:10), 4, has.nf=FALSE), c(rep(NA_real_, 6), 
   "frollmeanFast: non-finite values are present in input, skip non-finite unaware attempt and run with extra care for NFs straighaway",
   "frollfun: processing fun MEAN algo fast took.*",
   "frollfunR: processing.*took.*"
-), warning="has.nf=FALSE used but non-finite values are present in input, use default has.nf=NA to avoid this warning") #7021
+), warning="has.nf=FALSE used but non-finite values are present in input, use default has.nf=NA to avoid this warning")  
 test(6000.0673, frollmean(c(1:2,NA,4:10), 2, has.nf=FALSE), c(NA, 1.5, NA, NA, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*sequentially.*single rolling computation.*",
@@ -328,7 +328,7 @@ test(6000.0673, frollmean(c(1:2,NA,4:10), 2, has.nf=FALSE), c(NA, 1.5, NA, NA, 4
   "frollmeanFast: non-finite values are present in input, re-running with extra care for NFs",
   "frollfun: processing fun MEAN algo fast took.*",
   "frollfunR: processing.*took.*"
-), warning="has.nf=FALSE used but non-finite values are present in input, use default has.nf=NA to avoid this warning") #7021
+), warning="has.nf=FALSE used but non-finite values are present in input, use default has.nf=NA to avoid this warning")  
 test(6000.0674, frollmean(c(1:2,NA,4:10), 4, align="center"), c(rep(NA_real_, 4), 5.5, 6.5, 7.5, 8.5, NA, NA), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*sequentially.*single rolling computation.*",
@@ -337,7 +337,7 @@ test(6000.0674, frollmean(c(1:2,NA,4:10), 4, align="center"), c(rep(NA_real_, 4)
   "frollfun: align 0, shift answer by -2",
   "frollfun: processing fun MEAN algo fast took.*",
   "frollfunR: processing.*took.*"
-)) #7021
+))  
 options(datatable.verbose=FALSE)
 
 #### fill constant
@@ -438,7 +438,7 @@ test(6000.1196, frollmean(c(1:5,NA), 1:6, algo="exact", na.rm=TRUE, adaptive=TRU
   "frolladaptivemeanExact: non-finite values are present in input, re-running with extra care for NFs",
   "frolladaptivefun: processing fun MEAN algo exact took.*",
   "frollfunR: processing.*took.*"
-)) #7021
+))  
 #### exact na.rm=TRUE verbose=TRUE
 test(6000.1197, frollmean(c(1:5,NA), 2, algo="exact", na.rm=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
@@ -676,7 +676,7 @@ test(6000.171, frollmean(x, n), output=c(
   "frollfunR: 1:",
   "frollmeanFast: running for input length 10, window 3, hasnf 0, narm 0",
   "frollfun: processing fun MEAN algo fast took.*",
-  "frollfunR: processing.*took.*")) #7021
+  "frollfunR: processing.*took.*"))  
 test(6000.172, frollmean(list(x, x+1), n), output=c(
   "frollfunR: allocating memory for results 2x1",
   "frollfunR: .*in parallel.*",
@@ -686,7 +686,7 @@ test(6000.172, frollmean(list(x, x+1), n), output=c(
   "frollfunR: 2:",
   "frollmeanFast: running for input length 10, window 3, hasnf 0, narm 0",
   "frollfun: processing fun MEAN algo fast took.*",
-  "frollfunR: processing.*took.*")) #7021
+  "frollfunR: processing.*took.*"))  
 test(6000.173, frollmean(x, c(n, n+1)), output=c(
   "frollfunR: allocating memory for results 1x2",
   "frollfunR: .*in parallel.*",
@@ -696,7 +696,7 @@ test(6000.173, frollmean(x, c(n, n+1)), output=c(
   "frollfunR: 2:",
   "frollmeanFast: running for input length 10, window 4, hasnf 0, narm 0",
   "frollfun: processing fun MEAN algo fast took.*",
-  "frollfunR: processing.*took.*")) #7021
+  "frollfunR: processing.*took.*"))  
 test(6000.174, frollmean(list(x, x+1), c(n, n+1)), output=c(
   "frollfunR: allocating memory for results 2x2",
   "frollfunR: .*in parallel.*",
@@ -712,14 +712,14 @@ test(6000.174, frollmean(list(x, x+1), c(n, n+1)), output=c(
   "frollfunR: 4:",
   "frollmeanFast: running for input length 10, window 4, hasnf 0, narm 0",
   "frollfun: processing fun MEAN algo fast took.*",
-  "frollfunR: processing.*took.*")) #7021
+  "frollfunR: processing.*took.*"))  
 test(6000.175, frollmean(x, n, algo="exact"), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*algo='exact' is already parallelised.*",
   "frollfunR: 1:",
   "frollmeanExact: running in parallel for input length 10, window 3, hasnf 0, narm 0",
   "frollfun: processing fun MEAN algo exact took.*",
-  "frollfunR: processing.*took.*")) #7021
+  "frollfunR: processing.*took.*"))  
 test(6000.176, frollmean(x, n, align="center"), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*sequentially.*single rolling computation.*",
@@ -727,7 +727,7 @@ test(6000.176, frollmean(x, n, align="center"), output=c(
   "frollmeanFast: running for input length 10, window 3, hasnf 0, narm 0",
   "frollfun: align 0, shift answer by -1",
   "frollfun: processing fun MEAN algo fast took.*",
-  "frollfunR: processing.*took.*")) #7021
+  "frollfunR: processing.*took.*"))  
 test(6000.177, frollmean(x, n, align="left"), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*sequentially.*single rolling computation.*",
@@ -735,7 +735,7 @@ test(6000.177, frollmean(x, n, align="left"), output=c(
   "frollmeanFast: running for input length 10, window 3, hasnf 0, narm 0",
   "frollfun: align -1, shift answer by -2",
   "frollfun: processing fun MEAN algo fast took.*",
-  "frollfunR: processing.*took.*")) #7021
+  "frollfunR: processing.*took.*"))  
 nn = c(1:4,2:3,1:4)
 test(6000.178, frollmean(x, nn, adaptive=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
@@ -743,14 +743,14 @@ test(6000.178, frollmean(x, nn, adaptive=TRUE), output=c(
   "frollfunR: 1:",
   "frolladaptivemeanFast: running for input length 10, hasnf 0, narm 0",
   "frolladaptivefun: processing fun MEAN algo fast took.*",
-  "frollfunR: processing.*took.*")) #7021
+  "frollfunR: processing.*took.*"))  
 test(6000.179, frollmean(x, nn, algo="exact", adaptive=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*algo='exact' is already parallelised.*",
   "frollfunR: 1:",
   "frolladaptivemeanExact: running in parallel for input length 10, hasnf 0, narm 0",
   "frolladaptivefun: processing fun MEAN algo exact took.*",
-  "frollfunR: processing.*took.*")) #7021
+  "frollfunR: processing.*took.*"))  
 
 x[8] = NA
 test(6000.180, frollmean(x, n), output=c(
@@ -760,7 +760,7 @@ test(6000.180, frollmean(x, n), output=c(
   "frollmeanFast: running for input length 10, window 3, hasnf 0, narm 0",
   "frollmeanFast: non-finite values are present in input, re-running with extra care for NFs",
   "frollfun: processing fun MEAN algo fast took.*",
-  "frollfunR: processing.*took.*")) #7021
+  "frollfunR: processing.*took.*"))  
 test(6000.181, frollmean(x, n, algo="exact"), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*algo='exact' is already parallelised.*",
@@ -768,7 +768,7 @@ test(6000.181, frollmean(x, n, algo="exact"), output=c(
   "frollmeanExact: running in parallel for input length 10, window 3, hasnf 0, narm 0",
   "frollmeanExact: non-finite values are present in input, na.rm=FALSE and algo='exact' propagates NFs properply, no need to re-run",
   "frollfun: processing fun MEAN algo exact took.*",
-  "frollfunR: processing.*took.*")) #7021
+  "frollfunR: processing.*took.*"))  
 test(6000.182, frollmean(x, nn, adaptive=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*sequentially because adaptive.*",
@@ -776,7 +776,7 @@ test(6000.182, frollmean(x, nn, adaptive=TRUE), output=c(
   "frolladaptivemeanFast: running for input length 10, hasnf 0, narm 0",
   "frolladaptivemeanFast: non-finite values are present in input, re-running with extra care for NFs",
   "frolladaptivefun: processing fun MEAN algo fast took.*",
-  "frollfunR: processing.*took.*")) #7021
+  "frollfunR: processing.*took.*"))  
 test(6000.183, frollmean(x, nn, algo="exact", adaptive=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*algo='exact' is already parallelised.*",
@@ -784,7 +784,7 @@ test(6000.183, frollmean(x, nn, algo="exact", adaptive=TRUE), output=c(
   "frolladaptivemeanExact: running in parallel for input length 10, hasnf 0, narm 0",
   "frolladaptivemeanExact: non-finite values are present in input, na.rm=FALSE and algo='exact' propagates NFs properply, no need to re-run",
   "frolladaptivefun: processing fun MEAN algo exact took.*",
-  "frollfunR: processing.*took.*")) #7021
+  "frollfunR: processing.*took.*"))  
 
 d = as.data.table(list(1:10/2, 10:1/4))
 test(6000.184, frollmean(d[,1], 3, algo="exact"), output=c(
@@ -794,7 +794,7 @@ test(6000.184, frollmean(d[,1], 3, algo="exact"), output=c(
   "frollmeanExact: running in parallel for input length 10, window 3, hasnf 0, narm 0",
   "frollfun: processing fun MEAN algo exact took.*",
   "frollfunR: processing.*took.*"
-)) #7021
+))  
 test(6000.185, frollmean(d, 3:4, algo="exact"), output=c(
   "frollfunR: allocating memory for results 2x2",
   "frollfunR: .*sequentially.*algo='exact'.*already parallelised.*",
@@ -811,7 +811,7 @@ test(6000.185, frollmean(d, 3:4, algo="exact"), output=c(
   "frollmeanExact: running in parallel for input length 10, window 4, hasnf 0, narm 0",
   "frollfun: processing fun MEAN algo exact took.*",
   "frollfunR: processing.*took.*"
-)) #7021
+))  
 options(datatable.verbose=FALSE)
 
 ## test warnings
@@ -861,9 +861,9 @@ options(datatable.verbose=FALSE)
 
 ## frollmax adaptive
 options(datatable.verbose=TRUE) ## adaptive frollmax no fast algo
-test(6000.3, frollmax(1:4, c(2,2,2,2), adaptive=TRUE), output="frolladaptivefun: algo fast not implemented, fall back to exact") #7021
-test(6000.3001, frollmax(1:4, c(2,2,2,2), algo="fast", adaptive=TRUE), output="frolladaptivefun: algo fast not implemented, fall back to exact") #7021
-test(6000.3002, frollmax(1:4, c(2,2,2,2), algo="exact", adaptive=TRUE), notOutput="frolladaptivefun: algo fast not implemented, fall back to exact") #7021
+test(6000.3, frollmax(1:4, c(2,2,2,2), adaptive=TRUE), output="frolladaptivefun: algo fast not implemented, fall back to exact")  
+test(6000.3001, frollmax(1:4, c(2,2,2,2), algo="fast", adaptive=TRUE), output="frolladaptivefun: algo fast not implemented, fall back to exact")  
+test(6000.3002, frollmax(1:4, c(2,2,2,2), algo="exact", adaptive=TRUE), notOutput="frolladaptivefun: algo fast not implemented, fall back to exact")  
 options(datatable.verbose=FALSE)
 n = c(3,2,2,4,2,1,4,8)
 x = c(7,2,3,6,3,2,6,6) # no NA
@@ -1022,9 +1022,9 @@ test(6000.564, frollapply(FUN=mean, 1:3, list(c(0,-1,1)), adaptive=TRUE), error=
 
 ## frollmin adaptive
 options(datatable.verbose=TRUE) ## adaptive frollmin no fast algo
-test(6000.6, frollmin(1:4, c(2,2,2,2), adaptive=TRUE), output="frolladaptivefun: algo fast not implemented, fall back to exact") #7021
-test(6000.6001, frollmin(1:4, c(2,2,2,2), algo="fast", adaptive=TRUE), output="frolladaptivefun: algo fast not implemented, fall back to exact") #7021
-test(6000.6002, frollmin(1:4, c(2,2,2,2), algo="exact", adaptive=TRUE), notOutput="frolladaptivefun: algo fast not implemented, fall back to exact") #7021
+test(6000.6, frollmin(1:4, c(2,2,2,2), adaptive=TRUE), output="frolladaptivefun: algo fast not implemented, fall back to exact")  
+test(6000.6001, frollmin(1:4, c(2,2,2,2), algo="fast", adaptive=TRUE), output="frolladaptivefun: algo fast not implemented, fall back to exact")  
+test(6000.6002, frollmin(1:4, c(2,2,2,2), algo="exact", adaptive=TRUE), notOutput="frolladaptivefun: algo fast not implemented, fall back to exact")  
 options(datatable.verbose=FALSE)
 n = c(3,2,2,4,2,1,4,8)
 x = c(7,2,3,6,3,2,6,6) # no NA
@@ -1200,7 +1200,7 @@ test(6000.931, frollprod(1:3, 2), c(NA, 2, 6), output="frollprodFast: running fo
 test(6000.932, frollprod(1:3, 2, align="left"), c(2, 6, NA), output="frollfun: align")
 test(6000.933, frollprod(c(1,2,NA), 2), c(NA, 2, NA), output="non-finite values are present in input, re-running with extra care for NFs")
 test(6000.934, frollprod(c(NA,2,3), 2), c(NA, NA, 6), output="non-finite values are present in input, skip non-finite inaware attempt and run with extra care for NFs straighaway")
-test(6000.935, frollprod(1:3, c(2,2,2), adaptive=TRUE), c(NA, 2, 6), output="algo fast not implemented, fall back to exact") #7021
+test(6000.935, frollprod(1:3, c(2,2,2), adaptive=TRUE), c(NA, 2, 6), output="algo fast not implemented, fall back to exact")  
 test(6000.936, frollprod(c(NA,2,3), c(2,2,2), adaptive=TRUE), c(NA, NA, 6), output="non-finite values are present in input, na.rm=FALSE and algo='exact' propagates NFs properply, no need to re-run")
 options(datatable.verbose=FALSE)
 # floating point overflow
@@ -1433,7 +1433,7 @@ test(6001.715, frollvar(1:3, 0, algo="exact"), c(NA_real_,NA_real_,NA_real_), op
 test(6001.716, frollvar(c(1:2,NA), 0, algo="exact"), c(NA_real_,NA_real_,NA_real_))
 test(6001.717, frollvar(c(1:2,NA), 0, algo="exact", na.rm=TRUE), c(NA_real_,NA_real_,NA_real_))
 test(6001.718, frollvar(c(1:2,NA), 2), c(NA,0.5,NA), options=c("datatable.verbose"=TRUE), output="redirecting to frollvarExact")
-test(6001.721, frollvar(adaptive=TRUE, 1:3, c(2,0,2)), c(NA,NA,0.5), options=c("datatable.verbose"=TRUE), output="algo fast not implemented, fall back to exact") #7021
+test(6001.721, frollvar(adaptive=TRUE, 1:3, c(2,0,2)), c(NA,NA,0.5), options=c("datatable.verbose"=TRUE), output="algo fast not implemented, fall back to exact")  
 test(6001.722, frollvar(adaptive=TRUE, 1:3, c(2,0,2), fill=99), c(99,NA,0.5))
 test(6001.723, frollvar(adaptive=TRUE, c(1:2,NA), c(2,0,2)), c(NA_real_,NA_real_,NA_real_))
 test(6001.724, frollvar(adaptive=TRUE, c(1:2,NA), c(2,0,2), na.rm=TRUE), c(NA_real_,NA_real_,NA_real_))
@@ -1492,7 +1492,7 @@ test(6001.8194, frollsd(c(NA,2:3), 2, has.nf=FALSE), c(NA,NA,sqrt(0.5)), warning
 test(6001.8195, frollsd(c(NA,2:3), 2), c(NA,NA,sqrt(0.5)), options=c("datatable.verbose"=TRUE), output="skip non-finite inaware attempt and run with extra care")
 test(6001.8196, frollsd(c(NA,2:3), 2, has.nf=FALSE, algo="exact"), c(NA,NA,sqrt(0.5)), warning="used but non-finite values are present in input")
 test(6001.8197, frollsd(c(NA,2:3), 2, algo="exact", na.rm=TRUE), c(NA,NA,sqrt(0.5)), options=c("datatable.verbose"=TRUE), output="re-running with extra care for NF")
-test(6001.8201, frollsd(adaptive=TRUE, 1:3, c(2,2,2)), c(NA,sqrt(0.5),sqrt(0.5)), options=c("datatable.verbose"=TRUE), output="frolladaptivefun: algo fast not implemented, fall back to exact") #7021
+test(6001.8201, frollsd(adaptive=TRUE, 1:3, c(2,2,2)), c(NA,sqrt(0.5),sqrt(0.5)), options=c("datatable.verbose"=TRUE), output="frolladaptivefun: algo fast not implemented, fall back to exact")  
 test(6001.8202, frollsd(adaptive=TRUE, 1:3, c(2,2,2)), c(NA,sqrt(0.5),sqrt(0.5)), options=c("datatable.verbose"=TRUE), output="frolladaptivesdExact: calling sqrt(frolladaptivevarExact(...))")
 test(6001.821, frollsd(adaptive=TRUE, 1:3, c(2,0,2)), c(NA,NA,sqrt(0.5)))
 test(6001.822, frollsd(adaptive=TRUE, 1:3, c(2,0,2), fill=99), c(99,NA,sqrt(0.5)))

--- a/inst/tests/froll.Rraw
+++ b/inst/tests/froll.Rraw
@@ -308,36 +308,36 @@ test(6000.0671, frollmean(c(1:2,NA,4:10), 4), c(rep(NA_real_, 6), 5.5, 6.5, 7.5,
   "frollfunR: 1:",
   "frollmeanFast: running for input length 10, window 4, hasnf 0, narm 0",
   "frollmeanFast: non-finite values are present in input, skip non-finite unaware attempt and run with extra care for NFs straighaway",
-  "frollfun: processing fun 0 algo 0 took.*",
+  "frollfun: processing fun MEAN algo fast took.*",
   "frollfunR: processing.*took.*"
-))
+)) #7021
 test(6000.0672, frollmean(c(1:2,NA,4:10), 4, has.nf=FALSE), c(rep(NA_real_, 6), 5.5, 6.5, 7.5, 8.5), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*sequentially.*single rolling computation.*",
   "frollfunR: 1:",
   "frollmeanFast: running for input length 10, window 4, hasnf -1, narm 0",
   "frollmeanFast: non-finite values are present in input, skip non-finite unaware attempt and run with extra care for NFs straighaway",
-  "frollfun: processing fun 0 algo 0 took.*",
+  "frollfun: processing fun MEAN algo fast took.*",
   "frollfunR: processing.*took.*"
-), warning="has.nf=FALSE used but non-finite values are present in input, use default has.nf=NA to avoid this warning")
+), warning="has.nf=FALSE used but non-finite values are present in input, use default has.nf=NA to avoid this warning") #7021
 test(6000.0673, frollmean(c(1:2,NA,4:10), 2, has.nf=FALSE), c(NA, 1.5, NA, NA, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*sequentially.*single rolling computation.*",
   "frollfunR: 1:",
   "frollmeanFast: running for input length 10, window 2, hasnf -1, narm 0",
   "frollmeanFast: non-finite values are present in input, re-running with extra care for NFs",
-  "frollfun: processing fun 0 algo 0 took.*",
+  "frollfun: processing fun MEAN algo fast took.*",
   "frollfunR: processing.*took.*"
-), warning="has.nf=FALSE used but non-finite values are present in input, use default has.nf=NA to avoid this warning")
+), warning="has.nf=FALSE used but non-finite values are present in input, use default has.nf=NA to avoid this warning") #7021
 test(6000.0674, frollmean(c(1:2,NA,4:10), 4, align="center"), c(rep(NA_real_, 4), 5.5, 6.5, 7.5, 8.5, NA, NA), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*sequentially.*single rolling computation.*",
   "frollmeanFast: running for input length 10, window 4, hasnf 0, narm 0",
   "frollmeanFast: non-finite values are present in input, skip non-finite unaware attempt and run with extra care for NFs straighaway",
   "frollfun: align 0, shift answer by -2",
-  "frollfun: processing fun 0 algo 0 took.*",
+  "frollfun: processing fun MEAN algo fast took.*",
   "frollfunR: processing.*took.*"
-))
+)) #7021
 options(datatable.verbose=FALSE)
 
 #### fill constant
@@ -436,9 +436,9 @@ test(6000.1196, frollmean(c(1:5,NA), 1:6, algo="exact", na.rm=TRUE, adaptive=TRU
   "frollfunR: 1:",
   "frolladaptivemeanExact: running in parallel for input length 6, hasnf 0, narm 1",
   "frolladaptivemeanExact: non-finite values are present in input, re-running with extra care for NFs",
-  "frolladaptivefun: processing fun 0 algo 1 took.*",
+  "frolladaptivefun: processing fun MEAN algo exact took.*",
   "frollfunR: processing.*took.*"
-))
+)) #7021
 #### exact na.rm=TRUE verbose=TRUE
 test(6000.1197, frollmean(c(1:5,NA), 2, algo="exact", na.rm=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
@@ -446,7 +446,7 @@ test(6000.1197, frollmean(c(1:5,NA), 2, algo="exact", na.rm=TRUE), output=c(
   "frollfunR: 1:",
   "frollmeanExact: running in parallel for input length 6, window 2, hasnf 0, narm 1",
   "frollmeanExact: non-finite values are present in input, re-running with extra care for NFs",
-  "frollfun: processing fun 0 algo 1 took.*",
+  "frollfun: processing fun MEAN algo exact took.*",
   "frollfunR: processing.*took.*"
 ))
 options(datatable.verbose=FALSE)
@@ -675,82 +675,82 @@ test(6000.171, frollmean(x, n), output=c(
   "frollfunR: .*sequentially.*single rolling computation.*",
   "frollfunR: 1:",
   "frollmeanFast: running for input length 10, window 3, hasnf 0, narm 0",
-  "frollfun: processing fun 0 algo 0 took.*",
-  "frollfunR: processing.*took.*"))
+  "frollfun: processing fun MEAN algo fast took.*",
+  "frollfunR: processing.*took.*")) #7021
 test(6000.172, frollmean(list(x, x+1), n), output=c(
   "frollfunR: allocating memory for results 2x1",
   "frollfunR: .*in parallel.*",
   "frollfunR: 1:",
   "frollmeanFast: running for input length 10, window 3, hasnf 0, narm 0",
-  "frollfun: processing fun 0 algo 0 took.*",
+  "frollfun: processing fun MEAN algo fast took.*",
   "frollfunR: 2:",
   "frollmeanFast: running for input length 10, window 3, hasnf 0, narm 0",
-  "frollfun: processing fun 0 algo 0 took.*",
-  "frollfunR: processing.*took.*"))
+  "frollfun: processing fun MEAN algo fast took.*",
+  "frollfunR: processing.*took.*")) #7021
 test(6000.173, frollmean(x, c(n, n+1)), output=c(
   "frollfunR: allocating memory for results 1x2",
   "frollfunR: .*in parallel.*",
   "frollfunR: 1:",
   "frollmeanFast: running for input length 10, window 3, hasnf 0, narm 0",
-  "frollfun: processing fun 0 algo 0 took.*",
+  "frollfun: processing fun MEAN algo fast took.*",
   "frollfunR: 2:",
   "frollmeanFast: running for input length 10, window 4, hasnf 0, narm 0",
-  "frollfun: processing fun 0 algo 0 took.*",
-  "frollfunR: processing.*took.*"))
+  "frollfun: processing fun MEAN algo fast took.*",
+  "frollfunR: processing.*took.*")) #7021
 test(6000.174, frollmean(list(x, x+1), c(n, n+1)), output=c(
   "frollfunR: allocating memory for results 2x2",
   "frollfunR: .*in parallel.*",
   "frollfunR: 1:",
   "frollmeanFast: running for input length 10, window 3, hasnf 0, narm 0",
-  "frollfun: processing fun 0 algo 0 took.*",
+  "frollfun: processing fun MEAN algo fast took.*",
   "frollfunR: 2:",
   "frollmeanFast: running for input length 10, window 4, hasnf 0, narm 0",
-  "frollfun: processing fun 0 algo 0 took.*",
+  "frollfun: processing fun MEAN algo fast took.*",
   "frollfunR: 3:",
   "frollmeanFast: running for input length 10, window 3, hasnf 0, narm 0",
-  "frollfun: processing fun 0 algo 0 took.*",
+  "frollfun: processing fun MEAN algo fast took.*",
   "frollfunR: 4:",
   "frollmeanFast: running for input length 10, window 4, hasnf 0, narm 0",
-  "frollfun: processing fun 0 algo 0 took.*",
-  "frollfunR: processing.*took.*"))
+  "frollfun: processing fun MEAN algo fast took.*",
+  "frollfunR: processing.*took.*")) #7021
 test(6000.175, frollmean(x, n, algo="exact"), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*algo='exact' is already parallelised.*",
   "frollfunR: 1:",
   "frollmeanExact: running in parallel for input length 10, window 3, hasnf 0, narm 0",
-  "frollfun: processing fun 0 algo 1 took.*",
-  "frollfunR: processing.*took.*"))
+  "frollfun: processing fun MEAN algo exact took.*",
+  "frollfunR: processing.*took.*")) #7021
 test(6000.176, frollmean(x, n, align="center"), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*sequentially.*single rolling computation.*",
   "frollfunR: 1:",
   "frollmeanFast: running for input length 10, window 3, hasnf 0, narm 0",
   "frollfun: align 0, shift answer by -1",
-  "frollfun: processing fun 0 algo 0 took.*",
-  "frollfunR: processing.*took.*"))
+  "frollfun: processing fun MEAN algo fast took.*",
+  "frollfunR: processing.*took.*")) #7021
 test(6000.177, frollmean(x, n, align="left"), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*sequentially.*single rolling computation.*",
   "frollfunR: 1:",
   "frollmeanFast: running for input length 10, window 3, hasnf 0, narm 0",
   "frollfun: align -1, shift answer by -2",
-  "frollfun: processing fun 0 algo 0 took.*",
-  "frollfunR: processing.*took.*"))
+  "frollfun: processing fun MEAN algo fast took.*",
+  "frollfunR: processing.*took.*")) #7021
 nn = c(1:4,2:3,1:4)
 test(6000.178, frollmean(x, nn, adaptive=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*sequentially because adaptive.*",
   "frollfunR: 1:",
   "frolladaptivemeanFast: running for input length 10, hasnf 0, narm 0",
-  "frolladaptivefun: processing fun 0 algo 0 took.*",
-  "frollfunR: processing.*took.*"))
+  "frolladaptivefun: processing fun MEAN algo fast took.*",
+  "frollfunR: processing.*took.*")) #7021
 test(6000.179, frollmean(x, nn, algo="exact", adaptive=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*algo='exact' is already parallelised.*",
   "frollfunR: 1:",
   "frolladaptivemeanExact: running in parallel for input length 10, hasnf 0, narm 0",
-  "frolladaptivefun: processing fun 0 algo 1 took.*",
-  "frollfunR: processing.*took.*"))
+  "frolladaptivefun: processing fun MEAN algo exact took.*",
+  "frollfunR: processing.*took.*")) #7021
 
 x[8] = NA
 test(6000.180, frollmean(x, n), output=c(
@@ -759,32 +759,32 @@ test(6000.180, frollmean(x, n), output=c(
   "frollfunR: 1:",
   "frollmeanFast: running for input length 10, window 3, hasnf 0, narm 0",
   "frollmeanFast: non-finite values are present in input, re-running with extra care for NFs",
-  "frollfun: processing fun 0 algo 0 took.*",
-  "frollfunR: processing.*took.*"))
+  "frollfun: processing fun MEAN algo fast took.*",
+  "frollfunR: processing.*took.*")) #7021
 test(6000.181, frollmean(x, n, algo="exact"), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*algo='exact' is already parallelised.*",
   "frollfunR: 1:",
   "frollmeanExact: running in parallel for input length 10, window 3, hasnf 0, narm 0",
   "frollmeanExact: non-finite values are present in input, na.rm=FALSE and algo='exact' propagates NFs properply, no need to re-run",
-  "frollfun: processing fun 0 algo 1 took.*",
-  "frollfunR: processing.*took.*"))
+  "frollfun: processing fun MEAN algo exact took.*",
+  "frollfunR: processing.*took.*")) #7021
 test(6000.182, frollmean(x, nn, adaptive=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*sequentially because adaptive.*",
   "frollfunR: 1:",
   "frolladaptivemeanFast: running for input length 10, hasnf 0, narm 0",
   "frolladaptivemeanFast: non-finite values are present in input, re-running with extra care for NFs",
-  "frolladaptivefun: processing fun 0 algo 0 took.*",
-  "frollfunR: processing.*took.*"))
+  "frolladaptivefun: processing fun MEAN algo fast took.*",
+  "frollfunR: processing.*took.*")) #7021
 test(6000.183, frollmean(x, nn, algo="exact", adaptive=TRUE), output=c(
   "frollfunR: allocating memory for results 1x1",
   "frollfunR: .*algo='exact' is already parallelised.*",
   "frollfunR: 1:",
   "frolladaptivemeanExact: running in parallel for input length 10, hasnf 0, narm 0",
   "frolladaptivemeanExact: non-finite values are present in input, na.rm=FALSE and algo='exact' propagates NFs properply, no need to re-run",
-  "frolladaptivefun: processing fun 0 algo 1 took.*",
-  "frollfunR: processing.*took.*"))
+  "frolladaptivefun: processing fun MEAN algo exact took.*",
+  "frollfunR: processing.*took.*")) #7021
 
 d = as.data.table(list(1:10/2, 10:1/4))
 test(6000.184, frollmean(d[,1], 3, algo="exact"), output=c(
@@ -792,26 +792,26 @@ test(6000.184, frollmean(d[,1], 3, algo="exact"), output=c(
   "frollfunR: .*algo='exact' is already parallelised.*",
   "frollfunR: 1:",
   "frollmeanExact: running in parallel for input length 10, window 3, hasnf 0, narm 0",
-  "frollfun: processing fun 0 algo 1 took.*",
+  "frollfun: processing fun MEAN algo exact took.*",
   "frollfunR: processing.*took.*"
-))
+)) #7021
 test(6000.185, frollmean(d, 3:4, algo="exact"), output=c(
   "frollfunR: allocating memory for results 2x2",
   "frollfunR: .*sequentially.*algo='exact'.*already parallelised.*",
   "frollfunR: 1:",
   "frollmeanExact: running in parallel for input length 10, window 3, hasnf 0, narm 0",
-  "frollfun: processing fun 0 algo 1 took.*",
+  "frollfun: processing fun MEAN algo exact took.*",
   "frollfunR: 2:",
   "frollmeanExact: running in parallel for input length 10, window 4, hasnf 0, narm 0",
-  "frollfun: processing fun 0 algo 1 took.*",
+  "frollfun: processing fun MEAN algo exact took.*",
   "frollfunR: 3:",
   "frollmeanExact: running in parallel for input length 10, window 3, hasnf 0, narm 0",
-  "frollfun: processing fun 0 algo 1 took.*",
+  "frollfun: processing fun MEAN algo exact took.*",
   "frollfunR: 4:",
   "frollmeanExact: running in parallel for input length 10, window 4, hasnf 0, narm 0",
-  "frollfun: processing fun 0 algo 1 took.*",
+  "frollfun: processing fun MEAN algo exact took.*",
   "frollfunR: processing.*took.*"
-))
+)) #7021
 options(datatable.verbose=FALSE)
 
 ## test warnings
@@ -861,9 +861,9 @@ options(datatable.verbose=FALSE)
 
 ## frollmax adaptive
 options(datatable.verbose=TRUE) ## adaptive frollmax no fast algo
-test(6000.3, frollmax(1:4, c(2,2,2,2), adaptive=TRUE), output="frolladaptivefun: algo 0 not implemented, fall back to 1")
-test(6000.3001, frollmax(1:4, c(2,2,2,2), algo="fast", adaptive=TRUE), output="frolladaptivefun: algo 0 not implemented, fall back to 1")
-test(6000.3002, frollmax(1:4, c(2,2,2,2), algo="exact", adaptive=TRUE), notOutput="frolladaptivefun: algo 0 not implemented, fall back to 1")
+test(6000.3, frollmax(1:4, c(2,2,2,2), adaptive=TRUE), output="frolladaptivefun: algo fast not implemented, fall back to exact") #7021
+test(6000.3001, frollmax(1:4, c(2,2,2,2), algo="fast", adaptive=TRUE), output="frolladaptivefun: algo fast not implemented, fall back to exact") #7021
+test(6000.3002, frollmax(1:4, c(2,2,2,2), algo="exact", adaptive=TRUE), notOutput="frolladaptivefun: algo fast not implemented, fall back to exact") #7021
 options(datatable.verbose=FALSE)
 n = c(3,2,2,4,2,1,4,8)
 x = c(7,2,3,6,3,2,6,6) # no NA
@@ -1022,9 +1022,9 @@ test(6000.564, frollapply(FUN=mean, 1:3, list(c(0,-1,1)), adaptive=TRUE), error=
 
 ## frollmin adaptive
 options(datatable.verbose=TRUE) ## adaptive frollmin no fast algo
-test(6000.6, frollmin(1:4, c(2,2,2,2), adaptive=TRUE), output="frolladaptivefun: algo 0 not implemented, fall back to 1")
-test(6000.6001, frollmin(1:4, c(2,2,2,2), algo="fast", adaptive=TRUE), output="frolladaptivefun: algo 0 not implemented, fall back to 1")
-test(6000.6002, frollmin(1:4, c(2,2,2,2), algo="exact", adaptive=TRUE), notOutput="frolladaptivefun: algo 0 not implemented, fall back to 1")
+test(6000.6, frollmin(1:4, c(2,2,2,2), adaptive=TRUE), output="frolladaptivefun: algo fast not implemented, fall back to exact") #7021
+test(6000.6001, frollmin(1:4, c(2,2,2,2), algo="fast", adaptive=TRUE), output="frolladaptivefun: algo fast not implemented, fall back to exact") #7021
+test(6000.6002, frollmin(1:4, c(2,2,2,2), algo="exact", adaptive=TRUE), notOutput="frolladaptivefun: algo fast not implemented, fall back to exact") #7021
 options(datatable.verbose=FALSE)
 n = c(3,2,2,4,2,1,4,8)
 x = c(7,2,3,6,3,2,6,6) # no NA
@@ -1200,7 +1200,7 @@ test(6000.931, frollprod(1:3, 2), c(NA, 2, 6), output="frollprodFast: running fo
 test(6000.932, frollprod(1:3, 2, align="left"), c(2, 6, NA), output="frollfun: align")
 test(6000.933, frollprod(c(1,2,NA), 2), c(NA, 2, NA), output="non-finite values are present in input, re-running with extra care for NFs")
 test(6000.934, frollprod(c(NA,2,3), 2), c(NA, NA, 6), output="non-finite values are present in input, skip non-finite inaware attempt and run with extra care for NFs straighaway")
-test(6000.935, frollprod(1:3, c(2,2,2), adaptive=TRUE), c(NA, 2, 6), output="algo 0 not implemented, fall back to 1")
+test(6000.935, frollprod(1:3, c(2,2,2), adaptive=TRUE), c(NA, 2, 6), output="algo fast not implemented, fall back to exact") #7021
 test(6000.936, frollprod(c(NA,2,3), c(2,2,2), adaptive=TRUE), c(NA, NA, 6), output="non-finite values are present in input, na.rm=FALSE and algo='exact' propagates NFs properply, no need to re-run")
 options(datatable.verbose=FALSE)
 # floating point overflow
@@ -1433,7 +1433,7 @@ test(6001.715, frollvar(1:3, 0, algo="exact"), c(NA_real_,NA_real_,NA_real_), op
 test(6001.716, frollvar(c(1:2,NA), 0, algo="exact"), c(NA_real_,NA_real_,NA_real_))
 test(6001.717, frollvar(c(1:2,NA), 0, algo="exact", na.rm=TRUE), c(NA_real_,NA_real_,NA_real_))
 test(6001.718, frollvar(c(1:2,NA), 2), c(NA,0.5,NA), options=c("datatable.verbose"=TRUE), output="redirecting to frollvarExact")
-test(6001.721, frollvar(adaptive=TRUE, 1:3, c(2,0,2)), c(NA,NA,0.5), options=c("datatable.verbose"=TRUE), output="not implemented, fall back to")
+test(6001.721, frollvar(adaptive=TRUE, 1:3, c(2,0,2)), c(NA,NA,0.5), options=c("datatable.verbose"=TRUE), output="algo fast not implemented, fall back to exact") #7021
 test(6001.722, frollvar(adaptive=TRUE, 1:3, c(2,0,2), fill=99), c(99,NA,0.5))
 test(6001.723, frollvar(adaptive=TRUE, c(1:2,NA), c(2,0,2)), c(NA_real_,NA_real_,NA_real_))
 test(6001.724, frollvar(adaptive=TRUE, c(1:2,NA), c(2,0,2), na.rm=TRUE), c(NA_real_,NA_real_,NA_real_))
@@ -1492,7 +1492,7 @@ test(6001.8194, frollsd(c(NA,2:3), 2, has.nf=FALSE), c(NA,NA,sqrt(0.5)), warning
 test(6001.8195, frollsd(c(NA,2:3), 2), c(NA,NA,sqrt(0.5)), options=c("datatable.verbose"=TRUE), output="skip non-finite inaware attempt and run with extra care")
 test(6001.8196, frollsd(c(NA,2:3), 2, has.nf=FALSE, algo="exact"), c(NA,NA,sqrt(0.5)), warning="used but non-finite values are present in input")
 test(6001.8197, frollsd(c(NA,2:3), 2, algo="exact", na.rm=TRUE), c(NA,NA,sqrt(0.5)), options=c("datatable.verbose"=TRUE), output="re-running with extra care for NF")
-test(6001.8201, frollsd(adaptive=TRUE, 1:3, c(2,2,2)), c(NA,sqrt(0.5),sqrt(0.5)), options=c("datatable.verbose"=TRUE), output="frolladaptivefun: algo 0 not implemented, fall back to 1")
+test(6001.8201, frollsd(adaptive=TRUE, 1:3, c(2,2,2)), c(NA,sqrt(0.5),sqrt(0.5)), options=c("datatable.verbose"=TRUE), output="frolladaptivefun: algo fast not implemented, fall back to exact") #7021
 test(6001.8202, frollsd(adaptive=TRUE, 1:3, c(2,2,2)), c(NA,sqrt(0.5),sqrt(0.5)), options=c("datatable.verbose"=TRUE), output="frolladaptivesdExact: calling sqrt(frolladaptivevarExact(...))")
 test(6001.821, frollsd(adaptive=TRUE, 1:3, c(2,0,2)), c(NA,NA,sqrt(0.5)))
 test(6001.822, frollsd(adaptive=TRUE, 1:3, c(2,0,2), fill=99), c(99,NA,sqrt(0.5)))

--- a/src/data.table.h
+++ b/src/data.table.h
@@ -259,6 +259,7 @@ typedef enum { // adding rolling functions here and in frollfunR in frollR.c
   VAR = 6,
   SD = 7
 } rollfun_t;
+extern const char *const rfunNames[]; // Array of roll function names defined in froll.c
 // froll.c
 void frollfun(rollfun_t rfun, unsigned int algo, const double *x, uint64_t nx, ans_t *ans, int k, int align, double fill, bool narm, int hasnf, bool verbose, bool par);
 void frollmeanFast(const double *x, uint64_t nx, ans_t *ans, int k, double fill, bool narm, int hasnf, bool verbose);

--- a/src/froll.c
+++ b/src/froll.c
@@ -112,10 +112,7 @@ void frollfun(rollfun_t rfun, unsigned int algo, const double *x, uint64_t nx, a
     }
   }
   if (verbose) {
-    if(algo == 0)
-      snprintf(end(ans->message[0]), 500, _("%s: processing fun %s algo %s took %.3fs\n"), __func__, rfunStr, "fast", omp_get_wtime()-tic);
-    else
-      snprintf(end(ans->message[0]), 500, _("%s: processing fun %s algo %s took %.3fs\n"), __func__, rfunStr, "exact", omp_get_wtime()-tic);
+    snprintf(end(ans->message[0]), 500, _("%s: processing fun %s algo %s took %.3fs\n"), __func__, rfunStr, (algo == 0) ? "fast" : "exact", omp_get_wtime()-tic);
   }
 }
 

--- a/src/froll.c
+++ b/src/froll.c
@@ -105,9 +105,8 @@ void frollfun(rollfun_t rfun, unsigned int algo, const double *x, uint64_t nx, a
       ans->dbl_v[i] = fill;
     }
   }
-  if (verbose) {
+  if (verbose)
     snprintf(end(ans->message[0]), 500, _("%s: processing fun %s algo %s took %.3fs\n"), __func__, rfunNames[rfun], (algo == 0) ? "fast" : "exact", omp_get_wtime()-tic);
-  }
 }
 
 #undef SUM_WINDOW_STEP_FRONT

--- a/src/froll.c
+++ b/src/froll.c
@@ -21,8 +21,16 @@
  */
 void frollfun(rollfun_t rfun, unsigned int algo, const double *x, uint64_t nx, ans_t *ans, int k, int align, double fill, bool narm, int hasnf, bool verbose, bool par) {
   double tic = 0;
-  if (verbose)
+  char rfunStr[7];   
+
+  const char *rfunNames[] = {
+  "MEAN", "SUM", "MAX", "MIN", "PROD", "MEDIAN", "VAR", "SD"}; 
+
+  if (verbose){
     tic = omp_get_wtime();
+    snprintf(rfunStr, sizeof(rfunStr), "%s", rfunNames[rfun]);
+  }
+
   if (nx < k) {                      // if window width bigger than input just return vector of fill values
     if (verbose)
       snprintf(end(ans->message[0]), 500, _("%s: window width longer than input vector, returning all NA vector\n"), __func__);
@@ -103,8 +111,12 @@ void frollfun(rollfun_t rfun, unsigned int algo, const double *x, uint64_t nx, a
       ans->dbl_v[i] = fill;
     }
   }
-  if (verbose)
-    snprintf(end(ans->message[0]), 500, _("%s: processing fun %d algo %u took %.3fs\n"), __func__, rfun, algo, omp_get_wtime()-tic);
+  if (verbose) {
+    if(algo == 0)
+      snprintf(end(ans->message[0]), 500, _("%s: processing fun %s algo %s took %.3fs\n"), __func__, rfunStr, "fast", omp_get_wtime()-tic);
+    else
+      snprintf(end(ans->message[0]), 500, _("%s: processing fun %s algo %s took %.3fs\n"), __func__, rfunStr, "exact", omp_get_wtime()-tic);
+  }
 }
 
 #undef SUM_WINDOW_STEP_FRONT

--- a/src/froll.c
+++ b/src/froll.c
@@ -1,5 +1,7 @@
 #include "data.table.h"
 
+const char *const rfunNames[] = {
+  "MEAN", "SUM", "MAX", "MIN", "PROD", "MEDIAN", "VAR", "SD"}; //constant definition of froll functions
 /*
   OpenMP is used here to parallelize the loops in most of the
     implementations of rolling functions.
@@ -21,16 +23,8 @@
  */
 void frollfun(rollfun_t rfun, unsigned int algo, const double *x, uint64_t nx, ans_t *ans, int k, int align, double fill, bool narm, int hasnf, bool verbose, bool par) {
   double tic = 0;
-  char rfunStr[7];   
-
-  const char *rfunNames[] = {
-  "MEAN", "SUM", "MAX", "MIN", "PROD", "MEDIAN", "VAR", "SD"}; 
-
-  if (verbose){
+  if (verbose)
     tic = omp_get_wtime();
-    snprintf(rfunStr, sizeof(rfunStr), "%s", rfunNames[rfun]);
-  }
-
   if (nx < k) {                      // if window width bigger than input just return vector of fill values
     if (verbose)
       snprintf(end(ans->message[0]), 500, _("%s: window width longer than input vector, returning all NA vector\n"), __func__);
@@ -112,7 +106,7 @@ void frollfun(rollfun_t rfun, unsigned int algo, const double *x, uint64_t nx, a
     }
   }
   if (verbose) {
-    snprintf(end(ans->message[0]), 500, _("%s: processing fun %s algo %s took %.3fs\n"), __func__, rfunStr, (algo == 0) ? "fast" : "exact", omp_get_wtime()-tic);
+    snprintf(end(ans->message[0]), 500, _("%s: processing fun %s algo %s took %.3fs\n"), __func__, rfunNames[rfun], (algo == 0) ? "fast" : "exact", omp_get_wtime()-tic);
   }
 }
 

--- a/src/frolladaptive.c
+++ b/src/frolladaptive.c
@@ -83,7 +83,6 @@ void frolladaptivefun(rollfun_t rfun, unsigned int algo, const double *x, uint64
     snprintf(end(ans->message[0]), 500, _("%s: processing fun %s algo %s took %.3fs\n"), __func__, rfunNames[rfun], (algo == 0) ? "fast" : "exact", omp_get_wtime()-tic);
 }
 
-
 #undef MEAN_WINDOW_STEP_VALUE
 #define MEAN_WINDOW_STEP_VALUE                                   \
   if (wn>0) {                                                    \

--- a/src/frolladaptive.c
+++ b/src/frolladaptive.c
@@ -8,19 +8,9 @@
  *   recalculate whole fun for each observation, for mean roundoff correction is adjusted
  */
 void frolladaptivefun(rollfun_t rfun, unsigned int algo, const double *x, uint64_t nx, ans_t *ans, const int *k, double fill, bool narm, int hasnf, bool verbose) {
-  
   double tic = 0;
-  char rfunStr[7];   
-
-  // enum ordered based from the file src/data.table.h
-  const char *rfunNames[] = {
-  "MEAN", "SUM", "MAX", "MIN", "PROD", "MEDIAN", "VAR", "SD"}; 
-
-  if (verbose){
+  if (verbose)
     tic = omp_get_wtime();
-    snprintf(rfunStr, sizeof(rfunStr), "%s", rfunNames[rfun]);
-  }
-  
   switch (rfun) {
   case MEAN :
     if (algo==0) {
@@ -89,8 +79,8 @@ void frolladaptivefun(rollfun_t rfun, unsigned int algo, const double *x, uint64
   default: // # nocov
     internal_error(__func__, "Unknown rfun value in frolladaptive: %d", rfun); // # nocov
   }
-  if (verbose) {
-    snprintf(end(ans->message[0]), 500, _("%s: processing fun %s algo %s took %.3fs\n"), __func__, rfunStr, (algo == 0) ? "fast" : "exact", omp_get_wtime()-tic);
+  if (verbose) 
+    snprintf(end(ans->message[0]), 500, _("%s: processing fun %s algo %s took %.3fs\n"), __func__, rfunNames[rfun], (algo == 0) ? "fast" : "exact", omp_get_wtime()-tic);
 }
 
 

--- a/src/frolladaptive.c
+++ b/src/frolladaptive.c
@@ -30,7 +30,7 @@ void frolladaptivefun(rollfun_t rfun, unsigned int algo, const double *x, uint64
     if (algo==0 && verbose) {
       //frolladaptivemaxFast(x, nx, ans, k, fill, narm, hasnf, verbose); // frolladaptivemaxFast does not exists as of now
       snprintf(end(ans->message[0]), 500, _("%s: algo fast not implemented, fall back to exact\n"), __func__);
-      //set algo to 1 to print exact instead of fast in snprinf "fun %s" (line 93)
+      //set algo to 1 to print exact instead of fast in snprinf "fun %s" (Last snprintf in this function)
       algo = 1;
     }
     frolladaptivemaxExact(x, nx, ans, k, fill, narm, hasnf, verbose);
@@ -39,7 +39,7 @@ void frolladaptivefun(rollfun_t rfun, unsigned int algo, const double *x, uint64
     if (algo==0 && verbose) {
       //frolladaptiveminFast(x, nx, ans, k, fill, narm, hasnf, verbose); // frolladaptiveminFast does not exists as of now
       snprintf(end(ans->message[0]), 500, _("%s: algo fast not implemented, fall back to exact\n"), __func__);
-      //set algo to 1 to print exact instead of fast in snprinf "fun %s" (line 93)
+      //set algo to 1 to print exact instead of fast in snprinf "fun %s" (Last snprintf in this function)
       algo = 1;
     }
     frolladaptiveminExact(x, nx, ans, k, fill, narm, hasnf, verbose);

--- a/src/frolladaptive.c
+++ b/src/frolladaptive.c
@@ -79,7 +79,7 @@ void frolladaptivefun(rollfun_t rfun, unsigned int algo, const double *x, uint64
   default: // # nocov
     internal_error(__func__, "Unknown rfun value in frolladaptive: %d", rfun); // # nocov
   }
-  if (verbose) 
+  if (verbose)
     snprintf(end(ans->message[0]), 500, _("%s: processing fun %s algo %s took %.3fs\n"), __func__, rfunNames[rfun], (algo == 0) ? "fast" : "exact", omp_get_wtime()-tic);
 }
 

--- a/src/frolladaptive.c
+++ b/src/frolladaptive.c
@@ -8,9 +8,19 @@
  *   recalculate whole fun for each observation, for mean roundoff correction is adjusted
  */
 void frolladaptivefun(rollfun_t rfun, unsigned int algo, const double *x, uint64_t nx, ans_t *ans, const int *k, double fill, bool narm, int hasnf, bool verbose) {
+  
   double tic = 0;
-  if (verbose)
+  char rfunStr[7];   
+
+  // enum ordered based from the file src/data.table.h
+  const char *rfunNames[] = {
+  "MEAN", "SUM", "MAX", "MIN", "PROD", "MEDIAN", "VAR", "SD"}; 
+
+  if (verbose){
     tic = omp_get_wtime();
+    snprintf(rfunStr, sizeof(rfunStr), "%s", rfunNames[rfun]);
+  }
+  
   switch (rfun) {
   case MEAN :
     if (algo==0) {
@@ -29,51 +39,62 @@ void frolladaptivefun(rollfun_t rfun, unsigned int algo, const double *x, uint64
   case MAX :
     if (algo==0 && verbose) {
       //frolladaptivemaxFast(x, nx, ans, k, fill, narm, hasnf, verbose); // frolladaptivemaxFast does not exists as of now
-      snprintf(end(ans->message[0]), 500, _("%s: algo %u not implemented, fall back to %u\n"), __func__, algo, (unsigned int) 1);
+      snprintf(end(ans->message[0]), 500, _("%s: algo fast not implemented, fall back to exact\n"), __func__);
+      algo = 1;
     }
     frolladaptivemaxExact(x, nx, ans, k, fill, narm, hasnf, verbose);
     break;
   case MIN :
     if (algo==0 && verbose) {
       //frolladaptiveminFast(x, nx, ans, k, fill, narm, hasnf, verbose); // frolladaptiveminFast does not exists as of now
-      snprintf(end(ans->message[0]), 500, _("%s: algo %u not implemented, fall back to %u\n"), __func__, algo, (unsigned int) 1);
+      snprintf(end(ans->message[0]), 500, _("%s: algo fast not implemented, fall back to exact\n"), __func__);
+      algo = 1;
     }
     frolladaptiveminExact(x, nx, ans, k, fill, narm, hasnf, verbose);
     break;
   case PROD :
     if (algo==0 && verbose) {
       //frolladaptiveprodFast(x, nx, ans, k, fill, narm, hasnf, verbose); // frolladaptiveprodFast does not exists as of now
-      snprintf(end(ans->message[0]), 500, _("%s: algo %u not implemented, fall back to %u\n"), __func__, algo, (unsigned int) 1);
+      snprintf(end(ans->message[0]), 500, _("%s: algo fast not implemented, fall back to exact\n"), __func__);
+      algo = 1;
     }
     frolladaptiveprodExact(x, nx, ans, k, fill, narm, hasnf, verbose);
     break;
   case MEDIAN :
     if (algo==0 && verbose) {
       //frolladaptivemedianFast(x, nx, ans, k, fill, narm, hasnf, verbose); // frolladaptivemedianFast does not exists as of now
-      snprintf(end(ans->message[0]), 500, _("%s: algo %u not implemented, fall back to %u\n"), __func__, algo, (unsigned int) 1);
+      snprintf(end(ans->message[0]), 500, _("%s: algo fast not implemented, fall back to exact\n"), __func__);
+      algo = 1;
     }
     frolladaptivemedianExact(x, nx, ans, k, fill, narm, hasnf, verbose);
     break;
   case VAR :
     if (algo==0 && verbose) {
       //frolladaptivevarFast(x, nx, ans, k, fill, narm, hasnf, verbose); // frolladaptivevarFast does not exists as of now
-      snprintf(end(ans->message[0]), 500, _("%s: algo %u not implemented, fall back to %u\n"), __func__, algo, (unsigned int) 1);
+      snprintf(end(ans->message[0]), 500, _("%s: algo fast not implemented, fall back to exact\n"), __func__);
+      algo = 1;
     }
     frolladaptivevarExact(x, nx, ans, k, fill, narm, hasnf, verbose);
     break;
   case SD :
     if (algo==0 && verbose) {
       //frolladaptivesdFast(x, nx, ans, k, fill, narm, hasnf, verbose); // frolladaptivesdFast does not exists as of now
-      snprintf(end(ans->message[0]), 500, _("%s: algo %u not implemented, fall back to %u\n"), __func__, algo, (unsigned int) 1);
+      snprintf(end(ans->message[0]), 500, _("%s: algo fast not implemented, fall back to exact\n"), __func__);
+      algo = 1;
     }
     frolladaptivesdExact(x, nx, ans, k, fill, narm, hasnf, verbose);
     break;
   default: // # nocov
     internal_error(__func__, "Unknown rfun value in frolladaptive: %d", rfun); // # nocov
   }
-  if (verbose)
-    snprintf(end(ans->message[0]), 500, _("%s: processing fun %d algo %u took %.3fs\n"), __func__, rfun, algo, omp_get_wtime()-tic);
+  if (verbose) {
+    if(algo == 0)
+      snprintf(end(ans->message[0]), 500, _("%s: processing fun %s algo %s took %.3fs\n"), __func__, rfunStr, "fast", omp_get_wtime()-tic);
+    else
+      snprintf(end(ans->message[0]), 500, _("%s: processing fun %s algo %s took %.3fs\n"), __func__, rfunStr, "exact", omp_get_wtime()-tic);
+  }
 }
+
 
 #undef MEAN_WINDOW_STEP_VALUE
 #define MEAN_WINDOW_STEP_VALUE                                   \

--- a/src/frolladaptive.c
+++ b/src/frolladaptive.c
@@ -40,6 +40,7 @@ void frolladaptivefun(rollfun_t rfun, unsigned int algo, const double *x, uint64
     if (algo==0 && verbose) {
       //frolladaptivemaxFast(x, nx, ans, k, fill, narm, hasnf, verbose); // frolladaptivemaxFast does not exists as of now
       snprintf(end(ans->message[0]), 500, _("%s: algo fast not implemented, fall back to exact\n"), __func__);
+      //set algo to 1 to print exact instead of fast in snprinf "fun %s" (line 93)
       algo = 1;
     }
     frolladaptivemaxExact(x, nx, ans, k, fill, narm, hasnf, verbose);
@@ -48,6 +49,7 @@ void frolladaptivefun(rollfun_t rfun, unsigned int algo, const double *x, uint64
     if (algo==0 && verbose) {
       //frolladaptiveminFast(x, nx, ans, k, fill, narm, hasnf, verbose); // frolladaptiveminFast does not exists as of now
       snprintf(end(ans->message[0]), 500, _("%s: algo fast not implemented, fall back to exact\n"), __func__);
+      //set algo to 1 to print exact instead of fast in snprinf "fun %s" (line 93)
       algo = 1;
     }
     frolladaptiveminExact(x, nx, ans, k, fill, narm, hasnf, verbose);
@@ -88,11 +90,7 @@ void frolladaptivefun(rollfun_t rfun, unsigned int algo, const double *x, uint64
     internal_error(__func__, "Unknown rfun value in frolladaptive: %d", rfun); // # nocov
   }
   if (verbose) {
-    if(algo == 0)
-      snprintf(end(ans->message[0]), 500, _("%s: processing fun %s algo %s took %.3fs\n"), __func__, rfunStr, "fast", omp_get_wtime()-tic);
-    else
-      snprintf(end(ans->message[0]), 500, _("%s: processing fun %s algo %s took %.3fs\n"), __func__, rfunStr, "exact", omp_get_wtime()-tic);
-  }
+    snprintf(end(ans->message[0]), 500, _("%s: processing fun %s algo %s took %.3fs\n"), __func__, rfunStr, (algo == 0) ? "fast" : "exact", omp_get_wtime()-tic);
 }
 
 


### PR DESCRIPTION
Closes https://github.com/Rdatatable/data.table/issues/7021.

Previously, the frolladaptivefun and rfollfun algo verbose messages were not super user friendly, displaying messages like:

```frolladaptivefun: algo 0 not implemented, fall back to 1```

The wanted adjustment was for it to instead produce:

```frolladaptivefun: algo fast not implemented, fall back to exact```

There was also:
```frollfun: processing fun 0 algo 0 took...```

and the desired result was instead:
```frollfun: processing fun mean algo fast took...```

We adjusted for the desired functionality by creating an array of strings called rfunNames, using the rfun enum as an index to select the proper display type for the running function and then displaying fast or exact dependent on the value of value (0 for fast, 1 for exact).

Here is an example of the current output (from running tests) with the changed files in this PR:
```frolladaptivefun: processing fun MIN algo exact took 0.000s```
```frolladaptivefun: algo fast not implemented, fall back to exact```

We have additionally adjusted the NEWS.md file and the corresponding tests in inst/tests/froll.Rraw.