### PR TITLE
Get other.Rraw running again in r-devel

### DIFF
--- a/inst/tests/other.Rraw
+++ b/inst/tests/other.Rraw
@@ -58,13 +58,12 @@ if (all(c("package:reshape", "package:reshape2") %in% search())) {
 
 if (loaded[["ggplot2"]]) {
   DT = data.table( a=1:5, b=11:50, d=c("A","B","C","D"), f=1:5, grp=1:5 )
-  test(1.1, names(print(ggplot(DT,aes(b,f))+geom_point()))[c(1,3)], c("data","scales")) # update as described in #3047
-  test(1.2, DT[,print(ggplot(.SD,aes(b,f))+geom_point()),by=list(grp%%2L)],data.table(grp=integer()))  # %%2 to reduce time needed for ggplot2 to plot
+  print_without_error = \(x) !inherits(tryCatch(print(x), error=identity), "error")
+  test(1.1, print_without_error(ggplot(DT, aes(b,f)) + geom_point())) # update as described in #3047
+  test(1.2, DT[, print_without_error(ggplot(.SD, aes(b,f)) + geom_point()), by=list(grp %% 2L)][, all(V1)])  # %%2 to reduce time needed for ggplot2 to plot
   if (loaded[["hexbin"]]) {
     # Test reported by C Neff on 11 Oct 2011
-    # TODO(r-lib/gtable#94): don't suppressWarnings() here.
-    x <- suppressWarnings(print(ggplot(DT) + geom_hex(aes(b, f)) + facet_wrap(~grp)))
-    test(1.3, names(x)[c(1L, 3L)], c("data", "scales"))
+    test(1.3, print_without_error(ggplot(DT) + geom_hex(aes(b, f)) + facet_wrap(~grp)))
   }
   # Test plotting ITime with ggplot2 which seems to require an as.data.frame method for ITime, #1713
   datetimes = c("2011 NOV18 09:29:16", "2011 NOV18 10:42:40", "2011 NOV18 23:47:12",
@@ -76,8 +75,12 @@ if (loaded[["ggplot2"]]) {
   # test(1.4, print(DT[,qplot(idate,itime)])$ranges,
   #           message="Don't know how to automatically pick scale for object of type ITime. Defaulting to continuous")
 
-  test(1.5, print(DT[,qplot(idate,as.POSIXct(itime,tzone=""))])$ranges, print(qplot(idate,as.POSIXct(itime,tzone=""),data=DT))$ranges)
-  try(graphics.off(),silent=TRUE)
+  # qplot() soon to be deleted, unclear how to adapt the test meaningfully after that...
+  invisible(try(qplot(), silent=TRUE)) # force deprecation warning
+  test(1.5, all.equal(
+    print(DT[, qplot(idate, as.POSIXct(itime, tzone=""))]),
+    print(qplot(idate, as.POSIXct(itime, tzone=""), data=DT))))
+  try(graphics.off(), silent=TRUE)
 }
 
 if (loaded[["plyr"]]) {

--- a/inst/tests/other.Rraw
+++ b/inst/tests/other.Rraw
@@ -58,7 +58,7 @@ if (all(c("package:reshape", "package:reshape2") %in% search())) {
 
 if (loaded[["ggplot2"]]) {
   DT = data.table( a=1:5, b=11:50, d=c("A","B","C","D"), f=1:5, grp=1:5 )
-  print_without_error = \(x) !inherits(tryCatch(print(x), error=identity), "error")
+  print_without_error = function(x) !inherits(tryCatch(print(x), error=identity), "error")
   test(1.1, print_without_error(ggplot(DT, aes(b,f)) + geom_point())) # update as described in #3047
   test(1.2, DT[, print_without_error(ggplot(.SD, aes(b,f)) + geom_point()), by=list(grp %% 2L)][, all(V1)])  # %%2 to reduce time needed for ggplot2 to plot
   if (loaded[["hexbin"]]) {

--- a/inst/tests/other.Rraw
+++ b/inst/tests/other.Rraw
@@ -26,8 +26,10 @@ INT = data.table:::INT
 
 if (anyDuplicated(pkgs)) stop("Packages defined to be loaded for integration tests in 'inst/tests/other.Rraw' contains duplicates.")
 
+# attach at the end for #5101;
+# attach.required=FALSE for Depends resolution order (see https://stat.ethz.ch/pipermail/r-devel/2026-July/084630.html)
 f = function(pkg) suppressWarnings(suppressMessages(isTRUE(
-  library(pkg, character.only=TRUE, logical.return=TRUE, warn.conflicts=FALSE, pos="package:base")  # attach at the end for #5101
+  library(pkg, character.only=TRUE, logical.return=TRUE, warn.conflicts=FALSE, pos="package:base", attach.required=FALSE)
 )))
 loaded = sapply(pkgs, f)
 if (!all(loaded)) {

--- a/inst/tests/other.Rraw
+++ b/inst/tests/other.Rraw
@@ -169,10 +169,11 @@ if (loaded[["nlme"]]) {
 
 if (loaded[["bit64"]]) {
   # these don't pass UBSAN/USAN because of the overflow, so just here in other.Rraw
-  test(9.1, as.character((as.integer64(2^62)-1)*2+1), "9223372036854775807")
-  test(9.2, as.character((as.integer64(2^62)-1)*2+2), NA_character_, warning="integer64 overflow")
-  test(9.3, as.character(-(as.integer64(2^62)-1)*2-1), "-9223372036854775807")
-  test(9.4, as.character(-(as.integer64(2^62)-1)*2-2), NA_character_, warning="integer64.*flow")
+  # Use 'L' to avoid integer64-double math when 'long double' is unavailable.
+  test(9.1, as.character((as.integer64(2^62)-1L)*2L+1L), "9223372036854775807")
+  test(9.2, as.character((as.integer64(2^62)-1L)*2L+2L), NA_character_, warning="integer64 overflow")
+  test(9.3, as.character(-(as.integer64(2^62)-1L)*2L-1L), "-9223372036854775807")
+  test(9.4, as.character(-(as.integer64(2^62)-1L)*2L-2L), NA_character_, warning="integer64.*flow")
 }
 
 if (loaded[["gdata"]]) {

--- a/inst/tests/other.Rraw
+++ b/inst/tests/other.Rraw
@@ -201,7 +201,9 @@ if (loaded[["knitr"]]) {
 if (loaded[["parallel"]]) {
   #1745 and #1727
   if (.Platform$OS.type=="windows") {
-    warning("This test of auto fallback to single threaded mode when data.table is used from package parallel, does not run on Windows because 'mc.cores'>1 is not supported on Windows; i.e., parallel package isn't parallel on Windows, IIUC. Whereas data.table is parallel built-in on Windows for some functions (fwrite/fread/fsort and expanding) using OpenMP.")
+    cat(
+      strwrap("This test of auto fallback to single threaded mode when data.table is used from package parallel, does not run on Windows because 'mc.cores'>1 is not supported on Windows; i.e., parallel package isn't parallel on Windows, IIUC. Whereas data.table is parallel built-in on Windows for some functions (fwrite/fread/fsort and expanding) using OpenMP.\n"),
+      sep="\n")
   } else {
     setDTthreads(2)
     if (getDTthreads()!=2) {

--- a/inst/tests/other.Rraw
+++ b/inst/tests/other.Rraw
@@ -74,7 +74,7 @@ if (loaded[["ggplot2"]]) {
   #           message="Don't know how to automatically pick scale for object of type ITime. Defaulting to continuous")
 
   # qplot() soon to be deleted, unclear how to adapt the test meaningfully after that...
-  invisible(try(qplot(), silent=TRUE)) # force deprecation warning
+  invisible(tryCatch(qplot(), condition=function(.) NULL)) # force deprecation warning
   test(1.5, all.equal(
     print(DT[, qplot(idate, as.POSIXct(itime, tzone=""))]),
     print(qplot(idate, as.POSIXct(itime, tzone=""), data=DT))))

--- a/inst/tests/other.Rraw
+++ b/inst/tests/other.Rraw
@@ -1,9 +1,9 @@
-pkgs = c("DBI", "RSQLite", "bit64", "caret", "dplyr", "gdata", "ggplot2", "hexbin", "knitr", "nanotime", "nlme", "parallel", "plyr", "R.utils", "sf", "vctrs", "xts", "yaml", "zoo")
+pkgs = c("DBI", "RSQLite", "bit64", "ggplot2", "caret", "dplyr", "gdata", "hexbin", "knitr", "nanotime", "nlme", "parallel", "plyr", "R.utils", "sf", "vctrs", "zoo", "xts", "yaml")
 # First expression of this file must be as above: .gitlab-ci.yml uses parse(,n=1L) to read one expression from this file and installs pkgs.
 # So that these dependencies of other.Rraw are maintained in a single place.
 # TEST_DATA_TABLE_WITH_OTHER_PACKAGES is off by default so this other.Rraw doesn't run on CRAN. It is run by GLCI, locally in dev, and by
 # users running test.data.table("other.Rraw").
-# zoo needs to be before xts for #5101 otherwise xts's dependency zoo gets attached at position 2 if xts is loaded first
+# TODO(R>=3.6.0): use attach.required=FALSE to let us keep pkgs= in alphabetical order (https://stat.ethz.ch/pipermail/r-devel/2026-July/084630.html)
 
 # Optional Suggest-ed package tests moved from tests.Rraw to here in #5516. Retaining their comments:
 #  "xts",            # we have xts methods in R/xts.R
@@ -26,10 +26,8 @@ INT = data.table:::INT
 
 if (anyDuplicated(pkgs)) stop("Packages defined to be loaded for integration tests in 'inst/tests/other.Rraw' contains duplicates.")
 
-# attach at the end for #5101;
-# attach.required=FALSE for Depends resolution order (see https://stat.ethz.ch/pipermail/r-devel/2026-July/084630.html)
 f = function(pkg) suppressWarnings(suppressMessages(isTRUE(
-  library(pkg, character.only=TRUE, logical.return=TRUE, warn.conflicts=FALSE, pos="package:base", attach.required=FALSE)
+  library(pkg, character.only=TRUE, logical.return=TRUE, warn.conflicts=FALSE, pos="package:base") # attach at the end for #5101
 )))
 loaded = sapply(pkgs, f)
 if (!all(loaded)) {

--- a/inst/tests/other.Rraw
+++ b/inst/tests/other.Rraw
@@ -57,7 +57,7 @@ if (all(c("package:reshape", "package:reshape2") %in% search())) {
 if (loaded[["ggplot2"]]) {
   DT = data.table( a=1:5, b=11:50, d=c("A","B","C","D"), f=1:5, grp=1:5 )
   test(1.1, ggplot(DT, aes(b,f)) + geom_point(), check_value=FALSE) # update as described in #3047
-  test(1.2, DT[, ggplot(.SD, aes(b,f)) + geom_point(), by=list(grp %% 2L)], check_value=FALSE)  # %%2 to reduce time needed for ggplot2 to plot
+  test(1.2, DT[, { ggplot(.SD, aes(b,f)) + geom_point(); TRUE}, by=list(grp %% 2L)], check_value=FALSE)  # %%2 to reduce time needed for ggplot2 to plot
   if (loaded[["hexbin"]]) {
     # Test reported by C Neff on 11 Oct 2011
     test(1.3, ggplot(DT) + geom_hex(aes(b, f)) + facet_wrap(~grp), check_value=FALSE)

--- a/inst/tests/other.Rraw
+++ b/inst/tests/other.Rraw
@@ -56,12 +56,11 @@ if (all(c("package:reshape", "package:reshape2") %in% search())) {
 
 if (loaded[["ggplot2"]]) {
   DT = data.table( a=1:5, b=11:50, d=c("A","B","C","D"), f=1:5, grp=1:5 )
-  print_without_error = function(x) !inherits(tryCatch(print(x), error=identity), "error")
-  test(1.1, print_without_error(ggplot(DT, aes(b,f)) + geom_point())) # update as described in #3047
-  test(1.2, DT[, print_without_error(ggplot(.SD, aes(b,f)) + geom_point()), by=list(grp %% 2L)][, all(V1)])  # %%2 to reduce time needed for ggplot2 to plot
+  test(1.1, ggplot(DT, aes(b,f)) + geom_point(), check_value=FALSE) # update as described in #3047
+  test(1.2, DT[, ggplot(.SD, aes(b,f)) + geom_point(), by=list(grp %% 2L)], check_value=FALSE)  # %%2 to reduce time needed for ggplot2 to plot
   if (loaded[["hexbin"]]) {
     # Test reported by C Neff on 11 Oct 2011
-    test(1.3, print_without_error(ggplot(DT) + geom_hex(aes(b, f)) + facet_wrap(~grp)))
+    test(1.3, ggplot(DT) + geom_hex(aes(b, f)) + facet_wrap(~grp), check_value=FALSE)
   }
   # Test plotting ITime with ggplot2 which seems to require an as.data.frame method for ITime, #1713
   datetimes = c("2011 NOV18 09:29:16", "2011 NOV18 10:42:40", "2011 NOV18 23:47:12",

--- a/inst/tests/other.Rraw
+++ b/inst/tests/other.Rraw
@@ -63,9 +63,9 @@ if (loaded[["ggplot2"]]) {
     test(1.3, ggplot(DT) + geom_hex(aes(b, f)) + facet_wrap(~grp), check_value=FALSE)
   }
   # Test plotting ITime with ggplot2 which seems to require an as.data.frame method for ITime, #1713
-  datetimes = c("2011 NOV18 09:29:16", "2011 NOV18 10:42:40", "2011 NOV18 23:47:12",
-                "2011 NOV19 01:06:01", "2011 NOV19 11:35:34", "2011 NOV19 11:51:09")
-  DT = IDateTime(strptime(datetimes,"%Y %b%d %H:%M:%S"))
+  datetimes = c("2011-11-18 09:29:16", "2011-11-18 10:42:40", "2011-11-18 23:47:12",
+                "2011-11-19 01:06:01", "2011-11-19 11:35:34", "2011-11-19 11:51:09")
+  DT = IDateTime(strptime(datetimes, "%F %T"))
 
   # without as.POSIXct() there is a message but if it gets solved and goes away in future then i) don't fail and ii) restore
   #   test without as.POSIXct needed and without message
@@ -74,9 +74,12 @@ if (loaded[["ggplot2"]]) {
 
   # qplot() soon to be deleted, unclear how to adapt the test meaningfully after that...
   invisible(tryCatch(qplot(), condition=function(.) NULL)) # force deprecation warning
+  # suppressWarnings: in locales where 'human-readable' formatting of date/datetime uses
+  #   multibyte characters, we'll get a warning. We'd have to muddle this with scale
+  #   specifications to get around this robustly; simpler for this test to just suppress.
   test(1.5, all.equal(
-    print(DT[, qplot(idate, as.POSIXct(itime, tzone=""))]),
-    print(qplot(idate, as.POSIXct(itime, tzone=""), data=DT))))
+    suppressWarnings(print(DT[, qplot(idate, as.POSIXct(itime, tzone=""))])),
+    suppressWarnings(print(qplot(idate, as.POSIXct(itime, tzone=""), data=DT)))))
   try(graphics.off(), silent=TRUE)
 }
 

--- a/inst/tests/other.Rraw
+++ b/inst/tests/other.Rraw
@@ -1,9 +1,9 @@
 pkgs = c("DBI", "RSQLite", "bit64", "ggplot2", "caret", "dplyr", "gdata", "hexbin", "knitr", "nanotime", "nlme", "parallel", "plyr", "R.utils", "sf", "vctrs", "zoo", "xts", "yaml")
 # First expression of this file must be as above: .gitlab-ci.yml uses parse(,n=1L) to read one expression from this file and installs pkgs.
 # So that these dependencies of other.Rraw are maintained in a single place.
-# TEST_DATA_TABLE_WITH_OTHER_PACKAGES is off by default so this other.Rraw doesn't run on CRAN. It is run by GLCI, locally in dev, and by
-# users running test.data.table("other.Rraw").
 # TODO(R>=3.6.0): use attach.required=FALSE to let us keep pkgs= in alphabetical order (https://stat.ethz.ch/pipermail/r-devel/2026-July/084630.html)
+# TEST_DATA_TABLE_WITH_OTHER_PACKAGES is off by default so this other.Rraw doesn't run on CRAN. It is run by GLCI, locally in dev, and by
+#   users running test.data.table("other.Rraw").
 
 # Optional Suggest-ed package tests moved from tests.Rraw to here in #5516. Retaining their comments:
 #  "xts",            # we have xts methods in R/xts.R

--- a/inst/tests/other.Rraw
+++ b/inst/tests/other.Rraw
@@ -77,9 +77,14 @@ if (loaded[["ggplot2"]]) {
   # suppressWarnings: in locales where 'human-readable' formatting of date/datetime uses
   #   multibyte characters, we'll get a warning. We'd have to muddle this with scale
   #   specifications to get around this robustly; simpler for this test to just suppress.
-  test(1.5, all.equal(
-    suppressWarnings(print(DT[, qplot(idate, as.POSIXct(itime, tzone=""))])),
-    suppressWarnings(print(qplot(idate, as.POSIXct(itime, tzone=""), data=DT)))))
+  p1 = suppressWarnings(DT[, qplot(idate, as.POSIXct(itime, tzone=""))])
+  p2 = suppressWarnings(qplot(idate, as.POSIXct(itime, tzone=""), data=DT))
+  # ggplot2 internal representation of plots has changed several times over. The recommended
+  #   flow to compare the plots is to use {vdiffr}; we just care that any internal coercion
+  #   of IDate/ITime goes off without a hitch, so just comparing file size should be "good enough".
+  ggsave(t1 <- tempfile(), p1, device='png')
+  ggsave(t2 <- tempfile(), p2, device='png')
+  test(1.5, file.size(t1), file.size(t2))
   try(graphics.off(), silent=TRUE)
 }
 


### PR DESCRIPTION
A few changes here:

 - We need to mess with the attach order. Originally tried `attach.required=FALSE` but that's not present on R 3.5.0.
 - {ggplot2} internals have moved around again. I _think_ the intent of those tests is just to ensure `print(<ggplot-obj>)` works without error, so switched those to use the new `check_value=FALSE`.
 - Robustness improvement for a {bit64} test when lacking proper `long double`. I'm of half a mind to just delete that test because it's _only_ testing {bit64} functionality anyway...
 - Since #7210, `warning()` outside of `test()` is caught, so change an intentional warning on Windows to `cat()`.

Split off from #7832 as the actual debugging of package code should be done artisinally.
