### PR TITLE
Fix for as.IDate() to retain names even before some as.Date() calls did so in R (4.1.2)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -68,7 +68,7 @@
 
 14. Subtracting an `IDate` from a `Date` is fast again by avoiding unnecessary conversion to `POSIXlt`/`POSIXct`, [#7825](https://github.com/Rdatatable/data.table/issues/7825). Thanks @gilesheywood for the report and @ben-schwen for the fix.
 
-15. `as.IDate()` and `as.ITime()` now preserve names, matching base `as.Date()` behavior, [#7252](https://github.com/Rdatatable/data.table/issues/7252). Thanks @DavisVaughan for the report and @venom1204 for the PR.
+15. `as.IDate()` and `as.ITime()` now preserve names, matching base `as.Date()` behavior, [#7252](https://github.com/Rdatatable/data.table/issues/7252). Thanks @DavisVaughan for the report, @venom1204 for the PR, and @MichaelChirico for patching the fix back to old versions of R.
 
 16. `copy()` is now more consistent about reallocating nested `data.table`s, [#7456](https://github.com/Rdatatable/data.table/issues/7456). The resulting list is now only overwritten when necessary, list columns inside data.tables are searched recursively, and their attributes are walked in search of data.tables to reallocate as well. Thanks to @be-marc for the report, @david-cortes for additional information, and @aitap for the fix.
 

--- a/R/IDateTime.R
+++ b/R/IDateTime.R
@@ -47,10 +47,10 @@ as.IDate.POSIXct = function(x, tz = attr(x, "tzone", exact=TRUE), ...) {
   if (is_utc(tz)) {
     ans = as.integer(as.numeric(x) %/% 86400L)  # %/% returns a new object, so setattr() is safe
     setattr(ans, "class", c("IDate", "Date"))
-    copy_names(ans, names(x))
   } else {
-    as.IDate(as.Date(x, tz =  tz %||% '', ...))
+    ans = as.IDate(as.Date(x, tz =  tz %||% '', ...))
   }
+  copy_names(ans, names(x))
 }
 
 as.IDate.IDate = function(x, ...) x


### PR DESCRIPTION
Follow-up to #7800 for pre-R-4.1.2 behavior of `as.Date.POSIXlt`.