### PR TITLE
Updates for R-CMD-check-occasional to pass with minimal CI noise

### DIFF
--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -1,4 +1,5 @@
 on:
+  push:
   schedule:
    - cron: '17 13 23 * *' # 23rd of month at 13:17 UTC
   workflow_dispatch:
@@ -85,6 +86,7 @@ jobs:
           _R_CHECK_FORCE_SUGGESTS_: false
           _R_CHECK_CRAN_INCOMING_REMOTE_: false
           _R_CHECK_TESTS_NLINES_: 0
+          _R_CHECK_DEPENDS_ONLY_: false
         run: |
           options(crayon.enabled = TRUE)
           message("*** Using the following repos for installation ***")
@@ -108,7 +110,8 @@ jobs:
           message("Will try and set TEST_DATA_TABLE_WITH_OTHER_PACKAGES=", as.character(run_other), " in R CMD check.")
           # IINM rcmdcheck isolates its env from the calling process', besides what's passed to env=
           env = c(
-            TEST_DATA_TABLE_WITH_OTHER_PACKAGES=as.character(run_other)
+            TEST_DATA_TABLE_WITH_OTHER_PACKAGES=as.character(run_other),
+            "_R_CHECK_DEPENDS_ONLY_"="false"
           )
 
           do_vignettes = requireNamespace("litedown", quietly=TRUE)

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -111,7 +111,7 @@ jobs:
           # IINM rcmdcheck isolates its env from the calling process', besides what's passed to env=
           env = c(
             TEST_DATA_TABLE_WITH_OTHER_PACKAGES=as.character(run_other),
-            "_R_CHECK_DEPENDS_ONLY_"="false"
+            _R_CHECK_DEPENDS_ONLY_="false"
           )
 
           do_vignettes = requireNamespace("litedown", quietly=TRUE)

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -76,9 +76,17 @@ jobs:
             sudo apt-get update
             sudo apt-get install -y libcurl4-openssl-dev libudunits2-dev libgdal-dev libgeos-dev libproj-dev pandoc
 
+      - name: Install R Package Build Dependencies on MacOS
+        if: matrix.os == 'macOS-latest'
+        uses: r-hub/actions/setup-r-sysreqs@v1
+        with:
+          type: 'minimal'
+
       - name: Install check dependencies (macOS)
         if: matrix.os == 'macOS-latest'
-        run: brew install gdal proj
+        run: |
+          brew install gdal proj gettext
+          brew link --force gettext
 
       - name: Check
         env:

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -117,7 +117,7 @@ jobs:
           message("Will try and set TEST_DATA_TABLE_WITH_OTHER_PACKAGES=", as.character(run_other), " in R CMD check.")
           if (run_other) {
             desc = read.dcf("DESCRIPTION")
-            desc[1, "Suggests"] = paste(c(desc[1, "Suggests"], other_pkgs), collapse = ", ")
+            desc[1L, "Suggests"] = toString(unique(c(desc[1, "Suggests"], other_pkgs)))
             write.dcf(desc, "DESCRIPTION")
           }
           # IINM rcmdcheck isolates its env from the calling process', besides what's passed to env=

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -111,7 +111,7 @@ jobs:
           # IINM rcmdcheck isolates its env from the calling process', besides what's passed to env=
           env = c(
             TEST_DATA_TABLE_WITH_OTHER_PACKAGES=as.character(run_other),
-            _R_CHECK_DEPENDS_ONLY_="false"
+            `_R_CHECK_DEPENDS_ONLY_`="false"
           )
 
           do_vignettes = requireNamespace("litedown", quietly=TRUE)

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -86,7 +86,6 @@ jobs:
           _R_CHECK_FORCE_SUGGESTS_: false
           _R_CHECK_CRAN_INCOMING_REMOTE_: false
           _R_CHECK_TESTS_NLINES_: 0
-          _R_CHECK_DEPENDS_ONLY_: false
         run: |
           options(crayon.enabled = TRUE)
           message("*** Using the following repos for installation ***")
@@ -108,10 +107,14 @@ jobs:
             message(sprintf("Skipping other.Rraw since some required packages are not available: %s\n", toString(other_pkgs[!has_other_pkg])))
           }
           message("Will try and set TEST_DATA_TABLE_WITH_OTHER_PACKAGES=", as.character(run_other), " in R CMD check.")
