### PR TITLE
test() distinguishes NA, NaN in vectors

### DIFF
--- a/R/test.data.table.R
+++ b/R/test.data.table.R
@@ -666,7 +666,7 @@ test = function(num, x, y=TRUE, ...,
           identical(vapply_1c(xc,typeof), vapply_1c(yc,typeof))) return(invisible(TRUE))
       }
     }
-    if (is.atomic(x) && is.atomic(y) && isTRUE(all.equal.result<-all.equal(x,y,check.names=!isTRUE(y))) && typeof(x)==typeof(y)) return(invisible(TRUE))
+    if (is.atomic(x) && is.atomic(y) && isTRUE(all.equal.result<-all.equal(x,y,check.names=!isTRUE(y))) && typeof(x)==typeof(y) && all(is.nan(x)==is.nan(y))) return(invisible(TRUE))
     # For test 617 on r-prerel-solaris-sparc on 7 Mar 2013
     # nocov start
     if (!fail) {
@@ -677,7 +677,7 @@ test = function(num, x, y=TRUE, ...,
         if (is.data.table(x)) compactprint(x) else {
           if (is.atomic(x) && is.atomic(y) && length(x) == length(y) && identical(dim(x), dim(y))) {
             total = length(x)
-            diff_idx = which(x != y | xor(is.na(x), is.na(y))) # careful to only evaluate '!=' for atomic inputs; which: drop NA-NA
+            diff_idx = which(x != y | xor(is.na(x), is.na(y)) | xor(is.nan(x), is.nan(y))) # careful to only evaluate '!=' for atomic inputs; which: drop NA-NA
             x = x[diff_idx]
             nn = length(x)
             names(x) = sprintf("%s[%d]", label, diff_idx)

--- a/inst/tests/self.Rraw
+++ b/inst/tests/self.Rraw
@@ -12,3 +12,13 @@ test(1.1, test(0, warning("a"), warning=c("a", "b"), check_value=FALSE), FALSE,
           output="Test 0 produced 1 warnings but expected 2\nExpected: a\n          b\nObserved: a")
 test(1.2, test(0, {warning("a"); warning("b")}, warning="a", check_value=FALSE), FALSE,
           output="Test 0 produced 2 warnings but expected 1\nExpected: a\nObserved: a\n          b")
+
+# test() distinguishes NA and NaN, especially in vectors
+test(2.1, test(0, NA_real_, NaN), FALSE,
+          output="First 1 different of 1 \\(1 total.*x.*NA.*First 1 different of 1.*y.*NaN")
+test(2.2, test(0, list(NA), list(NaN)), FALSE,
+          output="x = list\\(NA\\).*y = list\\(NaN\\)")
+test(2.3, test(0, c(1, NA), c(1, NaN)), FALSE,
+          output="First 1 different of 1 \\(2 total.*x.*NA.*First 1 different of 1.*y.*NaN")
+test(2.4, test(0, c(1, NA, NA, NaN, 2, 3), c(1, NA, NaN, NaN, NA, NaN)), FALSE,
+          output="First 3 different of 3 \\(6 total.*NA.*2.*3.*First 3 different of 3.*NaN.*NA.*NaN")


### PR DESCRIPTION
**NB: targeting #7863**

Closes #7853 

 1. `test(0, data.table(a=NA_real_), data.table(a=NaN))` currently passes. I'll mark that for follow-up since, IINM, it will require a breaking change to `all.equal.data.table()`.
 2. `froll.Rraw` is not currently passing. @jangorecki could you PTAL and see if we should just update the tests or if this is exposing some unintended behavior?