### PR TITLE
docs: add x. prefix join examples to joins vignette

### DIFF
--- a/vignettes/datatable-joins.Rmd
+++ b/vignettes/datatable-joins.Rmd
@@ -226,7 +226,23 @@ Products[
         total_value = price * count)
 ]
 ```
+#### 3.1.4. Identifying matches in key-only tables
 
+When joining a table `y` to a "lookup" table `x` that contains only keys, the resulting join column defaults to the value in `y`. To explicitly check if a match was found in `x`, we can use the `x.` prefix. If `x.col` is `NA`, no match was found.
+
+```{r}
+# Lookup table of authorized IDs
+authorized_ids = data.table(user_id = c(1L, 2L, 5L), key = "user_id")
+# New login attempts
+logins = data.table(user_id = c(1L, 3L, 5L))
+
+# By selecting x.user_id, we can identify which logins exist in the authorized table
+authorized_ids[logins, on = .(user_id), .(user_id, is_authorized = !is.na(x.user_id))]
+#    user_id is_authorized
+# 1:       1          TRUE
+# 2:       3         FALSE
+# 3:       5          TRUE
+```
 
 ##### Summarizing with `on` in `data.table`
 
@@ -253,7 +269,7 @@ dt2 = ProductReceived[
 identical(dt1, dt2)
 ```
 
-#### 3.1.4. Joining based on several columns
+#### 3.1.5. Joining based on several columns
 
 So far we have just joined `data.table`s based on 1 column, but it's important to know that the package can join tables matching several columns.
 
@@ -627,6 +643,31 @@ ProductPriceHistory[ProductSales,
                     roll = TRUE,
                     nomatch = NULL,
                     j = .(product_id, date, count, price)]
+```
+
+### 5.1. Calculating Staleness (Join Distance)
+
+In rolling joins, `data.table` matches to the nearest available record. By default, the join column in the result displays the value from the i table (the time you "queried"). To see the actual time of the record that was found in `x`, use the `x`. prefix. The difference between these two is often called "staleness."
+
+```{r}
+# Prices updated at specific times
+prices = data.table(
+  time = as.ITime(c("10:00:00", "10:05:00", "10:10:00")),
+  price = c(100, 105, 110),
+  key = "time"
+)
+
+# A trade happens at 10:07:00
+trade = data.table(time = as.ITime("10:07:00"))
+
+# Using x.time to see the actual record time found
+prices[trade, on = .(time), roll = TRUE, 
+       .(queried_time = time, 
+         actual_time = x.time, 
+         price, 
+         staleness = time - x.time)]
+#    queried_time actual_time price staleness
+# 1:     10:07:00    10:05:00   105  00:02:00
 ```
 
 ## 6. Taking advantage of joining speed

--- a/vignettes/datatable-joins.Rmd
+++ b/vignettes/datatable-joins.Rmd
@@ -236,12 +236,10 @@ authorized_ids = data.table(user_id = c(1L, 2L, 5L), key = "user_id")
 # New login attempts
 logins = data.table(user_id = c(1L, 3L, 5L))
 
-# By selecting x.user_id, we can identify which logins exist in the authorized table
-authorized_ids[logins, on = .(user_id), .(user_id, is_authorized = !is.na(x.user_id))]
-#    user_id is_authorized
-# 1:       1          TRUE
-# 2:       3         FALSE
-# 3:       5          TRUE
+# Use "user_id" as a string in the 'on' argument
+authorized_ids[logins, on = "user_id", 
+               .(user_id = i.user_id, 
+                 is_authorized = !is.na(x.user_id))]
 ```
 
 ##### Summarizing with `on` in `data.table`
@@ -661,13 +659,12 @@ prices = data.table(
 trade = data.table(time = as.ITime("10:07:00"))
 
 # Using x.time to see the actual record time found
-prices[trade, on = .(time), roll = TRUE, 
-       .(queried_time = time, 
+# Use "time" as a string to avoid conflict with base::time
+prices[trade, on = "time", roll = TRUE, 
+       .(queried_time = i.time, 
          actual_time = x.time, 
          price, 
-         staleness = time - x.time)]
-#    queried_time actual_time price staleness
-# 1:     10:07:00    10:05:00   105  00:02:00
+         staleness = i.time - x.time)]
 ```
 
 ## 6. Taking advantage of joining speed

--- a/vignettes/datatable-joins.Rmd
+++ b/vignettes/datatable-joins.Rmd
@@ -236,10 +236,8 @@ authorized_ids = data.table(user_id = c(1L, 2L, 5L), key = "user_id")
 # New login attempts
 logins = data.table(user_id = c(1L, 3L, 5L))
 
-# Use "user_id" as a string in the 'on' argument
-authorized_ids[logins, on = "user_id", 
-               .(user_id = i.user_id, 
-                 is_authorized = !is.na(x.user_id))]
+# By selecting x.user_id, we can identify which logins exist in the authorized table
+authorized_ids[logins, on = "user_id", .(user_id, is_authorized = !is.na(x.user_id))]
 ```
 
 ##### Summarizing with `on` in `data.table`
@@ -649,6 +647,7 @@ In rolling joins, `data.table` matches to the nearest available record. By defau
 
 ```{r}
 # Prices updated at specific times
+# Prices updated at specific times
 prices = data.table(
   time = as.ITime(c("10:00:00", "10:05:00", "10:10:00")),
   price = c(100, 105, 110),
@@ -659,12 +658,11 @@ prices = data.table(
 trade = data.table(time = as.ITime("10:07:00"))
 
 # Using x.time to see the actual record time found
-# Use "time" as a string to avoid conflict with base::time
-prices[trade, on = "time", roll = TRUE, 
-       .(queried_time = i.time, 
+prices[trade, on = .(time), roll = TRUE, 
+       .(queried_time = time, 
          actual_time = x.time, 
          price, 
-         staleness = i.time - x.time)]
+         staleness = time - x.time)]
 ```
 
 ## 6. Taking advantage of joining speed


### PR DESCRIPTION
Closes #662.

Adds examples demonstrating the use of the `x.` prefix in joins, including:

- Identifying matches in key-only lookup tables.
- Calculating staleness in rolling joins.

hi @tdhock @joshhwuu can you have a review of this when you got time .

this was a long standing documentation issue, and I just wanted to help get it closed. If this has already been documented and the issue can be closed as is, thats perfectly fine as well.

Thanks.
