### PR TITLE
Start self.Rraw suite for tests of test(), test.data.table()

### DIFF
--- a/inst/tests/self.Rraw
+++ b/inst/tests/self.Rraw
@@ -1,0 +1,14 @@
+if (exists("test.data.table", .GlobalEnv, inherits=FALSE)) {
+  if ((tt<-compiler::enableJIT(-1))>0)
+    cat("This is dev mode and JIT is enabled (level ", tt, ") so there will be a brief pause around the first test.\n", sep="")
+} else {
+  library(data.table)
+
+  test = data.table:::test
+}
+
+# multiple expected/observed warnings in test() are printed on aligned lines, #7092
+test(1.1, test(0, warning("a"), warning=c("a", "b"), check_value=FALSE), FALSE,
+          output="Test 0 produced 1 warnings but expected 2\nExpected: a\n          b\nObserved: a")
+test(1.2, test(0, {warning("a"); warning("b")}, warning="a", check_value=FALSE), FALSE,
+          output="Test 0 produced 2 warnings but expected 1\nExpected: a\nObserved: a\n          b")

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -21670,11 +21670,7 @@ test(2370.3, yearmon(x, format="character"), c("1111M11", "2019M01", "2019M02", 
 test(2370.4, yearmon("2016-08-03 01:02:03.45", format="character"), "2016M08")
 test(2370.5, yearmon(NA, format="character"), NA_character_)
 
-# multiple expected/observed warnings in test() are printed on aligned lines, #7092
-test(2371.1, test(0, warning("a"), warning=c("a", "b"), check_value=FALSE), FALSE,
-             output="Test 0 produced 1 warnings but expected 2\nExpected: a\n          b\nObserved: a")
-test(2372.2, test(0, {warning("a"); warning("b")}, warning="a", check_value=FALSE), FALSE,
-             output="Test 0 produced 2 warnings but expected 1\nExpected: a\nObserved: a\n          b")
+# test 2371, of test() itself, moved to self.Rraw
 
 # group-by on empty table works
 empty_dt = data.table()

--- a/tests/self.R
+++ b/tests/self.R
@@ -1,0 +1,2 @@
+library(data.table)
+test.data.table(script="self.Rraw")


### PR DESCRIPTION
Towards #6109. I used XML search to find any nested calls of `test(... test() ...)` in tests.Rraw and only found the one.

More tests to be added as they arise.