### PR TITLE
use ellipsis instead of ... in prettyprint

### DIFF
--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -253,7 +253,7 @@ char.trunc = function(x, trunc.char = getOption("datatable.prettyprint.char")) {
   nchar_chars = nchar(x, 'char')
   is_full_width = nchar_width > nchar_chars
   idx = !is.na(x) & pmin(nchar_width, nchar_chars) > trunc.char
-  x[idx] = paste0(strtrim(x[idx], trunc.char * fifelse(is_full_width[idx], 2L, 1L)), "...")
+  x[idx] = paste0(strtrim(x[idx], trunc.char * fifelse(is_full_width[idx], 2L, 1L)), "\u2026")
   x
 }
 

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -252,8 +252,8 @@ char.trunc = function(x, trunc.char = getOption("datatable.prettyprint.char")) {
   nchar_width = nchar(x, 'width') # Check whether string is full-width or half-width, #5096
   nchar_chars = nchar(x, 'char')
   is_full_width = nchar_width > nchar_chars
-  idx = !is.na(x) & pmin(nchar_width, nchar_chars) > trunc.char 
-  dots = if (l10n_info()$'UTF-8') "\u2026" else "..." 
+  idx = !is.na(x) & pmin(nchar_width, nchar_chars) > trunc.char
+  dots = if (l10n_info()$'UTF-8') "\u2026" else "..."
   x[idx] = paste0(strtrim(x[idx], trunc.char * fifelse(is_full_width[idx], 2L, 1L)), dots)
   x
 }

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -252,8 +252,9 @@ char.trunc = function(x, trunc.char = getOption("datatable.prettyprint.char")) {
   nchar_width = nchar(x, 'width') # Check whether string is full-width or half-width, #5096
   nchar_chars = nchar(x, 'char')
   is_full_width = nchar_width > nchar_chars
-  idx = !is.na(x) & pmin(nchar_width, nchar_chars) > trunc.char
-  x[idx] = paste0(strtrim(x[idx], trunc.char * fifelse(is_full_width[idx], 2L, 1L)), "\u2026")
+  idx = !is.na(x) & pmin(nchar_width, nchar_chars) > trunc.char 
+  dots = if (l10n_info()$'UTF-8') "\u2026" else "..." 
+  x[idx] = paste0(strtrim(x[idx], trunc.char * fifelse(is_full_width[idx], 2L, 1L)), dots)
   x
 }
 

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18182,15 +18182,15 @@ if (utf8_check(nc)) {
     paste0(strrep(ja_ko, 2L), "   ", strrep(ja_n, 3L), " ", strrep(accented_a, 3L)),
     paste(strrep(ja_ko, 3L), strrep(ja_n, 4L), strrep(accented_a, 3L))))
   test(2253.18, options=list(datatable.prettyprint.char = 3L), gsub(clean_regex, "", capture.output(print(DT))[-1L]),
-    c(paste0(ja_ko, "      ", strrep(ja_n, 2L), " ", strrep(accented_a, 3L)),
-    paste0(strrep(ja_ko, 2L), "    ", strrep(ja_n, 3L), " ", strrep(accented_a, 3L)),
+    c(paste0(ja_ko, "    ", strrep(ja_n, 2L), " ", strrep(accented_a, 3L)),
+    paste0(strrep(ja_ko, 2L), "  ", strrep(ja_n, 3L), " ", strrep(accented_a, 3L)),
     paste(strrep(ja_ko, 3L), paste0(strrep(ja_n, 3L), dots), strrep(accented_a, 3L))))
   test(2253.19, options=list(datatable.prettyprint.char = 1L), gsub(clean_regex, "", capture.output(print(DT))[-1L]),
     c(paste0(ja_ko, " ", paste0(ja_n, dots), " ", paste0(accented_a, dots)),
     paste0(c(ja_ko, ja_n, accented_a), dots, collapse=" "),
     paste0(c(ja_ko, ja_n, accented_a), dots, collapse=" ")))
   # test for data.table with NA, #6441
-  test(2253.20, options=list(datatable.prettyprint.char = 1L), data.table(a = c("abc", NA)), output="      a\n1: a...\n2: <NA>")
+  test(2253.20, options=list(datatable.prettyprint.char = 1L), data.table(a = c("abc", NA)), output="      a\n1:   a\u2026\n2: <NA>")
 } else {
   cat("Tests 2253* skipped because they need a UTF-8 locale.\n")
 }})

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -18188,12 +18188,17 @@ if (utf8_check(nc)) {
   test(2253.19, options=list(datatable.prettyprint.char = 1L), gsub(clean_regex, "", capture.output(print(DT))[-1L]),
     c(paste0(ja_ko, " ", paste0(ja_n, dots), " ", paste0(accented_a, dots)),
     paste0(c(ja_ko, ja_n, accented_a), dots, collapse=" "),
-    paste0(c(ja_ko, ja_n, accented_a), dots, collapse=" ")))
+    paste0(c(ja_ko, ja_n, accented_a), dots, collapse=" "))) 
   # test for data.table with NA, #6441
   test(2253.20, options=list(datatable.prettyprint.char = 1L), data.table(a = c("abc", NA)), output="      a\n1:   a\u2026\n2: <NA>")
 } else {
   cat("Tests 2253* skipped because they need a UTF-8 locale.\n")
 }})
