### PR TITLE
handle openmp deprecation

### DIFF
--- a/src/fread.c
+++ b/src/fread.c
@@ -2496,7 +2496,11 @@ int freadMain(freadMainArgs _args)
     {
       int me = omp_get_thread_num();
       bool myShowProgress = false;
+#if defined(_OPENMP) && _OPENMP >= 202011
+      #pragma omp masked
+#else
       #pragma omp master
+#endif
       {
         nth = omp_get_num_threads();
         if (me != 0) {


### PR DESCRIPTION
Building locally I saw the the following warning:

```
fread.c:2479:15: warning: ‘master’ construct deprecated since OpenMP 5.1, use ‘masked’ [-Wdeprecated-openmp]
```
Link to relevant documentation:
https://www.openmp.org/spec-html/5.1/openmpse16.html

Note I'm unsure on the potential use of the `filter` clause so it is probably worth digging in to a little first.

