### PR TITLE
markdown fields in revdep_check_failure.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/revdep_check_failure.yml
+++ b/.github/ISSUE_TEMPLATE/revdep_check_failure.yml
@@ -19,12 +19,12 @@ body:
     validations:
       required: true
 
-  - type: textarea
+  - type: markdown
     id: check-output
     attributes:
       label: Failing check output
       description: |
-        Paste the relevant `R CMD check` output showing the failure.
+        Write markdown describing the relevant `R CMD check` output showing the failure.
         The output can be found in the
         [Monsoon results](https://rcdata.nau.edu/genomic-ml/data.table-revdeps/analyze/)
         or from a local revdep check.
@@ -44,12 +44,12 @@ body:
     validations:
       required: true
 
-  - type: textarea
+  - type: markdown
     id: additional-context
     attributes:
       label: Additional context
       description: |
-        Any other relevant information: @mentions of the commit/PR
+        Write markdown with any other relevant information: @mentions of the commit/PR
         author(s), links to Monsoon result pages, whether the fix
         should come from data.table or from the revdep package, etc.
         Minimal reproducible examples (MRE) can also be included here.

--- a/.github/ISSUE_TEMPLATE/revdep_check_failure.yml
+++ b/.github/ISSUE_TEMPLATE/revdep_check_failure.yml
@@ -19,7 +19,7 @@ body:
     validations:
       required: true
 
-  - type: markdown
+  - type: input
     id: check-output
     attributes:
       label: Failing check output
@@ -28,7 +28,6 @@ body:
         The output can be found in the
         [Monsoon results](https://rcdata.nau.edu/genomic-ml/data.table-revdeps/analyze/)
         or from a local revdep check.
-      render: text
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/revdep_check_failure.yml
+++ b/.github/ISSUE_TEMPLATE/revdep_check_failure.yml
@@ -25,6 +25,7 @@ body:
       label: Failing check output
       description: |
         Write markdown describing the relevant `R CMD check` output showing the failure.
+        Paste check output inside a fenced code block (triple backticks).
         The output can be found in the
         [Monsoon results](https://rcdata.nau.edu/genomic-ml/data.table-revdeps/analyze/)
         or from a local revdep check.

--- a/.github/ISSUE_TEMPLATE/revdep_check_failure.yml
+++ b/.github/ISSUE_TEMPLATE/revdep_check_failure.yml
@@ -19,7 +19,7 @@ body:
     validations:
       required: true
 
-  - type: input
+  - type: textarea
     id: check-output
     attributes:
       label: Failing check output
@@ -43,7 +43,7 @@ body:
     validations:
       required: true
 
-  - type: input
+  - type: textarea
     id: additional-context
     attributes:
       label: Additional context

--- a/.github/ISSUE_TEMPLATE/revdep_check_failure.yml
+++ b/.github/ISSUE_TEMPLATE/revdep_check_failure.yml
@@ -43,7 +43,7 @@ body:
     validations:
       required: true
 
-  - type: markdown
+  - type: input
     id: additional-context
     attributes:
       label: Additional context


### PR DESCRIPTION
Hi @Keykyrios can you please review?
I used this to file https://github.com/Rdatatable/data.table/issues/7770 and I noticed it would be easier if several fields were markdown.

check https://github.com/Rdatatable/data.table/blob/tdhock-revdep-form/.github/ISSUE_TEMPLATE/revdep_check_failure.yml to see if there are errors.