### PR TITLE
Do better showing differences between x,y in test() failure

### DIFF
--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -671,13 +671,21 @@ test = function(num, x, y=TRUE,
     # nocov start
     if (!fail) {
       catf("Test %s ran without errors but failed check that x equals y:\n", numStr)
-      failPrint = function(x, xsub) {
-        cat(">", substitute(x), "=", xsub, "\n") # notranslate
+      failPrint = function(x, diff_idx, xsub) {
+        label = substitute(x)
+        cat(">", label, "=", xsub, "\n") # notranslate
         if (is.data.table(x)) compactprint(x) else {
           nn = length(x)
-          catf("First %d of %d (type '%s'): \n", min(nn, 6L), length(x), typeof(x))
+          if (is.atomic(x)) {
+            total = length(x)
+            x = x[diff_idx] # careful to only evaluate '!=' in diff_idx for atomic inputs
+            names(x) = sprintf("%s[%d]", as.character(label), which(diff_idx))
+            catf("First %d different of %d (%d total, type '%s'): \n", min(nn, 6L), length(x), total, typeof(x))
+          } else {
+            catf("First %d of %d (type '%s'): \n", min(nn, 6L), length(x), typeof(x))
+          }
           # head.matrix doesn't restrict columns
-          if (length(d <- dim(x))) do.call(`[`, c(list(x, drop = FALSE), lapply(pmin(d, 6L), seq_len)))
+          if (length(d <- dim(x))) print(do.call(`[`, c(list(x, drop = FALSE), lapply(pmin(d, 6L), seq_len))))
           else print(head(x))
           if (typeof(x) == 'character' && anyNonAscii(x)) {
             catf("Non-ASCII string detected, raw representation:\n")
@@ -685,8 +693,8 @@ test = function(num, x, y=TRUE,
           }
         }
       }
-      failPrint(x, deparse(xsub))
-      failPrint(y, deparse(ysub))
+      failPrint(x, x!=y, deparse(xsub))
+      failPrint(y, x!=y, deparse(ysub))
       if (!isTRUE(all.equal.result)) cat(all.equal.result, sep="\n")
       fail = TRUE
     }

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -671,15 +671,16 @@ test = function(num, x, y=TRUE,
     # nocov start
     if (!fail) {
       catf("Test %s ran without errors but failed check that x equals y:\n", numStr)
-      failPrint = function(x, diff_idx, xsub) {
+      failPrint = function(x, y, xsub) {
         label = substitute(x)
         cat(">", label, "=", xsub, "\n") # notranslate
         if (is.data.table(x)) compactprint(x) else {
           nn = length(x)
           if (is.atomic(x)) {
             total = length(x)
-            x = x[diff_idx] # careful to only evaluate '!=' in diff_idx for atomic inputs
-            names(x) = sprintf("%s[%d]", as.character(label), which(diff_idx))
+            diff_idx = which(x != y | xor(is.na(x), is.na(y))) # careful to only evaluate '!=' for atomic inputs; which: drop NA-NA
+            x = x[diff_idx]
+            names(x) = sprintf("%s[%d]", as.character(label), diff_idx)
             catf("First %d different of %d (%d total, type '%s'): \n", min(nn, 6L), length(x), total, typeof(x))
           } else {
             catf("First %d of %d (type '%s'): \n", min(nn, 6L), length(x), typeof(x))
@@ -693,8 +694,8 @@ test = function(num, x, y=TRUE,
           }
         }
       }
-      failPrint(x, x!=y, deparse(xsub))
-      failPrint(y, x!=y, deparse(ysub))
+      failPrint(x, y, deparse(xsub))
+      failPrint(y, x, deparse(ysub))
       if (!isTRUE(all.equal.result)) cat(all.equal.result, sep="\n")
       fail = TRUE
     }

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -672,7 +672,7 @@ test = function(num, x, y=TRUE,
     if (!fail) {
       catf("Test %s ran without errors but failed check that x equals y:\n", numStr)
       failPrint = function(x, y, xsub) {
-        label = substitute(x)
+        label = as.character(substitute(x))
         cat(">", label, "=", xsub, "\n") # notranslate
         if (is.data.table(x)) compactprint(x) else {
           if (is.atomic(x)) {
@@ -680,7 +680,7 @@ test = function(num, x, y=TRUE,
             diff_idx = which(x != y | xor(is.na(x), is.na(y))) # careful to only evaluate '!=' for atomic inputs; which: drop NA-NA
             x = x[diff_idx]
             nn = length(x)
-            names(x) = sprintf("%s[%d]", as.character(label), diff_idx)
+            names(x) = sprintf("%s[%d]", label, diff_idx)
             catf("First %d different of %d (%d total, type '%s'): \n", min(nn, 6L), nn, total, typeof(x))
           } else {
             nn = length(x)

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -713,4 +713,4 @@ test = function(num, x, y=TRUE,
   invisible(!fail)
 }
 
-anyNonAscii = function(x) anyNA(iconv(x, to="ASCII")) # nocov
+anyNonAscii = function(x) anyNA(iconv(x[!is.na(x)], to="ASCII")) # nocov

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -675,15 +675,16 @@ test = function(num, x, y=TRUE,
         label = substitute(x)
         cat(">", label, "=", xsub, "\n") # notranslate
         if (is.data.table(x)) compactprint(x) else {
-          nn = length(x)
           if (is.atomic(x)) {
             total = length(x)
             diff_idx = which(x != y | xor(is.na(x), is.na(y))) # careful to only evaluate '!=' for atomic inputs; which: drop NA-NA
             x = x[diff_idx]
+            nn = length(x)
             names(x) = sprintf("%s[%d]", as.character(label), diff_idx)
-            catf("First %d different of %d (%d total, type '%s'): \n", min(nn, 6L), length(x), total, typeof(x))
+            catf("First %d different of %d (%d total, type '%s'): \n", min(nn, 6L), nn, total, typeof(x))
           } else {
-            catf("First %d of %d (type '%s'): \n", min(nn, 6L), length(x), typeof(x))
+            nn = length(x)
+            catf("First %d of %d (type '%s'): \n", min(nn, 6L), nn, typeof(x))
           }
           # head.matrix doesn't restrict columns
           if (length(d <- dim(x))) print(do.call(`[`, c(list(x, drop = FALSE), lapply(pmin(d, 6L), seq_len))))

--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -675,7 +675,7 @@ test = function(num, x, y=TRUE,
         label = as.character(substitute(x))
         cat(">", label, "=", xsub, "\n") # notranslate
         if (is.data.table(x)) compactprint(x) else {
-          if (is.atomic(x)) {
+          if (is.atomic(x) && is.atomic(y) && length(x) == length(y) && identical(dim(x), dim(y))) {
             total = length(x)
             diff_idx = which(x != y | xor(is.na(x), is.na(y))) # careful to only evaluate '!=' for atomic inputs; which: drop NA-NA
             x = x[diff_idx]


### PR DESCRIPTION
Closes #7834. **NB: merge target is not `master` currently**

Output from `test(1, c(1:10, 11:20, 30:21, 31:1000), c(1:10, 20:11, 30:21, 1000:31))`

```
Test 1 ran without errors but failed check that x equals y:
> x = c(1:10, 11:20, 30:21, 31:1000) 
First 6 different of 980 (1000 total, type 'integer'): 
x[11] x[12] x[13] x[14] x[15] x[16] 
   11    12    13    14    15    16 
> y = c(1:10, 20:11, 30:21, 1000:31) 
First 6 different of 980 (1000 total, type 'integer'): 
y[11] y[12] y[13] y[14] y[15] y[16] 
   20    19    18    17    16    15 
Mean relative difference: 0.9406426
```

It's a bit visually dense; we might prefer this alternative using a matrix representation:

```
Test 1 ran without errors but failed check that x equals y:
> x = c(1:10, 11:20, 30:21, 31:1000) 
First 6 different of 980 (1000 total, type 'integer'): 
                        
index: 11 12 13 14 15 16
value: 11 12 13 14 15 16
> y = c(1:10, 20:11, 30:21, 1000:31) 
First 6 different of 980 (1000 total, type 'integer'): 
                        
index: 11 12 13 14 15 16
value: 20 19 18 17 16 15
Mean relative difference: 0.9406426
```

See also other test cases:

```r
test(1, NA_character_, 'abc')
# Test 1 ran without errors but failed check that x equals y:
# > x = NA_character_ 
# First 1 different of 1 (1 total, type 'character'): 
# x[1] 
#   NA 
# > y = "abc" 
# First 1 different of 1 (1 total, type 'character'): 
#  y[1] 
# "abc" 
# 'is.NA' value mismatch: 0 in current 1 in target

x = c(1, 2, 3, NA, 4, NA)
y = c(NA, 2, 4, NA, 4, 5)
test(1, x, y)
# Test 1 ran without errors but failed check that x equals y:
# > x = x 
# First 3 different of 3 (6 total, type 'double'): 
# x[1] x[3] x[6] 
#    1    3   NA 
# > y = y 
# First 3 different of 3 (6 total, type 'double'): 
# y[1] y[3] y[6] 
#   NA    4    5 
# 'is.NA' value mismatch: 2 in current 2 in target
```

A case that's still not completely satisfactory -- it gives the impression of showing `x[11] == y[11]` -- but I'm willing to ignore for now:

```
test(1, c(1:10, 1.0000001), c(1:10, 1))
# Test 1 ran without errors but failed check that x equals y:
# > x = c(1:10, 1.0000001) 
# First 1 different of 1 (11 total, type 'double'): 
# x[11] 
#     1 
# > y = c(1:10, 1) 
# First 1 different of 1 (11 total, type 'double'): 
# y[11] 
#     1 
# Mean relative difference: 9.999999e-08
```