+
+# Test that char.trunc in prettyprint falls back to three dots if ellipsis is not supported in non UTF-8 encoding
+DT = data.table(a = c("abcd", NA, "f"))
+test(2253.24, options = list(datatable.prettyprint.char = 3L,Sys.setlocale("LC_CTYPE", "C")),
+  DT, output = "        a\n1: abc...\n2:   <NA>\n3:      f")
 
 # allow 1-D matrix in j for consistency, #783
 DT=data.table(a = rep(1:2, 3), b = 1:6)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -7266,7 +7266,7 @@ test(1514.9, fitsInInt64(9L), FALSE)
 # #1091
 options(datatable.prettyprint.char = 5L)
 DT = data.table(x=1:2, y=c("abcdefghijk", "lmnopqrstuvwxyz"))
-test(1515.1, grep("abcde...", capture.output(print(DT))), 2L)
+test(1515.1, grep("abcde\u2026", capture.output(print(DT))), 2L)
 options(datatable.prettyprint.char = NULL)
 
 # test 1516: chain setnames() - used while mapping source to target columns
@@ -18147,7 +18147,7 @@ ja_ko = "\u3053"
 ja_n = "\u3093"
 nc = c(accented_a, ja_ichi, ja_ni, ja_ko, ja_n)
 if (utf8_check(nc)) {
-  dots = "..."
+  dots = "\u2026"
   clean_regex = "^\\d+:\\s+" # removes row numbering from beginning of output
   # Tests for combining character latin a and acute accent, single row
   DT = data.table(strrep(accented_a, 4L))
@@ -18173,8 +18173,8 @@ if (utf8_check(nc)) {
   DT = data.table(paste0(ja_ichi), strrep(ja_ni, 2L), strrep(ja_ko, 3L), strrep(accented_a, 2L), "aaa")
   test(2253.13, options=list(datatable.prettyprint.char = 4L), capture.output(print(DT))[-1L], paste("1:", ja_ichi, strrep(ja_ni, 2L), strrep(ja_ko, 3L), strrep(accented_a, 2L), "aaa"))
   test(2253.14, options=list(datatable.prettyprint.char = 3L), capture.output(print(DT))[-1L], paste("1:", ja_ichi, strrep(ja_ni, 2L), strrep(ja_ko, 3L), strrep(accented_a, 2L), "aaa"))
-  test(2253.15, options=list(datatable.prettyprint.char = 2L), capture.output(print(DT))[-1L], paste("1:", ja_ichi, strrep(ja_ni, 2), paste0(strrep(ja_ko, 2), dots) , strrep(accented_a, 2), "aa..."))
-  test(2253.16, options=list(datatable.prettyprint.char = 1L), capture.output(print(DT))[-1L], paste("1:", ja_ichi, paste0(ja_ni, dots), paste0(ja_ko, dots), paste0(accented_a, dots), "a..."))
+  test(2253.15, options=list(datatable.prettyprint.char = 2L), capture.output(print(DT))[-1L], paste("1:", ja_ichi, strrep(ja_ni, 2), paste0(strrep(ja_ko, 2), dots) , strrep(accented_a, 2), "aa\u2026"))
+  test(2253.16, options=list(datatable.prettyprint.char = 1L), capture.output(print(DT))[-1L], paste("1:", ja_ichi, paste0(ja_ni, dots), paste0(ja_ko, dots), paste0(accented_a, dots), "a\u2026"))
   # Tests for multiple columns, multiple rows
   DT = data.table(strrep(ja_ko, 1:3L), strrep(ja_n, 2:4L), strrep(accented_a, 3))
   test(2253.17, options=list(datatable.prettyprint.char = 4L), gsub(clean_regex, "", capture.output(print(DT))[-1L]),


### PR DESCRIPTION
Hello everyone! closes #7715 
I'm opening my 1st PR and would be happy to contribute to this amazing project going forward. 
A little about me: I've been on and off `data.table` user for quite a few years now and consider myself rather proficient in R and I know some C as well, so hopefully I could contribute to some core `data.table` as well.

I introduced the small change described in issue #7715 and had to update some tests as well, namely:
```
1515.1, 2253.2, 2253.03, 2253.05, 2253.06, 2253.08, 2253.09,
2253.11, 2253.12, 2253.15, 2253.16, 2253.18, 2253.19
```

These 2 tests appear to be failing when I build the package locally (and in GH Actions jobs as well). I'll try to spend some time on it and fix, but any hints appreciated! @tdhock @ben-schwen @MichaelChirico 
```
2253.2
2253.18
```

Thank you,
Tomasz