### PR TITLE
Support more locales in R-CMD-check-occasional

### DIFF
--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -146,10 +146,7 @@ jobs:
           } else {
             message(sprintf("Skipping other.Rraw since some required packages are not available: %s\n", toString(other_pkgs[!has_other_pkg])))
           }
-          # IINM rcmdcheck isolates its env from the calling process', besides what's passed to env=
-          env = c(
-            TEST_DATA_TABLE_WITH_OTHER_PACKAGES=as.character(run_other)
-          )
+          Sys.setenv(TEST_DATA_TABLE_WITH_OTHER_PACKAGES=as.character(run_other))
 
           do_vignettes = requireNamespace("litedown", quietly=TRUE)
 
@@ -172,7 +169,7 @@ jobs:
             system2(Rbin, c("CMD", "build", ".", build_args))
             dt_tar = list.files(pattern = "^data[.]table_.*[.]tar[.]gz$")
             if (!length(dt_tar)) stop("Built tar.gz not found among: ", toString(list.files()))
-            res = system2(Rbin, c("CMD", "check", dt_tar[1L], check_args), stdout=TRUE, stderr=TRUE, env=sprintf("%s=%s", names(env), env))
+            res = system2(Rbin, c("CMD", "check", dt_tar[1L], check_args), stdout=TRUE, stderr=TRUE)
             if (!is.null(attr(res, "status")) || anyNA(res) || any(grepl("^Status:.*(ERROR|WARNING)", res))) {
               writeLines(as.character(res))
               stop("R CMD check failed")

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -21,6 +21,28 @@ jobs:
         # Mandarin: multibyte characters
         # Latvian, Azeri, Hungarian, Faroese, Albanian: collate order (#3502, see also #7837)
         locale: ['en_US.utf8', 'zh_CN.utf8', 'lv_LV.utf8', 'az_AZ.utf8', 'hu_HU.utf8', 'fo_FO.utf8', 'sq_MK.utf8']
+        # Only run non-English-locale CI runs on Ubuntu
+        include:
+          # For multibyte characters
+          - os: ubuntu-latest
+            r: 'devel'
+            locale: 'zh_CN.utf8' # Mandarin
+          # For collate order (#3502, see also #7837)
+          - os: ubuntu-latest
+            r: 'devel'
+            locale: 'lv_LV.utf8' # Latvian
+          - os: ubuntu-latest
+            r: 'devel'
+            locale: 'az_AZ.utf8' # Azeri
+          - os: ubuntu-latest
+            r: 'devel'
+            locale: 'hu_HU.utf8' # Hungarian
+          - os: ubuntu-latest
+            r: 'devel'
+            locale: 'fo_FO.utf8' # Faroese
+          - os: ubuntu-latest
+            r: 'devel'
+            locale: 'sq_MK.utf8' # Albanian (in North Macedonia)
         exclude:
           # macOS/arm64 only available for R>=4.1.0
           - os: macOS-latest

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -18,32 +18,40 @@ jobs:
       matrix:
         os: [macOS-latest, windows-latest, ubuntu-latest]
         r: ['devel', 'release', '3.5', '3.6', '4.0', '4.1', '4.2', '4.3', '4.4', '4.5']
-        # Mandarin: multibyte characters
-        # Latvian, Azeri, Hungarian, Faroese, Albanian: collate order (#3502, see also #7837)
-        locale: ['en_US.utf8', 'zh_CN.utf8', 'lv_LV.utf8', 'az_AZ.utf8', 'hu_HU.utf8', 'fo_FO.utf8', 'sq_MK.utf8']
-        # Only run non-English-locale CI runs on Ubuntu
-        include:
-          # For multibyte characters
-          - os: ubuntu-latest
-            r: 'devel'
-            locale: 'zh_CN.utf8' # Mandarin
-          # For collate order (#3502, see also #7837)
-          - os: ubuntu-latest
-            r: 'devel'
-            locale: 'lv_LV.utf8' # Latvian
-          - os: ubuntu-latest
-            r: 'devel'
-            locale: 'az_AZ.utf8' # Azeri
-          - os: ubuntu-latest
-            r: 'devel'
-            locale: 'hu_HU.utf8' # Hungarian
-          - os: ubuntu-latest
-            r: 'devel'
-            locale: 'fo_FO.utf8' # Faroese
-          - os: ubuntu-latest
-            r: 'devel'
-            locale: 'sq_MK.utf8' # Albanian (in North Macedonia)
+        locale: ['en_US.utf8',
+                 # Multibyte characters: Mandarin
+                 'zh_CN.utf8',
+                 # Collate order (#3502, see also #7837): Latvian, Azeri, Hungarian, Faroese, Albanian
+                 'lv_LV.utf8', 'az_AZ.utf8', 'hu_HU.utf8', 'fo_FO.utf8', 'sq_MK.utf8']
+        # we're constrained by GHA inflexibility to do a tedious thing here with 'exclude' below.
+        #   better would be for GHA to support multiple 'matrix' configs (one for ubuntu, one for other OS);
+        #   an approach with multiple jobs would tediously require copy-pasting the _rest_ of the steps
         exclude:
+          # only run non-English locale CI on Ubuntu
+          - os: macOS-latest
+            locale: 'zh_CN.utf8'
+          - os: macOS-latest
+            locale: 'lv_LV.utf8'
+          - os: macOS-latest
+            locale: 'az_AZ.utf8'
+          - os: macOS-latest
+            locale: 'hu_HU.utf8'
+          - os: macOS-latest
+            locale: 'fo_FO.utf8'
+          - os: macOS-latest
+            locale: 'sq_MK.utf8'
+          - os: windows-latest
+            locale: 'zh_CN.utf8'
+          - os: windows-latest
+            locale: 'lv_LV.utf8'
+          - os: windows-latest
+            locale: 'az_AZ.utf8'
+          - os: windows-latest
+            locale: 'hu_HU.utf8'
+          - os: windows-latest
+            locale: 'fo_FO.utf8'
+          - os: windows-latest
+            locale: 'sq_MK.utf8'
           # macOS/arm64 only available for R>=4.1.0
           - os: macOS-latest
             r: '3.5'

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -22,7 +22,9 @@ jobs:
                  # Multibyte characters: Mandarin
                  'zh_CN.utf8',
                  # Collate order (#3502, see also #7837): Latvian, Azeri, Hungarian, Faroese, Albanian
-                 'lv_LV.utf8', 'az_AZ.utf8', 'hu_HU.utf8', 'fo_FO.utf8', 'sq_MK.utf8']
+                 'lv_LV.utf8', 'az_AZ.utf8', 'hu_HU.utf8', 'fo_FO.utf8', 'sq_MK.utf8',
+                 # Local time formatting (for R bug #19117)
+                 'vi_VN.utf8']
         # we're constrained by GHA inflexibility to do a tedious thing here with 'exclude' below.
         #   better would be for GHA to support multiple 'matrix' configs (one for ubuntu, one for other OS);
         #   an approach with multiple jobs would tediously require copy-pasting the _rest_ of the steps

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -22,15 +22,6 @@ jobs:
         # Latvian, Azeri, Hungarian, Faroese, Albanian: collate order (#3502, see also #7837)
         locale: ['en_US.utf8', 'zh_CN.utf8', 'lv_LV.utf8', 'az_AZ.utf8', 'hu_HU.utf8', 'fo_FO.utf8', 'sq_MK.utf8']
         exclude:
