### PR TITLE
Avoid data.table:: for tests to work more reliably under cc()

### DIFF
--- a/inst/tests/tests.Rraw
+++ b/inst/tests/tests.Rraw
@@ -21339,7 +21339,7 @@ text = paste0(
  strrep("mary had a little lamb\n", 100),
  strrep("a", 500), "\n", "a"
 )
-test(2346, data.table::fread(text = text), data.table(mary = rep("mary", 99), had = "had", a = "a", little = "little", lamb = "lamb"), warning = "First discarded non-empty line")
+test(2346, fread(text=text), data.table(mary=rep("mary", 99L), had="had", a="a", little="little", lamb="lamb"), warning="First discarded non-empty line")
 
 # With 'i' containing NA and no GForce, columns for missing groups weren't fully missing, #7442
 DT = data.table(a="a", grp=1L)


### PR DESCRIPTION
If the installed version of {data.table} is still in a weird state, `data.table::` here will reference it and cause some confusing issues.

Better to use the value of `fread()` resolved in the current session.

This is the only call site with the issue; there are other `data.table::` in the file, but all are being intercepted by NSE and thus ignored:

https://github.com/Rdatatable/data.table/blob/914dd14bfddb08e53d625be21ceb0f2e65594c85/inst/tests/tests.Rraw#L18102-L18104

Merging as pretty inconsequential. cc @aitap as the author for FYI