### PR TITLE
update runner macosx version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -334,7 +334,7 @@ test-win-old:
 ## R-release on MacOS
 test-mac-rel:
   <<: *test-mac
-  image: macos-14-xcode-15
+  image: macos-15-xcode-16
   variables:
     R_VERSION: "$R_REL_VERSION"
     R_BIN: "$R_REL_MAC_BIN"
@@ -342,7 +342,7 @@ test-mac-rel:
 ## R-oldrel on MacOS
 test-mac-old:
   <<: *test-mac
-  image: macos-14-xcode-15
+  image: macos-15-xcode-16
   variables:
     R_VERSION: "$R_OLD_VERSION"
     R_BIN: "$R_OLD_MAC_BIN"


### PR DESCRIPTION
Update since [old version](https://gitlab.com/Rdatatable/data.table/-/jobs/15530645802) is apparently outdated

Lets see how [CI likes it](https://gitlab.com/Rdatatable/data.table/-/pipelines/2705247820)