### PR TITLE
Fix forder-order equivalence test for atypical collate locales

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -233,23 +233,29 @@ ForderObj = function(x, starts=NULL, maxgrpn=NULL, anyna=0L, anyinfnan=0L, anyno
   x
 }
 
-c_sortable_letters = letters
+c_sortable_pairs = apply(expand.grid(letters, letters), 1L, paste, collapse="")
 # For some tests of forder() compatibility with base sorting methods.
-# Subset the letters until the collation order matches C. This way we don't totally ignore
+# Subset the pairs of letters until the collation order matches C. This way we don't totally ignore
 #   any possible issues with sorting strings in unusual locales (even though this _should_
 #   be impossible given we _always_ use C-collated order, such a regression test is still
-#   beneficial as a sanity check).
-if (!identical(order(letters, method='shell'), order(letters, method='radix'))) {
+#   beneficial as a sanity check). Pairs of letters are needed for languages like Latvian which
+#   have some '<='-like letters e.g. 'i' and 'y' are considered something of a 'tie', except when a
+#   tie-breaker is needed. For example, 'ya' comes before 'ib' because of 'a' < 'b' and 'i' <= 'y',
+#   but the letters alone sort as 'i' < 'y'.
+if (!identical(order(c_sortable_pairs, method='shell'), order(c_sortable_pairs, method='radix'))) {
   repeat {
-    sorted_c = c_sortable_letters[order(c_sortable_letters, method='radix')]
-    sorted_r = c_sortable_letters[order(c_sortable_letters, method='shell')]
+    sorted_c = c_sortable_pairs[order(c_sortable_pairs, method='radix')]
+    sorted_r = c_sortable_pairs[order(c_sortable_pairs, method='shell')]
 
     mismatch = which(sorted_c != sorted_r)
     if (!length(mismatch)) break
-    c_sortable_letters = c_sortable_letters[-mismatch[1L]]
+    c_sortable_pairs = c_sortable_pairs[-mismatch[1L]]
   }
+} else {
+  # don't pull all 676 pairs, but also not sample() for stability
+  c_sortable_pairs = c_sortable_pairs[seq(1L, length(c_sortable_pairs), length.out=75L)]
 }
-if (length(c_sortable_letters) < 5L) {
+if (length(c_sortable_pairs) < 5L) {
   stop("This locale collates too differently from C; please report.")
 }
 
@@ -4474,12 +4480,12 @@ test(1221, DT[.(1),b], c("a","c","e"))
 seed = as.integer(Sys.time()) # sample(9999L, 1L) temporary fix, because all the set.seed(.) used above makes this sample() step deterministic (always seed=9107)
 # no NaN (because it's hard to match with base::order); tested below in 1988.4-8
 set.seed(seed)
-foo <- function(n) apply(matrix(sample(c_sortable_letters, n*8L, TRUE), ncol=8L), 1, paste, collapse="")
+foo <- function(n) apply(matrix(sample(c_sortable_pairs, n*4L, TRUE), ncol=4L), 1, paste, collapse="")
 i1 = as.integer(sample(c(-100:100), 1e3, TRUE))
 i2 = as.integer(sample(c(-100:100, -1e6, 1e6), 1e3, TRUE))
 d1 = as.numeric(sample(c(-100:100,Inf,-Inf), 1e3, TRUE))
 d2 = as.numeric(rnorm(1e3))
-c1 = sample(c_sortable_letters, 1e3, TRUE)
+c1 = sample(c_sortable_pairs, 1e3, TRUE)
 c2 = sample(foo(50), 1e3, TRUE)
 
 DT = data.table(i1, i2, d1, d2, c1, c2)
@@ -4748,11 +4754,11 @@ seed = as.integer(Sys.time())
 # forder consistently to save pull requests failing coverage tests randomly, issue #2346
 set.seed(seed)
 # these variable try to simulate groups of length 1, 2, < 200, > 200 so as to cover all different internal implementations
-foo <- function(n) apply(matrix(sample(c_sortable_letters, n*8L, TRUE), ncol=8L), 1, paste, collapse="")
+foo <- function(n) apply(matrix(sample(c_sortable_pairs, n*4L, TRUE), ncol=4L), 1, paste, collapse="")
 i1 = as.integer(sample(rep(c(-3:3, NA_integer_), c(1, 2, 190, 300, 7, 190, 210, 100))))
 i2 = as.integer(sample(rep(c(-2:2, -1e6, 1e6, NA_integer_), c(1, 2, 190, 300, 7, 190, 210, 100))))
 d1 = as.numeric(sample(rep(c(-2:2,Inf,-Inf, NA_real_, 5, -1e3), c(1, 190, 2, 300, 7, 50, 50, 100, 150, 150))))
-c1 = sample(rep(c(c_sortable_letters[1:5], NA_character_, "z"), c(1, 2, 190, 7, 300, 200, 300)))
+c1 = sample(rep(c(c_sortable_pairs[1:5], NA_character_, "z"), c(1, 2, 190, 7, 300, 200, 300)))
 c2 = sample(c(foo(200), NA_character_), 1e3, TRUE)
 
 DT = data.table(i1, i2, d1, c1, c2)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -4485,6 +4485,11 @@ d1 = as.numeric(sample(c(-100:100,Inf,-Inf), 1e3, TRUE))
 d2 = as.numeric(rnorm(1e3))
 c1 = sample(make_c_sortable(letters), 1e3, TRUE)
 c2 = sample(make_c_sortable(make_words(50L)), 1e3, TRUE)
+# With some probability, in some locales (esp. az_AZ), c2
+#   can be sorted leading forderv to give integer().
+if (length(unique(c2)) == 1) {
+  c2 = c(c2[-1L], "mmmmmmmmmmmmmmmmmmmmmmmmmmm")
+}
 
 DT = data.table(i1, i2, d1, d2, c1, c2)
 # randomise col order as well

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -4454,30 +4454,30 @@ test(1221, DT[.(1),b], c("a","c","e"))
 seed = as.integer(Sys.time()) # sample(9999L, 1L) temporary fix, because all the set.seed(.) used above makes this sample() step deterministic (always seed=9107)
 # no NaN (because it's hard to match with base::order); tested below in 1988.4-8
 set.seed(seed)
-safe_charset = letters
+c_sortable_letters = letters
 # Subset the letters until the collation order matches C. This way we don't totally ignore
 #   any possible issues with sorting strings in unusual locales (even though this _should_
 #   be impossible given we _always_ use C-collated order, such a regression test is still
 #   beneficial as a sanity check).
 if (!identical(order(letters, method='shell'), order(letters, method='radix'))) {
   repeat {
-    sorted_c = safe_charset[order(safe_charset, method='radix')]
-    sorted_r = safe_charset[order(safe_charset, method='shell')]
+    sorted_c = c_sortable_letters[order(c_sortable_letters, method='radix')]
+    sorted_r = c_sortable_letters[order(c_sortable_letters, method='shell')]
 
     mismatch = which(sorted_c != sorted_r)
     if (!length(mismatch)) break
-    safe_charset = safe_charset[-mismatch[1L]]
+    c_sortable_letters = c_sortable_letters[-mismatch[1L]]
   }
 }
-if (length(safe_charset) < 5L) {
+if (length(c_sortable_letters) < 5L) {
   stop("This locale collates too differently from C; please report.")
 }
-foo <- function(n) apply(matrix(sample(safe_charset, n*8L, TRUE), ncol=8L), 1, paste, collapse="")
+foo <- function(n) apply(matrix(sample(c_sortable_letters, n*8L, TRUE), ncol=8L), 1, paste, collapse="")
 i1 = as.integer(sample(c(-100:100), 1e3, TRUE))
 i2 = as.integer(sample(c(-100:100, -1e6, 1e6), 1e3, TRUE))
 d1 = as.numeric(sample(c(-100:100,Inf,-Inf), 1e3, TRUE))
 d2 = as.numeric(rnorm(1e3))
-c1 = sample(safe_charset, 1e3, TRUE)
+c1 = sample(c_sortable_letters, 1e3, TRUE)
 c2 = sample(foo(50), 1e3, TRUE)
 
 DT = data.table(i1, i2, d1, d2, c1, c2)
@@ -4745,30 +4745,12 @@ seed = as.integer(Sys.time())
 # Test 1844 is now added to consistently run the rare cases discovered here (depending on the seed) to cover all lines in
 # forder consistently to save pull requests failing coverage tests randomly, issue #2346
 set.seed(seed)
-safe_charset = letters
-# Subset the letters until the collation order matches C. This way we don't totally ignore
-#   any possible issues with sorting strings in unusual locales (even though this _should_
-#   be impossible given we _always_ use C-collated order, such a regression test is still
-#   beneficial as a sanity check).
-if (!identical(order(letters, method='shell'), order(letters, method='radix'))) {
-  repeat {
-    sorted_c = safe_charset[order(safe_charset, method='radix')]
-    sorted_r = safe_charset[order(safe_charset, method='shell')]
-
-    mismatch = which(sorted_c != sorted_r)
-    if (!length(mismatch)) break
-    safe_charset = safe_charset[-mismatch[1L]]
-  }
-}
-if (length(safe_charset) < 5L) {
-  stop("This locale collates too differently from C; please report.")
-}
 # these variable try to simulate groups of length 1, 2, < 200, > 200 so as to cover all different internal implementations
-foo <- function(n) apply(matrix(sample(safe_charset, n*8L, TRUE), ncol=8L), 1, paste, collapse="")
+foo <- function(n) apply(matrix(sample(c_sortable_letters, n*8L, TRUE), ncol=8L), 1, paste, collapse="")
 i1 = as.integer(sample(rep(c(-3:3, NA_integer_), c(1, 2, 190, 300, 7, 190, 210, 100))))
 i2 = as.integer(sample(rep(c(-2:2, -1e6, 1e6, NA_integer_), c(1, 2, 190, 300, 7, 190, 210, 100))))
 d1 = as.numeric(sample(rep(c(-2:2,Inf,-Inf, NA_real_, 5, -1e3), c(1, 190, 2, 300, 7, 50, 50, 100, 150, 150))))
-c1 = sample(rep(c(safe_charset[1:5], NA_character_, "z"), c(1, 2, 190, 7, 300, 200, 300)))
+c1 = sample(rep(c(c_sortable_letters[1:5], NA_character_, "z"), c(1, 2, 190, 7, 300, 200, 300)))
 c2 = sample(c(foo(200), NA_character_), 1e3, TRUE)
 
 DT = data.table(i1, i2, d1, c1, c2)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -1186,9 +1186,10 @@ test(353, DT[2,f:="c"], data.table(f=factor(c("a","c","a","b")),x=1:4))
 test(354, DT[3,f:=factor("foo")], data.table(f=factor(c("a","c","foo","b")),x=1:4))
 
 # Test growVector logic when adding levels  (don't need to grow levels for character cols)
-newlevels = format(as.hexmode(1:2000))
-DT = data.table(f=factor("000"),x=1:2010)
-test(355, DT[11:2010,f:=newlevels], data.table(f=factor(c(rep("000",10),newlevels)),x=1:2010))
+newlevels = make_c_sortable(format(as.hexmode(1:2000))) # hexmode with 'aa' will cause issues in some locales like fo_FO
+xx = seq_len(length(newlevels) + 10L)
+DT = data.table(f=factor("000"), x=xx)
+test(355, DT[10L + seq_along(newlevels), f := newlevels], data.table(f=factor(c(rep("000", 10L), newlevels)), x=xx))
 
 DT = data.table(f=c("a","b"),x=1:4)
 # Test coercing factor to character column

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -4454,35 +4454,61 @@ test(1221, DT[.(1),b], c("a","c","e"))
 seed = as.integer(Sys.time()) # sample(9999L, 1L) temporary fix, because all the set.seed(.) used above makes this sample() step deterministic (always seed=9107)
 # no NaN (because it's hard to match with base::order); tested below in 1988.4-8
 set.seed(seed)
-foo <- function(n) apply(matrix(sample(letters, n*8L, TRUE), ncol=8L), 1, paste, collapse="")
+safe_charset = letters
+# Subset the letters until the collation order matches C. This way we don't totally ignore
+#   any possible issues with sorting strings in unusual locales (even though this _should_
+#   be impossible given we _always_ use C-collated order, such a regression test is still
+#   beneficial as a sanity check).
+if (!identical(order(letters, method='shell'), order(letters, method='radix'))) {
+  repeat {
+    sorted_c = safe_charset[order(safe_charset, method='radix')]
+    sorted_r = safe_charset[order(safe_charset, method='shell')]
+
+    mismatch = which(sorted_c != sorted_r)
+    if (!length(mismatch)) break
+    safe_charset = safe_charset[-mismatch[1L]]
+  }
+}
+if (length(safe_charset) < 5L) {
+  stop("This locale collates too differently from C; please report.")
+}
+foo <- function(n) apply(matrix(sample(safe_charset, n*8L, TRUE), ncol=8L), 1, paste, collapse="")
 i1 = as.integer(sample(c(-100:100), 1e3, TRUE))
 i2 = as.integer(sample(c(-100:100, -1e6, 1e6), 1e3, TRUE))
 d1 = as.numeric(sample(c(-100:100,Inf,-Inf), 1e3, TRUE))
 d2 = as.numeric(rnorm(1e3))
-c1 = sample(letters, 1e3, TRUE)
+c1 = sample(safe_charset, 1e3, TRUE)
 c2 = sample(foo(50), 1e3, TRUE)
 
 DT = data.table(i1, i2, d1, d2, c1, c2)
 # randomise col order as well
-colorder=sample(ncol(DT))
-setcolorder(DT, colorder)
+setcolorder(DT, sample(ncol(DT)))
 
 test_no = 0L
 for (nvars in seq_along(names(DT))) {
-  signs = expand.grid(replicate(nvars, c(-1L, 1L), simplify=FALSE))
-  for (cols in combn(names(DT), nvars, simplify = FALSE)) {
-    for (i in seq_len(nrow(signs))) {
+  orders_grid = expand.grid(replicate(nvars, c(-1L, 1L), simplify=FALSE))
+  for (cols in combn(names(DT), nvars, simplify=FALSE)) {
+    for (i in seq_len(nrow(orders_grid))) {
+      orders = orders_grid[i, ]
       test_no <- test_no + 1L
       ll = as.call(c(
         as.name("order"),
         method="radix",
-        decreasing=list(signs[i, ] == -1L),
-        lapply(cols, as.name)
+        lapply(seq_along(cols), function(j) {
+          col = cols[j]
+          col_nm = as.name(col)
+          if (orders[j] == 1L)
+            col_nm
+          else if (is.character(DT[[col]]))
+            call("-", call("xtfrm", col_nm))
+          else
+            call("-", col_nm)
+        })
       ))
-      test(1223.0 + test_no*0.001, forderv(DT, by=cols, order=signs[i,]), with(DT, eval(ll)),
+      test(1223.0 + test_no*0.001, forderv(DT, by=cols, order=orders), with(DT, eval(ll)),
            context=sprintf(
              "seed = %d; setorder(DT, %s)",
-             seed, toString(paste0(fifelse(signs[i, ] == 1L, "", "-"), names(DT)))))
+             seed, toString(paste0(fifelse(orders == 1L, "", "-"), cols))))
     }
   }
 }
@@ -4718,58 +4744,70 @@ seed = as.integer(Sys.time())
 # This choice of seed by Arun was very good as it revealed problems that a fixed seed would not.
 # Test 1844 is now added to consistently run the rare cases discovered here (depending on the seed) to cover all lines in
 # forder consistently to save pull requests failing coverage tests randomly, issue #2346
-seedInfo = paste("forder decreasing argument test: seed = ", seed,"  ", sep="")
 set.seed(seed)
+safe_charset = letters
+# Subset the letters until the collation order matches C. This way we don't totally ignore
+#   any possible issues with sorting strings in unusual locales (even though this _should_
+#   be impossible given we _always_ use C-collated order, such a regression test is still
+#   beneficial as a sanity check).
+if (!identical(order(letters, method='shell'), order(letters, method='radix'))) {
+  repeat {
+    sorted_c = safe_charset[order(safe_charset, method='radix')]
+    sorted_r = safe_charset[order(safe_charset, method='shell')]
+
+    mismatch = which(sorted_c != sorted_r)
+    if (!length(mismatch)) break
+    safe_charset = safe_charset[-mismatch[1L]]
+  }
+}
+if (length(safe_charset) < 5L) {
+  stop("This locale collates too differently from C; please report.")
+}
 # these variable try to simulate groups of length 1, 2, < 200, > 200 so as to cover all different internal implementations
-foo <- function(n) apply(matrix(sample(letters, n*8L, TRUE), ncol=8L), 1, paste, sep="")
+foo <- function(n) apply(matrix(sample(safe_charset, n*8L, TRUE), ncol=8L), 1, paste, collapse="")
 i1 = as.integer(sample(rep(c(-3:3, NA_integer_), c(1, 2, 190, 300, 7, 190, 210, 100))))
 i2 = as.integer(sample(rep(c(-2:2, -1e6, 1e6, NA_integer_), c(1, 2, 190, 300, 7, 190, 210, 100))))
 d1 = as.numeric(sample(rep(c(-2:2,Inf,-Inf, NA_real_, 5, -1e3), c(1, 190, 2, 300, 7, 50, 50, 100, 150, 150))))
-c1 = sample(rep(c(letters[1:5], NA_character_, "z"), c(1, 2, 190, 7, 300, 200, 300)))
+c1 = sample(rep(c(safe_charset[1:5], NA_character_, "z"), c(1, 2, 190, 7, 300, 200, 300)))
 c2 = sample(c(foo(200), NA_character_), 1e3, TRUE)
 
 DT = data.table(i1, i2, d1, c1, c2)
 # randomise col order as well
-colorder=sample(ncol(DT))
-setcolorder(DT, names(DT)[colorder])
-seedInfo = paste(seedInfo, "colorder = ", paste(colorder, collapse=","), sep="")
-ans = vector("list", length(names(DT)))
+setcolorder(DT, sample(ncol(DT)))
 
 test_no = 0L
-oldnfail = nfail
-for (i in seq_along(names(DT))) {
-  cj = as.matrix(do.call(CJ, split(rep(c(1L,-1L), each=i), 1:i)))
-  ans[[i]] = combn(names(DT), i, function(x) {
-    tmp = apply(cj, 1, function(y) {
-      test_no <<- test_no + 1L
+for (nvars in seq_along(names(DT))) {
+  orders_grid = expand.grid(replicate(nvars, c(-1L, 1L), simplify=FALSE))
+  for (cols in combn(names(DT), nvars, simplify=FALSE)) {
+    for (i in seq_len(nrow(orders_grid))) {
+      orders = orders_grid[i, ]
+      test_no <- test_no + 1L
       ll = as.call(c(
         as.name("base_order"),
         method = "radix",
-        lapply(seq_along(x), function(j) {
-          x_nm = as.name(x[j])
-          if (y[j] == 1L)
-            x_nm
-          else {
-            if (is.character(DT[[x[j]]]))
-              as.call(c(as.name("-"), as.call(list(as.name("xtfrm"), x_nm))))
-            else
-              as.call(list(as.name("-"), x_nm))
-          }
+        lapply(seq_along(cols), function(j) {
+          col = cols[j]
+          col_nm = as.name(col)
+          if (orders[j] == 1L)
+            col_nm
+          else if (is.character(DT[[col]]))
+            call("-", call("xtfrm", col_nm))
+          else
+            call("-", col_nm)
         })
       ))
-      ans1 = forderv(DT, by=x, order=y, na.last=TRUE)         # adding tests for both nalast=TRUE and nalast=NA
+      ans1 = forderv(DT, by=cols, order=orders, na.last=TRUE)         # adding tests for both nalast=TRUE and nalast=NA
       test(1252.0 + test_no*0.001, ans1, with(DT, eval(ll)), context=sprintf("ll=%s", format(ll)))
-      test_no <<- test_no + 1L
+      test_no <- test_no + 1L
       ll <- as.call(c(as.list(ll), na.last=NA))
-      ans1 = forderv(DT, by=x, order=y, na.last=NA)           # nalast=NA here.
-      test(1252.0 + test_no*0.001, ans1[ans1 != 0], with(DT, eval(ll)), context=sprintf("ll=%s", format(ll)))
-    })
-    dim(tmp)=NULL
-    list(tmp)
-  })
+      ans1 = forderv(DT, by=cols, order=orders, na.last=NA)           # nalast=NA here.
+      test(1252.0 + test_no*0.001, ans1[ans1 != 0], with(DT, eval(ll)),
+          context=sprintf(
+            "seed = %d; setorder(DT, %s)",
+            seed, toString(paste0(fifelse(orders == 1L, "", "-"), cols))))
+    }
+  }
 }
-ans = NULL
-if (nfail > oldnfail) cat(seedInfo, "\n")  # to reproduce
 
 ###############
 # turning off tolerance for UPCs (> 11 s.f. stored in numeric), #342

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -12726,8 +12726,8 @@ test(1913.05, merge(y,dt), data.table(a=1L, b=1:3, key="a"))
 test(1913.06, merge(y, dt, all=TRUE), data.table(a=rep(c(0L,1L,2L),c(1,3,3)), b=c(NA_integer_,1:6), key="a"))
 #
 # merging data.tables is almost like merging data.frames
-d1 <- data.table(a=sample(letters, 10), b=sample(1:100, 10), key='a')
-d2 <- data.table(a=d1$a, b=sample(1:50, 10), c=rnorm(10), key='a')
+d1 <- data.table(a=sample(c_sortable_pairs, 10L), b=sample(1:100, 10L), key='a')
+d2 <- data.table(a=d1$a, b=sample(1:50, 10L), c=rnorm(10L), key='a')
 dtm <- merge(d1, d2, by='a', suffixes=c(".xx", ".yy"))
 dtm.df <- as.data.frame(dtm)
 dfm <- merge(as.data.frame(d1), as.data.frame(d2), by='a', suffixes=c('.xx', '.yy'))

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -233,30 +233,27 @@ ForderObj = function(x, starts=NULL, maxgrpn=NULL, anyna=0L, anyinfnan=0L, anyno
   x
 }
 
-c_sortable_pairs = apply(expand.grid(letters, letters), 1L, paste, collapse="")
 # For some tests of forder() compatibility with base sorting methods.
-# Subset the pairs of letters until the collation order matches C. This way we don't totally ignore
+# Subset the input until the locale collation order matches C. This way we don't totally ignore
 #   any possible issues with sorting strings in unusual locales (even though this _should_
 #   be impossible given we _always_ use C-collated order, such a regression test is still
-#   beneficial as a sanity check). Pairs of letters are needed for languages like Latvian which
-#   have some '<='-like letters e.g. 'i' and 'y' are considered something of a 'tie', except when a
-#   tie-breaker is needed. For example, 'ya' comes before 'ib' because of 'a' < 'b' and 'i' <= 'y',
-#   but the letters alone sort as 'i' < 'y'.
-if (!identical(order(c_sortable_pairs, method='shell'), order(c_sortable_pairs, method='radix'))) {
-  repeat {
-    sorted_c = c_sortable_pairs[order(c_sortable_pairs, method='radix')]
-    sorted_r = c_sortable_pairs[order(c_sortable_pairs, method='shell')]
+#   beneficial as a sanity check).
+# This is somewhat complicated and has gone through a few iterations.
+#  - Pairs of letters were tried for languages like Latvian which have some '<='-like letters,
+#    e.g. 'i' and 'y' are considered something of a 'tie', except when a tie-breaker is needed.
+#    For example, 'ya' comes before 'ib' because of 'a' < 'b' and 'i' <= 'y', but the letters
+#    alone sort as 'i' < 'y'.
+#  - But also there are locales like Faroese (fo_FO), which treats 'aa' like a single letter
+#    that sorts after 'z', which breaks an approach that glues bigrams together.
+make_c_sortable = function(x) {
+  while (!identical(idx_c<-order(x, method='radix'),
+                    idx_r<-order(x, method='shell'))) {
+    sorted_c = x[idx_c]
+    sorted_r = x[idx_r]
 
-    mismatch = which(sorted_c != sorted_r)
-    if (!length(mismatch)) break
-    c_sortable_pairs = c_sortable_pairs[-mismatch[1L]]
+    x = x[-which(sorted_c != sorted_r)[1L]]
   }
-} else {
-  # don't pull all 676 pairs, but also not sample() for stability
-  c_sortable_pairs = c_sortable_pairs[seq(1L, length(c_sortable_pairs), length.out=75L)]
-}
-if (length(c_sortable_pairs) < 5L) {
-  stop("This locale collates too differently from C; please report.")
+  x
 }
 
 ##########################
@@ -4480,13 +4477,13 @@ test(1221, DT[.(1),b], c("a","c","e"))
 seed = as.integer(Sys.time()) # sample(9999L, 1L) temporary fix, because all the set.seed(.) used above makes this sample() step deterministic (always seed=9107)
 # no NaN (because it's hard to match with base::order); tested below in 1988.4-8
 set.seed(seed)
-foo <- function(n) apply(matrix(sample(c_sortable_pairs, n*4L, TRUE), ncol=4L), 1, paste, collapse="")
+make_words <- function(n) apply(matrix(sample(letters, n*8L, TRUE), ncol=8L), 1, paste, collapse="")
 i1 = as.integer(sample(c(-100:100), 1e3, TRUE))
 i2 = as.integer(sample(c(-100:100, -1e6, 1e6), 1e3, TRUE))
 d1 = as.numeric(sample(c(-100:100,Inf,-Inf), 1e3, TRUE))
 d2 = as.numeric(rnorm(1e3))
-c1 = sample(c_sortable_pairs, 1e3, TRUE)
-c2 = sample(foo(50), 1e3, TRUE)
+c1 = sample(make_c_sortable(letters), 1e3, TRUE)
+c2 = sample(make_c_sortable(make_words(50L)), 1e3, TRUE)
 
 DT = data.table(i1, i2, d1, d2, c1, c2)
 # randomise col order as well
@@ -4754,12 +4751,12 @@ seed = as.integer(Sys.time())
 # forder consistently to save pull requests failing coverage tests randomly, issue #2346
 set.seed(seed)
 # these variable try to simulate groups of length 1, 2, < 200, > 200 so as to cover all different internal implementations
-foo <- function(n) apply(matrix(sample(c_sortable_pairs, n*4L, TRUE), ncol=4L), 1, paste, collapse="")
+make_words <- function(n) apply(matrix(sample(letters, n*4L, TRUE), ncol=4L), 1L, paste, collapse="")
 i1 = as.integer(sample(rep(c(-3:3, NA_integer_), c(1, 2, 190, 300, 7, 190, 210, 100))))
 i2 = as.integer(sample(rep(c(-2:2, -1e6, 1e6, NA_integer_), c(1, 2, 190, 300, 7, 190, 210, 100))))
 d1 = as.numeric(sample(rep(c(-2:2,Inf,-Inf, NA_real_, 5, -1e3), c(1, 190, 2, 300, 7, 50, 50, 100, 150, 150))))
-c1 = sample(rep(c(c_sortable_pairs[1:5], NA_character_, "z"), c(1, 2, 190, 7, 300, 200, 300)))
-c2 = sample(c(foo(200), NA_character_), 1e3, TRUE)
+c1 = sample(rep(c(make_c_sortable(letters[1:5]), NA_character_, "z"), c(1, 2, 190, 7, 300, 200, 300)))
+c2 = sample(c(make_c_sortable(make_words(200)), NA_character_), 1e3, TRUE)
 
 DT = data.table(i1, i2, d1, c1, c2)
 # randomise col order as well
@@ -12726,7 +12723,7 @@ test(1913.05, merge(y,dt), data.table(a=1L, b=1:3, key="a"))
 test(1913.06, merge(y, dt, all=TRUE), data.table(a=rep(c(0L,1L,2L),c(1,3,3)), b=c(NA_integer_,1:6), key="a"))
 #
 # merging data.tables is almost like merging data.frames
-d1 <- data.table(a=sample(c_sortable_pairs, 10L), b=sample(1:100, 10L), key='a')
+d1 <- data.table(a=sample(make_c_sortable(letters), 10L), b=sample(1:100, 10L), key='a')
 d2 <- data.table(a=d1$a, b=sample(1:50, 10L), c=rnorm(10L), key='a')
 dtm <- merge(d1, d2, by='a', suffixes=c(".xx", ".yy"))
 dtm.df <- as.data.frame(dtm)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -233,6 +233,26 @@ ForderObj = function(x, starts=NULL, maxgrpn=NULL, anyna=0L, anyinfnan=0L, anyno
   x
 }
 
+c_sortable_letters = letters
+# For some tests of forder() compatibility with base sorting methods.
+# Subset the letters until the collation order matches C. This way we don't totally ignore
+#   any possible issues with sorting strings in unusual locales (even though this _should_
+#   be impossible given we _always_ use C-collated order, such a regression test is still
+#   beneficial as a sanity check).
+if (!identical(order(letters, method='shell'), order(letters, method='radix'))) {
+  repeat {
+    sorted_c = c_sortable_letters[order(c_sortable_letters, method='radix')]
+    sorted_r = c_sortable_letters[order(c_sortable_letters, method='shell')]
+
+    mismatch = which(sorted_c != sorted_r)
+    if (!length(mismatch)) break
+    c_sortable_letters = c_sortable_letters[-mismatch[1L]]
+  }
+}
+if (length(c_sortable_letters) < 5L) {
+  stop("This locale collates too differently from C; please report.")
+}
+
 ##########################
 .do_not_rm = ls()  # objects that exist at this point should not be removed by rm_all(); e.g. test_*, base_messages, Ctest_dt_win_snprintf, prevtest, etc
 ##########################
@@ -4454,24 +4474,6 @@ test(1221, DT[.(1),b], c("a","c","e"))
 seed = as.integer(Sys.time()) # sample(9999L, 1L) temporary fix, because all the set.seed(.) used above makes this sample() step deterministic (always seed=9107)
 # no NaN (because it's hard to match with base::order); tested below in 1988.4-8
 set.seed(seed)
-c_sortable_letters = letters
-# Subset the letters until the collation order matches C. This way we don't totally ignore
-#   any possible issues with sorting strings in unusual locales (even though this _should_
-#   be impossible given we _always_ use C-collated order, such a regression test is still
-#   beneficial as a sanity check).
-if (!identical(order(letters, method='shell'), order(letters, method='radix'))) {
-  repeat {
-    sorted_c = c_sortable_letters[order(c_sortable_letters, method='radix')]
-    sorted_r = c_sortable_letters[order(c_sortable_letters, method='shell')]
-
-    mismatch = which(sorted_c != sorted_r)
-    if (!length(mismatch)) break
-    c_sortable_letters = c_sortable_letters[-mismatch[1L]]
-  }
-}
-if (length(c_sortable_letters) < 5L) {
-  stop("This locale collates too differently from C; please report.")
-}
 foo <- function(n) apply(matrix(sample(c_sortable_letters, n*8L, TRUE), ncol=8L), 1, paste, collapse="")
 i1 = as.integer(sample(c(-100:100), 1e3, TRUE))
 i2 = as.integer(sample(c(-100:100, -1e6, 1e6), 1e3, TRUE))

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -4452,7 +4452,6 @@ test(1221, DT[.(1),b], c("a","c","e"))
 # - Generate a random seed each time; the randomness allows catching errors quicker
 # - But save the seed so that we can generate the same data back if any error occurs
 seed = as.integer(Sys.time()) # sample(9999L, 1L) temporary fix, because all the set.seed(.) used above makes this sample() step deterministic (always seed=9107)
-seedInfo = paste("forder decreasing argument test: seed = ", seed,"  ", sep="")
 # no NaN (because it's hard to match with base::order); tested below in 1988.4-8
 set.seed(seed)
 foo <- function(n) apply(matrix(sample(letters, n*8L, TRUE), ncol=8L), 1, paste, collapse="")
@@ -4466,36 +4465,27 @@ c2 = sample(foo(50), 1e3, TRUE)
 DT = data.table(i1, i2, d1, d2, c1, c2)
 # randomise col order as well
 colorder=sample(ncol(DT))
-setcolorder(DT, names(DT)[colorder])
-seedInfo = paste(seedInfo, "colorder = ", paste(colorder, collapse=","), sep="")
+setcolorder(DT, colorder)
 
 test_no = 0L
-oldnfail = nfail
 for (nvars in seq_along(names(DT))) {
   signs = expand.grid(replicate(nvars, c(-1L, 1L), simplify=FALSE))
-  combn(names(DT), nvars, simplify=FALSE, function(x) {  # simplify=FALSE needed for R 3.1.0
+  for (cols in combn(names(DT), nvars, simplify = FALSE)) {
     for (i in seq_len(nrow(signs))) {
-      test_no <<- test_no + 1L
+      test_no <- test_no + 1L
       ll = as.call(c(
         as.name("order"),
         method="radix",
-        lapply(seq_along(x), function(j) {
-          if (signs[i,j] == 1L)
-            as.name(x[j])
-          else {
-            if (is.character(DT[[x[j]]]))
-              as.call(c(as.name("-"), as.call(list(as.name("xtfrm"), as.name(x[j])))))
-            else
-              as.call(list(as.name("-"), as.name(x[j])))
-          }
-        })
+        decreasing=list(signs[i, ] == -1L),
+        lapply(cols, as.name)
       ))
-      test(1223.0 + test_no*0.001, forderv(DT, by=x, order=signs[i,]), with(DT, eval(ll)), context=sprintf("signs[%d, ]==%s", i, paste(unlist(signs[i, ]), collapse=",")))
+      test(1223.0 + test_no*0.001, forderv(DT, by=cols, order=signs[i,]), with(DT, eval(ll)),
+           context=sprintf(
+             "seed = %d; setorder(DT, %s)",
+             seed, toString(paste0(fifelse(signs[i, ] == 1L, "", "-"), names(DT)))))
     }
-    integer()
-  })
+  }
 }
-if (nfail > oldnfail) cat(seedInfo, "\n")  # to reproduce
 rm_all()
 
 # fix for bug #44 - unique on null data.table should return null data.table

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -4487,7 +4487,7 @@ c1 = sample(make_c_sortable(letters), 1e3, TRUE)
 c2 = sample(make_c_sortable(make_words(50L)), 1e3, TRUE)
 # With some probability, in some locales (esp. az_AZ), c2
 #   can be sorted leading forderv to give integer().
-if (length(unique(c2)) == 1) {
+if (identical(order(c2), seq_along(c2))) {
   c2 = c(c2[-1L], "mmmmmmmmmmmmmmmmmmmmmmmmmmm")
 }
 


### PR DESCRIPTION
Running `test.data.table()` in an `LC_ALL=lv_LV.utf8` session can error [like](https://github.com/Rdatatable/data.table/actions/runs/30110510771/job/89538567966?pr=7832):

```
...Sys.getlocale()=='...LC_COLLATE=lv_LV.utf8...'...
Error in test.data.table() : 
  387 errors out of 12808. Search tests/tests.Rraw for test numbers 1223.007, 1223.011, 1223.021, 1223.022, 1223.029, 1223.03, 1223.049, 1223.05, 1223.057, 1223.058, 1223.061, 1223.063, 1223.065, 1223.066, 1223.067, 1223.069, 1223.07, 1223.121, 1223.122, 1223.123, 1223.124, 1223.129, 1223.13, 1223.133, 1223.134, 1223.137, 1223.138, 1223.139, 1223.14, 1223.141, 1223.142, 1223.201, 1223.202, 1223.205, 1223.206, 1223.209, 1223.21, 1223.211, 1223.212, 1223.213, 1223.214, 1223.225, 1223.226, 1223.227, 1223.228, 1223.229, 1223.231, 1223.377, 1223.378, 1223.381, 1223.382, 1223.385, 1223.386, 1223.389, 1223.39, 1223.457, 1223.458, 1223.461, 1223.462, 1223.465, 1223.466, 1223.469, 1223.47, 1252.017, 1252.018, 1252.019, 1252.02, 1252.045, 1252.046, 1252.047, 1252.048, 1252.049, 1252.05, 1252.051, 1252.052, 1252.069, 1252.07, 1252.071, 1252.072, 1252.073, 1252.074, 1252.075, 1252.076, 1252.085, 1252.086, 1252.087, 1252.088, 1252.089, 1252.09, 1252.091, 1252.092, 1252.093, 1252.094, 1252.09
```

It's all down to `xtfrm(letters)` not being able to support C-collated sorting, so using it in a locale where `sort(letters)` differs from ASCII causes issues.

In  [268c7d6](https://github.com/Rdatatable/data.table/pull/7837/commits/268c7d6a0cc8cc0f87b4391acffe44e8a44d9238), I tried just using `order(method='radix')` as much as possible, but tests `1252.*` explicitly guard against doing that given it's kinda pointless to test our implementation against... whatever drift has happened between our implementations since our algorithm was first merged into {base}.

So here, I take the approach to avoid using _all_ of `letters` in such cases, instead focusing on the C-sortable subset of `letters` (see comment below for more nuance on this).

According to Gemini, the three most adversarial locales for this exercise are `lv_LV`, `lt_LT`, and `az_AZ`, each of which leave only 11 letters in the chosen algorithm. I confirm that result, but it doesn't rule out there being some other more adversarial locale. Gemini also mentions `haw_US` and `sm_WS` could leave 9, but it seems like in practice those locales just use normal ASCII sorting.