+          if (run_other) {
+            desc = read.dcf("DESCRIPTION")
+            desc[1, "Suggests"] = paste(c(desc[1, "Suggests"], other_pkgs), collapse = ", ")
+            write.dcf(desc, "DESCRIPTION")
+          }
           # IINM rcmdcheck isolates its env from the calling process', besides what's passed to env=
           env = c(
-            TEST_DATA_TABLE_WITH_OTHER_PACKAGES=as.character(run_other),
-            `_R_CHECK_DEPENDS_ONLY_`="false"
+            TEST_DATA_TABLE_WITH_OTHER_PACKAGES=as.character(run_other)
           )
 
           do_vignettes = requireNamespace("litedown", quietly=TRUE)

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS-latest, windows-latest, ubuntu-latest]
-        r: ['devel', 'release', '3.5', '3.6', '4.0', '4.1', '4.2', '4.3']
+        r: ['devel', 'release', '3.5', '3.6', '4.0', '4.1', '4.2', '4.3', '4.4', '4.5']
         locale: ['en_US.utf8', 'zh_CN.utf8', 'lv_LV.utf8'] # Chinese for translations, Latvian for collate order (#3502)
         exclude:
           # only run non-English locale CI on Ubuntu

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -142,7 +142,7 @@ jobs:
             dt_tar = list.files(pattern = "^data[.]table_.*[.]tar[.]gz$")
             if (!length(dt_tar)) stop("Built tar.gz not found among: ", toString(list.files()))
             res = system2(Rbin, c("CMD", "check", dt_tar[1L], check_args), stdout=TRUE, stderr=TRUE, env=sprintf("%s=%s", names(env), env))
