### PR TITLE
docs: fix typo 'y' -> 'x' in between.Rd exclusive bounds description

### DIFF
--- a/man/between.Rd
+++ b/man/between.Rd
@@ -8,7 +8,7 @@
 Intended for use in \code{i} in \code{[.data.table}.
 
 \code{between} is equivalent to \code{lower<=x & x<=upper} when
-\code{incbounds=TRUE}, or \code{lower<x & y<upper} when \code{FALSE}. With a caveat that
+\code{incbounds=TRUE}, or \code{lower<x & x<upper} when \code{FALSE}. With a caveat that
 \code{NA} in \code{lower} or \code{upper} are taken as unlimited bounds not \code{NA}.
 This can be changed by setting \code{NAbounds} to \code{NA}.
 


### PR DESCRIPTION
## Summary

Fixes a typo in the Description section of `between.Rd` where the exclusive bounds formula incorrectly uses `y` instead of `x`.

## Problem

Line 11 of `man/between.Rd` states:

> `between` is equivalent to `lower<=x & x<=upper` when `incbounds=TRUE`, or `lower<x & y<upper` when `FALSE`.

The second formula uses `y` but should use `x`. The variable being tested is always `x` in the `between(x, lower, upper)` function signature. The variable `y` is only used in the infix `%between%` operator where `x %between% y` and `y` is a length-2 vector/list.

## Fix

Changed `lower<x & y<upper` to `lower<x & x<upper`.

## Files Changed

| File | Lines Changed | Type |
|------|---------------|------|
| man/between.Rd | 1 | Documentation |

## Validation

- `tools::checkRd('man/between.Rd')` — passes (no errors)
- Change is purely documentation (no code changes)

## Stata Migration Relevance

This fix is important for Stata migrants who read the documentation to understand `between()` behavior. Stata's `inrange()` function has clear documentation about its bounds, and an incorrect formula in the R documentation could confuse users trying to understand when bounds are inclusive vs exclusive.