-          # only run non-English locale CI on Ubuntu
-          - os: macOS-latest
-            locale: 'zh_CN.utf8'
-          - os: macOS-latest
-            locale: 'lv_LV.utf8'
-          - os: windows-latest
-            locale: 'zh_CN.utf8'
-          - os: windows-latest
-            locale: 'lv_LV.utf8'
           # macOS/arm64 only available for R>=4.1.0
           - os: macOS-latest
             r: '3.5'
@@ -47,24 +38,11 @@ jobs:
 
     steps:
       - name: Set locale
-        if: matrix.os == 'ubuntu-latest' && matrix.locale == 'en_US.utf8'
+        if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo locale-gen en_US
-          echo "LC_ALL=en_US.utf8" >> $GITHUB_ENV
-
-      - name: Set locale
-        if: matrix.locale == 'zh_CN.utf8'
-        run: |
-          sudo locale-gen 'zh_CN.utf8'
-          echo "LC_ALL=zh_CN.utf8" >> $GITHUB_ENV
-          echo "LANGUAGE=zh_CN" >> $GITHUB_ENV
-
-      - name: Set locale
-        if: matrix.locale == 'lv_LV.utf8'
-        run: |
-          sudo locale-gen 'lv_LV.utf8'
-          echo "LC_ALL=lv_LV.utf8" >> $GITHUB_ENV
-          echo "LANGUAGE=lv_LV" >> $GITHUB_ENV
+          sudo locale-gen "${{ matrix.locale }}"
+          echo "LC_ALL=${{ matrix.locale }}" >> $GITHUB_ENV
+          echo "LANGUAGE=$(echo '${{ matrix.locale }}' | cut -d'.' -f1)" >> $GITHUB_ENV
 
       - uses: actions/checkout@v7
 

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -163,12 +163,7 @@ jobs:
             check_args = c(check_args, "--no-build-vignettes", "--ignore-vignettes")
           }
           if (requireNamespace("rcmdcheck", quietly=TRUE)) {
-            if ("env" %in% names(formals(rcmdcheck::rcmdcheck))) {
-              rcmdcheck::rcmdcheck(args=check_args, build_args=build_args, error_on="warning", check_dir="check", env=env)
-            } else {
-              do.call(Sys.setenv, as.list(env))
-              rcmdcheck::rcmdcheck(args=check_args, build_args=build_args, error_on="warning", check_dir="check")
-            }
+            rcmdcheck::rcmdcheck(args=check_args, build_args=build_args, error_on="warning", check_dir="check")
           } else {
             Rbin = if (.Platform$OS.type == "windows") "R.exe" else "R"
             system2(Rbin, c("CMD", "build", ".", build_args))

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -132,7 +132,9 @@ jobs:
           other_pkgs = get(as.character(other_deps_expr[[1L]][[2L]]))
           # Many will not install on oldest R versions
           message("*** Installing fully optional packages ***")
-          try(install.packages(c(other_pkgs, "rcmdcheck")))
+          base_pkgs = rownames(installed.packages(priority = "base"))
+          install_pkgs = setdiff(c(other_pkgs, "rcmdcheck"), base_pkgs)
+          try(install.packages(install_pkgs))
 
           has_other_pkg = sapply(other_pkgs, requireNamespace, quietly=TRUE)
           run_other = all(has_other_pkg)
@@ -144,7 +146,8 @@ jobs:
           } else {
             message(sprintf("Skipping other.Rraw since some required packages are not available: %s\n", toString(other_pkgs[!has_other_pkg])))
           }
