### PR TITLE
Fix example(local=TRUE) for cedta (again)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -74,6 +74,8 @@
 
 17. `print()` works with multi-byte characters on R before 4.2.0, [#7848](https://github.com/Rdatatable/data.table/pull/7848). Thanks @MichaelChirico for the fix and @aitap for the improvement.
 
+18. `example(local=TRUE)` where the example uses `[.data.table` works again (e.g. `example(':=', package='data.table', local=TRUE, echo=FALSE)`), [#7833](https://github.com/Rdatatable/data.table/issues/7833) re-fixing [#2972](https://github.com/Rdatatable/data.table/issues/2972). Thanks @michaelChirico for the fix.
+
 ### Notes
 
 1. {data.table} now depends on R 3.5.0 (2018).

--- a/NEWS.md
+++ b/NEWS.md
@@ -74,7 +74,7 @@
 
 17. `print()` works with multi-byte characters on R before 4.2.0, [#7848](https://github.com/Rdatatable/data.table/pull/7848). Thanks @MichaelChirico for the fix and @aitap for the improvement.
 
-18. `example(local=TRUE)` where the example uses `[.data.table` works again (e.g. `example(':=', package='data.table', local=TRUE, echo=FALSE)`), [#7833](https://github.com/Rdatatable/data.table/issues/7833) re-fixing [#2972](https://github.com/Rdatatable/data.table/issues/2972). Thanks @michaelChirico for the fix.
+18. `example(local=TRUE)` where the example uses `[.data.table` works again (e.g. `example(':=', package='data.table', local=TRUE, echo=FALSE)`), [#7855](https://github.com/Rdatatable/data.table/issues/7855) re-fixing [#2972](https://github.com/Rdatatable/data.table/issues/2972). Thanks @michaelChirico for the fix.
 
 ### Notes
 

--- a/R/cedta.R
+++ b/R/cedta.R
@@ -64,7 +64,7 @@ cedta.pkgEvalsUserCode = c("gWidgetsWWW","statET","FastRWeb","slidify","rmarkdow
     if (exists("debugger.look", parent.frame(n+1L))) return(TRUE) # nocov
 
     # 'example' for #2972
-    if (length(sc) >= 8L && sc[[length(sc) - 7L]] %iscall% 'example') return(TRUE) # nocov
+    if (length(sc) >= 9L && sc[[length(sc) - 8L]] %iscall% 'example') return(TRUE) # nocov
   }
 
   if (nsname == "base") {


### PR DESCRIPTION
Split off from #7833 to keep the purposes separate: here, a bugfix with NEWS entry, there, test-only edits to get the suite more robust to different platforms/R versions.

Without the update to `cedta()` we get the telltale `cedta()` issues from here:

https://github.com/Rdatatable/data.table/blob/fae95de24aa224c0c7a2bebd86919ad0effcf545/inst/tests/other.Rraw#L227-L229

```
Expected: 
Observed: [ was called on a data.table in an environment that is not data.table-aware (i.e. cedta()), but ':=' was used, implying the owner of this call really intended for data.table methods to be called. See vignette('datatable-importing') for details on properly importing data.table.
Test 14.2 produced 1 errors but expected 0
Expected: 
Observed: could not find function "J"
```

AIUI this is because of #7162 adding one more item on the call stack during execution of `example()`.