### PR TITLE
docs: fix grammar in frollapply.Rd by.column section

### DIFF
--- a/man/frollapply.Rd
+++ b/man/frollapply.Rd
@@ -34,7 +34,7 @@
   }
 }
 \section{\code{by.column} argument}{
-  Setting \code{by.column} to \code{FALSE} allows to apply function on multiple variables rather than a single vector. Then \code{X} expects to be data.table, data.frame or a list of equal length vectors, and window size provided in \code{N} refers to number of rows (or length of a vectors in a list). See examples for use cases. Error \emph{"incorrect number of dimensions"} can be commonly observed when \code{by.column} was not set to \code{FALSE} when \code{FUN} expects its input to be a data.table or data.frame.
+  Setting \code{by.column} to \code{FALSE} allows applying function on multiple variables rather than a single vector. Then \code{X} expects to be data.table, data.frame or a list of equal length vectors, and window size provided in \code{N} refers to number of rows (or length of vectors in a list). See examples for use cases. Error \emph{"incorrect number of dimensions"} can be commonly observed when \code{by.column} was not set to \code{FALSE} when \code{FUN} expects its input to be a data.table or data.frame.
 }
 \section{\code{simplify} argument}{
   When set to \code{TRUE} (default), then results from rolling function which are normally stored in a list may be simplified either with \code{unlist} or \code{rbindlist}. It also attempts to match type, size and names of \code{fill} argument to the results of a function.


### PR DESCRIPTION
## Summary

Fix two grammar errors in the `\code{by.column}` argument section of `frollapply.Rd`.

## Changes

| Line | Before | After |
|------|--------|-------|
| 37 | "allows to apply function" | "allows applying function" |
| 37 | "length of a vectors" | "length of vectors" |

## Details

1. **"allows to apply"** → **"allows applying"**: The verb "allows" requires a gerund (allow + -ing) or a noun phrase before "to" (allow + someone + to). "Allows to apply" is a bare infinitive error.

2. **"length of a vectors"** → **"length of vectors"**: Article-noun disagreement. "A" is singular but "vectors" is plural. The correct form is "length of vectors" (no article).

## Validation

- `tools::checkRd('man/frollapply.Rd')` — passes (no errors)
- Change is purely documentation (no code changes)

## Stata Migration Relevance

The `frollapply` function enables rolling window operations with custom functions, which is a common pattern for Stata users migrating to R. Clear documentation of the `by.column` parameter helps Stata users understand how to apply functions across multiple columns, similar to Stata's `rolling` command.