-          # IINM rcmdcheck isolates its env from the calling process', besides what's passed to env=
+          # Set env var in calling process for older rcmdcheck versions (<1.4.0) that do not support env=
+          Sys.setenv(TEST_DATA_TABLE_WITH_OTHER_PACKAGES = as.character(run_other))
           env = c(
             TEST_DATA_TABLE_WITH_OTHER_PACKAGES=as.character(run_other)
           )
@@ -159,7 +162,9 @@ jobs:
             check_args = c(check_args, "--no-build-vignettes", "--ignore-vignettes")
           }
           if (requireNamespace("rcmdcheck", quietly=TRUE)) {
-            rcmdcheck::rcmdcheck(args = check_args, build_args = build_args, error_on = "warning", check_dir = "check", env=env)
+            rc_args = list(args = check_args, build_args = build_args, error_on = "warning", check_dir = "check")
+            if ("env" %in% names(formals(rcmdcheck::rcmdcheck))) rc_args$env = env
+            do.call(rcmdcheck::rcmdcheck, rc_args)
           } else {
             Rbin = if (.Platform$OS.type == "windows") "R.exe" else "R"
             system2(Rbin, c("CMD", "build", ".", build_args))

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -1,5 +1,4 @@
 on:
-  push:
   schedule:
    - cron: '17 13 23 * *' # 23rd of month at 13:17 UTC
   workflow_dispatch:

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -42,6 +42,8 @@ jobs:
             locale: 'fo_FO.utf8'
           - os: macOS-latest
             locale: 'sq_MK.utf8'
+          - os: macOS-latest
+            locale: 'vi_VN.utf8'
           - os: windows-latest
             locale: 'zh_CN.utf8'
           - os: windows-latest
@@ -54,6 +56,8 @@ jobs:
             locale: 'fo_FO.utf8'
           - os: windows-latest
             locale: 'sq_MK.utf8'
+          - os: windows-latest
+            locale: 'vi_VN.utf8'
           # macOS/arm64 only available for R>=4.1.0
           - os: macOS-latest
             r: '3.5'

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -134,7 +134,7 @@ jobs:
             tools:::.get_standard_package_names()$base) # skip parallel
           # Many will not install on oldest R versions
           message("*** Installing fully optional packages ***")
