### PR TITLE
fwrite: Improve validation of the na argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -80,10 +80,6 @@
 
 18. `example(local=TRUE)` where the example uses `[.data.table` works again (e.g. `example(':=', package='data.table', local=TRUE, echo=FALSE)`), [#7855](https://github.com/Rdatatable/data.table/issues/7855) re-fixing [#2972](https://github.com/Rdatatable/data.table/issues/2972). Thanks @michaelChirico for the fix.
 
-19. `fread()` returns a clearer error message when `dec = NA` is used, [#7737](https://github.com/Rdatatable/data.table/issues/7737). Thanks @mcol for the report and the fix.
-
-20. `fwrite()` returns a clearer error message when `na = data.frame()` is used, [#7866](https://github.com/Rdatatable/data.table/issues/7866). Thanks @mcol for the report and the fix.
-
 ### Notes
 
 1. {data.table} now depends on R 3.5.0 (2018).
@@ -101,6 +97,10 @@
 7. Verbose outputs from `frolladaptivefun()` and `frollfun()` are now clearer and more user friendly [#7021](https://github.com/Rdatatable/data.table/issues/7021). Thanks to @Omartech312, @aidengseay, @kkarissa, and @heb229 for the implementation, to @ben-schwen for the review, and to @jangorecki for the extensive guidance and review.
 
 8. Clarified `fread()` documentation and vignette regarding the interaction between `keepLeadingZeros = TRUE` and automatic header detection, [#5405](https://github.com/Rdatatable/data.table/issues/5405). Thanks @clemenskuehn for the report and @venom1204 for updating the documentation.
+
+9. `fread()` returns a clearer error message when `dec = NA` is used, [#7737](https://github.com/Rdatatable/data.table/issues/7737). Thanks @mcol for the report and the fix.
+
+10. `fwrite()` returns a clearer error message when `na = data.frame()` is used, [#7866](https://github.com/Rdatatable/data.table/issues/7866). Thanks @mcol for the report and the fix.
 
 ## data.table [v1.18.4](https://github.com/Rdatatable/data.table/milestone/45) (6 May 2026)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -82,6 +82,8 @@
 
 19. `fread()` returns a clearer error message when `dec = NA` is used, [#7737](https://github.com/Rdatatable/data.table/issues/7737). Thanks @mcol for the report and the fix.
 
+20. `fwrite()` returns a clearer error message when `na = data.frame()` is used, [#7866](https://github.com/Rdatatable/data.table/issues/7866). Thanks @mcol for the report and the fix.
+
 ### Notes
 
 1. {data.table} now depends on R 3.5.0 (2018).

--- a/R/fwrite.R
+++ b/R/fwrite.R
@@ -58,7 +58,7 @@ fwrite = function(x, file="", append=FALSE, quote="auto",
     length(nThread)==1L && !is.na(nThread) && nThread>=1L
   )
 
-  na = as.character(na[1L]) # fix for #1725
+  na = as.character(na) # fix for #1725
   is_gzip = compress == "gzip" || (compress == "auto" && endsWithAny(file, ".gz"))
 
   file = path.expand(file)  # "~/foo/bar"

--- a/R/fwrite.R
+++ b/R/fwrite.R
@@ -15,6 +15,7 @@ fwrite = function(x, file="", append=FALSE, quote="auto",
            verbose=getOption("datatable.verbose", FALSE),
            encoding = "",
            forceDecimal = FALSE) {
+  na = as.character(na) # fix for #1725
   if (length(encoding) != 1L || !encoding %chin% c("", "UTF-8", "native")) {
     stopf("Argument 'encoding' must be '', 'UTF-8' or 'native'.")
   }
@@ -58,7 +59,6 @@ fwrite = function(x, file="", append=FALSE, quote="auto",
     length(nThread)==1L && !is.na(nThread) && nThread>=1L
   )
 
-  na = as.character(na) # fix for #1725
   is_gzip = compress == "gzip" || (compress == "auto" && endsWithAny(file, ".gz"))
 
   file = path.expand(file)  # "~/foo/bar"

--- a/R/fwrite.R
+++ b/R/fwrite.R
@@ -15,7 +15,6 @@ fwrite = function(x, file="", append=FALSE, quote="auto",
            verbose=getOption("datatable.verbose", FALSE),
            encoding = "",
            forceDecimal = FALSE) {
-  na = as.character(na[1L]) # fix for #1725
   if (length(encoding) != 1L || !encoding %chin% c("", "UTF-8", "native")) {
     stopf("Argument 'encoding' must be '', 'UTF-8' or 'native'.")
   }
@@ -59,6 +58,7 @@ fwrite = function(x, file="", append=FALSE, quote="auto",
     length(nThread)==1L && !is.na(nThread) && nThread>=1L
   )
 
+  na = as.character(na[1L]) # fix for #1725
   is_gzip = compress == "gzip" || (compress == "auto" && endsWithAny(file, ".gz"))
 
   file = path.expand(file)  # "~/foo/bar"

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -10018,6 +10018,7 @@ test(1676.1, fwrite(dt, f, na=NULL), error=base_messages$stopifnot("length(na) =
 fwrite(dt, f, na=NA)
 test(1676.2, fread(f), data.table(x=1:2, y=c(NA, "a")))
 unlink(f)
+test(1676.3, fwrite(dt, na=data.frame()), error=base_messages$stopifnot("length(na) == 1L"))
 
 # duplicate names in foverlaps #1730
 a = data.table(start = 1:5, end = 2:6, c2 = rnorm(10), c2 = rnorm(10), key=c("start","end"))


### PR DESCRIPTION
This moves the conversion to character after the `stopifnot()`, so that we get a consistent error message for both `na = data.frame()` and `na = data.table()`.

Fixes #7866.