### PR TITLE
tests: suppress "built under newer R" warning

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18419,7 +18419,7 @@ test(2264.8, print(DT, show.indices=TRUE), output=ans)
 if (test_bit64) local({
   DT = data.table(a = 'abc', b = as.integer64(1))
   suppressPackageStartupMessages(unloadNamespace("bit64"))
-  on.exit(suppressPackageStartupMessages(library(bit64, pos="package:base")))
+  on.exit(suppressWarnings(suppressPackageStartupMessages(library(bit64, pos="package:base"))))
   test(2265, DT, output="abc\\s*1$")
 })
 


### PR DESCRIPTION
When using the .0 release of R with binary packages from CRAN, `library()` will complain about the binary package having been built under a newer (but still compatible in this case) version of R. This was already suppressed in most places, but not in test 2265. This previously caused tests [mac-rel](https://r-datatable.com/web/checks/data.table/test-mac-rel/tests/main.Rout.fail) and [win-rel](https://r-datatable.com/web/checks/data.table/test-win-rel/tests/main.Rout.fail) to fail. With the patch they do succeed ([mac](https://gitlab.com/Rdatatable/data.table/-/jobs/14237076099), [win](https://gitlab.com/Rdatatable/data.table/-/jobs/14236204878)).

Unrelated: the other two failures in [lin-dev-clang-cran](https://r-datatable.com/web/checks/data.table/test-lin-dev-clang-cran/00check.log), [lin-dev-gcc-strict-cran](https://r-datatable.com/web/checks/data.table/test-lin-dev-gcc-strict-cran/00check.log) were due to `makeindex` missing from TinyTeX (newly exposed by `tools::texi2pdf()` in R-devel r89983), now fixed ([clang](https://gitlab.com/Rdatatable/data.table/-/jobs/14237343508), [gcc-strict](https://gitlab.com/Rdatatable/data.table/-/jobs/14237343870)) in the container images.

Fixes: #7721