### PR TITLE
docs: fix shift.Rd Value section to reflect vector return for single n

### DIFF
--- a/man/shift.Rd
+++ b/man/shift.Rd
@@ -29,7 +29,7 @@ shift(x, n=1L, fill, type=c("lag", "lead", "shift", "cyclic"), give.names=FALSE)
   Note that when using \code{shift} with a list, it should be a list of lists rather than a flattened list. The function was not designed to handle flattened lists directly. This also applies to the use of list columns in a data.table. For example, \code{DT = data.table(x=as.list(1:4))} is a data.table with four rows. Applying \code{DT[, shift(x)]} now lags every entry individually, rather than shifting the full columns like \code{DT[, shift(as.integer(x))]} does. Using \code{DT = data.table(x=list(1:4))} creates a data.table with one row. Now \code{DT[, shift(x)]} returns a data.table with four rows where x is lagged. To get a shifted data.table with the same number of rows, wrap the \code{shift} function in \code{list} or \code{dot}, e.g., \code{DT[, .(shift(x))]}.
 }
 \value{
-  A list containing the lead/lag of input \code{x}.
+  When \code{x} is a vector and \code{length(n) == 1}, a vector of the same type and length as \code{x}. Otherwise, a list of vectors (one element for each combination of input column and \code{n} value).
 }
 
 \examples{


### PR DESCRIPTION
## Changes

Fixed the Value section of `shift.Rd` to accurately describe the return type behavior.

### Problem

The Value section stated:

> A list containing the lead/lag of input x.

But `shift()` returns a **vector** (not a list) when `x` is atomic and `length(n) == 1`. This is confirmed by `src/shift.c:181`:

```c
if (isVectorAtomic(obj) && length(ans) == 1) ans = VECTOR_ELT(ans, 0);
```

The Details section already documented this behavior correctly, but the Value section was inaccurate.

### Fix

Updated the Value section to:

> When x is a vector and length(n) == 1, a vector of the same type and length as x. Otherwise, a list of vectors (one element for each combination of input column and n value).

### Stata migration relevance

This fix is particularly important for Stata migrants who expect consistent return types from lag/lead operations. Stata's `L.var` always returns a vector, and the inaccurate Value section could lead users to believe `shift()` always returns a list, causing unexpected behavior in their code.

## Validation

- `tools::checkRd('man/shift.Rd')` passes (no errors)
- Change is purely documentation (no code changes)
- No other open PRs address this specific issue

## Duplicate check

- PR #7774 adds ordering notes and panel data examples but does NOT fix the Value section
- No other PRs address the Value section inaccuracy
