### PR TITLE
fix: col.names='none' suppresses print completely (#7735)

### DIFF
--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -126,8 +126,14 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
     trunc.cols = length(not_printed) > 0L
   }
   print_default = function(x) {
-    if (col.names != "none") cut_colnames = identity
-    cut_colnames(print(x, right=TRUE, quote=quote, na.print=na.print))
+    if (col.names == "none") {
+      # #7735: blank column names in output directly instead of using cut_colnames,
+      #   which also drops data rows lacking row-number colons (row.names=FALSE)
+      colnames(x) = rep.int("", ncol(x))
+      writeLines(capture.output(print(x, right=TRUE, quote=quote, na.print=na.print)))
+    } else {
+      cut_colnames(print(x, right=TRUE, quote=quote, na.print=na.print))
+    }
     # prints names of variables not shown in the print
     if (trunc.cols) trunc_cols_message(not_printed, abbs, class, col.names)
   }
@@ -141,8 +147,6 @@ print.data.table = function(x, topn=getOption("datatable.print.topn"),
     print_default(toprint)
     return(invisible(x))
   }
-  if (col.names == "none")
-    colnames(toprint) = rep.int("", ncol(toprint))
   if (nrow(toprint)>20L && col.names == "auto")
     # repeat colnames at the bottom if over 20 rows so you don't have to scroll up to see them
     #   option to shut this off per request of Oleg Bondar on SO, #1482


### PR DESCRIPTION
Fixes #7735.

## Summary

When `col.names="none"` is passed to `print.data.table()`, the data is silently suppressed (zero output). This affects both the `printdots=TRUE` path (large tables) and `printdots=FALSE` path (small tables).

## Root cause

The internal `print_default()` closure delegates to `cut_colnames()` (a package-level helper) when `col.names == "none"`. That helper filters output lines through `grepv("^\\s*(?:[0-9]+:|---)", ...)`, which expects row-number colons in every data line. When `row.names=FALSE`, data rows lack colons (e.g. `  1  a` not ` 1:  a`), so every line is dropped — producing empty output.

## Fix

Move the "blank column names" logic into `print_default()` itself:

- When `col.names == "none"`: set `colnames(x) = ""` and write output directly (no `cut_colnames` filter).
- When `col.names != "none"`: use `cut_colnames()` as before (identity when not "none").

This also removes the now-redundant `colnames(toprint) = ...` line that was at line 150 (only reachable in the `printdots=FALSE` path).

## Verification

Confirmed the issue reproduces with the current dev version:
```r
d = data.table(c1 = 1:2, c2 = letters[1:2])
print(d, nrows=Inf, class=FALSE, row.names=FALSE, col.names="none")
# prints nothing (should print data rows)
```

The fix restores correct output for:
- Small tables (`printdots=FALSE` path)
- Large tables (`printdots=TRUE` path)
- Both `row.names=TRUE` and `row.names=FALSE`
- `col.names="auto"` and `col.names="top"` remain unaffected