-          try(install.packages(c(other_pkgs, "rcmdcheck"))
+          try(install.packages(c(other_pkgs, "rcmdcheck")))
 
           has_other_pkg = sapply(other_pkgs, requireNamespace, quietly=TRUE)
           run_other = all(has_other_pkg)

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -1,4 +1,5 @@
 on:
+  push:
   schedule:
    - cron: '17 13 23 * *' # 23rd of month at 13:17 UTC
   workflow_dispatch:
@@ -17,7 +18,9 @@ jobs:
       matrix:
         os: [macOS-latest, windows-latest, ubuntu-latest]
         r: ['devel', 'release', '3.5', '3.6', '4.0', '4.1', '4.2', '4.3', '4.4', '4.5']
-        locale: ['en_US.utf8', 'zh_CN.utf8', 'lv_LV.utf8'] # Chinese for translations, Latvian for collate order (#3502)
+        # Mandarin: multibyte characters
+        # Latvian, Azeri, Hungarian, Faroese, Albanian: collate order (#3502, see also #7837)
+        locale: ['en_US.utf8', 'zh_CN.utf8', 'lv_LV.utf8', 'az_AZ.utf8', 'hu_HU.utf8', 'fo_FO.utf8', 'sq_MK.utf8']
         exclude:
           # only run non-English locale CI on Ubuntu
           - os: macOS-latest

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -130,7 +130,7 @@ jobs:
           other_deps_expr = parse('inst/tests/other.Rraw', n=1L)
           eval(other_deps_expr)
           other_pkgs = setdiff(
-            get(as.character(other_deps_expr[[1L]][[2L]]))
+            get(as.character(other_deps_expr[[1:2]])),
             tools:::.get_standard_package_names()$base) # skip parallel
           # Many will not install on oldest R versions
           message("*** Installing fully optional packages ***")

--- a/.github/workflows/R-CMD-check-occasional.yaml
+++ b/.github/workflows/R-CMD-check-occasional.yaml
@@ -129,12 +129,12 @@ jobs:
 
           other_deps_expr = parse('inst/tests/other.Rraw', n=1L)
           eval(other_deps_expr)
-          other_pkgs = get(as.character(other_deps_expr[[1L]][[2L]]))
+          other_pkgs = setdiff(
+            get(as.character(other_deps_expr[[1L]][[2L]]))
+            tools:::.get_standard_package_names()$base) # skip parallel
           # Many will not install on oldest R versions
           message("*** Installing fully optional packages ***")
-          base_pkgs = rownames(installed.packages(priority = "base"))
-          install_pkgs = setdiff(c(other_pkgs, "rcmdcheck"), base_pkgs)
-          try(install.packages(install_pkgs))
+          try(install.packages(c(other_pkgs, "rcmdcheck"))
 
           has_other_pkg = sapply(other_pkgs, requireNamespace, quietly=TRUE)
           run_other = all(has_other_pkg)
@@ -146,8 +146,7 @@ jobs:
           } else {
             message(sprintf("Skipping other.Rraw since some required packages are not available: %s\n", toString(other_pkgs[!has_other_pkg])))
           }
-          # Set env var in calling process for older rcmdcheck versions (<1.4.0) that do not support env=
-          Sys.setenv(TEST_DATA_TABLE_WITH_OTHER_PACKAGES = as.character(run_other))
+          # IINM rcmdcheck isolates its env from the calling process', besides what's passed to env=
           env = c(
             TEST_DATA_TABLE_WITH_OTHER_PACKAGES=as.character(run_other)
           )
@@ -162,9 +161,12 @@ jobs:
             check_args = c(check_args, "--no-build-vignettes", "--ignore-vignettes")
           }
           if (requireNamespace("rcmdcheck", quietly=TRUE)) {
-            rc_args = list(args = check_args, build_args = build_args, error_on = "warning", check_dir = "check")
-            if ("env" %in% names(formals(rcmdcheck::rcmdcheck))) rc_args$env = env
-            do.call(rcmdcheck::rcmdcheck, rc_args)
+            if ("env" %in% names(formals(rcmdcheck::rcmdcheck))) {
+              rcmdcheck::rcmdcheck(args=check_args, build_args=build_args, error_on="warning", check_dir="check", env=env)
+            } else {
+              do.call(Sys.setenv, as.list(env))
+              rcmdcheck::rcmdcheck(args=check_args, build_args=build_args, error_on="warning", check_dir="check")
+            }
           } else {
             Rbin = if (.Platform$OS.type == "windows") "R.exe" else "R"
             system2(Rbin, c("CMD", "build", ".", build_args))

--- a/inst/tests/optimize.Rraw
+++ b/inst/tests/optimize.Rraw
@@ -192,7 +192,8 @@ dt = data.table(x  = sample(letters, 300, TRUE),
                 i2 = sample(c(-10:10, NA), 300, TRUE),
                 d1 = as.numeric(sample(-10:10, 300, TRUE)),
                 d2 = as.numeric(sample(c(NA, NaN, -10:10), 300, TRUE)))
-if (test_bit64) {
+# is.na() test for ancient {bit64} on ancient R
+if (test_bit64 && is.na(integer64()[1L])) {
   dt[, `:=`(d3 = as.integer64(sample(-10:10, 300, TRUE)))]
   dt[, `:=`(d4 = as.integer64(sample(c(-10:10,NA), 300, TRUE)))]
 }

--- a/inst/tests/other.Rraw
+++ b/inst/tests/other.Rraw
@@ -203,7 +203,9 @@ if (loaded[["knitr"]]) {
     tmp = tempfile()
     on.exit({unlink(tmp); options(old)})
     invisible(knit(testDir("knitr.Rmd"), tmp, quiet=TRUE))
-    test(11.2, tools::Rdiff(tmp, testDir("knitr.md.save")), 0L)
+    # TODO(R>=3.6.0): Try removing this kludge
+    if (packageVersion("knitr") > "1.45")
+      test(11.2, tools::Rdiff(tmp, testDir("knitr.md.save")), 0L)
   })
 }
 