-            if (!is.null(attr(res, "status")) || is.na(res) || grep("^Status:.*(ERROR|WARNING)", res)) {
+            if (!is.null(attr(res, "status")) || anyNA(res) || any(grepl("^Status:.*(ERROR|WARNING)", res))) {
               writeLines(as.character(res))
               stop("R CMD check failed")
             }

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -1,5 +1,4 @@
 on:
-  push:
   schedule:
    - cron: '17 13 23 * *' # 23rd of month at 13:17 UTC
   workflow_dispatch:
@@ -126,14 +125,13 @@ jobs:
 
           has_other_pkg = sapply(other_pkgs, requireNamespace, quietly=TRUE)
           run_other = all(has_other_pkg)
-          if (!run_other) {
-            message(sprintf("Skipping other.Rraw since some required packages are not available: %s\n", toString(other_pkgs[!has_other_pkg])))
-          }
-          message("Will try and set TEST_DATA_TABLE_WITH_OTHER_PACKAGES=", as.character(run_other), " in R CMD check.")
           if (run_other) {
             desc = read.dcf("DESCRIPTION")
             desc[1L, "Suggests"] = toString(unique(c(desc[1, "Suggests"], other_pkgs)))
             write.dcf(desc, "DESCRIPTION")
+            message("Setting TEST_DATA_TABLE_WITH_OTHER_PACKAGES=TRUE to run other.Rraw")
+          } else {
+            message(sprintf("Skipping other.Rraw since some required packages are not available: %s\n", toString(other_pkgs[!has_other_pkg])))
           }
           # IINM rcmdcheck isolates its env from the calling process', besides what's passed to env=
           env = c(

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -80,6 +80,10 @@ jobs:
             sudo apt-get update
             sudo apt-get install -y libcurl4-openssl-dev libudunits2-dev libgdal-dev libgeos-dev libproj-dev pandoc
 
+      - name: Pre-untap untrusted Homebrew taps on macOS
+        if: matrix.os == 'macOS-latest'
+        run: brew untap aws/tap 2>/dev/null || true
+
       - name: Install R Package Build Dependencies on MacOS
         if: matrix.os == 'macOS-latest'
         uses: r-hub/actions/setup-r-sysreqs@v1
@@ -89,7 +93,6 @@ jobs:
       - name: Install check dependencies (macOS)
         if: matrix.os == 'macOS-latest'
         run: |
-          brew untap aws/tap 2>/dev/null || true # silence some 'brew' Annotations
           brew install gdal proj gettext
           brew link --overwrite --force gettext 2>/dev/null || true
 
@@ -100,7 +103,14 @@ jobs:
           _R_CHECK_CRAN_INCOMING_REMOTE_: false
           _R_CHECK_TESTS_NLINES_: 0
         run: |
-          options(crayon.enabled = TRUE)
+          options(crayon.enabled=TRUE)
+          dir.create("~/.R", showWarnings=FALSE)
+          # suppress noisy Annotation for e.g. {hexbin} about tabs v. spaces
+          cat("FCFLAGS += -Wno-tabs\nFFLAGS += -Wno-tabs\n", file="~/.R/Makevars", append=TRUE)
+          # e.g. Annotation about lacking macosx binaries: bin/macosx/sonoma-arm64/contrib/4.7
+          if (grepl("Under development", R.version$status)) options(pkgType="source")
+          # to avoid Annotation about certain packages being unavailable, use this old snapshot repo
+          if (getRversion() < "3.6") options(repos=c(CRAN="https://packagemanager.posit.co/cran/2020-04-24"))
           message("*** Using the following repos for installation ***")
           print(getOption("repos"))
           message("*** Installing Suggested packages ***")

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -70,6 +70,10 @@ jobs:
         with:
           r-version: ${{ matrix.r }}
 
+      - name: Set script permissions
+        run: chmod +x configure cleanup 2>/dev/null || true # Silence some GHA Annotations
+        shell: bash
+
       - name: Install check dependencies (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         run: |
@@ -85,8 +89,9 @@ jobs:
       - name: Install check dependencies (macOS)
         if: matrix.os == 'macOS-latest'
         run: |
+          brew untap aws/tap 2>/dev/null || true # silence some 'brew' Annotations
           brew install gdal proj gettext
-          brew link --force gettext
+          brew link --overwrite --force gettext 2>/dev/null || true
 
       - name: Check
         env:

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -11,7 +11,7 @@ jobs:
   R-CMD-check-occasional:
     runs-on: ${{ matrix.os }}
 
-    name: ${{ matrix.os }} (${{ matrix.r }})
+    name: ${{ matrix.os }} (${{ matrix.r }}, ${{ matrix.locale }})
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
The work here represents diagnosis+fix mainly by Gemini, with some back-and-forth + my input. I didn't quite keep all the commits from Gemini strictly pristine, but anything where there's any Gemini authorship has the commit message prefixed with `Gemini:` (with possible clean-up edits by me). The most crucial logjam was broken w.r.t. `_R_CHECK_DEPENDS_ONLY_`, as described by Gemini below:

---

Setting `_R_CHECK_DEPENDS_ONLY_: false` in .github/workflows/R-CMD-check-occasional.yaml overrides a default behavior of `--as-cran` in `R CMD check` that hides optional packages from the test suite:

### 1. Default Behavior of `--as-cran` in `R CMD check`

Under `--as-cran`, R automatically enables `_R_CHECK_DEPENDS_ONLY_=true`:

https://github.com/Rdatatable/data.table/blob/fae95de24aa224c0c7a2bebd86919ad0effcf545/.github/workflows/R-CMD-check-occasional.yaml#L117

When active, R creates a restricted, temporary library (`.libPaths()`) during the check containing **only** the packages explicitly listed in DESCRIPTION (`Depends`, `Imports`, `Suggests`, and `Enhances`), plus base/recommended R packages. Any other packages installed on the system are hidden from the search path during test execution.

### 2. Why This Broke `other.Rraw` in CI
In step 82 of R-CMD-check-occasional.yaml, the workflow installs "fully optional packages" (`other_pkgs` such as `caret`, `dplyr`, `ggplot2`, `sf`, `vctrs`, etc.) so they can be tested for interoperability in inst/tests/other.Rraw. These optional packages are intentionally not listed in `data.table`'s `DESCRIPTION` file.

Because they are omitted from `DESCRIPTION`, `--as-cran` stripped them from `.libPaths()` during check execution. Even though the step successfully installed all 19 optional packages and set `TEST_DATA_TABLE_WITH_OTHER_PACKAGES=TRUE`, inside `R CMD check`, `other.Rraw` could not find them and aborted across all CI runners with:
> `test.data.table('other.Rraw') failed to attach required package(s): caret, DBI, dplyr, gdata, ggplot2, hexbin, knitr, nanotime, nlme, plyr, RSQLite, sf, vctrs.`

### 3. Effect of the Change
By explicitly setting `_R_CHECK_DEPENDS_ONLY_: false`, we prevent `R CMD check` from isolating the check library strictly to `DESCRIPTION` dependencies. This allows `other.Rraw` to see and attach the optional packages installed in the runner library during the check.