### PR TITLE
simplify Date-IDate atime test

### DIFF
--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -407,16 +407,15 @@ test.list <- atime::atime_test_list(
     Fast = "2715663fcf0344c3f7c73241d391d8de347bdb9d",  # Merge commit of the PR that improves efficiency
     expr = data.table:::as.data.table.array(arr, na.rm=FALSE)),
 
-  # Date-IDate subtraction became much slower when chooseOpsMethod.IDate was added in #7213.
-  "Date-IDate subtraction regression in #7213" = atime::atime_test(
-    N = as.integer(10^seq(1, 5, by=0.5)),
+  # Date-IDate became much slower when chooseOpsMethod.IDate was added in #7213.
+  "Date-IDate regression in #7213" = atime::atime_test(
     setup = {
       short_date = as.Date("2000-01-01") + seq_len(40L)
       long_date = as.Date("2000-01-01") + seq_len(N)
     },
-    Before = "84b0e32f7a1bfdd8ec3a2c4012010b3ec072b31f", # Parent of the regression commit.
-    Regression = "cfa9f49bd27195962573ad493a31600d173abc5c", # Merge commit of #7213 which added chooseOpsMethod.IDate.
-    seconds.limit = 1,
+    Before = "84b0e32f7a1bfdd8ec3a2c4012010b3ec072b31f", # Parent of the Regression commit (https://github.com/Rdatatable/data.table/commit/cfa9f49bd27195962573ad493a31600d173abc5c).
+    Regression = "cfa9f49bd27195962573ad493a31600d173abc5c", # Merge commit of regression PR (https://github.com/Rdatatable/data.table/pull/7213) which added chooseOpsMethod.IDate.
+    Fixed = "3376b44e549315f35118daf23676298fc941d8f3", # Merge commit of fix PR (https://github.com/Rdatatable/data.table/pull/7828).
     # Reset the shared base S3 table to match the version under test (see "Caveat" in the intro above).
     expr = {
       ns = environment(data.table::as.IDate)

--- a/.ci/atime/tests.R
+++ b/.ci/atime/tests.R
@@ -418,21 +418,7 @@ test.list <- atime::atime_test_list(
     Fixed = "3376b44e549315f35118daf23676298fc941d8f3", # Merge commit of fix PR (https://github.com/Rdatatable/data.table/pull/7828).
     # Reset the shared base S3 table to match the version under test (see "Caveat" in the intro above).
     expr = {
-      ns = environment(data.table::as.IDate)
-      s3_table = get(".__S3MethodsTable__.", envir = baseenv())
-      s3_generics = c("chooseOpsMethod.IDate" = "chooseOpsMethod", "-.IDate" = "-")
-      for (s3_method in names(s3_generics)) {
-        if (exists(s3_method, envir = s3_table, inherits = FALSE)) {
-          rm(list = s3_method, envir = s3_table)
-        }
-        if (exists(s3_method, envir = ns, inherits = FALSE)) {
-          base::registerS3method(
-            s3_generics[[s3_method]], "IDate",
-            get(s3_method, envir = ns, inherits = FALSE),
-            envir = ns)
-        }
-      }
-      outer(short_date, data.table::as.IDate(long_date), `-`)
+      outer(short_date, data.table::as.IDate(long_date), data.table:::`-.IDate`)
     }),
 
   # https://github.com/Rdatatable/data.table/pull/7144 added the speedup code and this performance test.


### PR DESCRIPTION
I wonder if it is possible to have a simpler test case, that does not need to edit S3 method registration?
I tried removing that code, and using `` data.table:::`-.IDate` `` but I see that Before is slow, which is not what we want for this test case.

| this PR | master/PR7845 |
| - | - |
| <img width="399" height="765" alt="image" src="https://github.com/user-attachments/assets/1c85a42c-8b81-41b6-af77-6b0e6fcff2eb" /> | <img width="399" height="765" alt="image" src="https://github.com/user-attachments/assets/f4881c6a-0e62-4ac1-b331-f90006eb0633" /> |


Maybe we would need to use `data.table:::chooseOpsMethod.IDate` in expr?