### PR TITLE
Do not rename `data.table.dll` to `data_table.dll`

### DIFF
--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -97,9 +97,9 @@ test.list <- atime::atime_test_list(
     pkg_find_replace <- function(glob, FIND, REPLACE) {
       atime::glob_find_replace(file.path(new.pkg.path, glob), FIND, REPLACE)
     }
-    Package_regex <- gsub(".", "_?", old.Package, fixed = TRUE)
-    Package_ <- gsub(".", "_", old.Package, fixed = TRUE)
-    new.Package_ <- paste0(Package_, "_", sha)
+    Package_regex <- gsub(".", "([_.]?)", old.Package, fixed = TRUE)
+    Package_ <- gsub(".", "\\1", old.Package, fixed = TRUE)
+    new.Package_ <- paste0(Package_, "\\1", sha)
     pkg_find_replace(
       "DESCRIPTION",
       paste0("Package:\\s+", old.Package),
@@ -112,10 +112,6 @@ test.list <- atime::atime_test_list(
       file.path("R", "onLoad.R"),
       Package_regex,
       new.Package_)
-    pkg_find_replace(
-      file.path("R", "onLoad.R"),
-      sprintf('packageVersion\\("%s"\\)', old.Package),
-      sprintf('packageVersion\\("%s"\\)', new.Package))
     pkg_find_replace(
       file.path("src", "init.c"),
       paste0("R_init_", Package_regex),

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,4 +1,4 @@
-useDynLib("data_table", .registration=TRUE)
+useDynLib("data.table", .registration=TRUE)
 
 ## For S4-ization
 importFrom(methods, "S3Part<-", slotNames)

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -12,13 +12,13 @@
   # Runs when loaded but not attached to search() path; e.g., when a package just Imports (not Depends on) data.table
   if (!exists("test.data.table", .GlobalEnv, inherits=FALSE)) {
     # check when installed package is loaded but skip when developing the package with cc()
-    dllV = if (is.loaded("CdllVersion",PACKAGE="data_table")) .Call(CdllVersion) else "before 1.12.0"
+    dllV = if (is.loaded("CdllVersion",PACKAGE="data.table")) .Call(CdllVersion) else "before 1.18.99"
     RV = as.character(packageVersion("data.table"))
     if (dllV != RV) {
-      dll = if (.Platform$OS.type=="windows") "dll" else "so"
+      dll = .Platform$dynlib.ext
       # https://bugs.r-project.org/bugzilla/show_bug.cgi?id=17478
       # TODO(R>=4.0.0): Remove or adjust this message once we're sure all users are unaffected
-      stopf("The data_table.%s version (%s) does not match the package (%s). Please close all R sessions to release the old %s and reinstall data.table in a fresh R session. Prior to R version 3.6.0 patched, R's package installer could leave a package in an apparently functional state where new R code was calling old C code silently: https://bugs.r-project.org/bugzilla/show_bug.cgi?id=17478. Once a package is in this mismatch state it may produce wrong results silently until you next upgrade the package. This mismatch between R and C code can happen with any package not just data.table. It is just that data.table has added this check.", dll, dllV, RV, toupper(dll))
+      stopf("The data.table.%s version (%s) does not match the package (%s). Please close all R sessions to release the old %s and reinstall data.table in a fresh R session. Prior to R version 3.6.0 patched, R's package installer could leave a package in an apparently functional state where new R code was calling old C code silently: https://bugs.r-project.org/bugzilla/show_bug.cgi?id=17478. Once a package is in this mismatch state it may produce wrong results silently until you next upgrade the package. This mismatch between R and C code can happen with any package not just data.table. It is just that data.table has added this check.", dll, dllV, RV, toupper(dll))
     }
     builtPath = system.file("Meta", "package.rds", package="data.table")
     if (builtPath != "" && !identical(session_r_version>="4.0.0", (build_r_version <- readRDS(builtPath)$Built$R)>="4.0.0")) {
@@ -143,7 +143,7 @@ getRversion = function(...) stopf("Reminder to data.table developers: don't use 
 # 4) Defining getRversion with a stopf() here helps prevent new switches on getRversion() being added in future. Easily circumvented but the point is to issue the message above.
 
 .onUnload = function(libpath) {
-  library.dynam.unload("data_table", libpath)
+  library.dynam.unload("data.table", libpath)
 }
 
 # nocov end

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -10,6 +10,3 @@ PKG_LIBS = $(C_VISIBILITY) @PKG_LIBS@ @zlib_libs@
 all: $(SHLIB)
 	@echo PKG_CFLAGS = $(PKG_CFLAGS)
 	@echo PKG_LIBS = $(PKG_LIBS)
-	if [ "$(SHLIB)" != "data_table$(SHLIB_EXT)" ]; then mv $(SHLIB) data_table$(SHLIB_EXT); fi
-	if [ "$(OS)" != "Windows_NT" ] && [ `uname -s` = 'Darwin' ]; then install_name_tool -id data_table$(SHLIB_EXT) data_table$(SHLIB_EXT); fi
-

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,5 +1,2 @@
 PKG_CFLAGS = $(SHLIB_OPENMP_CFLAGS)
 PKG_LIBS = $(SHLIB_OPENMP_CFLAGS) -lz
-
-all: $(SHLIB)
-	mv $(SHLIB) data_table$(SHLIB_EXT)


### PR DESCRIPTION
According to old versions of WRE, R automatically replaces dots with understores in `R_init_<DLL name>()` since R-2.15, so renaming is no longer necessary. This also has the side effect of working around the [behaviour change from R r90101](https://bugs.r-project.org/show_bug.cgi?id=17549#c9) and producing correct source tarballs on Windows again: for now, after temporarily installing the package, `R CMD build` cleans up `data.table.dll`, but misses `data_table.dll`.