### PR TITLE
docs: fix \code{} tag in melt.Rd, add factor to nafill.Rd @param x

### DIFF
--- a/man/frolladapt.Rd
+++ b/man/frolladapt.Rd
@@ -35,6 +35,19 @@ dt
 n34 = frolladapt(idx, c(small=3, big=4), give.names=TRUE)
 n34
 dt[, frollmean(value, n34, adaptive=TRUE, give.names=TRUE)]
+
+## panel data: rolling mean within groups, respecting irregular date gaps
+## equivalent to Stata: rangestat (mean) rollmean3 = sales, int(date -2 0) by(firm)
+dt = data.table(
+  firm = rep(c("A", "B"), each = 4),
+  date = as.Date(c("2020-01-01", "2020-01-02", "2020-01-05", "2020-01-06",
+                    "2020-01-01", "2020-01-03", "2020-01-04", "2020-01-07")),
+  sales = c(10, 12, 15, 13, 20, 22, 18, 25)
+)
+setorder(dt, firm, date)
+dt[, rollmean3 := frollmean(sales, frolladapt(date, n=3L, partial=TRUE),
+                            adaptive=TRUE), by = firm]
+dt
 }
 \seealso{
   \code{\link{froll}}, \code{\link{frollapply}}

--- a/man/melt.data.table.Rd
+++ b/man/melt.data.table.Rd
@@ -56,8 +56,7 @@ more than once and the same column can be both as id and measure variables.
 variables.
 
 When all \code{measure.vars} are not of the same type, they'll be coerced
-according to the hierarchy \code{list} > \code{character} > \code{numeric >
-integer > logical}. For example, if any of the measure variables is a
+according to the hierarchy \code{list} > \code{character} > \code{numeric} > \code{integer} > \code{logical}. For example, if any of the measure variables is a
 \code{list}, then entire value column will be coerced to a list. 
 
 From version \code{1.9.6}, \code{melt} gains a feature with \code{measure.vars}

--- a/man/nafill.Rd
+++ b/man/nafill.Rd
@@ -14,7 +14,7 @@ nafill(x, type=c("const", "locf", "nocb"), fill=NA, nan=NA)
 setnafill(x, type=c("const", "locf", "nocb"), fill=NA, nan=NA, cols=seq_along(x))
 }
 \arguments{
-  \item{x}{ Vector, list, data.frame or data.table of logical, numeric or character columns. }
+  \item{x}{ Vector, list, data.frame or data.table of logical, numeric, character, or factor columns. }
   \item{type}{ Character, one of \emph{"const"}, \emph{"locf"} or \emph{"nocb"}. Defaults to \code{"const"}. }
   \item{fill}{ Value to be used to replace missing observations. See examples. }
   \item{nan}{ Either \code{NaN} or \code{NA}; if the former, \code{NaN} is treated as distinct from \code{NA}, otherwise, they are treated the same during replacement. See Examples. }


### PR DESCRIPTION
Two small documentation fixes:

**1. melt.data.table.Rd line 59 — broken \code{} tag**

The type coercion hierarchy was rendered with inconsistent formatting:

```
\code{list} > \code{character} > \code{numeric > integer > logical}
```

The \code{} tag spanned across two lines, putting the `>` signs between numeric/integer/logical inside monospace code while leaving list/character comparisons as plain text. Fixed to wrap each type individually:

```
\code{list} > \code{character} > \code{numeric} > \code{integer} > \code{logical}
```

**2. nafill.Rd line 17 — @param x missing factor**

The `@param x` description listed supported types as "logical, numeric or character" but the Details section (line 24) and examples (lines 40-43) confirm factor is also supported. Updated to match.

### Validation

- `tools::checkRd('man/melt.data.table.Rd')` — passes
- `tools::checkRd('man/nafill.Rd')` — passes
- nafill with factor input verified working

### Files changed

| File | Change |
|------|--------|
| man/melt.data.table.Rd | Fix \code{} tag spanning lines 59-60 |
| man/nafill.Rd | Add "factor" to @param x type list |