### PR TITLE
tryCatch for nchar() on old R

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -72,6 +72,8 @@
 
 16. `copy()` is now more consistent about reallocating nested `data.table`s, [#7456](https://github.com/Rdatatable/data.table/issues/7456). The resulting list is now only overwritten when necessary, list columns inside data.tables are searched recursively, and their attributes are walked in search of data.tables to reallocate as well. Thanks to @be-marc for the report, @david-cortes for additional information, and @aitap for the fix.
 
+17. `print()` works with multi-byte characters on R before 4.2.0, [#7848](https://github.com/Rdatatable/data.table/pull/7848). Thanks @MichaelChirico for the fix and @aitap for the improvement.
+
 ### Notes
 
 1. {data.table} now depends on R 3.5.0 (2018).

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -256,8 +256,12 @@ char.trunc = function(x, trunc.char = getOption("datatable.prettyprint.char")) {
   if (is.null(trunc.char)) return(x)
   trunc.char = max(0L, suppressWarnings(as.integer(trunc.char[1L])), na.rm=TRUE)
   if (!is.character(x) || trunc.char <= 0L) return(x)
-  nchar_width = nchar(x, 'width', allowNA = TRUE)
-  nchar_chars = nchar(x, 'char', allowNA = TRUE)
+  nchar_width = tryCatch(nchar(x, 'width', allowNA=TRUE), error=identity)
+  if (inherits(nchar_width, "error")) { # for R<4.2 e.g. 2366.6 print of fread table gives 'invalid multibyte string'
+    x = encodeString(x)
+    x = nchar(x, 'width', allowNA=TRUE)
+  }
+  nchar_chars = nchar(x, 'char', allowNA=TRUE)
   is_full_width = nchar_width > nchar_chars
   is_full_width[is.na(is_full_width)] = FALSE
   idx = !is.na(x) & !is.na(nchar_width) & pmin(nchar_width, nchar_chars) > trunc.char

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -256,11 +256,8 @@ char.trunc = function(x, trunc.char = getOption("datatable.prettyprint.char")) {
   if (is.null(trunc.char)) return(x)
   trunc.char = max(0L, suppressWarnings(as.integer(trunc.char[1L])), na.rm=TRUE)
   if (!is.character(x) || trunc.char <= 0L) return(x)
-  nchar_width = tryCatch(nchar(x, 'width', allowNA=TRUE), error=identity)
-  if (inherits(nchar_width, "error")) { # for R<4.2 e.g. 2366.6 print of fread table gives 'invalid multibyte string'
-    x = encodeString(x)
-    nchar_width = nchar(x, 'width', allowNA=TRUE)
-  }
+  # TODO(R>=4.2.0): we only need the tryCatch() for old bug in allowNA=TRUE, see #7848
+  nchar_width = tryCatch(nchar(x, 'width', allowNA=TRUE), error=function(.) NA)
   nchar_chars = nchar(x, 'char', allowNA=TRUE)
   is_full_width = nchar_width > nchar_chars
   is_full_width[is.na(is_full_width)] = FALSE

--- a/R/print.data.table.R
+++ b/R/print.data.table.R
@@ -259,7 +259,7 @@ char.trunc = function(x, trunc.char = getOption("datatable.prettyprint.char")) {
   nchar_width = tryCatch(nchar(x, 'width', allowNA=TRUE), error=identity)
   if (inherits(nchar_width, "error")) { # for R<4.2 e.g. 2366.6 print of fread table gives 'invalid multibyte string'
     x = encodeString(x)
-    x = nchar(x, 'width', allowNA=TRUE)
+    nchar_width = nchar(x, 'width', allowNA=TRUE)
   }
   nchar_chars = nchar(x, 'char', allowNA=TRUE)
   is_full_width = nchar_width > nchar_chars


### PR DESCRIPTION
See e.g.

 - failing on 4.1: https://github.com/Rdatatable/data.table/actions/runs/30220885395/job/89843028144?pr=7832
 - passing on 4.2: https://github.com/Rdatatable/data.table/actions/runs/30220885395/job/89843028187?pr=7832 (NB: the test still fails, but tests/main.R passes)

h/t @joshhwuu for identifying the culprit R bugfix in the comment below.