--- a/inst/tests/other.Rraw
+++ b/inst/tests/other.Rraw
@@ -102,7 +102,9 @@ if (loaded[["dplyr"]]) {
   DT = data.table(A=c("b","c","a"), B=10:12)
   setindex(DT, A)
   DT2 = dplyr::arrange(DT, A)
-  test(2.2, DT2[A=="c"], data.table(A="c", B=11L))
+  # TODO(R>=3.6.0): Old versions of dplyr might coerce to tbl or data.frame; try removing this
+  if (is.data.table(DT2))
+    test(2.2, DT2[A=="c"], data.table(A="c", B=11L))
 }
 
 if (FALSE) {  # loaded[["reshape"]]

--- a/inst/tests/other.Rraw
+++ b/inst/tests/other.Rraw
@@ -718,13 +718,13 @@ if (loaded[["nanotime"]]) {
   test(27, na.omit(DT), DT[c(1,3)])
 
   # rbind with vectors with class attributes #5309
-  x = data.table(a=1L, b=as.nanotime(0))
+  x = data.table(a=1L, b=nanotime(0))
   y = data.table(a=2L, b=NA)
-  test(27.01, rbind(x,y), data.table(a = c(1L, 2L), b=as.nanotime(c(0, NA))))
-  test(27.02, rbind(y,x), data.table(a = c(2L, 1L), b=as.nanotime(c(NA, 0))))
+  test(27.01, rbind(x,y), data.table(a = c(1L, 2L), b=nanotime(c(0, NA))))
+  test(27.02, rbind(y,x), data.table(a = c(2L, 1L), b=nanotime(c(NA, 0))))
   y[, b := NULL]
-  test(27.03, rbind(x,y, fill = TRUE), data.table(a = c(1L, 2L), b=as.nanotime(c(0, NA))))
-  test(27.04, rbind(y,x, fill = TRUE), data.table(a = c(2L, 1L), b=as.nanotime(c(NA, 0))))
+  test(27.03, rbind(x,y, fill = TRUE), data.table(a = c(1L, 2L), b=nanotime(c(0, NA))))
+  test(27.04, rbind(y,x, fill = TRUE), data.table(a = c(2L, 1L), b=nanotime(c(NA, 0))))
 
   # Was 1.91-1.94 in nafill.Rraw, #6139
   l = list(a=nanotime(c(1:2,NA,4:5)), b=nanotime(c(NA,2L,NA,4L,NA)))
@@ -784,7 +784,7 @@ if (loaded[["dplyr"]]) {
 
 if (loaded[["nanotime"]]) {
   # respect dec=',' for nanotime, related to #6446, corresponding to tests 2281.*
-  test(31, fwrite(data.table(as.nanotime(.POSIXct(0))), dec=',', sep=';'), output="1970-01-01T00:00:00,000000000Z")
+  test(31, fwrite(data.table(nanotime(.POSIXct(0))), dec=',', sep=';'), output="1970-01-01T00:00:00,000000000Z")
 }
 
 # tables() with large environment #6607

--- a/inst/tests/other.Rraw
+++ b/inst/tests/other.Rraw
@@ -205,9 +205,7 @@ if (loaded[["knitr"]] && packageVersion("knitr") > "1.45") {
     tmp = tempfile()
     on.exit({unlink(tmp); options(old)})
     invisible(knit(testDir("knitr.Rmd"), tmp, quiet=TRUE))
-    # TODO(R>=3.6.0): Try removing this kludge
-    if (packageVersion("knitr") > "1.45")
-      test(11.2, tools::Rdiff(tmp, testDir("knitr.md.save")), 0L)
+    test(11.2, tools::Rdiff(tmp, testDir("knitr.md.save")), 0L)
   })
 }
 

--- a/inst/tests/other.Rraw
+++ b/inst/tests/other.Rraw
@@ -97,14 +97,13 @@ if (loaded[["plyr"]]) {
   test(2.1, plyr::arrange(DT,b), data.table(a=INT(1,3,5,7,9,2,4,6,8,10),b=INT(1,1,1,1,1,2,2,2,2,2)))
 }
 
-if (loaded[["dplyr"]]) {
+# in versions 0.7.0-0.8.5 of dplyr, arrange() returns a data.frame.
+if (loaded[["dplyr"]] && packageVersion("dplyr") >= "1.0.0") {
   # dplyr::arrange uses vctrs::vec_slice which is implemented in C and bypasses `[` dispatch; #5042
   DT = data.table(A=c("b","c","a"), B=10:12)
   setindex(DT, A)
   DT2 = dplyr::arrange(DT, A)
-  # TODO(R>=3.6.0): Old versions of dplyr might coerce to tbl or data.frame; try removing this
-  if (is.data.table(DT2))
-    test(2.2, DT2[A=="c"], data.table(A="c", B=11L))
+  test(2.2, DT2[A=="c"], data.table(A="c", B=11L))
 }
 
 if (FALSE) {  # loaded[["reshape"]]
@@ -194,7 +193,8 @@ if (loaded[["gdata"]]) {
   unlink(f)
 }
 
-if (loaded[["knitr"]]) {
+# trivial '```r' vs '``` r' difference in older knitr
+if (loaded[["knitr"]] && packageVersion("knitr") > "1.45") {
   # That data.table-unaware code in packages like knitr still work
   # kable in knitr v1.6 uses DF[...] syntax inside it but the user might have passed a data.table.
   # Which is fine and works thanks to cedta().

--- a/inst/tests/other.Rraw
+++ b/inst/tests/other.Rraw
@@ -1,9 +1,11 @@
-pkgs = c("DBI", "RSQLite", "bit64", "ggplot2", "caret", "dplyr", "gdata", "hexbin", "knitr", "nanotime", "nlme", "parallel", "plyr", "R.utils", "sf", "vctrs", "zoo", "xts", "yaml")
+pkgs = c("DBI", "RSQLite", "bit64", "ggplot2", "caret", "dplyr", "gdata", "hexbin", "knitr", "nanotime", "nlme", "parallel", "plyr", "R.oo", "R.utils", "sf", "vctrs", "zoo", "xts", "yaml")
 # First expression of this file must be as above: .gitlab-ci.yml uses parse(,n=1L) to read one expression from this file and installs pkgs.
 # So that these dependencies of other.Rraw are maintained in a single place.
 # TODO(R>=3.6.0): use attach.required=FALSE to let us keep pkgs= in alphabetical order (https://stat.ethz.ch/pipermail/r-devel/2026-July/084630.html)
 # TEST_DATA_TABLE_WITH_OTHER_PACKAGES is off by default so this other.Rraw doesn't run on CRAN. It is run by GLCI, locally in dev, and by
 #   users running test.data.table("other.Rraw").
+# TODO(HenrikBengtsson/R.oo#31): I think we can remove 'R.oo' once it can install in certain locales;
+#   for now, we have to include it in 'pkgs' to ensure tests don't try to proceed when 'R.oo' is found missing.
 
 # Optional Suggest-ed package tests moved from tests.Rraw to here in #5516. Retaining their comments:
 #  "xts",            # we have xts methods in R/xts.R

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -20769,8 +20769,10 @@ DT[1, V1 := factor("a", levels = c("a", samelevel))]
 test(2311.3, nlevels(DT$V1), 2L) # used to be 3
 
 # avoid translateChar*() in OpenMP threads, #6883
-DF = list(rep(iconv("\uf8", from = "UTF-8", to = "latin1"), 2e6))
-test(2312, fwrite(DF, nullfile(), encoding = "UTF-8", nThread = 2L), NULL)
+DF = list(rep(iconv("\uf8", from="UTF-8", to="latin1"), 2e6))
+# TODO(R>=3.6.0): nullfile() added to base
+if (!exists("nullfile")) nullfile <- function() if (.Platform$OS.type == "windows") "nul:" else "/dev/null"
+test(2312, fwrite(DF, nullfile(), encoding="UTF-8", nThread=2L), check_value=FALSE)
 
 # avoid memcpy of 0-length inputs
 test(2313,

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -136,9 +136,11 @@ sugg = c(
 )
 for (s in sugg) {
   assign(paste0("test_",s), loaded<-suppressWarnings(suppressMessages(
-    library(s, character.only=TRUE, logical.return=TRUE, quietly=TRUE, warn.conflicts=FALSE, pos="package:base")  # attach at the end for #5101
+    # tryCatch() here, not library(logical.return=), because of https://github.com/HenrikBengtsson/R.oo/issues/31;
+    #   library(logical.return=) throws an error when R.utils doesn't find R.oo, not logical FALSE.
+    tryCatch(library(s, character.only=TRUE, quietly=TRUE, warn.conflicts=FALSE, pos="package:base"), error=identity)  # attach at the end for #5101
   )))
-  if (!loaded) cat("\n**** Suggested package",s,"is not installed or has dependencies missing. Tests using it will be skipped.\n\n")
+  if (inherits(loaded, "error")) cat("\n**** Suggested package",s,"is not installed or has dependencies missing. Tests using it will be skipped.\n\n")
 }
 
 test_longdouble = isTRUE(capabilities()["long.double"]) && identical(as.integer(.Machine$longdouble.digits), 64L)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -253,7 +253,7 @@ make_c_sortable = function(x) {
     sorted_c = x[idx_c]
     sorted_r = x[idx_r]
 
-    x = x[-which(sorted_c != sorted_r)[1L]]
+    x = x[-idx_c[which(sorted_c != sorted_r)[1L]]]
   }
   x
 }
@@ -4484,11 +4484,6 @@ d1 = as.numeric(sample(c(-100:100,Inf,-Inf), 1e3, TRUE))
 d2 = as.numeric(rnorm(1e3))
 c1 = sample(make_c_sortable(letters), 1e3, TRUE)
 c2 = sample(make_c_sortable(make_words(50L)), 1e3, TRUE)
-# With some probability, in some locales (esp. az_AZ), c2
-#   can be sorted leading forderv to give integer().
-if (identical(order(c2), seq_along(c2))) {
-  c2 = c(c2[-1L], "mmmmmmmmmmmmmmmmmmmmmmmmmmm")
-}
 
 DT = data.table(i1, i2, d1, d2, c1, c2)
 # randomise col order as well

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -135,12 +135,12 @@ sugg = c(
   "R.utils"         # many fread test input files are compressed to save space; fundamental to test environment
 )
 for (s in sugg) {
-  assign(paste0("test_",s), loaded<-suppressWarnings(suppressMessages(
+  assign(paste0("test_",s), loaded <- !inherits(what="error", suppressWarnings(suppressMessages(
     # tryCatch() here, not library(logical.return=), because of https://github.com/HenrikBengtsson/R.oo/issues/31;
     #   library(logical.return=) throws an error when R.utils doesn't find R.oo, not logical FALSE.
     tryCatch(library(s, character.only=TRUE, quietly=TRUE, warn.conflicts=FALSE, pos="package:base"), error=identity)  # attach at the end for #5101
-  )))
-  if (inherits(loaded, "error")) cat("\n**** Suggested package",s,"is not installed or has dependencies missing. Tests using it will be skipped.\n\n")
+  ))))
+  if (!loaded) cat("\n**** Suggested package",s,"is not installed or has dependencies missing. Tests using it will be skipped.\n\n")
 }
 
 test_longdouble = isTRUE(capabilities()["long.double"]) && identical(as.integer(.Machine$longdouble.digits), 64L)

--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -627,15 +627,12 @@ test(166, suppressWarnings(split(DT,DT$grp)[[2]]), DT[grp==2])
 # 167 tested graphics::plot, moved to other.Rraw 28 to save ram, #5517
 
 # IDateTime conversion methods that ggplot2 uses (it calls as.data.frame method)
-# Since %b is e.g. "nov." in LC_TIME=fr_FR.UTF-8 locale, we need to
-# have the target/y value in these tests depend on the locale as well, #3450.
-NOV = format(strptime("2000-11-01", "%Y-%m-%d"), "%b")
-x = c("09:29:16","10:42:40","23:47:12","01:06:01","11:35:34","11:51:09")
-datetimes = paste0("2011 ", NOV, c(18,18,18,19,19,19), " ", x)
-DT = IDateTime(strptime(datetimes,"%Y %b%d %H:%M:%S"))
-test(168.1, DT[,as.data.frame(itime)], data.frame(V1=as.ITime(x)))
-test(168.2, as.character(DT[,as.POSIXct(itime,tz="UTC")]), paste(Sys.Date(), x))
-test(168.3, as.character(DT[,as.POSIXct(idate,tz="UTC")]), c("2011-11-18","2011-11-18","2011-11-18","2011-11-19","2011-11-19","2011-11-19"))
+dates = paste0("2011-11-", rep(18:19, each=3L))
+times = c("09:29:16", "10:42:40", "23:47:12", "01:06:01", "11:35:34", "11:51:09")
+DT = IDateTime(as.POSIXlt(paste(dates, times)))
+test(168.1, DT[, as.data.frame(itime)], data.frame(V1=as.ITime(times)))
+test(168.2, as.character(DT[, as.POSIXct(itime, tz="UTC")]), paste(Sys.Date(), times))
+test(168.3, as.character(DT[, as.POSIXct(idate, tz="UTC")]), dates)
 
 # test of . in formula, using inheritance
 DT = data.table(y=1:100,x=101:200,y=201:300,grp=1:5)


### PR DESCRIPTION
As surfaced during review, `lv_LV` is not quite enough to catch all possible collation issues.

Since this CI is only run "rarely", combinatorial explosion of settings is not so big a concern.

Besides simply adding the locales, there are a few fixes to the suite to get it green. Mostly, it's because on R 3.5, we install from an ancient snapshot of CRAN:

 - Workaroung upstream bug where {R.oo} doesn't install in certain locales
 - Ancient (<0.3.0) {nanotime} lacked `as.nanotime()`; AFAICT, `nanotime()` is identical
 - Ancient (<0.9-8, I think) {bit64} didn't give `NA` for out-of-bouds indexing
 - {rcmdcheck} didn't always have `env=`; it turns out we can just `Sys.setenv()` for all cases anyway.