### PR TITLE
Use silent=TRUE to suppress tables() output

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -21606,7 +21606,7 @@ xenv$N = list(a=1:5)
 xenv$DF = data.frame(a = 1:2)
 xenv$DF$b = data.table(c = 3:4, d = 5:6)
 test(2366.1,
-     tables(env=xenv, depth=1L, index=TRUE)[, .(NAME, NROW, NCOL, INDICES, KEY)],
+     tables(env=xenv, depth=1L, index=TRUE, silent=TRUE)[, .(NAME, NROW, NCOL, INDICES, KEY)],
      data.table(
        NAME = c("DF$b", "DT", "L[[1]]", "L[[2]]", "M$b"),
        NROW = c(2L, 1L, 3L, 4L, 3L),
@@ -21616,11 +21616,11 @@ test(2366.1,
      ))
 setindex(xenv$M$b, b)
 test(2366.2,
-     tables(env=xenv, depth=1L, index=TRUE)[, .(INDICES, KEY)],
+     tables(env=xenv, depth=1L, index=TRUE, silent=TRUE)[, .(INDICES, KEY)],
      data.table(INDICES = list(NULL, NULL, NULL, NULL, "b"), KEY = list(NULL, NULL, NULL, NULL, NULL)))
 setkey(xenv$M$b, a)
 test(2366.3,
-     tables(env=xenv, depth=1L, index=TRUE)[, .(INDICES, KEY)],
+     tables(env=xenv, depth=1L, index=TRUE, silent=TRUE)[, .(INDICES, KEY)],
      data.table(INDICES = list(NULL, NULL, NULL, NULL, "b"), KEY = list(NULL, NULL, NULL, NULL, "a")))
 # test for depth>1L
 test(2366.4, tables(env=xenv, depth=2L), error="depth>1L is not implemented yet")
@@ -21628,8 +21628,8 @@ rm(xenv)
 
 # no data.table test
 xenv_empty = new.env()
-test(2366.5, tables(env=xenv_empty, depth=1L), invisible(data.table(NULL)))
-test(2366.6, tables(env=xenv_empty), invisible(data.table(NULL)))
+test(2366.5, tables(env=xenv_empty, depth=1L, silent=TRUE), invisible(data.table(NULL)))
+test(2366.6, tables(env=xenv_empty, silent=TRUE), invisible(data.table(NULL)))
 rm(xenv_empty)
 
 # fread supports connections #561


### PR DESCRIPTION
`tables()` tests need to either provide `output=` or `silent=TRUE` or they spill output to the test log.

Split off from #7833 to keep that one purely changes to other.Rraw.