### PR TITLE
docs: add panel data example to frolladapt.Rd

### DIFF
--- a/man/frolladapt.Rd
+++ b/man/frolladapt.Rd
@@ -35,6 +35,19 @@ dt
 n34 = frolladapt(idx, c(small=3, big=4), give.names=TRUE)
 n34
 dt[, frollmean(value, n34, adaptive=TRUE, give.names=TRUE)]
+
+## panel data: rolling mean within groups, respecting irregular date gaps
+## equivalent to Stata: rangestat (mean) rollmean3 = sales, int(date -2 0) by(firm)
+dt = data.table(
+  firm = rep(c("A", "B"), each = 4),
+  date = as.Date(c("2020-01-01", "2020-01-02", "2020-01-05", "2020-01-06",
+                    "2020-01-01", "2020-01-03", "2020-01-04", "2020-01-07")),
+  sales = c(10, 12, 15, 13, 20, 22, 18, 25)
+)
+setorder(dt, firm, date)
+dt[, rollmean3 := frollmean(sales, frolladapt(date, n=3L, partial=TRUE),
+                            adaptive=TRUE), by = firm]
+dt
 }
 \seealso{
   \code{\link{froll}}, \code{\link{frollapply}}


### PR DESCRIPTION
## Summary

Adds a panel data example to  showing how to compute rolling means within groups using  +  with `by=`. This is the data.table equivalent of Stata's `rangestat` with `by()` for time-aware rolling windows.

**Stata equivalent:**
```stata
rangestat (mean) rollmean3 = sales, int(date -2 0) by(firm)
```

**data.table equivalent (new example):**
```r
dt = data.table(
  firm = rep(c("A", "B"), each = 4),
  date = as.Date(c("2020-01-01", "2020-01-02", "2020-01-05", "2020-01-06",
                    "2020-01-01", "2020-01-03", "2020-01-04", "2020-01-07")),
  sales = c(10, 12, 15, 13, 20, 22, 18, 25)
)
setorder(dt, firm, date)
dt[, rollmean3 := frollmean(sales, frolladapt(date, n=3L, partial=TRUE),
                            adaptive=TRUE), by = firm]
```

## Rationale

The `frolladapt.Rd` page had only single-entity examples despite `frolladapt` being the key function for time-aware rolling windows in data.table. Panel data rolling operations (e.g., `rangestat ... by(firm)` in Stata) are the most common migration pattern where users need rolling calculations within groups respecting irregular time gaps.

The existing `froll.Rd` note (line 72) warns that rolling functions operate on physical order, but `frolladapt.Rd` didn't show the grouped usage pattern that makes this practical for panel data.

## Validation

- `tools::checkRd('man/frolladapt.Rd')` passes (no output = no errors)
- All example code runs successfully in R
- 1 file changed, 13 lines added

## Files Changed

| File | Lines Added | Lines Removed | Type |
|------|------------|---------------|------|
| man/frolladapt.Rd | 13 | 0 | Documentation (Rd) |

## Duplicate Check

- Checked open PRs: no frolladapt-related PRs found
- Checked issues: #7294 (about classed `n` for automatic `adaptive` detection, different scope)